### PR TITLE
added in CLI flag & req params for saving request datasets to a name

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -40,9 +40,7 @@ var runCmd = &cobra.Command{
 			structure *dataset.Structure
 			results   []byte
 		)
-		// rgraph := LoadQueryResultsGraph()
-		// rqgraph := LoadResourceQueriesGraph()
-		// ns := LoadNamespaceGraph()
+
 		r := GetRepo()
 
 		store, err := GetIpfsFilestore()
@@ -110,11 +108,21 @@ var runCmd = &cobra.Command{
 		ds.Data, err = store.Put(memfile.NewMemfileBytes("data", results), false)
 		ExitIfErr(err)
 
-		dspath, err := dsfs.SaveDataset(store, ds, false)
+		name, err := cmd.Flags().GetString("name")
+		ExitIfErr(err)
+
+		pin := name != ""
+
+		dspath, err := dsfs.SaveDataset(store, ds, pin)
 		ExitIfErr(err)
 
 		err = r.PutDataset(dspath, ds)
 		ExitIfErr(err)
+
+		if name != "" {
+			err = r.PutName(name, dspath)
+			ExitIfErr(err)
+		}
 
 		// rgraph.AddResult(dspath, dspath)
 		// err = SaveQueryResultsGraph(rgraph)
@@ -149,4 +157,5 @@ func init() {
 	// runCmd.Flags().StringP("save", "s", "", "save the resulting dataset to a given address")
 	runCmd.Flags().StringP("output", "o", "", "file to write to")
 	runCmd.Flags().StringP("format", "f", "csv", "set output format [csv,json]")
+	runCmd.Flags().StringP("name", "n", "", "save output to local repository with given name")
 }

--- a/core/queries/handlers.go
+++ b/core/queries/handlers.go
@@ -90,8 +90,24 @@ func (h *Handlers) runHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	format := r.FormValue("format")
+	if format == "" {
+		format = "csv"
+	}
+	df, err := dataset.ParseDataFormatString(format)
+	if err != nil {
+		util.WriteErrResponse(w, http.StatusBadRequest, err)
+		return
+	}
+
+	p := &RunParams{
+		SaveName: r.FormValue("name"),
+		Dataset:  ds,
+	}
+	p.Format = df
+
 	res := &repo.DatasetRef{}
-	if err := h.Run(ds, res); err != nil {
+	if err := h.Run(p, res); err != nil {
 		fmt.Println("err:")
 		fmt.Println(err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)


### PR DESCRIPTION
give basic result saving to `qri run` CLI command and `/run` API endpoint