### PR TITLE
 feat(RPC): change default port, provide RPC listener

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ LABEL maintainer="sparkle_pony_2000@qri.io"
 ADD . /go/src/github.com/qri-io/qri
 RUN cd /go/src/github.com/qri-io/qri
 
-# RUN go get -u github.com/whyrusleeping/gx
-# RUN go get -u github.com/whyrusleeping/gx-go
-# RUN gx install
-# RUN go get ./...
+RUN go get -v github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/dataset_sql github.com/qri-io/doggos github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/viper
+
+RUN go get -u github.com/whyrusleeping/gx github.com/whyrusleeping/gx-go
+RUN cd /go/src/github.com/qri-io/qri && pwd && gx install
 
 RUN go install github.com/qri-io/qri
 # set default port to 8080, default log level, QRI_PATH env, IPFS_PATH env

--- a/api/config.go
+++ b/api/config.go
@@ -11,14 +11,17 @@ const (
 	DEVELOP_MODE    = "develop"
 	PRODUCTION_MODE = "production"
 	TEST_MODE       = "test"
+	DefaultPort     = "2503"
+	DefaultRPCPort  = "2504"
 )
 
 func DefaultConfig() *Config {
 	return &Config{
-		Logger: logging.DefaultLogger,
-		Mode:   "develop",
-		Port:   "8080",
-		Online: true,
+		Logger:  logging.DefaultLogger,
+		Mode:    "develop",
+		Port:    DefaultPort,
+		RPCPort: DefaultRPCPort,
+		Online:  true,
 	}
 }
 
@@ -38,6 +41,8 @@ type Config struct {
 	Mode string
 	// port to listen on, will be read from PORT env variable if present.
 	Port string
+	// port to listen for RPC calls on, if empty server will not register a RPC listener
+	RPCPort string
 	// root url for service
 	UrlRoot string
 	// DNS service discovery. Should be either "env" or "dns", default is env
@@ -67,7 +72,7 @@ type Config struct {
 func (cfg *Config) Validate() (err error) {
 	// make sure port is set
 	if cfg.Port == "" {
-		cfg.Port = "8080"
+		cfg.Port = DefaultPort
 	}
 
 	err = requireConfigStrings(map[string]string{

--- a/api/handlers/datasets.go
+++ b/api/handlers/datasets.go
@@ -17,7 +17,7 @@ import (
 )
 
 func NewDatasetHandlers(log logging.Logger, r repo.Repo) *DatasetHandlers {
-	req := core.NewDatasetRequests(r)
+	req := core.NewDatasetRequests(r, nil)
 	h := DatasetHandlers{*req, log, r}
 	return &h
 }

--- a/api/handlers/history.go
+++ b/api/handlers/history.go
@@ -17,7 +17,7 @@ type HistoryHandlers struct {
 }
 
 func NewHistoryHandlers(log logging.Logger, r repo.Repo) *HistoryHandlers {
-	req := core.NewHistoryRequests(r)
+	req := core.NewHistoryRequests(r, nil)
 	h := HistoryHandlers{*req, log}
 	return &h
 }

--- a/api/handlers/peers.go
+++ b/api/handlers/peers.go
@@ -14,7 +14,7 @@ import (
 )
 
 func NewPeerHandlers(log logging.Logger, r repo.Repo, node *p2p.QriNode) *PeerHandlers {
-	req := core.NewPeerRequests(r, node)
+	req := core.NewPeerRequests(node, nil)
 	h := PeerHandlers{*req, log}
 	return &h
 }

--- a/api/handlers/profile.go
+++ b/api/handlers/profile.go
@@ -8,7 +8,6 @@ import (
 	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/logging"
 	"github.com/qri-io/qri/repo"
-	"github.com/qri-io/qri/repo/profile"
 )
 
 // ProfileHandlers wraps a requests struct to interface with http.HandlerFunc
@@ -91,7 +90,7 @@ func (h *ProfileHandlers) setProfilePhotoHandler(w http.ResponseWriter, r *http.
 		}
 	}
 
-	res := &profile.Profile{}
+	res := &core.Profile{}
 	if err := h.SetProfilePhoto(p, res); err != nil {
 		h.log.Infof("error initializing dataset: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
@@ -128,7 +127,7 @@ func (h *ProfileHandlers) setPosterHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	res := &profile.Profile{}
+	res := &core.Profile{}
 	if err := h.SetPosterPhoto(p, res); err != nil {
 		h.log.Infof("error initializing dataset: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)

--- a/api/handlers/profile.go
+++ b/api/handlers/profile.go
@@ -18,7 +18,7 @@ type ProfileHandlers struct {
 }
 
 func NewProfileHandlers(log logging.Logger, r repo.Repo) *ProfileHandlers {
-	req := core.NewProfileRequests(r)
+	req := core.NewProfileRequests(r, nil)
 	h := ProfileHandlers{*req, log}
 	return &h
 }
@@ -38,7 +38,7 @@ func (h *ProfileHandlers) ProfileHandler(w http.ResponseWriter, r *http.Request)
 
 func (h *ProfileHandlers) getProfileHandler(w http.ResponseWriter, r *http.Request) {
 	args := true
-	res := &profile.Profile{}
+	res := &core.Profile{}
 	if err := h.GetProfile(&args, res); err != nil {
 		h.log.Infof("error getting profile: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
@@ -49,12 +49,12 @@ func (h *ProfileHandlers) getProfileHandler(w http.ResponseWriter, r *http.Reque
 }
 
 func (h *ProfileHandlers) saveProfileHandler(w http.ResponseWriter, r *http.Request) {
-	p := &profile.Profile{}
+	p := &core.Profile{}
 	if err := json.NewDecoder(r.Body).Decode(p); err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
 	}
-	res := &profile.Profile{}
+	res := &core.Profile{}
 	if err := h.SaveProfile(p, res); err != nil {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return

--- a/api/handlers/queries.go
+++ b/api/handlers/queries.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewQueryHandlers(log logging.Logger, r repo.Repo) *QueryHandlers {
-	req := core.NewQueryRequests(r)
+	req := core.NewQueryRequests(r, nil)
 	return &QueryHandlers{*req, log}
 }
 

--- a/api/handlers/search.go
+++ b/api/handlers/search.go
@@ -17,7 +17,7 @@ type SearchHandlers struct {
 }
 
 func NewSearchHandlers(log logging.Logger, r repo.Repo) *SearchHandlers {
-	req := core.NewSearchRequests(r)
+	req := core.NewSearchRequests(r, nil)
 	return &SearchHandlers{*req, log}
 }
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -34,7 +34,8 @@ var datasetAddCmd = &cobra.Command{
 				ErrExit(fmt.Errorf("please provide a --name"))
 			}
 
-			req := core.NewDatasetRequests(RepoOrClient(false))
+			req, err := DatasetRequests(false)
+			ExitIfErr(err)
 
 			root := strings.TrimSuffix(args[0], "/"+dsfs.PackageFileDataset.String())
 			p := &core.AddParams{
@@ -42,7 +43,7 @@ var datasetAddCmd = &cobra.Command{
 				Hash: root,
 			}
 			res := &repo.DatasetRef{}
-			err := req.AddDataset(p, res)
+			err = req.AddDataset(p, res)
 			ExitIfErr(err)
 
 			PrintInfo("Successfully added dataset %s: %s", addDsName, res.Path.String())
@@ -69,7 +70,8 @@ func initDataset() {
 	metaFile, err = loadFileIfPath(addDsMetaFilepath)
 	ExitIfErr(err)
 
-	req := core.NewDatasetRequests(RepoOrClient(false))
+	req, err := DatasetRequests(false)
+	ExitIfErr(err)
 
 	p := &core.InitDatasetParams{
 		Name:         addDsName,

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -34,7 +34,7 @@ var datasetAddCmd = &cobra.Command{
 				ErrExit(fmt.Errorf("please provide a --name"))
 			}
 
-			req := core.NewDatasetRequests(GetRepo(false))
+			req := core.NewDatasetRequests(RepoOrClient(false))
 
 			root := strings.TrimSuffix(args[0], "/"+dsfs.PackageFileDataset.String())
 			p := &core.AddParams{
@@ -69,7 +69,7 @@ func initDataset() {
 	metaFile, err = loadFileIfPath(addDsMetaFilepath)
 	ExitIfErr(err)
 
-	req := core.NewDatasetRequests(GetRepo(false))
+	req := core.NewDatasetRequests(RepoOrClient(false))
 
 	p := &core.InitDatasetParams{
 		Name:         addDsName,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 )
 
@@ -41,14 +41,20 @@ func cachePath() string {
 }
 
 func userHomeDir() string {
-	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		if home == "" {
-			home = os.Getenv("USERPROFILE")
-		}
-		return home
+	dir, err := homedir.Dir()
+	if err != nil {
+		panic(err)
 	}
-	return os.Getenv("HOME")
+	return dir
+
+	// if runtime.GOOS == "windows" {
+	// 	home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+	// 	if home == "" {
+	// 		home = os.Getenv("USERPROFILE")
+	// 	}
+	// 	return home
+	// }
+	// return os.Getenv("HOME")
 }
 
 func loadFileIfPath(path string) (file *os.File, err error) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -77,7 +77,7 @@ func initConfig() (created bool) {
 
 	ipfsFsPath := os.Getenv("IPFS_PATH")
 	if ipfsFsPath == "" {
-		ipfsFsPath = "$HOME/.ipfs"
+		ipfsFsPath = filepath.Join(home, ".ipfs")
 	}
 	ipfsFsPath = strings.Replace(ipfsFsPath, "~", home, 1)
 	viper.SetDefault(IpfsFsPath, ipfsFsPath)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,7 +51,8 @@ func init() {
 }
 
 // initConfig reads in config file and ENV variables if set.
-func initConfig() {
+func initConfig() (created bool) {
+	var err error
 	home := userHomeDir()
 	SetNoColor()
 
@@ -84,11 +85,13 @@ func initConfig() {
 	viper.SetConfigName("config") // name of config file (without extension)
 	viper.AddConfigPath(qriPath)  // add QRI_PATH env var
 
-	err := EnsureConfigFile()
+	created, err = EnsureConfigFile()
 	ExitIfErr(err)
 
 	err = viper.ReadInConfig()
 	ExitIfErr(err)
+
+	return
 }
 
 func configFilepath() string {
@@ -99,12 +102,12 @@ func configFilepath() string {
 	return path
 }
 
-func EnsureConfigFile() error {
+func EnsureConfigFile() (bool, error) {
 	if _, err := os.Stat(configFilepath()); os.IsNotExist(err) {
 		fmt.Println("writing config file")
-		return WriteConfigFile(defaultCfg)
+		return true, WriteConfigFile(defaultCfg)
 	}
-	return nil
+	return false, nil
 }
 
 func WriteConfigFile(cfg *Config) error {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -30,7 +30,7 @@ var exportCmd = &cobra.Command{
 		}
 
 		r := GetRepo(false)
-		req := core.NewDatasetRequests(r)
+		req := core.NewDatasetRequests(r, nil)
 
 		p := &core.GetDatasetParams{
 			Name: args[0],

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -34,7 +34,8 @@ var infoCmd = &cobra.Command{
 			}
 		}
 
-		req := core.NewDatasetRequests(RepoOrClient(false))
+		req, err := DatasetRequests(false)
+		ExitIfErr(err)
 
 		for i, arg := range args {
 			rt, ref := dsfs.RefType(arg)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -34,7 +34,7 @@ var infoCmd = &cobra.Command{
 			}
 		}
 
-		req := core.NewDatasetRequests(GetRepo(false))
+		req := core.NewDatasetRequests(RepoOrClient(false))
 
 		for i, arg := range args {
 			rt, ref := dsfs.RefType(arg)

--- a/cmd/init-ipfs.go
+++ b/cmd/init-ipfs.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/ipfs/go-datastore"
 	ipfs "github.com/qri-io/cafs/ipfs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -11,20 +10,13 @@ var (
 	initIpfsConfigFile string
 )
 
-// defaultDatasets is a hard-coded dataset added when a new qri repo is created
-// this hash must always be available
-var defaultDatasets = []datastore.Key{
-	// fivethirtyeight comic characters
-	datastore.NewKey("/ipfs/QmcqkHFA2LujZxY38dYZKmxsUstN4unk95azBjwEhwrnM6"),
-}
-
 // initCmd represents the init command
 var initIpfsCmd = &cobra.Command{
 	Use:   "init-ipfs",
 	Short: "Initialize an ipfs repository",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := ipfs.InitRepo(viper.GetString(IpfsFsPath), initIpfsConfigFile, defaultDatasets)
+		err := ipfs.InitRepo(viper.GetString(IpfsFsPath), initIpfsConfigFile)
 		ExitIfErr(err)
 	},
 }

--- a/cmd/init-ipfs.go
+++ b/cmd/init-ipfs.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/ipfs/go-datastore"
 	ipfs "github.com/qri-io/cafs/ipfs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -10,13 +11,20 @@ var (
 	initIpfsConfigFile string
 )
 
+// defaultDatasets is a hard-coded dataset added when a new qri repo is created
+// this hash must always be available
+var defaultDatasets = []datastore.Key{
+	// fivethirtyeight comic characters
+	datastore.NewKey("/ipfs/QmcqkHFA2LujZxY38dYZKmxsUstN4unk95azBjwEhwrnM6"),
+}
+
 // initCmd represents the init command
 var initIpfsCmd = &cobra.Command{
 	Use:   "init-ipfs",
 	Short: "Initialize an ipfs repository",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := ipfs.InitRepo(viper.GetString(IpfsFsPath), initIpfsConfigFile)
+		err := ipfs.InitRepo(viper.GetString(IpfsFsPath), initIpfsConfigFile, defaultDatasets)
 		ExitIfErr(err)
 	},
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -4,7 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/core"
+	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
+)
+
+var (
+	dsListLimit, dsListOffset int
 )
 
 var datasetListCmd = &cobra.Command{
@@ -14,11 +20,18 @@ var datasetListCmd = &cobra.Command{
 	Long:    ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		// TODO - add limit & offset params
-		refs, err := GetRepo(false).Namespace(100, 0)
+		r, err := DatasetRequests(false)
+		ExitIfErr(err)
+
+		p := &core.ListParams{
+			Limit:  dsListLimit,
+			Offset: dsListOffset,
+		}
+		refs := []*repo.DatasetRef{}
+		err = r.List(p, &refs)
 		ExitIfErr(err)
 
 		outformat := cmd.Flag("format").Value.String()
-
 		switch outformat {
 		case "":
 			for _, ref := range refs {
@@ -38,4 +51,6 @@ var datasetListCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(datasetListCmd)
 	datasetListCmd.Flags().StringP("format", "f", "", "set output format [json]")
+	datasetListCmd.Flags().IntVarP(&dsListLimit, "limit", "l", 25, "limit results, default 25")
+	datasetListCmd.Flags().IntVarP(&dsListOffset, "offset", "o", 0, "offset results, default 0")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+	"github.com/qri-io/dataset"
 	"github.com/spf13/cobra"
 )
 
@@ -10,14 +13,29 @@ var datasetListCmd = &cobra.Command{
 	Short:   "list your local datasets",
 	Long:    ``,
 	Run: func(cmd *cobra.Command, args []string) {
+		// TODO - add limit & offset params
 		refs, err := GetRepo(false).Namespace(100, 0)
 		ExitIfErr(err)
-		for _, ref := range refs {
-			PrintInfo("%s\t\t\t: %s", ref.Name, ref.Path)
+
+		outformat := cmd.Flag("format").Value.String()
+
+		switch outformat {
+		case "":
+			for _, ref := range refs {
+				PrintInfo("%s\t\t\t: %s", ref.Name, ref.Path)
+			}
+		case dataset.JSONDataFormat.String():
+			data, err := json.MarshalIndent(refs, "", "  ")
+			ExitIfErr(err)
+			fmt.Printf("%s\n", string(data))
+		default:
+			ErrExit(fmt.Errorf("unrecognized format: %s", outformat))
 		}
+
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(datasetListCmd)
+	datasetListCmd.Flags().StringP("format", "f", "", "set output format [json]")
 }

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -125,7 +125,7 @@ func PrintQuery(i int, r *repo.DatasetRef) {
 	white := color.New(color.FgWhite).SprintFunc()
 	cyan := color.New(color.FgCyan).SprintFunc()
 	blue := color.New(color.FgBlue).SprintFunc()
-	fmt.Printf("%s:\t%s\n\t%s\n", cyan(i), white(r.Dataset.QueryString), blue(r.Path))
+	fmt.Printf("%s:\t%s\n\t%s\n", cyan(i), white(r.Dataset.Transform.Data), blue(r.Path))
 }
 
 func PrintResults(r *dataset.Structure, data []byte, format dataset.DataFormat) {

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/qri-io/qri/core"
+	"github.com/spf13/cobra"
+)
+
+var (
+	setProfileFilepath string
+)
+
+// profileCmd represents the profile command
+var profileCmd = &cobra.Command{
+	Use:   "profile",
+	Short: "show or edit user profile information",
+}
+
+var profileGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "get profile info",
+	Run: func(cmd *cobra.Command, args []string) {
+		r, err := ProfileRequests(false)
+		ExitIfErr(err)
+
+		in := true
+		res := &core.Profile{}
+		err = r.GetProfile(&in, res)
+		ExitIfErr(err)
+
+		data, err := json.MarshalIndent(res, "", "  ")
+		ExitIfErr(err)
+		PrintSuccess(string(data))
+	},
+}
+
+var profileSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "add peers to the profile list",
+	Run: func(cmd *cobra.Command, args []string) {
+		var (
+			dataFile *os.File
+			err      error
+		)
+
+		r, err := ProfileRequests(false)
+		ExitIfErr(err)
+
+		dataFile, err = loadFileIfPath(setProfileFilepath)
+		ExitIfErr(err)
+
+		p := &core.Profile{}
+		err = json.NewDecoder(dataFile).Decode(p)
+		ExitIfErr(err)
+
+		res := &core.Profile{}
+		err = r.SaveProfile(p, res)
+		ExitIfErr(err)
+
+		data, err := json.MarshalIndent(res, "", "  ")
+		ExitIfErr(err)
+		PrintSuccess(string(data))
+	},
+}
+
+func init() {
+	profileSetCmd.Flags().StringVarP(&setProfileFilepath, "file", "f", "", "json file to update profile info")
+
+	profileCmd.AddCommand(profileGetCmd)
+	profileCmd.AddCommand(profileSetCmd)
+	RootCmd.AddCommand(profileCmd)
+}

--- a/cmd/queries.go
+++ b/cmd/queries.go
@@ -14,11 +14,12 @@ var queriesCmd = &cobra.Command{
 	Long:    ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			req := core.NewQueryRequests(GetRepo(false))
+			req, err := QueryRequests(false)
+			ExitIfErr(err)
 			p := core.NewListParams("-created", pageNum, pageSize)
 
 			res := []*repo.DatasetRef{}
-			err := req.List(&p, &res)
+			err = req.List(&p, &res)
 			ExitIfErr(err)
 
 			for i, q := range res {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -19,7 +19,7 @@ var datasetRemoveCmd = &cobra.Command{
 			ErrExit(fmt.Errorf("please specify a dataset path or name to get the info of"))
 		}
 
-		req := core.NewDatasetRequests(GetRepo(false))
+		req := core.NewDatasetRequests(RepoOrClient(false))
 
 		for _, arg := range args {
 			rt, ref := dsfs.RefType(arg)

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -19,7 +19,8 @@ var datasetRemoveCmd = &cobra.Command{
 			ErrExit(fmt.Errorf("please specify a dataset path or name to get the info of"))
 		}
 
-		req := core.NewDatasetRequests(RepoOrClient(false))
+		req, err := DatasetRequests(false)
+		ExitIfErr(err)
 
 		for _, arg := range args {
 			rt, ref := dsfs.RefType(arg)

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -18,13 +18,14 @@ var datasetRenameCmd = &cobra.Command{
 			ErrExit(fmt.Errorf("please provide current & new dataset names"))
 		}
 
-		req := core.NewDatasetRequests(RepoOrClient(false))
+		req, err := DatasetRequests(false)
+		ExitIfErr(err)
 		p := &core.RenameParams{
 			Current: args[0],
 			New:     args[1],
 		}
 		res := &repo.DatasetRef{}
-		err := req.Rename(p, res)
+		err = req.Rename(p, res)
 		ExitIfErr(err)
 
 		PrintSuccess("renamed dataset %s", res.Name)

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -18,7 +18,7 @@ var datasetRenameCmd = &cobra.Command{
 			ErrExit(fmt.Errorf("please provide current & new dataset names"))
 		}
 
-		req := core.NewDatasetRequests(GetRepo(false))
+		req := core.NewDatasetRequests(RepoOrClient(false))
 		p := &core.RenameParams{
 			Current: args[0],
 			New:     args[1],

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"net"
+	"net/rpc"
+	"strings"
+
 	ipfs "github.com/qri-io/cafs/ipfs"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/fs"
@@ -23,6 +27,33 @@ func GetRepo(online bool) repo.Repo {
 	r, err := fs_repo.NewRepo(fs, viper.GetString(QriRepoPath), id)
 	ExitIfErr(err)
 	return r
+}
+
+// RepoOrClient returns either a
+func RepoOrClient(online bool) (repo.Repo, *rpc.Client) {
+	if fs, err := ipfs.NewFilestore(func(cfg *ipfs.StoreCfg) {
+		cfg.FsRepoPath = viper.GetString(IpfsFsPath)
+		cfg.Online = online
+	}); err == nil {
+		id := ""
+		if fs.Node().PeerHost != nil {
+			id = fs.Node().PeerHost.ID().Pretty()
+		}
+
+		r, err := fs_repo.NewRepo(fs, viper.GetString(QriRepoPath), id)
+		ExitIfErr(err)
+		return r, nil
+	} else if strings.Contains(err.Error(), "lock") {
+		// TODO - bad bad hardcode
+		conn, err := net.Dial("tcp", ":2504")
+		if err != nil {
+			ErrExit(err)
+		}
+		return nil, rpc.NewClient(conn)
+	} else {
+		ErrExit(err)
+	}
+	return nil, nil
 }
 
 func GetIpfsFilestore(online bool) *ipfs.Filestore {

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -48,6 +48,30 @@ func DatasetRequests(online bool) (*core.DatasetRequests, error) {
 	return core.NewDatasetRequests(r, cli), nil
 }
 
+func QueryRequests(online bool) (*core.QueryRequests, error) {
+	r, cli, err := RepoOrClient(online)
+	if err != nil {
+		return nil, err
+	}
+	return core.NewQueryRequests(r, cli), nil
+}
+
+func ProfileRequests(online bool) (*core.ProfileRequests, error) {
+	r, cli, err := RepoOrClient(online)
+	if err != nil {
+		return nil, err
+	}
+	return core.NewProfileRequests(r, cli), nil
+}
+
+func SearchRequests(online bool) (*core.SearchRequests, error) {
+	r, cli, err := RepoOrClient(online)
+	if err != nil {
+		return nil, err
+	}
+	return core.NewSearchRequests(r, cli), nil
+}
+
 // RepoOrClient returns either a
 func RepoOrClient(online bool) (repo.Repo, *rpc.Client, error) {
 	if fs, err := ipfs.NewFilestore(func(cfg *ipfs.StoreCfg) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,8 +27,8 @@ var runCmd = &cobra.Command{
 			ErrExit(fmt.Errorf("Please provide a query string to execute"))
 		}
 
-		r := GetRepo(false)
-		req := core.NewQueryRequests(r)
+		req, err := QueryRequests(false)
+		ExitIfErr(err)
 
 		format, err := dataset.ParseDataFormatString(cmd.Flag("format").Value.String())
 		if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -59,7 +59,13 @@ var runCmd = &cobra.Command{
 		results, err := ioutil.ReadAll(f)
 		ExitIfErr(err)
 
-		PrintResults(res.Dataset.Structure, results, res.Dataset.Structure.Format)
+		switch cmd.Flag("format").Value.String() {
+		case "csv", "json":
+			fmt.Printf("%s", string(results))
+		default:
+			PrintResults(res.Dataset.Structure, results, res.Dataset.Structure.Format)
+		}
+
 	},
 }
 
@@ -67,6 +73,6 @@ func init() {
 	RootCmd.AddCommand(runCmd)
 	// runCmd.Flags().StringP("save", "s", "", "save the resulting dataset to a given address")
 	runCmd.Flags().StringP("output", "o", "", "file to write to")
-	runCmd.Flags().StringP("format", "f", "csv", "set output format [csv,json]")
+	runCmd.Flags().StringP("format", "f", "", "set output format [csv,json]")
 	runCmd.Flags().StringVarP(&runCmdName, "name", "n", "", "save output to name")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -42,12 +42,9 @@ var runCmd = &cobra.Command{
 			SaveName: runCmdName,
 			Dataset: &dataset.Dataset{
 				Timestamp: time.Now().In(time.UTC),
-				Query: &dataset.Query{
+				Transform: &dataset.Transform{
 					Syntax: "sql",
-					Abstract: &dataset.AbstractQuery{
-						Syntax:    "sql",
-						Statement: args[0],
-					},
+					Data:   args[0],
 				},
 			},
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,8 +27,9 @@ var runCmd = &cobra.Command{
 			ErrExit(fmt.Errorf("Please provide a query string to execute"))
 		}
 
-		req, err := QueryRequests(false)
+		r, cli, err := RepoOrClient(false)
 		ExitIfErr(err)
+		req := core.NewQueryRequests(r, cli)
 
 		format, err := dataset.ParseDataFormatString(cmd.Flag("format").Value.String())
 		if err != nil {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -24,7 +24,8 @@ var searchCmd = &cobra.Command{
 			ErrExit(fmt.Errorf("wrong number of arguments. expected qri search [query]"))
 		}
 
-		req := core.NewSearchRequests(GetRepo(false))
+		req, err := SearchRequests(false)
+		ExitIfErr(err)
 
 		if searchCmdReindex {
 			PrintInfo("building index...")
@@ -44,7 +45,7 @@ var searchCmd = &cobra.Command{
 		}
 		res := []*repo.DatasetRef{}
 
-		err := req.Search(p, &res)
+		err = req.Search(p, &res)
 		ExitIfErr(err)
 
 		outformat := cmd.Flag("format").Value.String()

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
@@ -45,13 +47,26 @@ var searchCmd = &cobra.Command{
 		err := req.Search(p, &res)
 		ExitIfErr(err)
 
-		for i, ref := range res {
-			PrintDatasetRefInfo(i, ref)
+		outformat := cmd.Flag("format").Value.String()
+
+		switch outformat {
+		case "":
+			for i, ref := range res {
+				PrintDatasetRefInfo(i, ref)
+			}
+		case dataset.JSONDataFormat.String():
+			data, err := json.MarshalIndent(res, "", "  ")
+			ExitIfErr(err)
+			fmt.Printf("%s\n", string(data))
+		default:
+			ErrExit(fmt.Errorf("unrecognized format: %s", outformat))
 		}
+
 	},
 }
 
 func init() {
 	searchCmd.Flags().BoolVarP(&searchCmdReindex, "reindex", "r", false, "re-generate search index from scratch. might take a while.")
+	searchCmd.Flags().StringP("format", "f", "", "set output format [json]")
 	RootCmd.AddCommand(searchCmd)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -67,9 +67,9 @@ var serverCmd = &cobra.Command{
 }
 
 func init() {
-	serverCmd.Flags().StringVarP(&serverCmdPort, "port", "p", "3000", "port to start server on")
+	serverCmd.Flags().StringVarP(&serverCmdPort, "port", "p", api.DefaultPort, "port to start server on")
 	serverCmd.Flags().BoolVarP(&serverInitIpfs, "init-ipfs", "", false, "initialize a new default ipfs repo if empty")
-	serverCmd.Flags().BoolVarP(&serverMemOnly, "mem-only", "", false, "run qri entirely in-memory")
+	serverCmd.Flags().BoolVarP(&serverMemOnly, "mem-only", "", false, "run qri entirely in-memory, persisting nothing")
 	serverCmd.Flags().BoolVarP(&serverOffline, "offline", "", false, "disable networking")
 	RootCmd.AddCommand(serverCmd)
 }
@@ -80,7 +80,9 @@ func initRepoIfEmpty(repoPath, configPath string) error {
 			if err := os.MkdirAll(repoPath, os.ModePerm); err != nil {
 				return err
 			}
-			return ipfs.InitRepo(repoPath, configPath)
+			if err := ipfs.InitRepo(repoPath, configPath, defaultDatasets); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -80,7 +80,7 @@ func initRepoIfEmpty(repoPath, configPath string) error {
 			if err := os.MkdirAll(repoPath, os.ModePerm); err != nil {
 				return err
 			}
-			if err := ipfs.InitRepo(repoPath, configPath, defaultDatasets); err != nil {
+			if err := ipfs.InitRepo(repoPath, configPath); err != nil {
 				return err
 			}
 		}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -46,7 +46,7 @@ var updateCmd = &cobra.Command{
 			ErrExit(fmt.Errorf("either a metadata or data option is required"))
 		}
 
-		req := core.NewDatasetRequests(GetRepo(false))
+		req := core.NewDatasetRequests(RepoOrClient(false))
 
 		p := &core.GetDatasetParams{
 			Name: args[0],

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -46,7 +46,8 @@ var updateCmd = &cobra.Command{
 			ErrExit(fmt.Errorf("either a metadata or data option is required"))
 		}
 
-		req := core.NewDatasetRequests(RepoOrClient(false))
+		req, err := DatasetRequests(false)
+		ExitIfErr(err)
 
 		p := &core.GetDatasetParams{
 			Name: args[0],

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -29,7 +29,9 @@ and check each of it's rows against the constraints listed
 in the dataset's fields.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
-			req := core.NewDatasetRequests(RepoOrClient(false))
+			req, err := DatasetRequests(false)
+			ExitIfErr(err)
+
 			for _, arg := range args {
 				rt, ref := dsfs.RefType(arg)
 				p := &core.ValidateDatasetParams{}
@@ -78,7 +80,8 @@ func validateDataset() {
 	metaFile, err = loadFileIfPath(validateDsMetaFilepath)
 	ExitIfErr(err)
 
-	req := core.NewDatasetRequests(RepoOrClient(false))
+	req, err := DatasetRequests(false)
+	ExitIfErr(err)
 
 	p := &core.ValidateDatasetParams{
 		Name:         validateDsName,

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -29,7 +29,7 @@ and check each of it's rows against the constraints listed
 in the dataset's fields.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
-			req := core.NewDatasetRequests(GetRepo(false))
+			req := core.NewDatasetRequests(RepoOrClient(false))
 			for _, arg := range args {
 				rt, ref := dsfs.RefType(arg)
 				p := &core.ValidateDatasetParams{}
@@ -78,7 +78,7 @@ func validateDataset() {
 	metaFile, err = loadFileIfPath(validateDsMetaFilepath)
 	ExitIfErr(err)
 
-	req := core.NewDatasetRequests(GetRepo(false))
+	req := core.NewDatasetRequests(RepoOrClient(false))
 
 	p := &core.ValidateDatasetParams{
 		Name:         validateDsName,

--- a/core/core.go
+++ b/core/core.go
@@ -17,11 +17,11 @@ func Receivers(node *p2p.QriNode) []CoreRequests {
 	r := node.Repo
 	return []CoreRequests{
 		NewDatasetRequests(r, nil),
-		NewHistoryRequests(r),
-		NewPeerRequests(r, node),
-		NewProfileRequests(r),
-		NewQueryRequests(r),
-		NewSearchRequests(r),
+		NewHistoryRequests(r, nil),
+		NewPeerRequests(node, nil),
+		NewProfileRequests(r, nil),
+		NewQueryRequests(r, nil),
+		NewSearchRequests(r, nil),
 	}
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"github.com/qri-io/qri/p2p"
+)
+
+// CoreRequests defines a set of core methods
+type CoreRequests interface {
+	// CoreRequestsName confirms participation in the CoreRequests interface while
+	// also giving a human readable string for logging purposes
+	CoreRequestsName() string
+}
+
+// Requests returns a slice of CoreRequests that defines the full local
+// API of core methods
+func Receivers(node *p2p.QriNode) []CoreRequests {
+	r := node.Repo
+	return []CoreRequests{
+		NewDatasetRequests(r, nil),
+		NewHistoryRequests(r),
+		NewPeerRequests(r, node),
+		NewProfileRequests(r),
+		NewQueryRequests(r),
+		NewSearchRequests(r),
+	}
+}
+
+// func RemoteClient(addr string) (*rpc.Client, error) {
+// 	conn, err := net.Dial("tcp", addr)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("dial error: %s", err)
+// 	}
+// 	return rpc.NewClient(conn), nil
+// }

--- a/core/datasets_test.go
+++ b/core/datasets_test.go
@@ -49,7 +49,7 @@ func TestDatasetRequestsInit(t *testing.T) {
 		return
 	}
 
-	req := NewDatasetRequests(mr)
+	req := NewDatasetRequests(mr, nil)
 	for i, c := range cases {
 		got := &repo.DatasetRef{}
 		err := req.InitDataset(c.p, got)
@@ -103,7 +103,7 @@ func TestDatasetRequestsList(t *testing.T) {
 		// TODO: re-enable {&ListParams{OrderBy: "name", Limit: 30, Offset: 0}, []*repo.DatasetRef{cities, counter, movies}, ""},
 	}
 
-	req := NewDatasetRequests(mr)
+	req := NewDatasetRequests(mr, nil)
 	for i, c := range cases {
 		got := []*repo.DatasetRef{}
 		err := req.List(c.p, &got)
@@ -156,7 +156,7 @@ func TestDatasetRequestsGet(t *testing.T) {
 		{&GetDatasetParams{Path: path, Name: "cats", Hash: "123"}, moviesDs, ""},
 	}
 
-	req := NewDatasetRequests(mr)
+	req := NewDatasetRequests(mr, nil)
 	for i, c := range cases {
 		got := &repo.DatasetRef{}
 		err := req.Get(c.p, got)
@@ -198,7 +198,7 @@ func TestDatasetRequestsUpdate(t *testing.T) {
 	// {&UpdateParams{Path: path, Name: "cats", Hash: "123"}, moviesDs, ""},
 	}
 
-	req := NewDatasetRequests(mr)
+	req := NewDatasetRequests(mr, nil)
 	for i, c := range cases {
 		got := &repo.DatasetRef{}
 		err := req.Update(c.p, got)
@@ -230,7 +230,7 @@ func TestDatasetRequestsRename(t *testing.T) {
 		{&RenameParams{Current: "new_movies", New: "new_movies"}, "", "name 'new_movies' already exists"},
 	}
 
-	req := NewDatasetRequests(mr)
+	req := NewDatasetRequests(mr, nil)
 	for i, c := range cases {
 		got := &repo.DatasetRef{}
 		err := req.Rename(c.p, got)
@@ -269,7 +269,7 @@ func TestDatasetRequestsDelete(t *testing.T) {
 		{&DeleteParams{Path: path}, nil, ""},
 	}
 
-	req := NewDatasetRequests(mr)
+	req := NewDatasetRequests(mr, nil)
 	for i, c := range cases {
 		got := false
 		err := req.Delete(c.p, &got)
@@ -313,7 +313,7 @@ func TestDatasetRequestsStructuredData(t *testing.T) {
 		{&StructuredDataParams{Format: dataset.JSONDataFormat, Path: archivePath, Limit: 0, Offset: 0, All: true}, 0, ""},
 	}
 
-	req := NewDatasetRequests(mr)
+	req := NewDatasetRequests(mr, nil)
 	for i, c := range cases {
 		got := &StructuredData{}
 		err := req.StructuredData(c.p, got)
@@ -361,7 +361,7 @@ func TestDatasetRequestsAddDataset(t *testing.T) {
 		return
 	}
 
-	req := NewDatasetRequests(mr)
+	req := NewDatasetRequests(mr, nil)
 	for i, c := range cases {
 		got := &repo.DatasetRef{}
 		err := req.AddDataset(c.p, got)

--- a/core/datasets_test.go
+++ b/core/datasets_test.go
@@ -34,6 +34,9 @@ func TestDatasetRequestsInit(t *testing.T) {
 		// Ensure that structure validation is being called
 		{&InitDatasetParams{DataFilename: badStructureFile.FileName(),
 			Data: badStructureFile}, nil, "invalid structure: error: cannot use the same name, 'colb' more than once"},
+		// should reject invalid names
+		{&InitDatasetParams{DataFilename: jobsByAutomationFile.FileName(), Name: "foo bar baz", Data: jobsByAutomationFile}, nil,
+			"invalid name: error: illegal name 'foo bar baz', names must start with a letter and consist of only a-z,0-9, and _. max length 144 characters"},
 		// this should work
 		{&InitDatasetParams{DataFilename: jobsByAutomationFile.FileName(), Data: jobsByAutomationFile}, nil, ""},
 		// Ensure that we can't double-add data

--- a/core/history.go
+++ b/core/history.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"net/rpc"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/dataset/dsfs"
@@ -10,11 +11,16 @@ import (
 
 type HistoryRequests struct {
 	repo repo.Repo
+	cli  *rpc.Client
 }
 
 func (d HistoryRequests) CoreRequestsName() string { return "history" }
 
-func NewHistoryRequests(r repo.Repo) *HistoryRequests {
+func NewHistoryRequests(r repo.Repo, cli *rpc.Client) *HistoryRequests {
+	if r != nil && cli != nil {
+		panic(fmt.Errorf("both repo and client supplied to NewHistoryRequests"))
+	}
+
 	return &HistoryRequests{
 		repo: r,
 	}
@@ -26,6 +32,10 @@ type LogParams struct {
 }
 
 func (d *HistoryRequests) Log(params *LogParams, res *[]*repo.DatasetRef) (err error) {
+	if d.cli != nil {
+		return d.cli.Call("HistoryRequests.Log", params, res)
+	}
+
 	log := []*repo.DatasetRef{}
 	limit := params.Limit
 	ref := &repo.DatasetRef{Path: params.Path}

--- a/core/history.go
+++ b/core/history.go
@@ -12,6 +12,8 @@ type HistoryRequests struct {
 	repo repo.Repo
 }
 
+func (d HistoryRequests) CoreRequestsName() string { return "history" }
+
 func NewHistoryRequests(r repo.Repo) *HistoryRequests {
 	return &HistoryRequests{
 		repo: r,

--- a/core/history_test.go
+++ b/core/history_test.go
@@ -30,7 +30,7 @@ func TestHistoryRequestsLog(t *testing.T) {
 		{&LogParams{Path: path}, []*repo.DatasetRef{&repo.DatasetRef{Path: path}}, ""},
 	}
 
-	req := NewHistoryRequests(mr)
+	req := NewHistoryRequests(mr, nil)
 	for i, c := range cases {
 		got := []*repo.DatasetRef{}
 		err := req.Log(c.p, &got)

--- a/core/peers.go
+++ b/core/peers.go
@@ -24,6 +24,8 @@ type PeerRequests struct {
 	qriNode *p2p.QriNode
 }
 
+func (d PeerRequests) CoreRequestsName() string { return "peers" }
+
 func (d *PeerRequests) List(p *ListParams, res *[]*profile.Profile) error {
 	replies := make([]*profile.Profile, p.Limit)
 	i := 0

--- a/core/peers_test.go
+++ b/core/peers_test.go
@@ -28,7 +28,7 @@ func TestPeerRequestsList(t *testing.T) {
 	}
 
 	// TODO - need to upgrade this to include a mock node
-	req := NewPeerRequests(mr, &p2p.QriNode{})
+	req := NewPeerRequests(&p2p.QriNode{Repo: mr}, nil)
 	for i, c := range cases {
 		got := []*profile.Profile{}
 		err := req.List(c.p, &got)

--- a/core/profile.go
+++ b/core/profile.go
@@ -1,10 +1,13 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/rpc"
+	"time"
 
 	"github.com/qri-io/cafs/memfs"
 	"github.com/qri-io/qri/repo"
@@ -13,31 +16,101 @@ import (
 
 type ProfileRequests struct {
 	repo repo.Repo
+	cli  *rpc.Client
 }
 
 func (d ProfileRequests) CoreRequestsName() string { return "profile" }
 
-func NewProfileRequests(r repo.Repo) *ProfileRequests {
+func NewProfileRequests(r repo.Repo, cli *rpc.Client) *ProfileRequests {
+	if r != nil && cli != nil {
+		panic(fmt.Errorf("both repo and client supplied to NewProfileRequests"))
+	}
+
 	return &ProfileRequests{
 		repo: r,
+		cli:  cli,
 	}
 }
 
-func (r *ProfileRequests) GetProfile(in *bool, res *profile.Profile) error {
+type Profile struct {
+	Id          string           `json:"id"`
+	Created     time.Time        `json:"created,omitempty"`
+	Updated     time.Time        `json:"updated,omitempty"`
+	Username    string           `json:"username"`
+	Type        profile.UserType `json:"type"`
+	Email       string           `json:"email"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	HomeUrl     string           `json:"homeUrl"`
+	Color       string           `json:"color"`
+	Thumb       string           `json:"thumb"`
+	Profile     string           `json:"profile"`
+	Poster      string           `json:"poster"`
+	Twitter     string           `json:"twitter"`
+}
+
+func unmarshalProfile(p *Profile) (*profile.Profile, error) {
+	// silly workaround for gob encoding
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("err re-encoding json: %s", err.Error())
+	}
+
+	_p := &profile.Profile{}
+	if err := json.Unmarshal(data, _p); err != nil {
+		return nil, fmt.Errorf("error unmarshaling json: %s", err.Error())
+	}
+
+	return _p, nil
+}
+
+func marshalProfile(p *profile.Profile) (*Profile, error) {
+	// silly workaround for gob encoding
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("err re-encoding json: %s", err.Error())
+	}
+
+	_p := &Profile{}
+	if err := json.Unmarshal(data, _p); err != nil {
+		return nil, fmt.Errorf("error unmarshaling json: %s", err.Error())
+	}
+
+	return _p, nil
+}
+
+func (r *ProfileRequests) GetProfile(in *bool, res *Profile) error {
+	if r.cli != nil {
+		return r.cli.Call("ProfileRequests.GetProfile", in, res)
+	}
+
 	profile, err := r.repo.Profile()
 	if err != nil {
 		return err
 	}
-	*res = *profile
+
+	_p, err := marshalProfile(profile)
+	if err != nil {
+		return err
+	}
+	*res = *_p
 	return nil
 }
 
-func (r *ProfileRequests) SaveProfile(p *profile.Profile, res *profile.Profile) error {
+func (r *ProfileRequests) SaveProfile(p *Profile, res *Profile) error {
+	if r.cli != nil {
+		return r.cli.Call("ProfileRequests.SaveProfile", p, res)
+	}
 	if p == nil {
 		return fmt.Errorf("profile required for update")
 	}
 
-	if err := r.repo.SaveProfile(p); err != nil {
+	_p, err := unmarshalProfile(p)
+	if err != nil {
+		return err
+	}
+
+	if err := r.repo.SaveProfile(_p); err != nil {
 		return err
 	}
 
@@ -46,7 +119,12 @@ func (r *ProfileRequests) SaveProfile(p *profile.Profile, res *profile.Profile) 
 		return err
 	}
 
-	*res = *profile
+	p2, err := marshalProfile(profile)
+	if err != nil {
+		return err
+	}
+
+	*res = *p2
 	return nil
 }
 
@@ -58,6 +136,10 @@ type FileParams struct {
 }
 
 func (r *ProfileRequests) SetProfilePhoto(p *FileParams, res *profile.Profile) error {
+	if r.cli != nil {
+		return r.cli.Call("ProfileRequests.SetProfilePhoto", p, res)
+	}
+
 	if p.Data == nil {
 		return fmt.Errorf("file is required")
 	}
@@ -99,6 +181,10 @@ func (r *ProfileRequests) SetProfilePhoto(p *FileParams, res *profile.Profile) e
 }
 
 func (r *ProfileRequests) SetPosterPhoto(p *FileParams, res *profile.Profile) error {
+	if r.cli != nil {
+		return r.cli.Call("ProfileRequests.SetPosterPhoto", p, res)
+	}
+
 	if p.Data == nil {
 		return fmt.Errorf("file is required")
 	}

--- a/core/profile.go
+++ b/core/profile.go
@@ -15,6 +15,8 @@ type ProfileRequests struct {
 	repo repo.Repo
 }
 
+func (d ProfileRequests) CoreRequestsName() string { return "profile" }
+
 func NewProfileRequests(r repo.Repo) *ProfileRequests {
 	return &ProfileRequests{
 		repo: r,

--- a/core/profile.go
+++ b/core/profile.go
@@ -135,7 +135,7 @@ type FileParams struct {
 	Data     io.Reader // reader of structured data. either Url or Data is required
 }
 
-func (r *ProfileRequests) SetProfilePhoto(p *FileParams, res *profile.Profile) error {
+func (r *ProfileRequests) SetProfilePhoto(p *FileParams, res *Profile) error {
 	if r.cli != nil {
 		return r.cli.Call("ProfileRequests.SetProfilePhoto", p, res)
 	}
@@ -176,11 +176,16 @@ func (r *ProfileRequests) SetProfilePhoto(p *FileParams, res *profile.Profile) e
 		return fmt.Errorf("error saving profile: %s", err.Error())
 	}
 
-	*res = *pro
+	_p, err := marshalProfile(pro)
+	if err != nil {
+		return err
+	}
+
+	*res = *_p
 	return nil
 }
 
-func (r *ProfileRequests) SetPosterPhoto(p *FileParams, res *profile.Profile) error {
+func (r *ProfileRequests) SetPosterPhoto(p *FileParams, res *Profile) error {
 	if r.cli != nil {
 		return r.cli.Call("ProfileRequests.SetPosterPhoto", p, res)
 	}
@@ -219,5 +224,11 @@ func (r *ProfileRequests) SetPosterPhoto(p *FileParams, res *profile.Profile) er
 		return fmt.Errorf("error saving profile: %s", err.Error())
 	}
 
+	_p, err := marshalProfile(pro)
+	if err != nil {
+		return err
+	}
+
+	*res = *_p
 	return nil
 }

--- a/core/profile_test.go
+++ b/core/profile_test.go
@@ -26,9 +26,9 @@ func TestProfileRequestsGet(t *testing.T) {
 		return
 	}
 
-	req := NewProfileRequests(mr)
+	req := NewProfileRequests(mr, nil)
 	for i, c := range cases {
-		got := &profile.Profile{}
+		got := &Profile{}
 		err := req.GetProfile(&c.in, got)
 
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
@@ -40,12 +40,12 @@ func TestProfileRequestsGet(t *testing.T) {
 
 func TestProfileRequestsSave(t *testing.T) {
 	cases := []struct {
-		p   *profile.Profile
-		res *profile.Profile
+		p   *Profile
+		res *Profile
 		err string
 	}{
 		{nil, nil, "profile required for update"},
-		{&profile.Profile{}, nil, ""},
+		{&Profile{}, nil, ""},
 		// TODO - moar tests
 	}
 
@@ -55,9 +55,9 @@ func TestProfileRequestsSave(t *testing.T) {
 		return
 	}
 
-	req := NewProfileRequests(mr)
+	req := NewProfileRequests(mr, nil)
 	for i, c := range cases {
-		got := &profile.Profile{}
+		got := &Profile{}
 		err := req.SaveProfile(c.p, got)
 
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
@@ -73,9 +73,9 @@ func TestProfileRequestsSetProfilePhoto(t *testing.T) {
 		respath datastore.Key
 		err     string
 	}{
-		{"", datastore.Key{}, "file is required"},
-		{"testdata/ink_big_photo.jpg", datastore.Key{}, "file size too large. max size is 250kb"},
-		{"testdata/q_bang.svg", datastore.Key{}, "invalid file format. only .jpg & .png images allowed"},
+		{"", datastore.NewKey(""), "file is required"},
+		{"testdata/ink_big_photo.jpg", datastore.NewKey(""), "file size too large. max size is 250kb"},
+		{"testdata/q_bang.svg", datastore.NewKey(""), "invalid file format. only .jpg & .png images allowed"},
 		{"testdata/rico_400x400.jpg", datastore.NewKey("/map/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1"), ""},
 	}
 
@@ -85,7 +85,7 @@ func TestProfileRequestsSetProfilePhoto(t *testing.T) {
 		return
 	}
 
-	req := NewProfileRequests(mr)
+	req := NewProfileRequests(mr, nil)
 	for i, c := range cases {
 		p := &FileParams{}
 		if c.infile != "" {
@@ -98,15 +98,15 @@ func TestProfileRequestsSetProfilePhoto(t *testing.T) {
 			p.Data = r
 		}
 
-		res := &profile.Profile{}
+		res := &Profile{}
 		err := req.SetProfilePhoto(p, res)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch. expected: %s, got: %s", i, c.err, err.Error())
 			continue
 		}
 
-		if !c.respath.Equal(res.Profile) {
-			t.Errorf("case %d profile hash mismatch. expected: %s, got: %s", i, c.respath.String(), res.Profile.String())
+		if !c.respath.Equal(datastore.NewKey(res.Profile)) {
+			t.Errorf("case %d profile hash mismatch. expected: %s, got: %s", i, c.respath.String(), res.Profile)
 			continue
 		}
 	}
@@ -118,9 +118,9 @@ func TestProfileRequestsSetPosterPhoto(t *testing.T) {
 		respath datastore.Key
 		err     string
 	}{
-		{"", datastore.Key{}, "file is required"},
-		{"testdata/ink_big_photo.jpg", datastore.Key{}, "file size too large. max size is 250kb"},
-		{"testdata/q_bang.svg", datastore.Key{}, "invalid file format. only .jpg & .png images allowed"},
+		{"", datastore.NewKey(""), "file is required"},
+		{"testdata/ink_big_photo.jpg", datastore.NewKey(""), "file size too large. max size is 250kb"},
+		{"testdata/q_bang.svg", datastore.NewKey(""), "invalid file format. only .jpg & .png images allowed"},
 		{"testdata/rico_poster_1500x500.jpg", datastore.NewKey("/map/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL"), ""},
 	}
 
@@ -130,7 +130,7 @@ func TestProfileRequestsSetPosterPhoto(t *testing.T) {
 		return
 	}
 
-	req := NewProfileRequests(mr)
+	req := NewProfileRequests(mr, nil)
 	for i, c := range cases {
 		p := &FileParams{}
 		if c.infile != "" {
@@ -143,15 +143,15 @@ func TestProfileRequestsSetPosterPhoto(t *testing.T) {
 			p.Data = r
 		}
 
-		res := &profile.Profile{}
+		res := &Profile{}
 		err := req.SetProfilePhoto(p, res)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch. expected: %s, got: %s", i, c.err, err.Error())
 			continue
 		}
 
-		if !c.respath.Equal(res.Profile) {
-			t.Errorf("case %d profile hash mismatch. expected: %s, got: %s", i, c.respath.String(), res.Profile.String())
+		if !c.respath.Equal(datastore.NewKey(res.Profile)) {
+			t.Errorf("case %d profile hash mismatch. expected: %s, got: %s", i, c.respath.String(), res.Profile)
 			continue
 		}
 	}

--- a/core/queries.go
+++ b/core/queries.go
@@ -43,8 +43,9 @@ func (d *QueryRequests) List(p *ListParams, res *[]*repo.DatasetRef) error {
 
 	results := make([]*repo.DatasetRef, len(items))
 	for i, item := range items {
-		results[i].Path = item.DatasetPath
+		results[i] = &repo.DatasetRef{Path: item.DatasetPath}
 		if ds, err := dsfs.LoadDataset(d.repo.Store(), item.DatasetPath); err == nil {
+			results[i].Name = ds.Transform.Data
 			results[i].Dataset = ds
 		}
 	}

--- a/core/queries.go
+++ b/core/queries.go
@@ -166,7 +166,7 @@ func (r *QueryRequests) Run(p *RunParams, res *repo.DatasetRef) error {
 	if err != nil {
 		return fmt.Errorf("formatting error: %s", err.Error())
 	}
-	qpath, err := dsfs.SaveTransform(store, abst, false)
+	qpath, err := dsfs.SaveAbstractTransform(store, abst, false)
 	if err != nil {
 		return fmt.Errorf("error calculating query hash: %s", err.Error())
 	}

--- a/core/queries.go
+++ b/core/queries.go
@@ -16,6 +16,8 @@ type QueryRequests struct {
 	repo repo.Repo
 }
 
+func (d QueryRequests) CoreRequestsName() string { return "queries" }
+
 func NewQueryRequests(r repo.Repo) *QueryRequests {
 	return &QueryRequests{
 		repo: r,
@@ -215,7 +217,7 @@ func (r *QueryRequests) Run(p *RunParams, res *repo.DatasetRef) error {
 	if err := dsfs.DerefDatasetTransform(store, ds); err != nil {
 		return fmt.Errorf("error dereferencing dataset query: %s", err.Error())
 	}
-	fmt.Println(ds.AbstractTransform.Path().String())
+	// fmt.Println(ds.AbstractTransform.Path().String())
 
 	ref := &repo.DatasetRef{Name: p.SaveName, Path: dspath, Dataset: ds}
 

--- a/core/search.go
+++ b/core/search.go
@@ -30,8 +30,8 @@ func (d *SearchRequests) Search(p *repo.SearchParams, res *[]*repo.DatasetRef) e
 	// 		return err
 	// 	}
 
-	if s, ok := d.repo.(repo.Searchable); ok {
-		results, err := s.Search(*p)
+	if searchable, ok := d.repo.(repo.Searchable); ok {
+		results, err := searchable.Search(*p)
 		if err != nil {
 			return fmt.Errorf("error searching: %s", err.Error())
 		}

--- a/core/search.go
+++ b/core/search.go
@@ -14,6 +14,8 @@ type SearchRequests struct {
 	// node  *p2p.QriNode
 }
 
+func (d SearchRequests) CoreRequestsName() string { return "search" }
+
 func NewSearchRequests(r repo.Repo) *SearchRequests {
 	return &SearchRequests{
 		repo: r,

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -5,9 +5,9 @@ import (
 	"math/rand"
 
 	pstore "gx/ipfs/QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr/go-libp2p-peerstore"
+	math2 "gx/ipfs/QmViBzgruNUoLNBnXcx8YWbDNwV8MNGEGKkLo6JGetygdw/go-ipfs/thirdparty/math2"
 	ma "gx/ipfs/QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji/go-multiaddr"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
-	math2 "gx/ipfs/QmdKL1GVaUaDVt3JUWiYQSLYRsJMym2KRWxsiXAeEU6pzX/go-ipfs/thirdparty/math2"
 )
 
 // DefaultBootstrapAddresses follows the pattern of IPFS boostrapping off known "gateways".

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -18,20 +18,7 @@ import (
 // One day it would be super nice to bootstrap from a stored history & only
 // use these for first-round bootstrapping.
 var DefaultBootstrapAddresses = []string{
-	// "/ip4/35.192.124.143/tcp/4001/ipfs/QmQffqhgce94UFS9mSvvqcAWXQNr1bcZRM659VFakySair",
-	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
-	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
-	"/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-	"/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
-	"/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
-	"/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
-	"/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-	"/ip6/2604:a880:1:20::203:d001/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
-	"/ip6/2400:6180:0:d0::151:6001/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
-	"/ip6/2604:a880:800:10::4a:5001/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
-	"/ip6/2a03:b0c0:0:1010::23:1001/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+	"/ip4/35.192.124.143/tcp/4001/ipfs/QmXNqD5ATi1ejL4HNzUzDyeWn46hHgJTqA26JmYiUWERcb",
 }
 
 // Bootstrap samples a subset of peers & requests their peers list
@@ -50,6 +37,9 @@ func (n *QriNode) Bootstrap(boostrapAddrs []string) {
 		go func() {
 			if err := n.Host.Connect(context.Background(), pi); err == nil {
 				n.log.Infof("boostrapping to: %s", pi.ID.Pretty())
+				if err = n.AddQriPeer(pi); err != nil {
+					n.log.Infof("error adding peer: %s", err.Error())
+				}
 				n.RequestPeersList(pi.ID)
 			} else {
 				n.log.Infof("error connecting to host: %s", err.Error())

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -18,7 +18,20 @@ import (
 // One day it would be super nice to bootstrap from a stored history & only
 // use these for first-round bootstrapping.
 var DefaultBootstrapAddresses = []string{
-	"/ip4/35.192.124.143/tcp/4001/ipfs/QmQffqhgce94UFS9mSvvqcAWXQNr1bcZRM659VFakySair",
+	// "/ip4/35.192.124.143/tcp/4001/ipfs/QmQffqhgce94UFS9mSvvqcAWXQNr1bcZRM659VFakySair",
+	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
+	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
+	"/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+	"/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
+	"/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
+	"/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
+	"/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+	"/ip6/2604:a880:1:20::203:d001/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
+	"/ip6/2400:6180:0:d0::151:6001/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
+	"/ip6/2604:a880:800:10::4a:5001/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
+	"/ip6/2a03:b0c0:0:1010::23:1001/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
 }
 
 // Bootstrap samples a subset of peers & requests their peers list

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -10,12 +10,12 @@ import (
 
 	yamux "gx/ipfs/QmNWCEvi7bPRcvqAV8AKLGVNoQdArWi7NJayka2SM4XtRe/go-smux-yamux"
 	pstore "gx/ipfs/QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr/go-libp2p-peerstore"
+	core "gx/ipfs/QmViBzgruNUoLNBnXcx8YWbDNwV8MNGEGKkLo6JGetygdw/go-ipfs/core"
 	msmux "gx/ipfs/QmVniQJkdzLZaZwzwMdd3dJTvWiJ1DQEkreVy6hs6h7Vk5/go-smux-multistream"
 	ma "gx/ipfs/QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji/go-multiaddr"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 	crypto "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
 	host "gx/ipfs/Qmc1XhrFEiSeBNn3mpfg6gEuYCt5im2gYmNVmncsvmpeAk/go-libp2p-host"
-	core "gx/ipfs/QmdKL1GVaUaDVt3JUWiYQSLYRsJMym2KRWxsiXAeEU6pzX/go-ipfs/core"
 	swarm "gx/ipfs/QmdQFrFnPrKRQtpeHKjZ3cVNwxmGKKS2TvhJTuN9C9yduh/go-libp2p-swarm"
 	discovery "gx/ipfs/QmefgzMbKZYsmHFkLqxgaTBG9ypeEjrdWRD5WXH4j1cWDL/go-libp2p/p2p/discovery"
 	bhost "gx/ipfs/QmefgzMbKZYsmHFkLqxgaTBG9ypeEjrdWRD5WXH4j1cWDL/go-libp2p/p2p/host/basic"

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -3,7 +3,7 @@ package p2p
 import (
 	"context"
 	"fmt"
-	"time"
+	// "time"
 
 	pstore "gx/ipfs/QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr/go-libp2p-peerstore"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
@@ -13,10 +13,10 @@ func (n *QriNode) AddQriPeer(pinfo pstore.PeerInfo) error {
 	// add this peer to our store
 	n.QriPeers.AddAddrs(pinfo.ID, pinfo.Addrs, pstore.TempAddrTTL)
 
-	if profile, _ := n.Repo.Peers().GetPeer(pinfo.ID); profile != nil {
-		// we've already seen this peer
-		return nil
-	}
+	// if profile, _ := n.Repo.Peers().GetPeer(pinfo.ID); profile != nil {
+	// 	// we've already seen this peer
+	// 	return nil
+	// }
 
 	if err := n.RequestProfileInfo(pinfo); err != nil {
 		return err
@@ -24,7 +24,7 @@ func (n *QriNode) AddQriPeer(pinfo pstore.PeerInfo) error {
 
 	// some time later ask for a list of their peers, you know, "for a friend"
 	go func() {
-		time.Sleep(time.Second * 2)
+		// time.Sleep(time.Second * 2)
 		n.RequestPeersList(pinfo.ID)
 	}()
 

--- a/p2p/record.go
+++ b/p2p/record.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TODO - work in progress
-func (qn *QriNode) PutQueryKey(key datastore.Key, q *dataset.Query) error {
+func (qn *QriNode) PutQueryKey(key datastore.Key, q *dataset.Transform) error {
 	data, err := q.MarshalJSON()
 	if err != nil {
 		return err

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "gxDependencies": [
     {
-      "hash": "QmdKL1GVaUaDVt3JUWiYQSLYRsJMym2KRWxsiXAeEU6pzX",
+      "hash": "QmViBzgruNUoLNBnXcx8YWbDNwV8MNGEGKkLo6JGetygdw",
       "name": "go-ipfs",
-      "version": "0.4.12"
+      "version": "0.4.13"
     },
     {
       "author": "whyrusleeping",

--- a/repo/dataset_ref.go
+++ b/repo/dataset_ref.go
@@ -16,7 +16,7 @@ import (
 // be stored as metadata within the dataset itself.
 type DatasetRef struct {
 	// The dataset being referenced
-	Dataset *dataset.Dataset `json:"dataset"`
+	Dataset *dataset.Dataset `json:"dataset,omitempty"`
 	// Unique name reference for this dataset
 	Name string `json:"name,omitempty"`
 	// Content-addressed path for this dataset

--- a/repo/fs/query_logs.go
+++ b/repo/fs/query_logs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/qri/repo"
@@ -20,16 +21,34 @@ func NewQueryLog(base string, file File, store cafs.Filestore) QueryLog {
 	return QueryLog{basepath: basepath(base), file: file, store: store}
 }
 
-func (ql QueryLog) LogQuery(ref *repo.DatasetRef) error {
+func (ql QueryLog) LogQuery(item *repo.QueryLogItem) error {
 	log, err := ql.logs()
 	if err != nil {
 		return err
 	}
-	log = append([]*repo.DatasetRef{&repo.DatasetRef{Name: ref.Name, Path: ref.Path}}, log...)
+	log = append(log, item)
+	sort.Slice(log, func(i, j int) bool { return log[i].Time.Before(log[j].Time) })
 	return ql.saveFile(log, ql.file)
 }
 
-func (ql QueryLog) GetQueryLogs(limit, offset int) ([]*repo.DatasetRef, error) {
+func (ql QueryLog) QueryLogItem(q *repo.QueryLogItem) (*repo.QueryLogItem, error) {
+	log, err := ql.logs()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range log {
+		if item.DatasetPath.Equal(q.DatasetPath) ||
+			item.Query == q.Query ||
+			item.Time.Equal(q.Time) ||
+			item.Key.Equal(q.Key) {
+			return item, nil
+		}
+	}
+	return nil, repo.ErrNotFound
+}
+
+func (ql QueryLog) ListQueryLogs(limit, offset int) ([]*repo.QueryLogItem, error) {
 	logs, err := ql.logs()
 	if err != nil {
 		return nil, err
@@ -46,73 +65,8 @@ func (ql QueryLog) GetQueryLogs(limit, offset int) ([]*repo.DatasetRef, error) {
 	return logs[offset:stop], nil
 }
 
-// func (r QueryLog) PutDataset(path datastore.Key, ds *dataset.Dataset) error {
-// 	d, err := r.logs()
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d[path.String()] = ds
-// 	return r.saveFile(d, r.file)
-// }
-
-// func (r QueryLog) PutQueryLog(logs []*repo.repo.DatasetRef) error {
-// 	ds, err := r.logs()
-// 	if err != nil {
-// 		return err
-// 	}
-// 	for _, dr := range logs {
-// 		ps := dr.Path.String()
-// 		if ps != "" && dr.Dataset != nil {
-// 			ds[ps] = dr.Dataset
-// 		}
-// 	}
-// 	return r.saveFile(ds, r.file)
-// }
-
-// func (r QueryLog) GetDataset(path datastore.Key) (*dataset.Dataset, error) {
-// 	ds, err := r.logs()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	ps := path.String()
-// 	for p, d := range ds {
-// 		if ps == p {
-// 			return d, nil
-// 		}
-// 	}
-// 	if r.store != nil {
-// 		return dsfs.LoadDataset(r.store, path)
-// 	}
-
-// 	return nil, datastore.ErrNotFound
-// }
-
-// func (r QueryLog) DeleteDataset(path datastore.Key) error {
-// 	ds, err := r.logs()
-// 	if err != nil {
-// 		return err
-// 	}
-// 	delete(ds, path.String())
-// 	return r.saveFile(ds, r.file)
-// }
-
-// func (r QueryLog) Query(q query.Query) (query.Results, error) {
-// 	ds, err := r.logs()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	re := make([]query.Entry, 0, len(ds))
-// 	for path, d := range ds {
-// 		re = append(re, query.Entry{Key: path, Value: d})
-// 	}
-// 	res := query.ResultsWithEntries(q, re)
-// 	res = query.NaiveQueryApply(q, res)
-// 	return res, nil
-// }
-
-func (r *QueryLog) logs() ([]*repo.DatasetRef, error) {
-	ds := []*repo.DatasetRef{}
+func (r *QueryLog) logs() ([]*repo.QueryLogItem, error) {
+	ds := []*repo.QueryLogItem{}
 	data, err := ioutil.ReadFile(r.filepath(r.file))
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/repo/graph.go
+++ b/repo/graph.go
@@ -145,10 +145,10 @@ func (nl NodeList) nodesFromDatasetRef(r Repo, ref *DatasetRef) *dsgraph.Node {
 		root.AddLinks(dsgraph.Link{From: root, To: commit})
 	}
 
-	if ds.AbstractStructure != nil && ds.AbstractStructure.Path().String() != "" {
+	if ds.Abstract != nil && ds.Abstract.Path().String() != "" {
 		root.AddLinks(dsgraph.Link{
 			From: root,
-			To:   nl.node(dsgraph.NtAbstStructure, ds.AbstractStructure.Path().String()),
+			To:   nl.node(dsgraph.NtAbstDataset, ds.Abstract.Path().String()),
 		})
 	}
 

--- a/repo/graph.go
+++ b/repo/graph.go
@@ -259,18 +259,20 @@ func WalkRepoDatasets(r Repo, visit func(depth int, ref *DatasetRef, err error) 
 
 	// TODO - make properly parallel
 	go func() {
-		refs, err := r.GetQueryLogs(1000, 0)
+		items, err := r.ListQueryLogs(1000, 0)
 		if err != nil {
 			done <- err
 		}
-		for _, ref := range refs {
-			ref.Dataset, err = dsfs.LoadDatasetRefs(store, ref.Path)
+		for _, item := range items {
+			ref := &DatasetRef{Path: item.DatasetPath}
+
+			ref.Dataset, err = dsfs.LoadDatasetRefs(store, item.DatasetPath)
 			// TODO - remove this once loading is more consistent.
 			if err != nil {
-				ref.Dataset, err = dsfs.LoadDatasetRefs(store, ref.Path)
+				ref.Dataset, err = dsfs.LoadDatasetRefs(store, item.DatasetPath)
 			}
 			if err != nil {
-				ref.Dataset, err = dsfs.LoadDatasetRefs(store, ref.Path)
+				ref.Dataset, err = dsfs.LoadDatasetRefs(store, item.DatasetPath)
 			}
 
 			kontinue, err := visit(0, ref, err)

--- a/repo/graph_test.go
+++ b/repo/graph_test.go
@@ -23,7 +23,7 @@ func TestRepoGraph(t *testing.T) {
 		return
 	}
 
-	expect := 9
+	expect := 8
 	count := 0
 	for range nodes {
 		count++
@@ -98,11 +98,9 @@ func makeTestRepo() (Repo, error) {
 	ds2 := &dataset.Dataset{
 		Title:    "dataset 2",
 		Previous: datastore.NewKey(""),
-		Query: &dataset.Query{
-			Abstract: &dataset.AbstractQuery{
-				Syntax:    "sql",
-				Statement: "select * from a,b where b.id = 'foo'",
-			},
+		Transform: &dataset.Transform{
+			Syntax: "sql",
+			Data:   "select * from a,b where b.id = 'foo'",
 			Resources: map[string]*dataset.Dataset{
 				"a": dataset.NewDatasetRef(datastore.NewKey("/path/to/a")),
 				"b": dataset.NewDatasetRef(datastore.NewKey("/path/to/b")),
@@ -118,7 +116,7 @@ func makeTestRepo() (Repo, error) {
 	}
 
 	data1p, _ := store.Put(memfs.NewMemfileBytes("data1", []byte("dataset_1")), true)
-	ds1.Data = data1p
+	ds1.Data = data1p.String()
 	ds1p, err := dsfs.SaveDataset(store, ds1, true)
 	if err != nil {
 		return nil, fmt.Errorf("error putting dataset: %s", err.Error())
@@ -127,7 +125,7 @@ func makeTestRepo() (Repo, error) {
 	r.PutName("ds1", ds1p)
 
 	data2p, _ := store.Put(memfs.NewMemfileBytes("data2", []byte("dataset_2")), true)
-	ds2.Data = data2p
+	ds2.Data = data2p.String()
 	ds2p, err := dsfs.SaveDataset(store, ds2, true)
 	if err != nil {
 		return nil, fmt.Errorf("error putting dataset: %s", err.Error())

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -7,6 +7,7 @@ package repo
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
@@ -105,10 +106,19 @@ type Datasets interface {
 	Query(query.Query) (query.Results, error)
 }
 
+type QueryLogItem struct {
+	Query       string
+	Name        string
+	Key         datastore.Key
+	DatasetPath datastore.Key
+	Time        time.Time
+}
+
 // QueryLog keeps logs
 type QueryLog interface {
-	LogQuery(*DatasetRef) error
-	GetQueryLogs(limit, offset int) ([]*DatasetRef, error)
+	LogQuery(*QueryLogItem) error
+	ListQueryLogs(limit, offset int) ([]*QueryLogItem, error)
+	QueryLogItem(q *QueryLogItem) (*QueryLogItem, error)
 }
 
 // SearchParams encapsulates parameters provided to Searchable.Search

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -53,7 +53,7 @@ func NewTestRepo() (mr repo.Repo, err error) {
 			return
 		}
 
-		ds.Data = datakey
+		ds.Data = datakey.String()
 
 		dskey, err = dsfs.SaveDataset(ms, ds, true)
 		if err != nil {


### PR DESCRIPTION
changed default port to 2503. added RPC listener on default 2504. We've been planning to do this for a while, but a proper reason to do so hadn't come up until we needed to be able to
use the CLI while a server is running (while ssh'd into a container).

This commit is a spike that only supports DatasetRequests for now
while I work out the details of this pattern.

also, closes #163, closes #161, closes #160, closes #174 