### PR TITLE
refactor(p2p): distinguish between IPFS & qri PeerID's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer="sparkle_pony_2000@qri.io"
 ADD . /go/src/github.com/qri-io/qri
 RUN cd /go/src/github.com/qri-io/qri
 
-RUN go get -v github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/dataset_sql github.com/qri-io/doggos github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/viper
+# RUN make install-deps
+RUN go get -v github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/viper github.com/qri-io/varName github.com/qri-io/datasetDiffer github.com/datatogether/cdxj github.com/qri-io/cafs
 
 RUN go get -u github.com/whyrusleeping/gx github.com/whyrusleeping/gx-go
 RUN cd /go/src/github.com/qri-io/qri && pwd && gx install
@@ -28,4 +29,4 @@ RUN mkdir -p $IPFS_PATH && mkdir -p $QRI_PATH \
 # VOLUME $QRI_PATH
 
 # Set binary as entrypoint, initalizing ipfs repo if none is mounted
-CMD ["qri", "server", "--init"]
+CMD ["qri", "connect", "--setup"]

--- a/api/handlers/peers.go
+++ b/api/handlers/peers.go
@@ -132,11 +132,11 @@ func (h *PeerHandlers) connectToPeerHandler(w http.ResponseWriter, r *http.Reque
 
 func (h *PeerHandlers) getPeerHandler(w http.ResponseWriter, r *http.Request) {
 	res := &profile.Profile{}
-	args := &core.GetParams{
-		Hash:     r.URL.Path[len("/peers/"):],
-		Username: r.FormValue("username"),
+	args := &core.PeerInfoParams{
+		PeerID:   r.URL.Path[len("/peers/"):],
+		Peername: r.FormValue("peername"),
 	}
-	err := h.Get(args, res)
+	err := h.Info(args, res)
 	if err != nil {
 		h.log.Infof("error getting peer profile: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -84,6 +85,9 @@ func TestCommandsIntegration(t *testing.T) {
 	os.Setenv("IPFS_PATH", filepath.Join(path, "ipfs"))
 	os.Setenv("QRI_PATH", filepath.Join(path, "qri"))
 
+	t.Log("PATH:", path)
+	fmt.Println(path)
+
 	commands := [][]string{
 		{"help"},
 		{"version"},
@@ -91,13 +95,14 @@ func TestCommandsIntegration(t *testing.T) {
 		{"profile", "get"},
 		{"profile", "set", "-f" + profileDataFilepath},
 		{"config", "get"},
+		{"info"},
 		{"add", "-f" + moviesFilePath, "-n" + "movies"},
 		{"list"},
-		{"save", "--data=" + movies2FilePath, "-m" + "commit_1", "movies"},
-		{"log", "-n" + "movies"},
-		{"export", "--dataset", "movies", "-o" + path},
-		{"rename", "movies", "movie"},
-		{"validate", "-n" + "movie"},
+		{"save", "--data=" + movies2FilePath, "-m" + "commit_1", "me/movies"},
+		{"log", "me/movies"},
+		{"export", "--dataset", "me/movies", "-o" + path},
+		{"rename", "me/movies", "me/movie"},
+		{"validate", "me/movie"},
 		{"remove", "movie"},
 	}
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -19,7 +19,7 @@ var (
 	connectCmdPort string
 	connectMemOnly bool
 	connectOffline bool
-	connectInit    bool
+	connectSetup   bool
 )
 
 // connectCmd represents the run command
@@ -48,7 +48,7 @@ call it a “prime” port number.`,
 			err error
 		)
 
-		if connectInit && !QRIRepoInitialized() {
+		if connectSetup && !QRIRepoInitialized() {
 			setupCmd.Run(&cobra.Command{}, []string{})
 		}
 
@@ -57,7 +57,7 @@ call it a “prime” port number.`,
 			// or options for BYO user profile
 			r, err = repo.NewMemRepo(
 				&profile.Profile{
-					Username: "mem user",
+					Peername: "mem user",
 				},
 				memfs.NewMapstore(),
 				repo.MemPeers{},
@@ -145,8 +145,8 @@ func initializeDistributedAssets(node *p2p.QriNode) {
 }
 
 func init() {
-	connectCmd.Flags().StringVarP(&connectCmdPort, "port", "p", api.DefaultPort, "port to start connect on")
-	connectCmd.Flags().BoolVarP(&connectInit, "init", "", false, "initialize if necessary, reading options from enviornment variables")
+	connectCmd.Flags().StringVarP(&connectCmdPort, "api-port", "p", api.DefaultPort, "port to start api on")
+	connectCmd.Flags().BoolVarP(&connectSetup, "setup", "", false, "run setup if necessary, reading options from enviornment variables")
 	connectCmd.Flags().BoolVarP(&connectMemOnly, "mem-only", "", false, "run qri entirely in-memory, persisting nothing")
 	connectCmd.Flags().BoolVarP(&connectOffline, "offline", "", false, "disable networking")
 	RootCmd.AddCommand(connectCmd)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,40 +18,45 @@ var datasetListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "show a list of datasets",
 	Long: `
-Usage:
-	qri list
-
 list shows lists of datasets, including names and current hashes. 
 
 The default list is the latest version of all datasets you have on your local 
 qri repository.`,
+	Example: `  show all of your datasets:
+  $ qri list`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// TODO - add limit & offset params
-		r, err := datasetRequests(false)
-		ExitIfErr(err)
-
-		p := &core.ListParams{
-			Limit:  dsListLimit,
-			Offset: dsListOffset,
-		}
-		refs := []*repo.DatasetRef{}
-		err = r.List(p, &refs)
-		ExitIfErr(err)
-
-		outformat := cmd.Flag("format").Value.String()
-		switch outformat {
-		case "":
-			for _, ref := range refs {
-				printInfo("%s\t\t\t: %s", ref.Name, ref.Path)
-			}
-		case dataset.JSONDataFormat.String():
-			data, err := json.MarshalIndent(refs, "", "  ")
+		if len(args) < 1 {
+			// TODO - add limit & offset params
+			r, err := datasetRequests(false)
 			ExitIfErr(err)
-			fmt.Printf("%s\n", string(data))
-		default:
-			ErrExit(fmt.Errorf("unrecognized format: %s", outformat))
-		}
 
+			p := &core.ListParams{
+				Limit:  dsListLimit,
+				Offset: dsListOffset,
+			}
+			refs := []*repo.DatasetRef{}
+			err = r.List(p, &refs)
+			ExitIfErr(err)
+
+			outformat := cmd.Flag("format").Value.String()
+			switch outformat {
+			case "":
+				for _, ref := range refs {
+					printInfo("%s\t\t\t: %s", ref.Name, ref.Path)
+				}
+			case dataset.JSONDataFormat.String():
+				data, err := json.MarshalIndent(refs, "", "  ")
+				ExitIfErr(err)
+				fmt.Printf("%s\n", string(data))
+			default:
+				ErrExit(fmt.Errorf("unrecognized format: %s", outformat))
+			}
+		} else {
+			// for _, ref := range args {
+			// ref, err := repo.ParseDatasetRef(ref)
+			// ExitIfErr(err)
+			// }
+		}
 	},
 }
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	// "encoding/json"
 	// "fmt"
 	// "github.com/qri-io/dataset"
@@ -27,7 +28,16 @@ We call these snapshots versions. Each version has an author (the peer that
 created the version) and a message explaining what changed. Log prints these 
 details in order of occurrence, starting with the most recent known version, 
 working backwards in time.`,
+	Example: `  show log for the dataset b5/precip:
+	$ qri log b5/precip`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			ErrExit(fmt.Errorf("please specify a dataset reference to log"))
+		}
+
+		ref, err := repo.ParseDatasetRef(args[0])
+		ExitIfErr(err)
+
 		// TODO - add limit & offset params
 		r, err := historyRequests(false)
 		ExitIfErr(err)
@@ -35,7 +45,7 @@ working backwards in time.`,
 		p := &core.LogParams{
 			// Limit:  dsLogLimit,
 			// Offset: dsLogOffset,
-			Name: dsLogName,
+			Name: ref.Name,
 		}
 		refs := []*repo.DatasetRef{}
 		err = r.Log(p, &refs)

--- a/cmd/peer.go
+++ b/cmd/peer.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/qri-io/qri/core"
+	"github.com/qri-io/qri/repo/profile"
+	"github.com/spf13/cobra"
+)
+
+// peerCmd represents the peer command
+var peerCmd = &cobra.Command{
+	Use:   "peer",
+	Short: "display info about qri peers",
+	Long:  ``,
+}
+
+var peerInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: `Get info on a qri peer`,
+	Example: `  show info on a user named "mr0grog":
+  $ qri peer info mr0grog`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			ErrExit(fmt.Errorf("peer name is required"))
+		}
+
+		printInfo("searching for peer %s...", args[0])
+		req, err := peerRequests(true)
+		ExitIfErr(err)
+
+		p := &core.PeerInfoParams{
+			Peername: args[0],
+		}
+
+		res := &profile.Profile{}
+		err = req.Info(p, res)
+		ExitIfErr(err)
+
+		data, err := json.MarshalIndent(res, "", "  ")
+		ExitIfErr(err)
+
+		printSuccess(string(data))
+	},
+}
+
+func init() {
+	// peerInfoCmd.Flags().StringP("format", "f", "", "set output format [json]")
+	peerCmd.AddCommand(peerInfoCmd)
+
+	RootCmd.AddCommand(peerCmd)
+}

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/qri-io/qri/repo"
+	"github.com/qri-io/qri/repo/profile"
 	"os"
 	"strings"
 	"time"
@@ -92,6 +93,14 @@ func printDatasetRefInfo(i int, ref *repo.DatasetRef) {
 	// table.Append(ds.FieldTypeStrings())
 	// table.Render()
 	// fmt.Println()
+}
+
+func printPeerInfo(i int, p *profile.Profile) {
+	white := color.New(color.FgWhite).SprintFunc()
+	// cyan := color.New(color.FgCyan).SprintFunc()
+	// blue := color.New(color.FgBlue).SprintFunc()
+	fmt.Printf("peername: %s\n", white(p.Peername))
+	fmt.Printf("peerID: %s\n", white(p.ID))
 }
 
 // func PrintDatasetDetailedInfo(ds *dataset.Dataset) {

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -89,8 +89,8 @@ var profileSetCmd = &cobra.Command{
 		err = json.NewDecoder(dataFile).Decode(set)
 		ExitIfErr(err)
 
-		if set.Username != "" {
-			p.Username = set.Username
+		if set.Peername != "" {
+			p.Peername = set.Peername
 		}
 		if set.Name != "" {
 			p.Name = set.Name
@@ -133,7 +133,7 @@ func init() {
 
 func editableProfileJSONBytes(res *core.Profile) ([]byte, error) {
 	mapr := map[string]interface{}{
-		"username":    res.Username,
+		"peername":    res.Peername,
 		"name":        res.Name,
 		"description": res.Description,
 		"homeUrl":     res.HomeURL,

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -23,11 +23,17 @@ with it, especially if you want other people to like your datasets.`,
 			ErrExit(fmt.Errorf("please provide current & new dataset names"))
 		}
 
+		current, err := repo.ParseDatasetRef(args[0])
+		ExitIfErr(err)
+
+		next, err := repo.ParseDatasetRef(args[1])
+		ExitIfErr(err)
+
 		req, err := datasetRequests(false)
 		ExitIfErr(err)
 		p := &core.RenameParams{
-			Current: args[0],
-			New:     args[1],
+			Current: current.Name,
+			New:     next.Name,
 		}
 		res := &repo.DatasetRef{}
 		err = req.Rename(p, res)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -6,24 +6,22 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	ipfs "github.com/qri-io/cafs/ipfs"
 	"github.com/qri-io/qri/core"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
-
-	config "gx/ipfs/QmViBzgruNUoLNBnXcx8YWbDNwV8MNGEGKkLo6JGetygdw/go-ipfs/repo/config"
+	// config "gx/ipfs/QmViBzgruNUoLNBnXcx8YWbDNwV8MNGEGKkLo6JGetygdw/go-ipfs/repo/config"
 )
 
 var (
 	setupOverwrite      bool
 	setupIPFS           bool
 	setupIPFSConfigFile string
-	setupIdentityData   string
+	setupConfigData     string
 	setupProfileData    string
-	setupDatasetsData   string
-	setupBootstrapData  string
 )
 
 // setupCmd represents the setup command
@@ -50,13 +48,11 @@ overwrite this info.`,
 			// this is usually a terrible idea
 			ErrExit(fmt.Errorf("repo already initialized"))
 		}
-		fmt.Println("setupializing qri repo")
+		fmt.Println("initializing qri repo")
 
 		envVars := map[string]*string{
-			"QRI_INIT_IDENTITY_DATA":  &setupIdentityData,
-			"QRI_INIT_PROFILE_DATA":   &setupProfileData,
-			"QRI_INIT_DATASETS_DATA":  &setupDatasetsData,
-			"QRI_INIT_BOOTSTRAP_DATA": &setupBootstrapData,
+			"QRI_SETUP_CONFIG_DATA":  &setupConfigData,
+			"QRI_SETUP_PROFILE_DATA": &setupProfileData,
 		}
 		mapEnvVars(envVars)
 
@@ -74,30 +70,15 @@ overwrite this info.`,
 		err := yaml.Unmarshal(cfgData, cfg)
 		ExitIfErr(err)
 
+		if setupConfigData != "" {
+			err = readAtFile(&setupConfigData)
+			ExitIfErr(err)
+			err = json.Unmarshal([]byte(setupConfigData), cfg)
+			ExitIfErr(err)
+		}
+
 		err = cfg.ensurePrivateKey()
 		ExitIfErr(err)
-
-		if setupDatasetsData != "" {
-			err = readAtFile(&setupDatasetsData)
-			ExitIfErr(err)
-
-			datasets := map[string]string{}
-			err = json.Unmarshal([]byte(setupDatasetsData), &datasets)
-			ExitIfErr(err)
-
-			cfg.DefaultDatasets = datasets
-		}
-
-		if setupBootstrapData != "" {
-			err = readAtFile(&setupBootstrapData)
-			ExitIfErr(err)
-
-			bootstrap := []string{}
-			err = json.Unmarshal([]byte(setupBootstrapData), &bootstrap)
-			ExitIfErr(err)
-
-			cfg.Bootstrap = bootstrap
-		}
 
 		if err := os.MkdirAll(QriRepoPath, os.ModePerm); err != nil {
 			ErrExit(fmt.Errorf("error creating home dir: %s", err.Error()))
@@ -108,27 +89,11 @@ overwrite this info.`,
 		err = viper.ReadInConfig()
 		ExitIfErr(err)
 
-		if setupIdentityData != "" {
-			err = readAtFile(&setupIdentityData)
-			ExitIfErr(err)
-
-			id := config.Identity{}
-			err = json.Unmarshal([]byte(setupIdentityData), &id)
-			ExitIfErr(err)
-
-			path := filepath.Join(os.TempDir(), "config")
-			data, err := json.Marshal(DefaultIPFSConfig(id))
-			ExitIfErr(err)
-
-			err = ioutil.WriteFile(path, data, os.ModePerm)
-			ExitIfErr(err)
-
-			setupIPFSConfigFile = path
-			defer os.Remove(path)
-		}
-
 		if setupIPFS {
 			err = ipfs.InitRepo(IpfsFsPath, setupIPFSConfigFile)
+			if err != nil && strings.Contains(err.Error(), "already") {
+				err = nil
+			}
 			ExitIfErr(err)
 		}
 
@@ -154,11 +119,9 @@ func init() {
 	RootCmd.AddCommand(setupCmd)
 	setupCmd.Flags().BoolVarP(&setupOverwrite, "overwrite", "", false, "overwrite repo if one exists")
 	setupCmd.Flags().BoolVarP(&setupIPFS, "init-ipfs", "", true, "initialize an IPFS repo if one isn't present")
-	// setupCmd.Flags().StringVarP(&setupIPFSConfigFile, "ipfs-config", "", "", "config file for setupialization")
-	setupCmd.Flags().StringVarP(&setupIdentityData, "id", "", "", "json-encoded identity data, specify a filepath with '@' prefix")
+	setupCmd.Flags().StringVarP(&setupIPFSConfigFile, "ipfs-config", "", "", "config file for initialization")
+	setupCmd.Flags().StringVarP(&setupConfigData, "id", "", "", "json-encoded configuration data, specify a filepath with '@' prefix")
 	setupCmd.Flags().StringVarP(&setupProfileData, "profile", "", "", "json-encoded user profile data, specify a filepath with '@' prefix")
-	setupCmd.Flags().StringVarP(&setupDatasetsData, "datasets", "", "", "json-encoded object of default datasets")
-	setupCmd.Flags().StringVarP(&setupBootstrapData, "bootstrap", "", "", "json-encoded array of boostrap multiaddrs")
 }
 
 // QRIRepoInitialized checks to see if a repository has been initialized at $QRI_PATH
@@ -205,112 +168,4 @@ func readAtFile(data *string) error {
 		*data = string(fileData)
 	}
 	return nil
-}
-
-// DefaultIPFSConfig returns the standard IPFS configuration
-// TODO - this is a bit of a hack for the moment, will be removed later
-// in favour of using IPFS Config package more directly.
-func DefaultIPFSConfig(identity config.Identity) *config.Config {
-	return &config.Config{
-		Identity: identity,
-		Datastore: config.Datastore{
-			StorageMax:         "10GB",
-			StorageGCWatermark: 90,
-			GCPeriod:           "1h",
-			Spec: map[string]interface{}{
-				"mounts": []map[string]interface{}{
-					{
-						"child": map[string]interface{}{
-							"path":      "blocks",
-							"shardFunc": "/repo/flatfs/shard/v1/next-to-last/2",
-							"sync":      true,
-							"type":      "flatfs",
-						},
-						"mountpoint": "/blocks",
-						"prefix":     "flatfs.datastore",
-						"type":       "measure",
-					},
-					{
-						"child": map[string]interface{}{
-							"compression": "none",
-							"path":        "datastore",
-							"type":        "levelds",
-						},
-						"mountpoint": "/",
-						"prefix":     "leveldb.datastore",
-						"type":       "measure",
-					},
-				},
-				"type": "mount",
-			},
-			HashOnRead:      false,
-			BloomFilterSize: 0,
-		},
-		Bootstrap: []string{
-			"/dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-			"/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
-			"/dnsaddr/bootstrap.libp2p.io/ipfs/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-			"/dnsaddr/bootstrap.libp2p.io/ipfs/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
-			"/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-			"/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
-			"/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
-			"/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
-			"/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-			"/ip6/2604:a880:1:20::203:d001/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
-			"/ip6/2400:6180:0:d0::151:6001/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
-			"/ip6/2604:a880:800:10::4a:5001/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
-			"/ip6/2a03:b0c0:0:1010::23:1001/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-		},
-		// setup the node's default addresses.
-		// NOTE: two swarm listen addrs, one tcp, one utp.
-		Addresses: config.Addresses{
-			Swarm: []string{
-				"/ip4/0.0.0.0/tcp/4001",
-				// "/ip4/0.0.0.0/udp/4002/utp", // disabled for now.
-				"/ip6/::/tcp/4001",
-			},
-			Announce:   []string{},
-			NoAnnounce: []string{},
-			API:        "/ip4/127.0.0.1/tcp/5001",
-			Gateway:    "/ip4/127.0.0.1/tcp/8080",
-		},
-
-		Discovery: config.Discovery{config.MDNS{
-			Enabled:  true,
-			Interval: 10,
-		}},
-
-		// setup the node mount points.
-		Mounts: config.Mounts{
-			IPFS: "/ipfs",
-			IPNS: "/ipns",
-		},
-
-		Ipns: config.Ipns{
-			ResolveCacheSize: 128,
-		},
-
-		Gateway: config.Gateway{
-			RootRedirect: "",
-			Writable:     false,
-			PathPrefixes: []string{},
-			HTTPHeaders: map[string][]string{
-				"Access-Control-Allow-Origin":  []string{"*"},
-				"Access-Control-Allow-Methods": []string{"GET"},
-				"Access-Control-Allow-Headers": []string{"X-Requested-With", "Range"},
-			},
-		},
-		Reprovider: config.Reprovider{
-			Interval: "12h",
-			Strategy: "all",
-		},
-		Swarm: config.SwarmConfig{
-			ConnMgr: config.ConnMgr{
-				LowWater:    config.DefaultConnMgrLowWater,
-				HighWater:   config.DefaultConnMgrHighWater,
-				GracePeriod: config.DefaultConnMgrGracePeriod.String(),
-				Type:        "basic",
-			},
-		},
-	}
 }

--- a/core/datasets.go
+++ b/core/datasets.go
@@ -225,7 +225,7 @@ func (r *DatasetRequests) Init(p *InitParams, res *repo.DatasetRef) error {
 
 	ds := &dataset.Dataset{
 		Meta:      &dataset.Meta{},
-		Commit:    &dataset.Commit{Title: "intiial commit"},
+		Commit:    &dataset.Commit{Title: "initial commit"},
 		Structure: st,
 	}
 	if p.URL != "" {

--- a/core/peers.go
+++ b/core/peers.go
@@ -101,29 +101,39 @@ func (d *PeerRequests) ConnectToPeer(pid *peer.ID, res *profile.Profile) error {
 	return nil
 }
 
-// Get peer profile details
-func (d *PeerRequests) Get(p *GetParams, res *profile.Profile) error {
+// PeerInfoParams defines parameters for the Info method
+type PeerInfoParams struct {
+	Peername string
+	PeerID   string
+}
+
+// Info shows peer profile details
+func (d *PeerRequests) Info(p *PeerInfoParams, res *profile.Profile) error {
 	if d.cli != nil {
-		return d.cli.Call("PeerRequests.Get", p, res)
+		return d.cli.Call("PeerRequests.Info", p, res)
 	}
 
-	// TODO - restore
-	// peers, err := d.repo.Peers()
-	// if err != nil {
-	// 	fmt.Println(err.Error())
-	// 	return err
-	// }
+	r := d.qriNode.Repo
 
-	// for name, repo := range peers {
-	// 	if p.Hash == name ||
-	// 		p.Username == repo.Profile.Username {
-	// 		*res = *repo.Profile
-	// 	}
-	// }
+	peers, err := r.Peers().List()
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
 
-	// if res != nil {
-	// 	return nil
-	// }
+	for _, peer := range peers {
+		if peer.ID == p.PeerID || peer.Peername == p.Peername {
+			*res = *peer
+			return nil
+		}
+		// if p.PeerID == name || p.Username == repo.Profile.Username {
+		// 	*res = *repo.Profile
+		// }
+	}
+
+	if res != nil {
+		return nil
+	}
 
 	// TODO - ErrNotFound plz
 	return fmt.Errorf("Not Found")

--- a/core/profile.go
+++ b/core/profile.go
@@ -42,7 +42,7 @@ type Profile struct {
 	ID          string           `json:"id"`
 	Created     time.Time        `json:"created,omitempty"`
 	Updated     time.Time        `json:"updated,omitempty"`
-	Username    string           `json:"username"`
+	Peername    string           `json:"peername"`
 	Type        profile.UserType `json:"type"`
 	Email       string           `json:"email"`
 	Name        string           `json:"name"`

--- a/p2p/datasets.go
+++ b/p2p/datasets.go
@@ -1,0 +1,34 @@
+package p2p
+
+// import (
+// 	"fmt"
+// 	"github.com/qri-io/qri/repo"
+// )
+
+// // RequestDatasetInfo get's qri profile information from a PeerInfo
+// func (n *QriNode) RequestDatasetInfo(ref *repo.DatasetRef) error {
+// 	// Get this repo's profile information
+// 	profile, err := n.Repo.Profile()
+// 	if err != nil {
+// 		fmt.Println("error getting node profile info:", err)
+// 		return err
+// 	}
+
+// 	res, err := n.SendMessage(pinfo.ID, &Message{
+// 		Type:    MtPeerInfo,
+// 		Payload: profile,
+// 	})
+// 	if err != nil {
+// 		fmt.Println("send profile message error:", err.Error())
+// 		return err
+// 	}
+
+// 	if res.Phase == MpResponse {
+// 		if err := n.handleProfileResponse(pinfo, res); err != nil {
+// 			fmt.Println("profile response error", err.Error())
+// 			return err
+// 		}
+// 	}
+
+// 	return nil
+// }

--- a/p2p/handlers.go
+++ b/p2p/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/qri-io/qri/repo/profile"
 
 	pstore "gx/ipfs/QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr/go-libp2p-peerstore"
+	ma "gx/ipfs/QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji/go-multiaddr"
 )
 
 func (n *QriNode) handlePingRequest(r *Message) *Message {
@@ -31,13 +32,13 @@ func (n *QriNode) handlePeerInfoRequest(r *Message) *Message {
 			return err
 		}
 
-		pid, err := p.PeerID()
+		pid, err := p.IPFSPeerID()
 		if err != nil {
 			return fmt.Errorf("error decoding base58 peer id: %s", err.Error())
 		}
 
 		p.Updated = time.Now()
-		n.log.Infof("adding peer: %s\n", pid.Pretty())
+		// n.log.Infof("adding peer: %s\n", pid.Pretty())
 		return n.Repo.Peers().PutPeer(pid, p)
 	}(r)
 
@@ -45,6 +46,10 @@ func (n *QriNode) handlePeerInfoRequest(r *Message) *Message {
 	if err != nil {
 		n.log.Infof("error getting repo profile: %s\n", err.Error())
 		return nil
+	}
+
+	if addrs, err := n.IPFSListenAddresses(); err == nil {
+		p.Addresses = addrs
 	}
 
 	return &Message{
@@ -63,15 +68,59 @@ func (n *QriNode) handleProfileResponse(pi pstore.PeerInfo, r *Message) error {
 	if err := json.Unmarshal(data, p); err != nil {
 		return err
 	}
+
 	// pinfo.Profile = p
 	// peers[pi.ID.Pretty()] = pinfo
-
-	// ignore any id property in case peers a lying jerks
-	p.ID = pi.ID.Pretty()
-	p.Updated = time.Now()
+	// ignore any id property in case peers are lying jerks
+	// p.ID = pi.ID.Pretty()
+	// p.Updated = time.Now()
 
 	n.log.Info("adding peer:", pi.ID.Pretty())
 	return n.Repo.Peers().PutPeer(pi.ID, p)
+}
+
+func (n *QriNode) handleNodesRequest(r *Message) *Message {
+	var addrs []string
+	if ipfs, err := n.IPFSNode(); err == nil {
+		maddrs := ipfs.PeerHost.Addrs()
+		addrs = make([]string, len(maddrs))
+		for i, maddr := range maddrs {
+			addrs[i] = maddr.String()
+		}
+	}
+
+	return &Message{
+		Type:    MtNodes,
+		Phase:   MpResponse,
+		Payload: addrs,
+	}
+}
+
+func (n *QriNode) handleNodesResponse(r *Message) error {
+	data, err := json.Marshal(r.Payload)
+	if err != nil {
+		return err
+	}
+
+	res := []string{}
+	if err := json.Unmarshal(data, &res); err != nil {
+		return err
+	}
+
+	for _, addr := range res {
+		fmt.Println(addr)
+		a, err := ma.NewMultiaddr(addr)
+		if err != nil {
+			return err
+		}
+		ipfsv, err := a.ValueForProtocol(ma.P_IPFS)
+		if err != nil {
+			return err
+		}
+		fmt.Println(ipfsv)
+	}
+
+	return nil
 }
 
 // PeersReqParams outlines params for requesting peers
@@ -119,12 +168,22 @@ func (n *QriNode) handlePeersResponse(r *Message) error {
 		return err
 	}
 
+	// we can ignore this error b/c we might not be running IPFS,
+	ipfsPeerID, _ := n.IPFSPeerID()
+	// qriPeerID := n.Identity
+
 	for _, p := range peers {
-		id, err := p.PeerID()
+		id, err := p.IPFSPeerID()
 		if err != nil {
 			fmt.Printf("error decoding base58 peer id: %s\n", err.Error())
 			continue
 		}
+
+		// skip self
+		if id == ipfsPeerID {
+			continue
+		}
+
 		if profile, err := n.Repo.Peers().GetPeer(id); err != nil || profile != nil && profile.Updated.Before(p.Updated) {
 			if err := n.Repo.Peers().PutPeer(id, p); err != nil {
 				fmt.Errorf("error putting peer: %s", err.Error())
@@ -265,5 +324,33 @@ func (n *QriNode) handleSearchRequest(r *Message) *Message {
 }
 
 func (n *QriNode) handleSearchResponse(pi pstore.PeerInfo, m *Message) error {
+	return fmt.Errorf("not yet finished")
+}
+
+func (n *QriNode) handleDatasetInfoRequest(r *Message) *Message {
+	data, err := json.Marshal(r.Payload)
+	if err != nil {
+		n.log.Info(err.Error())
+		return nil
+	}
+
+	ref := &repo.DatasetRef{}
+	if err = json.Unmarshal(data, ref); err != nil {
+		n.log.Infof(err.Error())
+		return &Message{
+			Phase:   MpError,
+			Type:    MtDatasetInfo,
+			Payload: ref,
+		}
+	}
+
+	return &Message{
+		Phase:   MpResponse,
+		Type:    MtDatasetInfo,
+		Payload: ref,
+	}
+}
+
+func (n *QriNode) handleDatasetInfoResponse(m *Message) error {
 	return fmt.Errorf("not yet finished")
 }

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -14,35 +14,32 @@ import (
 // MsgType indicates the type of message being sent
 // TODO - these should be switched out for string representations,
 // as changes to these ints as versions change will break the API real bad.
-type MsgType int
+type MsgType string
 
 const (
 	// MtUnknown is the default, errored message type
-	MtUnknown MsgType = iota
+	MtUnknown = MsgType("UNKNOWN")
 	// MtPeers is a peers list message
-	MtPeers
+	MtPeers = MsgType("PEERS")
 	// MtPeerInfo is a peer info message
-	MtPeerInfo
+	MtPeerInfo = MsgType("PEER_INFO")
 	// MtDatasets is a dataset list message
-	MtDatasets
+	MtDatasets = MsgType("DATASETS")
 	// MtNamespaces is a dataset namespace message
-	MtNamespaces
+	MtNamespaces = MsgType("NAMESPACES")
 	// MtSearch is a search message
-	MtSearch
+	MtSearch = MsgType("SEARCH")
 	// MtPing is a ping/pong message
-	MtPing
+	MtPing = MsgType("PING")
+	// MtNodes is a request for distributed web nodes associated with
+	// this peer
+	MtNodes = MsgType("NODES")
+	// MtDatasetInfo gets info on a dataset
+	MtDatasetInfo = MsgType("DATASET_INFO")
 )
 
 func (mt MsgType) String() string {
-	return map[MsgType]string{
-		MtUnknown:    "UNKNOWN",
-		MtPeerInfo:   "PEER_INFO",
-		MtPeers:      "PEERS",
-		MtDatasets:   "DATASETS",
-		MtNamespaces: "NAMESPACES",
-		MtSearch:     "SEARCH",
-		MtPing:       "PING",
-	}[mt]
+	return string(mt)
 }
 
 // MsgPhase tracks the point in a message lifecycle
@@ -214,7 +211,7 @@ func sendMessage(msg *Message, ws *WrappedStream) error {
 // When Message.HangUp is true, it exits. This will close the stream
 // on one of the sides. The other side's receiveMessage() will error
 // with EOF, thus also breaking out from the loop.
-// TODO - I know this is completely fucking awful. it'll get better in
+// TODO - I know this is completely awful. it'll get better in
 // due time
 func (n *QriNode) handleStream(ws *WrappedStream) {
 	for {
@@ -238,6 +235,10 @@ func (n *QriNode) handleStream(ws *WrappedStream) {
 				res = n.handlePeersRequest(r)
 			case MtPing:
 				res = n.handlePingRequest(r)
+			case MtNodes:
+				res = n.handleNodesRequest(r)
+			case MtDatasetInfo:
+				res = n.handleDatasetInfoRequest(r)
 			}
 		}
 

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -9,7 +9,7 @@ func TestPing(t *testing.T) {
 	// t.Parallel()
 	t.Skip("TestPing currently contains a race condition :/")
 
-	ntwk, err := NewTestNetwork()
+	ntwk, err := NewTestNetwork(context.Background(), t, 2)
 	if err != nil {
 		t.Errorf("error creating network: %s", err.Error())
 		return

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/qri-io/qri/repo/profile"
 
 	pstore "gx/ipfs/QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr/go-libp2p-peerstore"
+	"gx/ipfs/QmWRCn8vruNAzHx8i6SAXinuheRitKEGu8c7m26stKvsYx/go-testutil"
 	ma "gx/ipfs/QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji/go-multiaddr"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
+	// swarm "gx/ipfs/QmdQFrFnPrKRQtpeHKjZ3cVNwxmGKKS2TvhJTuN9C9yduh/go-libp2p-swarm"
 )
 
 func TestNewNode(t *testing.T) {
@@ -38,33 +40,36 @@ var repoID = 0
 func NewTestRepo() (repo.Repo, error) {
 	repoID++
 	return repo.NewMemRepo(&profile.Profile{
-		Username: fmt.Sprintf("tes-repo-%d", repoID),
+		Peername: fmt.Sprintf("tes-repo-%d", repoID),
 	}, memfs.NewMapstore(), repo.MemPeers{}, &analytics.Memstore{})
 }
 
-func NewTestNetwork() ([]*QriNode, error) {
-	cfgs := []struct {
-		port int
-	}{
-		{10000},
-		{10001},
-		{10002},
-	}
+func NewTestNetwork(ctx context.Context, t *testing.T, num int) ([]*QriNode, error) {
+	nodes := make([]*QriNode, 0, num)
 
-	nodes := make([]*QriNode, 0, len(cfgs))
-	for _, cfg := range cfgs {
+	for i := 0; i < num; i++ {
+		localnp := testutil.RandPeerNetParamsOrFatal(t)
+
 		r, err := NewTestRepo()
 		if err != nil {
 			return nil, fmt.Errorf("error creating test repo: %s", err.Error())
 		}
 
 		node, err := NewQriNode(r, func(o *NodeCfg) {
-			o.Port = cfg.port
+			// o.Port = localnp.Addr.Protocols()
 			o.QriBootstrapAddrs = []string{}
+			o.Addrs = []ma.Multiaddr{
+				localnp.Addr,
+			}
+			o.PrivKey = localnp.PrivKey
+			o.PeerID = localnp.ID
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error creating test node: %s", err.Error())
 		}
+		node.QriPeers.AddPubKey(localnp.ID, localnp.PubKey)
+		node.QriPeers.AddPrivKey(localnp.ID, localnp.PrivKey)
+
 		nodes = append(nodes, node)
 	}
 	return nodes, nil
@@ -73,10 +78,15 @@ func NewTestNetwork() ([]*QriNode, error) {
 func connectNodes(ctx context.Context, t *testing.T, nodes []*QriNode) {
 	var wg sync.WaitGroup
 	connect := func(n *QriNode, dst peer.ID, addr ma.Multiaddr) {
+		t.Logf("dialing %s from %s\n", n.Identity, dst)
 		n.QriPeers.AddAddr(dst, addr, pstore.PermanentAddrTTL)
+		// if sw, ok := n.Host.Network().(*swarm.Swarm); ok {
+		// 	if _, err := sw.Dial(ctx, dst); err != nil {
+		// 	}
 		if _, err := n.Host.Network().DialPeer(ctx, dst); err != nil {
 			t.Fatal("error swarm dialing to peer", err)
 		}
+		// }
 		wg.Done()
 	}
 
@@ -88,4 +98,34 @@ func connectNodes(ctx context.Context, t *testing.T, nodes []*QriNode) {
 		}
 	}
 	wg.Wait()
+
+	for _, n := range nodes {
+		log.Infof("%s swarm routing table: %s\n", n.Identity, n.Peers())
+	}
 }
+
+// func connectSwarms2(t *testing.T, ctx context.Context, swarms []*swarm.Swarm) {
+
+// 	var wg sync.WaitGroup
+// 	connect := func(s *swarm.Swarm, dst peer.ID, addr ma.Multiaddr) {
+// 		// TODO: make a DialAddr func.
+// 		s.peers.AddAddr(dst, addr, pstore.PermanentAddrTTL)
+// 		if _, err := s.Dial(ctx, dst); err != nil {
+// 			t.Fatal("error swarm dialing to peer", err)
+// 		}
+// 		wg.Done()
+// 	}
+
+// 	log.Info("Connecting swarms simultaneously.")
+// 	for i, s1 := range swarms {
+// 		for _, s2 := range swarms[i+1:] {
+// 			wg.Add(1)
+// 			connect(s1, s2.LocalPeer(), s2.ListenAddresses()[0]) // try the first.
+// 		}
+// 	}
+// 	wg.Wait()
+
+// 	for _, s := range swarms {
+// 		log.Infof("%s swarm routing table: %s", s.local, s.Peers())
+// 	}
+// }

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"fmt"
-	// "time"
 
 	pstore "gx/ipfs/QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr/go-libp2p-peerstore"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
@@ -33,6 +32,11 @@ func (n *QriNode) AddQriPeer(pinfo pstore.PeerInfo) error {
 	return nil
 }
 
+// RequestPeername attempts to find profile info for a given peername
+func (n *QriNode) RequestPeername(peername string) error {
+	return nil
+}
+
 // RequestProfileInfo get's qri profile information from a PeerInfo
 func (n *QriNode) RequestProfileInfo(pinfo pstore.PeerInfo) error {
 	// Get this repo's profile information
@@ -41,6 +45,12 @@ func (n *QriNode) RequestProfileInfo(pinfo pstore.PeerInfo) error {
 		fmt.Println("error getting node profile info:", err)
 		return err
 	}
+
+	addrs, err := n.IPFSListenAddresses()
+	if err != nil {
+		return err
+	}
+	profile.Addresses = addrs
 
 	res, err := n.SendMessage(pinfo.ID, &Message{
 		Type:    MtPeerInfo,

--- a/repo/dataset.go
+++ b/repo/dataset.go
@@ -41,12 +41,17 @@ func (r DatasetRef) String() (s string) {
 	return s
 }
 
+// IsPeerRef returns true if only Peername is set
+func (r DatasetRef) IsPeerRef() bool {
+	return r.Peername != "" && r.Name == "" && r.Path.String() == "" && r.Dataset == nil
+}
+
 var (
 	// fullDatasetPathRegex looks for dataset references in the forms:
 	// peername/dataset_name@/ipfs/hash
 	// peername/dataset_name@hash
 	fullDatasetPathRegex = regexp.MustCompile(`(\w+)/(\w+)@(/ipfs/)?(\w+)\b`)
-	//
+
 	peernameShorthandPathRegex = regexp.MustCompile(`(\w+[^/ipfs/])/(\w+)`)
 )
 
@@ -57,7 +62,6 @@ var (
 //
 // we swap in defaults as follows, all of which are represented as
 // empty strings:
-//     peer_name - defaults to the local peername
 //     network - defaults to /ipfs/
 //     hash - tip of version history (latest known commit)
 //
@@ -69,7 +73,7 @@ var (
 //     peer_name/dataset_name
 //     dataset_name@hash
 //     /network/hash
-//     dataset_name
+//     peername
 //     hash
 //
 // see tests for more exmples
@@ -110,7 +114,7 @@ func ParseDatasetRef(ref string) (*DatasetRef, error) {
 	}
 
 	return &DatasetRef{
-		Name: ref,
+		Peername: ref,
 	}, nil
 }
 

--- a/repo/dataset_test.go
+++ b/repo/dataset_test.go
@@ -15,9 +15,8 @@ func TestParseDatasetRef(t *testing.T) {
 		{"peer_name/dataset_name", &DatasetRef{Peername: "peer_name", Name: "dataset_name"}, ""},
 		{"peer_name/dataset_name@/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{Peername: "peer_name", Name: "dataset_name", Path: datastore.NewKey("/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, ""},
 		{"peer_name/dataset_name@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{Peername: "peer_name", Name: "dataset_name", Path: datastore.NewKey("/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, ""},
-		{"dataset_name", &DatasetRef{Name: "dataset_name"}, ""},
+		{"peer_name", &DatasetRef{Peername: "peer_name"}, ""},
 		// {"/not_ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{}, ""},
-		{"dataset_name", &DatasetRef{Name: "dataset_name"}, ""},
 		{"QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{Path: datastore.NewKey("/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, ""},
 	}
 

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -120,7 +120,7 @@ func ensureProfile(bp basepath, id string) error {
 	if _, err := os.Stat(bp.filepath(FileProfile)); os.IsNotExist(err) {
 		return bp.saveFile(&profile.Profile{
 			ID:       id,
-			Username: doggos.DoggoNick(id),
+			Peername: doggos.DoggoNick(id),
 		}, FileProfile)
 	}
 
@@ -139,8 +139,8 @@ func ensureProfile(bp basepath, id string) error {
 
 	if p.ID != id {
 		p.ID = id
-		if p.Username == "" {
-			p.Username = doggos.DoggoNick(p.ID)
+		if p.Peername == "" {
+			p.Peername = doggos.DoggoNick(p.ID)
 		}
 		bp.saveFile(p, FileProfile)
 	}

--- a/repo/fs/peer_store.go
+++ b/repo/fs/peer_store.go
@@ -26,11 +26,31 @@ func (r PeerStore) PutPeer(id peer.ID, p *profile.Profile) error {
 	if err != nil {
 		return err
 	}
-	if p.Username == "" {
-		p.Username = doggos.DoggoNick(id.Pretty())
+	if p.Peername == "" {
+		p.Peername = doggos.DoggoNick(id.Pretty())
 	}
 	ps[id.Pretty()] = p
 	return r.saveFile(ps, FilePeers)
+}
+
+// List hands back the list of peers
+func (r PeerStore) List() (map[string]*profile.Profile, error) {
+	return r.peers()
+}
+
+// GetID gives the peer.ID for a given peername
+func (r PeerStore) GetID(peername string) (peer.ID, error) {
+	ps, err := r.peers()
+	if err != nil {
+		return "", err
+	}
+
+	for _, profile := range ps {
+		if profile.Peername == peername {
+			return profile.PeerID()
+		}
+	}
+	return "", datastore.ErrNotFound
 }
 
 // GetPeer fetches a peer from the store
@@ -70,8 +90,8 @@ func (r PeerStore) Query(q query.Query) (query.Results, error) {
 
 	re := make([]query.Entry, 0, len(ps))
 	for id, peer := range ps {
-		if peer.Username == "" {
-			peer.Username = doggos.DoggoNick(id)
+		if peer.Peername == "" {
+			peer.Peername = doggos.DoggoNick(id)
 		}
 		re = append(re, query.Entry{Key: id, Value: peer})
 	}

--- a/repo/peers.go
+++ b/repo/peers.go
@@ -12,7 +12,9 @@ import (
 // Peers is a store of peer information
 // It's named peers to disambiguate from the lib-p2p peerstore
 type Peers interface {
+	List() (map[string]*profile.Profile, error)
 	Query(query.Query) (query.Results, error)
+	GetID(peername string) (peer.ID, error)
 	PutPeer(id peer.ID, profile *profile.Profile) error
 	GetPeer(id peer.ID) (*profile.Profile, error)
 	DeletePeer(id peer.ID) error
@@ -59,6 +61,25 @@ type MemPeers map[peer.ID]*profile.Profile
 func (m MemPeers) PutPeer(id peer.ID, profile *profile.Profile) error {
 	m[id] = profile
 	return nil
+}
+
+// GetID gives the peer.ID for a given peername
+func (m MemPeers) GetID(peername string) (peer.ID, error) {
+	for id, profile := range m {
+		if profile.Peername == peername {
+			return id, nil
+		}
+	}
+	return "", ErrNotFound
+}
+
+// List hands the full list of peers back
+func (m MemPeers) List() (map[string]*profile.Profile, error) {
+	res := map[string]*profile.Profile{}
+	for id, p := range m {
+		res[id.Pretty()] = p
+	}
+	return res, nil
 }
 
 // GetPeer give's peer info from the store for a given peer.ID

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -32,7 +32,7 @@ func init() {
 func NewTestRepo() (mr repo.Repo, err error) {
 	datasets := []string{"movies", "cities", "counter", "archive"}
 	p := &profile.Profile{
-		Username: "test_user",
+		Peername: "test_user",
 	}
 	ms := memfs.NewMapstore()
 	mr, err = repo.NewMemRepo(p, ms, repo.MemPeers{}, &analytics.Memstore{})


### PR DESCRIPTION
Introducing separate keys for qri has brought a few new complexities, this PR makes some inroads on keeping those two sorted.
qri repo peers are now stored according to *IPFS* ids, with the ID field in the peer itself being the actual peer ID. This is because we need to use IPFS Peer ID's for all network communication
(for now), and multiple IPFS Peer ID's may use the same qri Peer ID (in a situation where I use the same profile for multiple nodes)