### PR TITLE
WIP - feat(p2p): Support CLI methods that require p2p network

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - checkout
       - run: mkdir -p $TEST_RESULTS
-      - run: go get github.com/jstemmer/go-junit-report github.com/golang/lint/golint
+      - run: go get github.com/jstemmer/go-junit-report github.com/golang/lint/golint github.com/qri-io/datasetDiffer
       - run: 
           name: Run Lint Tests
           command: golint ./...

--- a/api/handlers/datasets.go
+++ b/api/handlers/datasets.go
@@ -111,9 +111,9 @@ func (h *DatasetHandlers) RenameHandler(w http.ResponseWriter, r *http.Request) 
 // ZipDatasetHandler is the endpoint for getting a zip archive of a dataset
 func (h *DatasetHandlers) ZipDatasetHandler(w http.ResponseWriter, r *http.Request) {
 	res := &repo.DatasetRef{}
-	args := &core.GetDatasetParams{
-		Path: datastore.NewKey(r.URL.Path[len("/download/"):]),
-		Hash: r.FormValue("hash"),
+	args := &repo.DatasetRef{
+		Path: r.URL.Path[len("/download/"):],
+		// Hash: r.FormValue("hash"),
 	}
 	err := h.Get(args, res)
 	if err != nil {
@@ -143,9 +143,9 @@ func (h *DatasetHandlers) listHandler(w http.ResponseWriter, r *http.Request) {
 
 func (h *DatasetHandlers) getHandler(w http.ResponseWriter, r *http.Request) {
 	res := &repo.DatasetRef{}
-	args := &core.GetDatasetParams{
-		Path: datastore.NewKey(r.URL.Path[len("/datasets/"):]),
-		Hash: r.FormValue("hash"),
+	args := &repo.DatasetRef{
+		Path: r.URL.Path[len("/datasets/"):],
+		// Hash: r.FormValue("hash"),
 	}
 	err := h.Get(args, res)
 	if err != nil {
@@ -213,11 +213,11 @@ func (h *DatasetHandlers) updateMetadataHandler(w http.ResponseWriter, r *http.R
 func (h *DatasetHandlers) deleteDatasetHandler(w http.ResponseWriter, r *http.Request) {
 	p := &core.RemoveParams{
 		Name: r.FormValue("name"),
-		Path: datastore.NewKey(r.URL.Path[len("/datasets"):]),
+		Path: r.URL.Path[len("/datasets"):],
 	}
 
 	ref := &repo.DatasetRef{}
-	if err := h.Get(&core.GetDatasetParams{Name: p.Name, Path: p.Path}, ref); err != nil {
+	if err := h.Get(&repo.DatasetRef{Name: p.Name, Path: p.Path}, ref); err != nil {
 		return
 	}
 

--- a/api/handlers/datasets.go
+++ b/api/handlers/datasets.go
@@ -264,21 +264,21 @@ func (h *DatasetHandlers) getStructuredDataHandler(w http.ResponseWriter, r *htt
 }
 
 func (h *DatasetHandlers) addHandler(w http.ResponseWriter, r *http.Request) {
-	p := &core.AddParams{}
+	p := &repo.DatasetRef{}
 	if r.Header.Get("Content-Type") == "application/json" {
 		if err := json.NewDecoder(r.Body).Decode(p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
 		// TODO - clean this up
-		p.Hash = r.URL.Path[len("/add/"):]
+		p.Path = r.URL.Path[len("/add/"):]
 		if p.Name == "" && r.FormValue("name") != "" {
 			p.Name = r.FormValue("name")
 		}
 	} else {
-		p = &core.AddParams{
+		p = &repo.DatasetRef{
 			Name: r.URL.Query().Get("name"),
-			Hash: r.URL.Path[len("/add/"):],
+			Path: r.URL.Path[len("/add/"):],
 		}
 	}
 

--- a/api/handlers/peers.go
+++ b/api/handlers/peers.go
@@ -103,7 +103,8 @@ func (h *PeerHandlers) listConnectionsHandler(w http.ResponseWriter, r *http.Req
 	// TODO: double check with @b5 on this change
 	listParams := core.ListParamsFromRequest(r)
 	peers := []string{}
-	if err := h.ConnectedPeers(&listParams.Limit, &peers); err != nil {
+
+	if err := h.ConnectedIPFSPeers(&listParams.Limit, &peers); err != nil {
 		h.log.Infof("error showing connected peers: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return

--- a/api/server.go
+++ b/api/server.go
@@ -143,6 +143,8 @@ func NewServerRoutes(s *Server) *http.ServeMux {
 	m.Handle("/peernamespace/", s.middleware(ph.PeerNamespaceHandler))
 
 	dsh := handlers.NewDatasetHandlers(s.log, s.qriNode.Repo)
+	// TODO - stupid hack for now.
+	dsh.DatasetRequests.Node = s.qriNode
 	m.Handle("/datasets", s.middleware(dsh.ListHandler))
 	m.Handle("/datasets/", s.middleware(dsh.GetHandler))
 	m.Handle("/add/", s.middleware(dsh.AddHandler))

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -52,12 +52,12 @@ changes to qri.`,
 
 				p := &core.AddParams{
 					Name: ref.Name,
-					Hash: ref.Path.String(),
+					Hash: ref.Path,
 				}
 				res := &repo.DatasetRef{}
 				err = req.Add(p, res)
 				ExitIfErr(err)
-				printInfo("Successfully added dataset %s: %s", addDsName, res.Path.String())
+				printInfo("Successfully added dataset %s: %s", addDsName, res.Path)
 			}
 		} else {
 			initDataset()
@@ -105,7 +105,7 @@ func initDataset() {
 	ExitIfErr(err)
 
 	// req.Get(&core.GetDatasetParams{ Name: p.Name }, res)
-	printSuccess("initialized dataset %s: %s", ref.Name, ref.Path.String())
+	printSuccess("initialized dataset %s: %s", ref.Name, ref.Path)
 }
 
 func init() {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -23,9 +23,8 @@ var datasetAddCmd = &cobra.Command{
 	Short:      "add a dataset to your local repository",
 	SuggestFor: []string{"init"},
 	Long: `
-Add creates a new dataset from data you supply. You can supply data from a file 
-or a URL. Please note that all data added to qri is made public on the 
-distributed web when you run qri connect.
+Add creates a new dataset from data you supply. Please note that all data added 
+to qri is made public on the distributed web when you run qri connect.
 
 When adding data, you can supply metadata and dataset structure, but it’s not 
 required. qri does what it can to infer the details you don’t provide. 
@@ -47,15 +46,11 @@ changes to qri.`,
 				ref, err := repo.ParseDatasetRef(arg)
 				ExitIfErr(err)
 
-				req, err := datasetRequests(false)
+				req, err := datasetRequests(true)
 				ExitIfErr(err)
 
-				p := &core.AddParams{
-					Name: ref.Name,
-					Hash: ref.Path,
-				}
 				res := &repo.DatasetRef{}
-				err = req.Add(p, res)
+				err = req.Add(ref, res)
 				ExitIfErr(err)
 				printInfo("Successfully added dataset %s: %s", addDsName, res.Path)
 			}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -98,7 +98,7 @@ func TestCommandsIntegration(t *testing.T) {
 		{"info"},
 		{"add", "-f" + moviesFilePath, "-n" + "movies"},
 		{"list"},
-		{"save", "--data=" + movies2FilePath, "-m" + "commit_1", "me/movies"},
+		{"save", "--data=" + movies2FilePath, "-t" + "commit_1", "me/movies"},
 		{"log", "me/movies"},
 		{"export", "--dataset", "me/movies", "-o" + path},
 		{"rename", "me/movies", "me/movie"},

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -179,8 +179,8 @@ type Config struct {
 	IPFSPath string
 	// Datastore configuration details
 	// Datastore       DatastoreCfg
-	// DefaultDatasets is a list of datasets to grab on initially joining the network
-	DefaultDatasets map[string]string
+	// DefaultDatasets is a list of dataset references to grab on initially joining the network
+	DefaultDatasets []string
 }
 
 // TODO - Is this is the right place for this?
@@ -268,9 +268,9 @@ func defaultCfgBytes() []byte {
 		Bootstrap:   p2p.DefaultBootstrapAddresses,
 		// defaultDatasets is a hard-coded dataset added when a new qri repo is created
 		// these hashes should always/highly available
-		DefaultDatasets: map[string]string{
+		DefaultDatasets: []string{
 			// fivethirtyeight comic characters
-			"comic_characters": "/ipfs/QmcqkHFA2LujZxY38dYZKmxsUstN4unk95azBjwEhwrnM6/dataset.json",
+			"me/comic_characters@/ipfs/QmcqkHFA2LujZxY38dYZKmxsUstN4unk95azBjwEhwrnM6/dataset.json",
 		},
 	}
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -124,18 +124,20 @@ func initializeDistributedAssets(node *p2p.QriNode) {
 
 	req := core.NewDatasetRequests(node.Repo, nil)
 
-	for name, path := range cfg.DefaultDatasets {
-		fmt.Printf("attempting to add default dataset: %s\n", path)
-		res := &repo.DatasetRef{}
-		err := req.Add(&core.AddParams{
-			Hash: path,
-			Name: name,
-		}, res)
+	for _, refstr := range cfg.DefaultDatasets {
+		fmt.Printf("attempting to add default dataset: %s\n", refstr)
+		ref, err := repo.ParseDatasetRef(refstr)
 		if err != nil {
-			fmt.Printf("add dataset %s error: %s\n", path, err.Error())
+			fmt.Println("error parsing dataset reference: '%s': %s", refstr, err.Error())
+			continue
+		}
+		res := &repo.DatasetRef{}
+		err = req.Add(ref, res)
+		if err != nil {
+			fmt.Printf("add dataset %s error: %s\n", refstr, err.Error())
 			return
 		}
-		fmt.Printf("added default dataset: %s\n", path)
+		fmt.Printf("added default dataset: %s\n", refstr)
 	}
 
 	cfg.Initialized = true

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	connectCmdPort string
-	connectMemOnly bool
-	connectOffline bool
-	connectSetup   bool
+	connectCmdPort    string
+	connectCmdRPCPort string
+	connectMemOnly    bool
+	connectOffline    bool
+	connectSetup      bool
 )
 
 // connectCmd represents the run command
@@ -70,6 +71,7 @@ call it a “prime” port number.`,
 		s, err := api.New(r, func(cfg *api.Config) {
 			cfg.Logger = log
 			cfg.Port = connectCmdPort
+			cfg.RPCPort = connectCmdRPCPort
 			cfg.MemOnly = connectMemOnly
 			cfg.Online = !connectOffline
 			cfg.BoostrapAddrs = viper.GetStringSlice("bootstrap")
@@ -145,7 +147,8 @@ func initializeDistributedAssets(node *p2p.QriNode) {
 }
 
 func init() {
-	connectCmd.Flags().StringVarP(&connectCmdPort, "api-port", "p", api.DefaultPort, "port to start api on")
+	connectCmd.Flags().StringVarP(&connectCmdPort, "api-port", "", api.DefaultPort, "port to start api on")
+	connectCmd.Flags().StringVarP(&connectCmdRPCPort, "rpc-port", "", api.DefaultRPCPort, "port to start rpc listener on")
 	connectCmd.Flags().BoolVarP(&connectSetup, "setup", "", false, "run setup if necessary, reading options from enviornment variables")
 	connectCmd.Flags().BoolVarP(&connectMemOnly, "mem-only", "", false, "run qri entirely in-memory, persisting nothing")
 	connectCmd.Flags().BoolVarP(&connectOffline, "offline", "", false, "disable networking")

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/qri-io/qri/core"
+	// "github.com/qri-io/qri/repo/profile"
+	"github.com/spf13/cobra"
+)
+
+// connectionsCmd lists
+var connectionsCmd = &cobra.Command{
+	Use:   "connections",
+	Short: `List open connections with qri & IPFS peers`,
+	Example: `  show open qri connections:
+  $ qri connections
+
+  show all IPFS connections:
+  $ qri connections --ipfs`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 0 {
+			ErrExit(fmt.Errorf("connections accepts no arguments"))
+		}
+		req, err := peerRequests(true)
+		ExitIfErr(err)
+
+		if cmd.Flag("ipfs").Value.String() == "true" {
+			limit := 200
+			res := []string{}
+			err := req.ConnectedIPFSPeers(&limit, &res)
+			ExitIfErr(err)
+			for i, p := range res {
+				printSuccess("%d.\t%s", i+1, p)
+			}
+		} else {
+			limit := 200
+			res := []core.Peer{}
+			err := req.ConnectedQriPeers(&limit, &res)
+			ExitIfErr(err)
+
+			i := 0
+			for _, p := range res {
+				printSuccess("%d.\t%s\t%s", i+1, p.ID, p.Peername)
+				i++
+			}
+		}
+	},
+}
+
+func init() {
+	// connectionsCmd.Flags().StringP("format", "f", "", "set output format [json]")
+	connectionsCmd.Flags().BoolP("ipfs", "", false, "show ipfs peers")
+
+	RootCmd.AddCommand(connectionsCmd)
+}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -47,7 +47,7 @@ To export everything about a dataset, use the --dataset flag.`,
 		dsr, err := repo.ParseDatasetRef(args[0])
 		ExitIfErr(err)
 
-		p := &core.GetDatasetParams{
+		p := &repo.DatasetRef{
 			Name: dsr.Name,
 			Path: dsr.Path,
 		}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -41,10 +41,10 @@ var infoCmd = &cobra.Command{
 			}
 		}
 
-		pr, err := peerRequests(true)
+		pr, err := peerRequests(false)
 		ExitIfErr(err)
 
-		req, err := datasetRequests(false)
+		req, err := datasetRequests(true)
 		ExitIfErr(err)
 
 		for i, arg := range args {
@@ -67,13 +67,8 @@ var infoCmd = &cobra.Command{
 					fmt.Printf("%s", string(data))
 				}
 			} else {
-				p := &core.GetDatasetParams{
-					Name: ref.Name,
-					Path: ref.Path,
-				}
-
 				res := &repo.DatasetRef{}
-				err = req.Get(p, res)
+				err = req.Get(ref, res)
 				ExitIfErr(err)
 
 				if outformat == "" {
@@ -84,7 +79,6 @@ var infoCmd = &cobra.Command{
 					fmt.Printf("%s", string(data))
 				}
 			}
-
 		}
 	},
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -56,6 +56,31 @@ qri repository.`,
 			// ref, err := repo.ParseDatasetRef(ref)
 			// ExitIfErr(err)
 			// }
+			r, err := datasetRequests(true)
+			ExitIfErr(err)
+
+			p := &core.ListParams{
+				Peername: args[0],
+				Limit:    dsListLimit,
+				Offset:   dsListOffset,
+			}
+			refs := []*repo.DatasetRef{}
+			err = r.List(p, &refs)
+			ExitIfErr(err)
+
+			outformat := cmd.Flag("format").Value.String()
+			switch outformat {
+			case "":
+				for _, ref := range refs {
+					printInfo("%s\t\t\t: %s", ref.Name, ref.Path)
+				}
+			case dataset.JSONDataFormat.String():
+				data, err := json.MarshalIndent(refs, "", "  ")
+				ExitIfErr(err)
+				fmt.Printf("%s\n", string(data))
+			default:
+				ErrExit(fmt.Errorf("unrecognized format: %s", outformat))
+			}
 		}
 	},
 }

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/qri-io/qri/repo/profile"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/core"
+	"github.com/spf13/cobra"
+)
+
+// peersCmd represents the info command
+var peersCmd = &cobra.Command{
+	Use:   "peers",
+	Short: "List known qri peers",
+	Long:  `peers lists the peers your qri node has seen before`,
+	Example: `  list qri peers:
+  $ qri peers`,
+	Run: func(cmd *cobra.Command, args []string) {
+		outformat := cmd.Flag("format").Value.String()
+		if outformat != "" {
+			format, err := dataset.ParseDataFormatString(outformat)
+			if err != nil {
+				ErrExit(fmt.Errorf("invalid data format: %s", cmd.Flag("format").Value.String()))
+			}
+			if format != dataset.JSONDataFormat {
+				ErrExit(fmt.Errorf("invalid data format. currently only json or plaintext are supported"))
+			}
+		}
+
+		pr, err := peerRequests(false)
+		ExitIfErr(err)
+
+		res := []*profile.Profile{}
+		err = pr.List(&core.ListParams{Limit: 1000}, &res)
+		ExitIfErr(err)
+
+		if outformat == "" {
+			for i, p := range res {
+				printPeerInfo(i, p)
+			}
+		} else {
+			data, err := json.MarshalIndent(res, "", "  ")
+			ExitIfErr(err)
+			fmt.Printf("%s", string(data))
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(peersCmd)
+	peersCmd.Flags().StringP("format", "f", "", "set output format [json]")
+}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/dataset/dsfs"
 	"github.com/qri-io/qri/core"
 	"github.com/spf13/cobra"
@@ -39,7 +38,7 @@ both qri & IPFS. Promise.`,
 			p := &core.RemoveParams{}
 			switch rt {
 			case "path":
-				p.Path = datastore.NewKey(ref)
+				p.Path = ref
 			case "name":
 				p.Name = ref
 			}

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -50,20 +50,29 @@ func getIpfsFilestore(online bool) *ipfs.Filestore {
 }
 
 func datasetRequests(online bool) (*core.DatasetRequests, error) {
-	r, cli, err := repoOrClient(online)
+	// TODO - bad bad hardcode
+	if conn, err := net.Dial("tcp", ":2504"); err == nil {
+		return core.NewDatasetRequests(nil, rpc.NewClient(conn)), nil
+	}
+
+	if !online {
+		// TODO - make this not terrible
+		r, cli, err := repoOrClient(online)
+		if err != nil {
+			return nil, err
+		}
+		return core.NewDatasetRequests(r, cli), nil
+	}
+
+	n, err := qriNode(online)
 	if err != nil {
 		return nil, err
 	}
-	return core.NewDatasetRequests(r, cli), nil
-}
 
-// func queryRequests(online bool) (*core.QueryRequests, error) {
-// 	r, cli, err := repoOrClient(online)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return core.NewQueryRequests(r, cli), nil
-// }
+	req := core.NewDatasetRequests(n.Repo, nil)
+	req.Node = n
+	return req, nil
+}
 
 func profileRequests(online bool) (*core.ProfileRequests, error) {
 	r, cli, err := repoOrClient(online)
@@ -90,7 +99,9 @@ func historyRequests(online bool) (*core.HistoryRequests, error) {
 }
 
 func peerRequests(online bool) (*core.PeerRequests, error) {
-	node, err := onlineQriNode()
+	return nil, nil
+
+	node, err := qriNode(online)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +139,7 @@ func repoOrClient(online bool) (repo.Repo, *rpc.Client, error) {
 	return nil, nil, fmt.Errorf("badbadnotgood")
 }
 
-func onlineQriNode() (node *p2p.QriNode, err error) {
+func qriNode(online bool) (node *p2p.QriNode, err error) {
 	var (
 		r  repo.Repo
 		fs *ipfs.Filestore
@@ -136,7 +147,7 @@ func onlineQriNode() (node *p2p.QriNode, err error) {
 
 	fs, err = ipfs.NewFilestore(func(cfg *ipfs.StoreCfg) {
 		cfg.FsRepoPath = IpfsFsPath
-		cfg.Online = true
+		cfg.Online = online
 	})
 
 	if err != nil {
@@ -162,16 +173,18 @@ func onlineQriNode() (node *p2p.QriNode, err error) {
 
 	node, err = p2p.NewQriNode(r, func(ncfg *p2p.NodeCfg) {
 		ncfg.Logger = log
-		ncfg.Online = true
+		ncfg.Online = online
 		ncfg.QriBootstrapAddrs = cfg.Bootstrap
 	})
 	if err != nil {
 		return
 	}
 
-	log.Info("p2p addresses:")
-	for _, a := range node.EncapsulatedAddresses() {
-		log.Infof("  %s", a.String())
+	if online {
+		log.Info("p2p addresses:")
+		for _, a := range node.EncapsulatedAddresses() {
+			log.Infof("  %s", a.String())
+		}
 	}
 
 	return

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -13,11 +13,14 @@ import (
 	"github.com/qri-io/qri/repo/fs"
 )
 
-var r repo.Repo
+var (
+	repository repo.Repo
+	rpcClient  *rpc.Client
+)
 
 func getRepo(online bool) repo.Repo {
-	if r != nil {
-		return r
+	if repository != nil {
+		return repository
 	}
 
 	if !QRIRepoInitialized() {
@@ -114,6 +117,12 @@ func peerRequests(online bool) (*core.PeerRequests, error) {
 }
 
 func repoOrClient(online bool) (repo.Repo, *rpc.Client, error) {
+	if repository != nil {
+		return repository, nil, nil
+	} else if rpcClient != nil {
+		return nil, rpcClient, nil
+	}
+
 	if fs, err := ipfs.NewFilestore(func(cfg *ipfs.StoreCfg) {
 		cfg.FsRepoPath = IpfsFsPath
 		cfg.Online = online
@@ -185,11 +194,14 @@ func qriNode(online bool) (node *p2p.QriNode, err error) {
 		return
 	}
 
+	// if online {
+	// 	log.Info("p2p addresses:")
+	// 	for _, a := range node.EncapsulatedAddresses() {
+	// 		log.Infof("  %s", a.String())
+	// 	}
+	// }
 	if online {
-		log.Info("p2p addresses:")
-		for _, a := range node.EncapsulatedAddresses() {
-			log.Infof("  %s", a.String())
-		}
+		log.Infof("connecting to the distributed web...")
 	}
 
 	return

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -99,7 +99,12 @@ func historyRequests(online bool) (*core.HistoryRequests, error) {
 }
 
 func peerRequests(online bool) (*core.PeerRequests, error) {
-	return nil, nil
+	// return nil, nil
+
+	// TODO - bad bad hardcode
+	if conn, err := net.Dial("tcp", ":2504"); err == nil {
+		return core.NewPeerRequests(nil, rpc.NewClient(conn)), nil
+	}
 
 	node, err := qriNode(online)
 	if err != nil {

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -47,23 +47,22 @@ collaboration are in the works. Sit tight sportsfans.`,
 			ErrExit(fmt.Errorf("please provide the name of an existing dataset so save updates to"))
 		}
 		if saveMetaFile == "" && saveDataFile == "" && saveStructureFile == "" {
-			ErrExit(fmt.Errorf("either a metadata or data option is required"))
+			ErrExit(fmt.Errorf("one of --structure, --meta or --data is required"))
 		}
 
 		ref, err := repo.ParseDatasetRef(args[0])
 		ExitIfErr(err)
 
-		req, err := datasetRequests(false)
-		ExitIfErr(err)
+		// req, err := datasetRequests(false)
+		// ExitIfErr(err)
 
-		// TODO - need to make sure users aren't forking by referncing commits other than tip
-		p := &repo.DatasetRef{
-			Name: ref.Name,
-			Path: ref.Path,
-		}
+		// TODO - this is silly:
+		ref.Peername = ""
+
+		req := core.NewDatasetRequests(getRepo(false), nil)
 
 		prev := &repo.DatasetRef{}
-		err = req.Get(p, prev)
+		err = req.Get(ref, prev)
 		ExitIfErr(err)
 
 		save := &core.SaveParams{}

--- a/core/core.go
+++ b/core/core.go
@@ -21,8 +21,13 @@ type Requests interface {
 // API of core methods
 func Receivers(node *p2p.QriNode) []Requests {
 	r := node.Repo
+
+	// TODO - horrible hack for meow
+	dsr := NewDatasetRequests(r, nil)
+	dsr.Node = node
+
 	return []Requests{
-		NewDatasetRequests(r, nil),
+		dsr,
 		NewHistoryRequests(r, nil),
 		NewPeerRequests(node, nil),
 		NewProfileRequests(r, nil),

--- a/core/datasets.go
+++ b/core/datasets.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"bytes"
-	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -27,15 +26,6 @@ import (
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/varName"
 )
-
-func init() {
-	gob.Register(&dataset.Dataset{})
-	// gob.Register(dataset.Dataset{})
-	gob.Register(&repo.DatasetRef{})
-	gob.Register(&jsonschema.RootSchema{})
-	// gob.Register(repo.DatasetRef{})
-
-}
 
 // DatasetRequests encapsulates business logic for this node's
 // user profile
@@ -65,6 +55,14 @@ func NewDatasetRequests(r repo.Repo, cli *rpc.Client) *DatasetRequests {
 func (r *DatasetRequests) List(p *ListParams, res *[]*repo.DatasetRef) error {
 	if r.cli != nil {
 		return r.cli.Call("DatasetRequests.List", p, res)
+	}
+
+	if p.Peername != "" && r.Node != nil {
+		replies, err := r.Node.RequestDatasetsList(p.Peername)
+		*res = replies
+		return err
+	} else if r.Node == nil {
+		return fmt.Errorf("cannot list datasets of peer without p2p connection")
 	}
 
 	store := r.repo.Store()

--- a/core/datasets_test.go
+++ b/core/datasets_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsfs"
 	"github.com/qri-io/qri/repo"
@@ -141,21 +140,22 @@ func TestDatasetRequestsGet(t *testing.T) {
 		t.Errorf("error getting path: %s", err.Error())
 		return
 	}
+	pathstr := path.String()
 	moviesDs, err := dsfs.LoadDataset(mr.Store(), path)
 	if err != nil {
 		t.Errorf("error loading dataset: %s", err.Error())
 		return
 	}
 	cases := []struct {
-		p   *GetDatasetParams
+		p   *repo.DatasetRef
 		res *dataset.Dataset
 		err string
 	}{
 		//TODO: probably delete some of these
-		{&GetDatasetParams{Path: datastore.NewKey("abc"), Name: "ABC", Hash: "123"}, nil, "error loading dataset: error getting file bytes: datastore: key not found"},
-		{&GetDatasetParams{Path: path, Name: "ABC", Hash: "123"}, nil, ""},
-		{&GetDatasetParams{Path: path, Name: "movies", Hash: "123"}, moviesDs, ""},
-		{&GetDatasetParams{Path: path, Name: "cats", Hash: "123"}, moviesDs, ""},
+		{&repo.DatasetRef{Path: "abc", Name: "ABC"}, nil, "error loading dataset: error getting file bytes: datastore: key not found"},
+		{&repo.DatasetRef{Path: pathstr, Name: "ABC"}, nil, ""},
+		{&repo.DatasetRef{Path: pathstr, Name: "movies"}, moviesDs, ""},
+		{&repo.DatasetRef{Path: pathstr, Name: "cats"}, moviesDs, ""},
 	}
 
 	req := NewDatasetRequests(mr, nil)
@@ -267,8 +267,8 @@ func TestDatasetRequestsRemove(t *testing.T) {
 		err string
 	}{
 		{&RemoveParams{}, nil, "either name or path is required"},
-		{&RemoveParams{Path: datastore.NewKey("abc"), Name: "ABC"}, nil, "repo: not found"},
-		{&RemoveParams{Path: path}, nil, ""},
+		{&RemoveParams{Path: "abc", Name: "ABC"}, nil, "repo: not found"},
+		{&RemoveParams{Path: path.String()}, nil, ""},
 	}
 
 	req := NewDatasetRequests(mr, nil)

--- a/core/datasets_test.go
+++ b/core/datasets_test.go
@@ -349,11 +349,11 @@ func TestDatasetRequestsStructuredData(t *testing.T) {
 
 func TestDatasetRequestsAdd(t *testing.T) {
 	cases := []struct {
-		p   *AddParams
+		p   *repo.DatasetRef
 		res *repo.DatasetRef
 		err string
 	}{
-		{&AddParams{Name: "abc", Hash: "hash###"}, nil, "can only add datasets when running an IPFS filestore"},
+		{&repo.DatasetRef{Name: "abc", Path: "hash###"}, nil, "can only add datasets when running an IPFS filestore"},
 	}
 
 	mr, err := testrepo.NewTestRepo()

--- a/core/history.go
+++ b/core/history.go
@@ -58,10 +58,10 @@ func (d *HistoryRequests) Log(params *LogParams, res *[]*repo.DatasetRef) (err e
 
 	log := []*repo.DatasetRef{}
 	limit := params.Limit
-	ref := &repo.DatasetRef{Path: params.Path}
+	ref := &repo.DatasetRef{Path: params.Path.String()}
 
 	for {
-		ref.Dataset, err = dsfs.LoadDataset(d.repo.Store(), ref.Path)
+		ref.Dataset, err = dsfs.LoadDataset(d.repo.Store(), datastore.NewKey(ref.Path))
 		if err != nil {
 			return err
 		}
@@ -73,7 +73,7 @@ func (d *HistoryRequests) Log(params *LogParams, res *[]*repo.DatasetRef) (err e
 		}
 		// TODO - clean this up
 		_, cleaned := dsfs.RefType(ref.Dataset.PreviousPath)
-		ref = &repo.DatasetRef{Path: datastore.NewKey(cleaned)}
+		ref = &repo.DatasetRef{Path: cleaned}
 	}
 
 	*res = log

--- a/core/history_test.go
+++ b/core/history_test.go
@@ -27,7 +27,7 @@ func TestHistoryRequestsLog(t *testing.T) {
 	}{
 		{&LogParams{}, nil, "either path or name is required"},
 		{&LogParams{Path: datastore.NewKey("/badpath")}, nil, "error loading dataset: error getting file bytes: datastore: key not found"},
-		{&LogParams{Path: path}, []*repo.DatasetRef{&repo.DatasetRef{Path: path}}, ""},
+		{&LogParams{Path: path}, []*repo.DatasetRef{&repo.DatasetRef{Path: path.String()}}, ""},
 	}
 
 	req := NewHistoryRequests(mr, nil)

--- a/core/params.go
+++ b/core/params.go
@@ -22,9 +22,10 @@ type GetParams struct {
 // ListParams define limits & offsets, not pages & page sizes.
 // TODO - rename this to PageParams.
 type ListParams struct {
-	OrderBy string
-	Limit   int
-	Offset  int
+	Peername string
+	OrderBy  string
+	Limit    int
+	Offset   int
 }
 
 // NewListParams creates a ListParams from page & pagesize, pages are 1-indexed

--- a/core/peers.go
+++ b/core/peers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/rpc"
 
-	"github.com/ipfs/go-datastore/query"
+	// "github.com/ipfs/go-datastore/query"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
@@ -51,9 +51,14 @@ func (d *PeerRequests) List(p *ListParams, res *[]*profile.Profile) error {
 		return err
 	}
 
-	ps, err := repo.QueryPeers(r.Peers(), query.Query{})
+	// ps, err := repo.QueryPeers(r.Peers(), query.Query{})
+	// if err != nil {
+	// 	return fmt.Errorf("error querying peers: %s", err.Error())
+	// }
+
+	ps, err := r.Peers().List()
 	if err != nil {
-		return fmt.Errorf("error querying peers: %s", err.Error())
+		return fmt.Errorf("error listing peers: %s", err.Error())
 	}
 
 	for _, peer := range ps {

--- a/p2p/datasets.go
+++ b/p2p/datasets.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/repo"
 )
 
@@ -37,7 +36,7 @@ func (n *QriNode) RequestDatasetsList(peername string) ([]*repo.DatasetRef, erro
 }
 
 // RequestDatasetInfo get's qri profile information from a PeerInfo
-func (n *QriNode) RequestDatasetInfo(ref *repo.DatasetRef) (*dataset.Dataset, error) {
+func (n *QriNode) RequestDatasetInfo(ref *repo.DatasetRef) (*repo.DatasetRef, error) {
 	id, err := n.Repo.Peers().IPFSPeerID(ref.Peername)
 	if err != nil {
 		return nil, fmt.Errorf("error getting peer IPFS id: %s", err.Error())
@@ -58,8 +57,8 @@ func (n *QriNode) RequestDatasetInfo(ref *repo.DatasetRef) (*dataset.Dataset, er
 	if err != nil {
 		return nil, err
 	}
-	ds := &dataset.Dataset{}
-	err = json.Unmarshal(data, ds)
+	resref := &repo.DatasetRef{}
+	err = json.Unmarshal(data, resref)
 
-	return ds, err
+	return resref, err
 }

--- a/p2p/datasets.go
+++ b/p2p/datasets.go
@@ -8,6 +8,34 @@ import (
 	"github.com/qri-io/qri/repo"
 )
 
+// RequestDatasetsList gets a list of a peer's datasets
+func (n *QriNode) RequestDatasetsList(peername string) ([]*repo.DatasetRef, error) {
+	id, err := n.Repo.Peers().IPFSPeerID(peername)
+	if err != nil {
+		return nil, fmt.Errorf("error getting peer IPFS id: %s", err.Error())
+	}
+
+	res, err := n.SendMessage(id, &Message{
+		Type:    MtDatasets,
+		Phase:   MpRequest,
+		Payload: nil,
+	})
+
+	if err != nil {
+		fmt.Println("send dataset info message error:", err.Error())
+		return nil, err
+	}
+
+	data, err := json.Marshal(res.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	ref := []*repo.DatasetRef{}
+	err = json.Unmarshal(data, &ref)
+	return ref, err
+}
+
 // RequestDatasetInfo get's qri profile information from a PeerInfo
 func (n *QriNode) RequestDatasetInfo(ref *repo.DatasetRef) (*dataset.Dataset, error) {
 	id, err := n.Repo.Peers().IPFSPeerID(ref.Peername)
@@ -30,7 +58,6 @@ func (n *QriNode) RequestDatasetInfo(ref *repo.DatasetRef) (*dataset.Dataset, er
 	if err != nil {
 		return nil, err
 	}
-
 	ds := &dataset.Dataset{}
 	err = json.Unmarshal(data, ds)
 

--- a/p2p/handlers.go
+++ b/p2p/handlers.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
-	"github.com/qri-io/dataset/dsfs"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
 
@@ -224,18 +222,18 @@ func (n *QriNode) handleDatasetsRequest(r *Message) *Message {
 
 	// replies := make([]*repo.DatasetRef, p.Limit)
 	// i := 0
-	for i, ref := range refs {
-		if i >= p.Limit {
-			break
-		}
-		ds, err := dsfs.LoadDataset(n.Repo.Store(), datastore.NewKey(ref.Path))
-		if err != nil {
-			n.log.Info("error loading dataset at path:", ref.Path)
-			return nil
-		}
-		refs[i].Dataset = ds
-		// i++
-	}
+	// for i, ref := range refs {
+	// 	if i >= p.Limit {
+	// 		break
+	// 	}
+	// 	ds, err := dsfs.LoadDataset(n.Repo.Store(), datastore.NewKey(ref.Path))
+	// 	if err != nil {
+	// 		n.log.Info("error loading dataset at path:", ref.Path)
+	// 		return nil
+	// 	}
+	// 	refs[i].Dataset = ds
+	// 	// i++
+	// }
 
 	// replies = replies[:i]
 	return &Message{

--- a/p2p/handlers.go
+++ b/p2p/handlers.go
@@ -361,10 +361,12 @@ func (n *QriNode) handleDatasetInfoRequest(r *Message) *Message {
 		}
 	}
 
+	ref.Dataset = ds
+
 	return &Message{
 		Phase:   MpResponse,
 		Type:    MtDatasetInfo,
-		Payload: ds,
+		Payload: ref,
 	}
 }
 

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -128,7 +128,7 @@ func (n *QriNode) ConnectedPeers() []string {
 	return peers
 }
 
-// ConnectedPeers lists all IPFS connected peers that support the
+// ConnectedQriPeers lists all IPFS connected peers that support the
 // qri protocol
 func (n *QriNode) ConnectedQriPeers() map[peer.ID]*profile.Profile {
 	conns := n.Host.Network().Conns()

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"fmt"
+	"github.com/qri-io/qri/repo/profile"
 
 	pstore "gx/ipfs/QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr/go-libp2p-peerstore"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
@@ -124,5 +125,21 @@ func (n *QriNode) ConnectedPeers() []string {
 		peers[i] = c.RemotePeer().Pretty()
 	}
 
+	return peers
+}
+
+// ConnectedPeers lists all IPFS connected peers that support the
+// qri protocol
+func (n *QriNode) ConnectedQriPeers() map[peer.ID]*profile.Profile {
+	conns := n.Host.Network().Conns()
+	peers := map[peer.ID]*profile.Profile{}
+	for _, c := range conns {
+		id := c.RemotePeer()
+		// if support, err := n.SupportsQriProtocol(id); err == nil && support {
+		if p, err := n.Repo.Peers().GetPeer(id); err == nil {
+			peers[id] = p
+		}
+		// }
+	}
 	return peers
 }

--- a/repo/dataset.go
+++ b/repo/dataset.go
@@ -118,6 +118,24 @@ func ParseDatasetRef(ref string) (*DatasetRef, error) {
 	}, nil
 }
 
+// IsLocalRef checks to see if a given reference needs to be
+// resolved against the network
+func IsLocalRef(r Repo, ref *DatasetRef) (bool, error) {
+	if ref.Peername == "" || ref.Peername == "me" {
+		return true, nil
+	}
+
+	p, err := r.Profile()
+	if err != nil {
+		return false, err
+	}
+
+	// TODO - check to see if repo has local / cached copy
+	// of the reference in question
+
+	return ref.Peername == p.Peername, nil
+}
+
 // TODO - this could be more robust?
 func stripProtocol(ref string) string {
 	if strings.HasPrefix(ref, "/ipfs/") {

--- a/repo/dataset_test.go
+++ b/repo/dataset_test.go
@@ -1,6 +1,9 @@
 package repo
 
 import (
+	"github.com/qri-io/analytics"
+	"github.com/qri-io/cafs/memfs"
+	"github.com/qri-io/qri/repo/profile"
 	"testing"
 )
 
@@ -45,6 +48,47 @@ func TestCompareDatasetRefs(t *testing.T) {
 		err := CompareDatasetRef(c.a, c.b)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mistmatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+	}
+}
+
+func TestIsLocalRef(t *testing.T) {
+	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille"}, memfs.NewMapstore(), MemPeers{}, &analytics.Memstore{})
+	if err != nil {
+		t.Errorf("error allocating mem repo: %s", err.Error())
+		return
+	}
+
+	cases := []struct {
+		input  string
+		expect bool
+		err    string
+	}{
+		{"me", true, ""},
+		{"you", false, ""},
+		{"them", false, ""},
+		{"you/foo", false, ""},
+		{"me/foo", true, ""},
+		{"lucille/foo", true, ""},
+		// TODO - add local datasets to memrepo, have them return true
+	}
+
+	for i, c := range cases {
+		ref, err := ParseDatasetRef(c.input)
+		if err != nil {
+			t.Errorf("case %d unexpected dataset ref parse error: %s", i, err.Error())
+			continue
+		}
+
+		got, err := IsLocalRef(repo, ref)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+
+		if got != c.expect {
+			t.Errorf("case %d expected: %t", i, c.expect)
 			continue
 		}
 	}

--- a/repo/dataset_test.go
+++ b/repo/dataset_test.go
@@ -1,7 +1,6 @@
 package repo
 
 import (
-	"github.com/ipfs/go-datastore"
 	"testing"
 )
 
@@ -13,11 +12,12 @@ func TestParseDatasetRef(t *testing.T) {
 	}{
 		{"", nil, "cannot parse empty string as dataset reference"},
 		{"peer_name/dataset_name", &DatasetRef{Peername: "peer_name", Name: "dataset_name"}, ""},
-		{"peer_name/dataset_name@/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{Peername: "peer_name", Name: "dataset_name", Path: datastore.NewKey("/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, ""},
-		{"peer_name/dataset_name@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{Peername: "peer_name", Name: "dataset_name", Path: datastore.NewKey("/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, ""},
+		{"peer_name/dataset_name@/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{Peername: "peer_name", Name: "dataset_name", Path: "/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y"}, ""},
+		{"peer_name/dataset_name@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{Peername: "peer_name", Name: "dataset_name", Path: "/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y"}, ""},
 		{"peer_name", &DatasetRef{Peername: "peer_name"}, ""},
+		{"tangelo_saluki/dog_names", &DatasetRef{Peername: "tangelo_saluki", Name: "dog_names"}, ""},
 		// {"/not_ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{}, ""},
-		{"QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{Path: datastore.NewKey("/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, ""},
+		{"QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", &DatasetRef{Path: "/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y"}, ""},
 	}
 
 	for i, c := range cases {

--- a/repo/fs/datasets.go
+++ b/repo/fs/datasets.go
@@ -49,9 +49,8 @@ func (r Datasets) PutDatasets(datasets []*repo.DatasetRef) error {
 		return err
 	}
 	for _, dr := range datasets {
-		ps := dr.Path.String()
-		if ps != "" && dr.Dataset != nil {
-			ds[ps] = dr.Dataset
+		if dr.Path != "" && dr.Dataset != nil {
+			ds[dr.Path] = dr.Dataset
 		}
 	}
 	return r.saveFile(ds, r.file)

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -180,11 +180,11 @@ func (r *Repo) Search(p repo.SearchParams) ([]*repo.DatasetRef, error) {
 		return refs, err
 	}
 	for _, ref := range refs {
-		if name, err := r.GetName(ref.Path); err == nil {
+		if name, err := r.GetName(datastore.NewKey(ref.Path)); err == nil {
 			ref.Name = name
 		}
 
-		if ds, err := r.GetDataset(ref.Path); err == nil {
+		if ds, err := r.GetDataset(datastore.NewKey(ref.Path)); err == nil {
 			ref.Dataset = ds
 		} else {
 			// fmt.Println(err.Error())

--- a/repo/fs/namestore.go
+++ b/repo/fs/namestore.go
@@ -46,7 +46,7 @@ func (n Namestore) PutName(name string, path datastore.Key) (err error) {
 
 	r := &repo.DatasetRef{
 		Name: name,
-		Path: path,
+		Path: path.String(),
 	}
 	names = append(names, r)
 
@@ -80,7 +80,7 @@ func (n Namestore) GetPath(name string) (datastore.Key, error) {
 	}
 	for _, ref := range names {
 		if ref.Name == name {
-			return ref.Path, nil
+			return datastore.NewKey(ref.Path), nil
 		}
 	}
 	return datastore.NewKey(""), repo.ErrNotFound
@@ -92,8 +92,9 @@ func (n Namestore) GetName(path datastore.Key) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	p := path.String()
 	for _, ref := range names {
-		if ref.Path.Equal(path) {
+		if ref.Path == p {
 			return ref.Name, nil
 		}
 	}
@@ -109,8 +110,8 @@ func (n Namestore) DeleteName(name string) error {
 
 	for i, ref := range names {
 		if ref.Name == name {
-			if ref.Path.String() != "" && n.index != nil {
-				if err := n.index.Delete(ref.Path.String()); err != nil {
+			if ref.Path != "" && n.index != nil {
+				if err := n.index.Delete(ref.Path); err != nil {
 					return err
 				}
 			}
@@ -170,7 +171,7 @@ func (n *Namestore) names() ([]*repo.DatasetRef, error) {
 		for name, path := range prevns {
 			ns[i] = &repo.DatasetRef{
 				Name: name,
-				Path: path,
+				Path: path.String(),
 			}
 			i++
 		}

--- a/repo/fs/peer_store.go
+++ b/repo/fs/peer_store.go
@@ -70,6 +70,25 @@ func (r PeerStore) GetPeer(id peer.ID) (*profile.Profile, error) {
 	return nil, datastore.ErrNotFound
 }
 
+// IPFSPeerID gives the IPFS peer.ID for a given peername
+func (r PeerStore) IPFSPeerID(peername string) (peer.ID, error) {
+	ps, err := r.peers()
+	if err != nil {
+		return "", err
+	}
+
+	for id, profile := range ps {
+		if profile.Peername == peername {
+			if ipfspid, err := profile.IPFSPeerID(); err == nil {
+				return ipfspid, nil
+			}
+			return peer.ID(id), nil
+		}
+	}
+
+	return "", datastore.ErrNotFound
+}
+
 // DeletePeer removes a peer from the store
 func (r PeerStore) DeletePeer(id peer.ID) error {
 	ps, err := r.peers()

--- a/repo/mem_datasets.go
+++ b/repo/mem_datasets.go
@@ -30,9 +30,8 @@ func (d MemDatasets) PutDataset(path datastore.Key, ds *dataset.Dataset) error {
 // PutDatasets adds multiple dataset references to the store
 func (d MemDatasets) PutDatasets(datasets []*DatasetRef) error {
 	for _, ds := range datasets {
-		ps := ds.Path.String()
-		if ps != "" {
-			d.datasets[ps] = ds.Dataset
+		if ds.Path != "" {
+			d.datasets[ds.Path] = ds.Dataset
 		}
 	}
 	return nil

--- a/repo/mem_namestore.go
+++ b/repo/mem_namestore.go
@@ -13,13 +13,13 @@ type MemNamestore []*DatasetRef
 func (r *MemNamestore) PutName(name string, path datastore.Key) error {
 	for _, ref := range *r {
 		if ref.Name == name {
-			ref.Path = path
+			ref.Path = path.String()
 			return nil
 		}
 	}
 	*r = append(*r, &DatasetRef{
 		Name: name,
-		Path: path,
+		Path: path.String(),
 	})
 	sl := *r
 	sort.Slice(sl, func(i, j int) bool { return sl[i].Name < sl[j].Name })
@@ -31,7 +31,7 @@ func (r *MemNamestore) PutName(name string, path datastore.Key) error {
 func (r MemNamestore) GetPath(name string) (datastore.Key, error) {
 	for _, ref := range r {
 		if ref.Name == name {
-			return ref.Path, nil
+			return datastore.NewKey(ref.Path), nil
 		}
 	}
 	return datastore.NewKey(""), ErrNotFound
@@ -39,8 +39,9 @@ func (r MemNamestore) GetPath(name string) (datastore.Key, error) {
 
 // GetName returns the name for a given path in the store
 func (r MemNamestore) GetName(path datastore.Key) (string, error) {
+	p := path.String()
 	for _, ref := range r {
-		if ref.Path.Equal(path) {
+		if ref.Path == p {
 			return ref.Name, nil
 		}
 	}

--- a/repo/peers.go
+++ b/repo/peers.go
@@ -14,6 +14,7 @@ import (
 type Peers interface {
 	List() (map[string]*profile.Profile, error)
 	Query(query.Query) (query.Results, error)
+	IPFSPeerID(peername string) (peer.ID, error)
 	GetID(peername string) (peer.ID, error)
 	PutPeer(id peer.ID, profile *profile.Profile) error
 	GetPeer(id peer.ID) (*profile.Profile, error)
@@ -70,6 +71,20 @@ func (m MemPeers) GetID(peername string) (peer.ID, error) {
 			return id, nil
 		}
 	}
+	return "", ErrNotFound
+}
+
+// IPFSPeerID gives the IPFS peer.ID for a given peername
+func (m MemPeers) IPFSPeerID(peername string) (peer.ID, error) {
+	for id, profile := range m {
+		if profile.Peername == peername {
+			if ipfspid, err := profile.IPFSPeerID(); err == nil {
+				return ipfspid, nil
+			}
+			return id, nil
+		}
+	}
+
 	return "", ErrNotFound
 }
 

--- a/repo/search/index.go
+++ b/repo/search/index.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"encoding/json"
+	"github.com/ipfs/go-datastore"
 	"log"
 	"time"
 
@@ -71,7 +72,7 @@ func LoadIndex(indexPath string) (Index, error) {
 	} else if err != nil {
 		return nil, err
 	} else {
-		log.Printf("Opening existing index...")
+		// log.Printf("Opening existing index...")
 	}
 
 	return repoIndex, nil
@@ -119,7 +120,7 @@ func indexDatasetRefs(store cafs.Filestore, i bleve.Index, refs []*repo.DatasetR
 	batch := i.NewBatch()
 	batchCount := 0
 	for _, ref := range refs {
-		ds, err := dsfs.LoadDataset(store, ref.Path)
+		ds, err := dsfs.LoadDataset(store, datastore.NewKey(ref.Path))
 		if err != nil {
 			log.Printf("error loading dataset: %s", err.Error())
 			continue
@@ -134,7 +135,7 @@ func indexDatasetRefs(store cafs.Filestore, i bleve.Index, refs []*repo.DatasetR
 		leanMetadata := NewIndexableMetadataStruct()
 		json.Unmarshal(data, leanMetadata)
 
-		batch.Index(ref.Path.String(), leanMetadata.MapValues())
+		batch.Index(ref.Path, leanMetadata.MapValues())
 		batchCount++
 
 		if batchCount >= batchSize {

--- a/repo/search/search.go
+++ b/repo/search/search.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/qri-io/bleve"
 	//_ "github.com/qri-io/bleve/config"
-	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/repo"
@@ -25,7 +24,7 @@ func Search(i Index, p repo.SearchParams) ([]*repo.DatasetRef, error) {
 
 	res := make([]*repo.DatasetRef, results.Hits.Len())
 	for i, hit := range results.Hits {
-		res[i] = &repo.DatasetRef{Path: datastore.NewKey(hit.ID)}
+		res[i] = &repo.DatasetRef{Path: hit.ID}
 	}
 
 	// fmt.Println(searchResults)

--- a/repo/test/test_namespace.go
+++ b/repo/test/test_namespace.go
@@ -82,8 +82,8 @@ func testNamespace(r repo.Repo) error {
 		if err != nil {
 			return fmt.Errorf("error putting test file in datastore: %s", err.Error())
 		}
-		ref.Path = path
-		if err := r.PutName(ref.Name, ref.Path); err != nil {
+		ref.Path = path.String()
+		if err := r.PutName(ref.Name, path); err != nil {
 			return fmt.Errorf("error putting name in repo for namespace test: %s", err.Error())
 		}
 	}
@@ -123,7 +123,7 @@ func testNamespace(r repo.Repo) error {
 	}
 
 	for _, ref := range refs {
-		if err := r.Store().Delete(ref.Path); err != nil {
+		if err := r.Store().Delete(datastore.NewKey(ref.Path)); err != nil {
 			return fmt.Errorf("error removing path from repo store: %s", err.Error())
 		}
 		if err := r.DeleteName(ref.Name); err != nil {


### PR DESCRIPTION
As an initial pass, these things will support dialing into the p2p package to do some cursory distributed stuff. This is going to be super brittle, often requiring the other peer to be fully online before stuff will work properly, but hey, gotta start somewhere.

### App Commands
* ~[ ] `qri info peername`~ _gotta restore this in a future PR_
* [x] `qri  info peername/datasetname`

### Dataset Commands
* [x] `qri list peername`
* ~[ ] `qri add peername/datasetname` - add remote dataset~ _will tackle later_

### Network commands
* [x] `connections` - list of peers you are connected to
