### PR TITLE
refactor(api): fix add bugs and remove unneeded peer functions

### DIFF
--- a/api/handlers/peers.go
+++ b/api/handlers/peers.go
@@ -37,30 +37,6 @@ func (h *PeerHandlers) PeersHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// PeerHandler is the endpoint for fetching a peer
-func (h *PeerHandlers) PeerHandler(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case "OPTIONS":
-		util.EmptyOkHandler(w, r)
-	case "GET":
-		h.getPeerHandler(w, r)
-	default:
-		util.NotFoundHandler(w, r)
-	}
-}
-
-// PeerNamespaceHandler is the endpoint for fetching a peer's datasets
-func (h *PeerHandlers) PeerNamespaceHandler(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case "OPTIONS":
-		util.EmptyOkHandler(w, r)
-	case "GET":
-		h.peerNamespaceHandler(w, r)
-	default:
-		util.NotFoundHandler(w, r)
-	}
-}
-
 // TODO: add back connect endpoint
 // ConnectToPeerHandler is the endpoint for explicitly connecting to a peer
 // func (h *PeerHandlers) ConnectToPeerHandler(w http.ResponseWriter, r *http.Request) {
@@ -131,34 +107,3 @@ func (h *PeerHandlers) listConnectionsHandler(w http.ResponseWriter, r *http.Req
 
 // 	util.WriteResponse(w, res)
 // }
-
-func (h *PeerHandlers) getPeerHandler(w http.ResponseWriter, r *http.Request) {
-	res := &profile.Profile{}
-	args := &core.PeerInfoParams{
-		PeerID:   r.URL.Path[len("/peers/"):],
-		Peername: r.FormValue("peername"),
-	}
-	err := h.Info(args, res)
-	if err != nil {
-		h.log.Infof("error getting peer profile: %s", err.Error())
-		util.WriteErrResponse(w, http.StatusInternalServerError, err)
-		return
-	}
-	util.WriteResponse(w, res)
-}
-
-func (h *PeerHandlers) peerNamespaceHandler(w http.ResponseWriter, r *http.Request) {
-	listParams := core.ListParamsFromRequest(r)
-	args := &core.NamespaceParams{
-		PeerID: r.URL.Path[len("/peernamespace/"):],
-		Limit:  listParams.Limit,
-		Offset: listParams.Offset,
-	}
-	res := []*repo.DatasetRef{}
-	if err := h.GetNamespace(args, &res); err != nil {
-		h.log.Infof("error getting peer namespace: %s", err.Error())
-		util.WriteErrResponse(w, http.StatusInternalServerError, err)
-		return
-	}
-	util.WriteResponse(w, res)
-}

--- a/api/server.go
+++ b/api/server.go
@@ -147,11 +147,9 @@ func NewServerRoutes(s *Server) *http.ServeMux {
 
 	ph := handlers.NewPeerHandlers(s.log, s.qriNode.Repo, s.qriNode)
 	m.Handle("/peers", s.middleware(ph.PeersHandler))
-	m.Handle("/peers/", s.middleware(ph.PeerHandler))
 	// TODO: add back connect endpoint
 	// m.Handle("/connect/", s.middleware(ph.ConnectToPeerHandler))
 	m.Handle("/connections", s.middleware(ph.ConnectionsHandler))
-	m.Handle("/peernamespace/", s.middleware(ph.PeerNamespaceHandler))
 
 	dsh := handlers.NewDatasetHandlers(s.log, s.qriNode.Repo)
 	// TODO - stupid hack for now.
@@ -161,7 +159,7 @@ func NewServerRoutes(s *Server) *http.ServeMux {
 	m.Handle("/save/", s.middleware(dsh.SaveHandler))
 	m.Handle("/remove/", s.middleware(dsh.RemoveHandler))
 	m.Handle("/me/", s.middleware(dsh.GetHandler))
-	m.Handle("/add/", s.middleware(dsh.AddHandler))
+	m.Handle("/add", s.middleware(dsh.AddHandler))
 	m.Handle("/rename", s.middleware(dsh.RenameHandler))
 	m.Handle("/export/", s.middleware(dsh.ZipDatasetHandler))
 

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -24,9 +24,9 @@ func TestServerRoutes(t *testing.T) {
 	}{
 		// {"GET", "/", nil, 200},
 		{"GET", "/status", nil, 200},
-		{"OPTIONS", "/add/", nil, 200},
-		{"POST", "/add/", nil, 400},
-		{"PUT", "/add/", nil, 400},
+		{"OPTIONS", "/add", nil, 200},
+		{"POST", "/add", nil, 400},
+		{"PUT", "/add", nil, 400},
 		// TODO: more tests for /add/ endpoint:
 		// {"POST", "/add/", {data to add dataset}, {response body}, 200}
 		// {"POST", "/add/", {badly formed body}, {response body}, 400}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -45,7 +45,7 @@ changes to qri.`,
 		ingest := (addDsFilepath != "" || addDsMetaFilepath != "" || addDsStructureFilepath != "" || addDsURL != "")
 
 		if len(args) == 0 {
-			ErrExit(fmt.Errorf("speficy the location of a dataset to add"))
+			ErrExit(fmt.Errorf("specify the location of a dataset to add"))
 		} else if ingest && len(args) != 1 {
 			ErrExit(fmt.Errorf("adding datasets with --structure, --meta, or --data requires exactly 1 argument for the new dataset name"))
 		}


### PR DESCRIPTION
Cleaning up api functions:
- needed to open file with DataFilename path and add to initParams{} in order to get Init() to work
- remove peer and peernamespace functions that were refactored into /[peername] and /list/[peername]