### PR TITLE
fix(build): always fetch dependencies from the network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: require-gopath
 	@echo ""
 	@echo "1/5 install non-gx deps:"
 	@echo ""
-	go get -v github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/viper github.com/qri-io/varName github.com/qri-io/datasetDiffer github.com/datatogether/cdxj
+	go get -v -u github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/viper github.com/qri-io/varName github.com/qri-io/datasetDiffer github.com/datatogether/cdxj
 	@echo ""
 	@echo "2/5 install gx:"
 	@echo ""


### PR DESCRIPTION
peers with outdated packages have run into issues building qri, adding the -u flag to step one of 'make build' should address this.

related: #217