### PR TITLE
Fix capitalization inconsistency

### DIFF
--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -11,7 +11,7 @@ import (
 // connectionsCmd lists
 var connectionsCmd = &cobra.Command{
 	Use:   "connections",
-	Short: `List open connections with qri & IPFS peers`,
+	Short: `list open connections with qri & IPFS peers`,
 	Example: `  show open qri connections:
   $ qri connections
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -15,7 +15,7 @@ import (
 var infoCmd = &cobra.Command{
 	Use:     "info",
 	Aliases: []string{"get", "describe"},
-	Short:   "Show summarized description of a dataset",
+	Short:   "show summarized description of a dataset",
 	Long:    `info describes users and datasets`,
 	Example: `  show b5 user info
 	get info for b5/comics:

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -13,7 +13,7 @@ import (
 // peersCmd represents the info command
 var peersCmd = &cobra.Command{
 	Use:   "peers",
-	Short: "List known qri peers",
+	Short: "list known qri peers",
 	Long:  `peers lists the peers your qri node has seen before`,
 	Example: `  list qri peers:
   $ qri peers`,

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -17,7 +17,7 @@ var (
 // searchCmd represents the search command
 var searchCmd = &cobra.Command{
 	Use:   "search",
-	Short: "Search for datasets",
+	Short: "search for datasets",
 	Long:  `Search looks through all of your namespaces for terms that match your query`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 && !searchCmdReindex {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -28,7 +28,7 @@ var (
 // setupCmd represents the setup command
 var setupCmd = &cobra.Command{
 	Use:   "setup",
-	Short: "Initialize qri and IPFS repositories, provision a new qri ID",
+	Short: "initialize qri and IPFS repositories, provision a new qri ID",
 	Long: `
 Setup is the first command you run to get a fresh install of qri. If you’ve 
 never run qri before, you’ll need to run setup before you can do anything. 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ const VersionNumber = "0.1.0-rc1"
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version number",
+	Short: "print the version number",
 	Long: `qri uses semantic versioning.
 	For updates & further information check https://github.com/qri-io/qri/releases`,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
At https://www.youtube.com/watch?v=1vmwTrN1Pl4&t=5m48s I noticed that the descriptions of the commands are inconsistently capitalized. This fixes the ones I could find in the repo. "Help" seems to be baked in, so will need to be fixed differently.