### PR TITLE
feat(webapp): fetch webapp hash via dnslink 

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -27,8 +27,9 @@ func DefaultConfig() *Config {
 		WebappPort:     DefaultWebappPort,
 		AllowedOrigins: []string{"http://localhost:2505"},
 		Online:         true,
-		WebappScripts: []string{
-			"http://localhost:2503/ipfs/QmPvTLU9G6aiGLTACwH3e5QhizFjJd5SKrYT15Xaa1D4wY",
+		WebappScripts:  []string{
+			// this is fetched via dnslink when the webapp server starts
+			// TODO - should have a sensible fallback for when dnslink lookup fails
 		},
 	}
 }

--- a/api/config.go
+++ b/api/config.go
@@ -27,9 +27,11 @@ func DefaultConfig() *Config {
 		WebappPort:     DefaultWebappPort,
 		AllowedOrigins: []string{"http://localhost:2505"},
 		Online:         true,
-		WebappScripts:  []string{
-			// this is fetched via dnslink when the webapp server starts
-			// TODO - should have a sensible fallback for when dnslink lookup fails
+		WebappScripts: []string{
+			// this is fetched and replaced via dnslink when the webapp server starts
+			// the value provided here is just a sensible fallback for when dnslink lookup fails,
+			// pointing to a known prior version of the the webapp
+			"http://localhost:2503/ipfs/QmZryqs5RwMwTHuD3AeBWStDfYJWGFbziEwot2aSYoeJFd",
 		},
 	}
 }

--- a/api/server.go
+++ b/api/server.go
@@ -98,6 +98,8 @@ func (s *Server) Serve() (err error) {
 		go func() {
 			if err := core.CheckVersion(context.Background(), node.Namesys); err == core.ErrUpdateRequired {
 				s.log.Info("This version of qri is out of date, please refer to https://github.com/qri-io/qri/releases/latest for more info")
+			} else if err != nil {
+				s.log.Infof("error checking for software update: %s", err.Error())
 			}
 		}()
 	}
@@ -165,7 +167,7 @@ func (s *Server) resolveWebappPath() {
 		s.log.Infof("error resolving IPNS Name: %s", err.Error())
 		return
 	}
-	s.log.Infof("webapp path: %s", p.String())
+	s.log.Debugf("webapp path: %s", p.String())
 	s.cfg.WebappScripts = []string{
 		fmt.Sprintf("http://localhost:2503%s", p.String()),
 	}

--- a/core/self_update.go
+++ b/core/self_update.go
@@ -14,19 +14,19 @@ import (
 * an update.
 *
 * In the future we'll do this automatically, but for now we can at least warn users that they need
-* to update their version
+* to update their version when one falls out of date
  */
 
-// previousVersion is a hard-coded reference the gx "lastpubver" file of the previous release
-const previousVersion = "/ipfs/QmcXZCLAgUdvXpt1fszjNGVGn6WnhsrJahkQXY3JJqxUWJ"
+var (
+	// lastPubVerHash is a hard-coded reference the gx "lastpubver" file of the previous release
+	lastPubVerHash = "/ipfs/QmcXZCLAgUdvXpt1fszjNGVGn6WnhsrJahkQXY3JJqxUWJ"
+	// prevIPNSName is the dnslink address to check for version agreement
+	prevIPNSName = "/ipns/cli.previous.qri.io"
+	// ErrUpdateRequired means this version of qri is out of date
+	ErrUpdateRequired = fmt.Errorf("update required")
+)
 
-// prevIPNSName is the dnslink address to check for version agreement
-const prevIPNSName = "/ipns/cli.previous.qri.io"
-
-// ErrUpdateRequired means this version of qri is out of date
-var ErrUpdateRequired = fmt.Errorf("update required")
-
-// CheckVersion uses a name resolver to lookup prevIPNSName, checking if the hard-coded previousVersion
+// CheckVersion uses a name resolver to lookup prevIPNSName, checking if the hard-coded lastPubVerHash
 // and the returned lookup match. If they don't, CheckVersion returns ErrUpdateRequired
 func CheckVersion(ctx context.Context, res namesys.Resolver) error {
 	p, err := res.Resolve(ctx, prevIPNSName)
@@ -34,7 +34,7 @@ func CheckVersion(ctx context.Context, res namesys.Resolver) error {
 		return fmt.Errorf("error resolving name: %s", err.Error())
 	}
 
-	if p.String() != previousVersion {
+	if p.String() != lastPubVerHash {
 		return ErrUpdateRequired
 	}
 	return nil

--- a/core/self_update.go
+++ b/core/self_update.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	namesys "gx/ipfs/QmViBzgruNUoLNBnXcx8YWbDNwV8MNGEGKkLo6JGetygdw/go-ipfs/namesys"
+)
+
+/*
+* self-updating checks IPNS entry that represents the desired hash of the previous version of
+* this program, which is the result of adding the complied binary of this program to IPFS.
+* If the returned value of a lookup differs, we have a version mismatch, and need to perform
+* an update.
+*
+* In the future we'll do this automatically, but for now we can at least warn users that they need
+* to update their version
+ */
+
+// previousVersion is a hard-coded reference the gx "lastpubver" file of the previous release
+const previousVersion = "/ipfs/QmcXZCLAgUdvXpt1fszjNGVGn6WnhsrJahkQXY3JJqxUWJ"
+
+// prevIPNSName is the dnslink address to check for version agreement
+const prevIPNSName = "/ipns/cli.previous.qri.io"
+
+// ErrUpdateRequired means this version of qri is out of date
+var ErrUpdateRequired = fmt.Errorf("update required")
+
+// CheckVersion uses a name resolver to lookup prevIPNSName, checking if the hard-coded previousVersion
+// and the returned lookup match. If they don't, CheckVersion returns ErrUpdateRequired
+func CheckVersion(ctx context.Context, res namesys.Resolver) error {
+	p, err := res.Resolve(ctx, prevIPNSName)
+	if err != nil {
+		return fmt.Errorf("error resolving name: %s", err.Error())
+	}
+
+	if p.String() != previousVersion {
+		return ErrUpdateRequired
+	}
+	return nil
+}

--- a/core/self_update_test.go
+++ b/core/self_update_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	namesys "gx/ipfs/QmViBzgruNUoLNBnXcx8YWbDNwV8MNGEGKkLo6JGetygdw/go-ipfs/namesys"
+)
+
+func TestCheckVersion(t *testing.T) {
+	name := prevIPNSName
+	ver := lastPubVerHash
+	defer func() {
+		prevIPNSName = name
+		lastPubVerHash = ver
+	}()
+
+	res := namesys.NewDNSResolver()
+
+	prevIPNSName = "foo"
+	expect := "error resolving name: not a valid domain name"
+	if err := CheckVersion(context.Background(), res); err != nil && err.Error() != expect {
+		t.Errorf("error mismatch. epxected: '%s', got: '%s'", expect, err.Error())
+		return
+	}
+
+	// TODO - not workin'
+	// if err := CheckVersion(context.Background(), res); err != nil {
+	// 	t.Errorf("error checking valid version: %s", err.Error())
+	// 	return
+	// }
+
+	// lastPubVerHash = "/def/not/good"
+	// if err := CheckVersion(context.Background(), res); err != nil && err != ErrUpdateRequired {
+	// 	t.Errorf("expected ErrUpdateRequired, got: %s", err.Error())
+	// } else if err == nil {
+	// 	t.Errorf("expected error, got nil")
+	// }
+}


### PR DESCRIPTION
So, we want to be able to modify & update the webapp independent of qri, to do that, I've created a new dnslink entry "webapp.qri.io" that can be resolved with `ipns name resolve webapp.qri.io`. For kicks I've also added ipns name resolving to the api server (this should be removed when we refactor
to just using regular IPFS API bindings).