### PR TITLE
chore(codeclimate): add initial codeclimate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,37 @@
+ratings:
+  paths: 
+  - "**/*.go"
+
+engines:
+  fixme:
+    enabled: true
+    config:
+      strings:
+      - TODO
+  golint:
+    enabled: true
+  govet:
+    enabled: true
+  gofmt:
+    enabled: true
+
+version: "2"
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  return-statements:
+    enabled: false
+  similar-code:
+    enabled: false


### PR DESCRIPTION
ripped directly from ipfs/go-ipfs without any reading or consideration whatsoever. Sounds responsible, right?