### PR TITLE
chore(config): add second hardcoded bootstrap peer, remove bad ds, fix tests

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -67,31 +67,29 @@ func TestServerRoutes(t *testing.T) {
 
 		// get dataset
 		{"GET", "/me/family_relationships", "", "getResponseFamilyRelationships.json", 200},
-		{"GET", "/me/family_relationships/at/map/QmY5Rm6HjXd2buGVbA5LLj7EPuMcbTiXoh9KRBRGEHxwvA", "", "getResponseFamilyRelationships.json", 200},
-		{"GET", "/at/map/QmY5Rm6HjXd2buGVbA5LLj7EPuMcbTiXoh9KRBRGEHxwvA", "", "getResponseFamilyRelationships.json", 200},
+		{"GET", "/me/family_relationships/at/map/QmdbJGpmZKsbKpBGQbWS7PjodGtrXX3hAHvxdgUsuf9a3N", "", "getResponseFamilyRelationships.json", 200},
+		{"GET", "/at/map/QmdbJGpmZKsbKpBGQbWS7PjodGtrXX3hAHvxdgUsuf9a3N", "", "getResponseFamilyRelationships.json", 200},
 
 		{"POST", "/rename", "renameRequest.json", "renameResponse.json", 200},
-
-		// {"GET", "/export/me/cities", "", "", 200},
 
 		{"POST", "/save/me/cities", "saveMetaRequest.json", "saveMetaResponse.json", 200},
 
 		// history
 		{"GET", "/history/me/cities", "", "historyResponse.json", 200},
-		{"GET", "/history/me/cities/at/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV", "", "historyResponsePath.json", 200},
-		{"GET", "/history/at/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV", "", "historyResponseAt.json", 200},
+		{"GET", "/history/me/cities/at/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC", "", "historyResponsePath.json", 200},
+		{"GET", "/history/at/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC", "", "historyResponseAt.json", 200},
 
-		/*14*/ {"GET", "/export/me/cities", "", "", 200},
-		{"GET", "/export/me/cities/at/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV", "", "", 200},
-		{"GET", "/export/at/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV", "", "", 200},
+		{"GET", "/export/me/cities", "", "", 200},
+		{"GET", "/export/me/cities/at/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC", "", "", 200},
+		{"GET", "/export/at/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC", "", "", 200},
 
 		// diff
 		{"GET", "/diff", "diffRequest.json", "diffResponse.json", 200},
 		{"GET", "/diff", "diffRequestPlusMinusColor.json", "diffResponsePlusMinusColor.json", 200},
 
 		// remove
-		{"POST", "/remove/me/cities/at/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV", "", "removeResponseWithPath.json", 200},
-		{"POST", "/remove/at/map/QmY5Rm6HjXd2buGVbA5LLj7EPuMcbTiXoh9KRBRGEHxwvA", "", "removeResponseByPath.json", 200},
+		{"POST", "/remove/me/cities/at/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC", "", "removeResponseWithPath.json", 200},
+		{"POST", "/remove/at/map/QmdbJGpmZKsbKpBGQbWS7PjodGtrXX3hAHvxdgUsuf9a3N", "", "removeResponseByPath.json", 200},
 
 		{"GET", "/connect/", "", "", 400},
 
@@ -142,6 +140,11 @@ func TestServerRoutes(t *testing.T) {
 			continue
 		}
 
+		if res.StatusCode != c.resStatus {
+			t.Errorf("case %d: %s - %s status code mismatch. expected: %d, got: %d", i, c.method, c.endpoint, c.resStatus, res.StatusCode)
+			continue
+		}
+
 		if c.resBodyPath == "" {
 			resBody = nil
 		} else {
@@ -175,11 +178,6 @@ func TestServerRoutes(t *testing.T) {
 				t.Logf("error written to: %s", path)
 				continue
 			}
-		}
-
-		if res.StatusCode != c.resStatus {
-			t.Errorf("case %d: %s - %s status code mismatch. expected: %d, got: %d", i, c.method, c.endpoint, c.resStatus, res.StatusCode)
-			continue
 		}
 	}
 }

--- a/api/testdata/addResponseFromURL.json
+++ b/api/testdata/addResponseFromURL.json
@@ -1,16 +1,5 @@
 {
   "data": {
-    "abstract": {
-      "qri": "ds:0",
-      "structure": {
-        "errCount": 0,
-        "format": "csv",
-        "formatConfig": {
-          "headerRow": true
-        },
-        "qri": "st:0"
-      }
-    },
     "commit": {
       "qri": "cm:0",
       "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",

--- a/api/testdata/diffRequest.json
+++ b/api/testdata/diffRequest.json
@@ -1,1 +1,1 @@
-{"left":"me/cities@/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA", "right":"me/cities@/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV"}
+{"left":"me/cities@/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM", "right":"me/cities@/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC"}

--- a/api/testdata/diffRequestPlusMinusColor.json
+++ b/api/testdata/diffRequestPlusMinusColor.json
@@ -1,1 +1,1 @@
-{"left":"me/cities@/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA", "right":"me/cities@/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV","format":"plusMinusColor"}
+{"left":"me/cities@/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM", "right":"me/cities@/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC","format":"plusMinusColor"}

--- a/api/testdata/getResponseFamilyRelationships.json
+++ b/api/testdata/getResponseFamilyRelationships.json
@@ -3,9 +3,8 @@
     "peername": "peer",
     "name": "family_relationships",
     "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-    "path": "/map/QmY5Rm6HjXd2buGVbA5LLj7EPuMcbTiXoh9KRBRGEHxwvA",
+    "path": "/map/QmdbJGpmZKsbKpBGQbWS7PjodGtrXX3hAHvxdgUsuf9a3N",
     "dataset": {
-      "abstract": "/map/Qmb3n8FvgDbLoU9d7e3vo1UAyVkwV1RnqXUqPKC3Rj2Ej7",
       "commit": {
         "qri": "cm:0",
         "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",

--- a/api/testdata/historyResponse.json
+++ b/api/testdata/historyResponse.json
@@ -4,19 +4,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV",
+      "path": "/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "message": "\t- modified title\n",
           "qri": "cm:0",
@@ -38,7 +27,7 @@
           "qri": "md:0",
           "title": "Updated Title"
         },
-        "previousPath": "/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA",
+        "previousPath": "/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -81,19 +70,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA",
+      "path": "/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "message": "added title and keywords",
           "qri": "cm:0",
@@ -115,7 +93,7 @@
           "qri": "md:0",
           "title": "test title"
         },
-        "previousPath": "/map/QmbvCThNst2f2JqG9VLorbqaDpH2fXo6AawFHAoZgqd1iX",
+        "previousPath": "/map/Qme1fYAJWVfcdJtqsiTcLNWFF8b4Dq7jy7knjUYUTuVmZS",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -158,19 +136,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmbvCThNst2f2JqG9VLorbqaDpH2fXo6AawFHAoZgqd1iX",
+      "path": "/map/Qme1fYAJWVfcdJtqsiTcLNWFF8b4Dq7jy7knjUYUTuVmZS",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "message": "want to expand this list to include more cities",
           "qri": "cm:0",
@@ -188,7 +155,7 @@
           },
           "qri": "md:0"
         },
-        "previousPath": "/map/QmdDXJjs6rBQGFUCgT3aGTv3ScXSKR5RrupmfLLch8uXPj",
+        "previousPath": "/map/QmaR2c8PFeUWPpbE6rxpD3WbhtSTuACbFBa7JMSZLAHRFX",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -231,19 +198,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmdDXJjs6rBQGFUCgT3aGTv3ScXSKR5RrupmfLLch8uXPj",
+      "path": "/map/QmaR2c8PFeUWPpbE6rxpD3WbhtSTuACbFBa7JMSZLAHRFX",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "qri": "cm:0",
           "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",

--- a/api/testdata/historyResponseAt.json
+++ b/api/testdata/historyResponseAt.json
@@ -4,19 +4,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV",
+      "path": "/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "message": "\t- modified title\n",
           "qri": "cm:0",
@@ -38,7 +27,7 @@
           "qri": "md:0",
           "title": "Updated Title"
         },
-        "previousPath": "/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA",
+        "previousPath": "/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -81,19 +70,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA",
+      "path": "/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "message": "added title and keywords",
           "qri": "cm:0",
@@ -115,7 +93,7 @@
           "qri": "md:0",
           "title": "test title"
         },
-        "previousPath": "/map/QmbvCThNst2f2JqG9VLorbqaDpH2fXo6AawFHAoZgqd1iX",
+        "previousPath": "/map/Qme1fYAJWVfcdJtqsiTcLNWFF8b4Dq7jy7knjUYUTuVmZS",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -158,19 +136,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmbvCThNst2f2JqG9VLorbqaDpH2fXo6AawFHAoZgqd1iX",
+      "path": "/map/Qme1fYAJWVfcdJtqsiTcLNWFF8b4Dq7jy7knjUYUTuVmZS",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "message": "want to expand this list to include more cities",
           "qri": "cm:0",
@@ -188,7 +155,7 @@
           },
           "qri": "md:0"
         },
-        "previousPath": "/map/QmdDXJjs6rBQGFUCgT3aGTv3ScXSKR5RrupmfLLch8uXPj",
+        "previousPath": "/map/QmaR2c8PFeUWPpbE6rxpD3WbhtSTuACbFBa7JMSZLAHRFX",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -231,19 +198,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmdDXJjs6rBQGFUCgT3aGTv3ScXSKR5RrupmfLLch8uXPj",
+      "path": "/map/QmaR2c8PFeUWPpbE6rxpD3WbhtSTuACbFBa7JMSZLAHRFX",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "qri": "cm:0",
           "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",
@@ -302,6 +258,6 @@
     "code": 200
   },
   "pagination": {
-    "nextUrl": "/history/at/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV"
+    "nextUrl": "/history/at/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC"
   }
 }

--- a/api/testdata/historyResponsePath.json
+++ b/api/testdata/historyResponsePath.json
@@ -4,19 +4,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV",
+      "path": "/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "message": "\t- modified title\n",
           "qri": "cm:0",
@@ -38,7 +27,7 @@
           "qri": "md:0",
           "title": "Updated Title"
         },
-        "previousPath": "/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA",
+        "previousPath": "/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -81,19 +70,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA",
+      "path": "/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "message": "added title and keywords",
           "qri": "cm:0",
@@ -115,7 +93,7 @@
           "qri": "md:0",
           "title": "test title"
         },
-        "previousPath": "/map/QmbvCThNst2f2JqG9VLorbqaDpH2fXo6AawFHAoZgqd1iX",
+        "previousPath": "/map/Qme1fYAJWVfcdJtqsiTcLNWFF8b4Dq7jy7knjUYUTuVmZS",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -158,19 +136,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmbvCThNst2f2JqG9VLorbqaDpH2fXo6AawFHAoZgqd1iX",
+      "path": "/map/Qme1fYAJWVfcdJtqsiTcLNWFF8b4Dq7jy7knjUYUTuVmZS",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "message": "want to expand this list to include more cities",
           "qri": "cm:0",
@@ -188,7 +155,7 @@
           },
           "qri": "md:0"
         },
-        "previousPath": "/map/QmdDXJjs6rBQGFUCgT3aGTv3ScXSKR5RrupmfLLch8uXPj",
+        "previousPath": "/map/QmaR2c8PFeUWPpbE6rxpD3WbhtSTuACbFBa7JMSZLAHRFX",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -231,19 +198,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmdDXJjs6rBQGFUCgT3aGTv3ScXSKR5RrupmfLLch8uXPj",
+      "path": "/map/QmaR2c8PFeUWPpbE6rxpD3WbhtSTuACbFBa7JMSZLAHRFX",
       "dataset": {
-        "abstract": {
-          "qri": "ds:0",
-          "structure": {
-            "errCount": 0,
-            "format": "csv",
-            "formatConfig": {
-              "headerRow": true
-            },
-            "qri": "st:0"
-          }
-        },
         "commit": {
           "qri": "cm:0",
           "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",
@@ -302,6 +258,6 @@
     "code": 200
   },
   "pagination": {
-    "nextUrl": "/history/me/cities/at/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV"
+    "nextUrl": "/history/me/cities/at/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC"
   }
 }

--- a/api/testdata/listResponse.json
+++ b/api/testdata/listResponse.json
@@ -4,9 +4,8 @@
       "peername": "peer",
       "name": "cities",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA",
+      "path": "/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM",
       "dataset": {
-        "abstract": "/map/Qmb3n8FvgDbLoU9d7e3vo1UAyVkwV1RnqXUqPKC3Rj2Ej7",
         "commit": {
           "message": "added title and keywords",
           "qri": "cm:0",
@@ -28,7 +27,7 @@
           "qri": "md:0",
           "title": "test title"
         },
-        "previousPath": "/map/QmbvCThNst2f2JqG9VLorbqaDpH2fXo6AawFHAoZgqd1iX",
+        "previousPath": "/map/Qme1fYAJWVfcdJtqsiTcLNWFF8b4Dq7jy7knjUYUTuVmZS",
         "qri": "ds:0",
         "structure": {
           "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",
@@ -71,9 +70,8 @@
       "peername": "peer",
       "name": "counter",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmctxMHe5oLVNCrUhybMFyDkAx43rHzCgDYtw6DNqSg3j8",
+      "path": "/map/Qmdg3KMzTT7UwxBZu8BGqBdF4YXM17rN51hn3hbQkJWT9v",
       "dataset": {
-        "abstract": "/map/Qmb3n8FvgDbLoU9d7e3vo1UAyVkwV1RnqXUqPKC3Rj2Ej7",
         "commit": {
           "qri": "cm:0",
           "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",
@@ -115,9 +113,8 @@
       "peername": "peer",
       "name": "craigslist",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmU5Tx7ZA3WUB4Yd3nMnUgAjCb1NVp323uLYi9q5AQYFg8",
+      "path": "/map/QmdV6TqbjvwDqZrqPDyXeMYujEZaiaG18YjXVRhD66VFfZ",
       "dataset": {
-        "abstract": "/map/QmW4cDbQYgie835Ro5uGfAeRU4PWPGcbuS5yn5uFRP4ddZ",
         "commit": {
           "qri": "cm:0",
           "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",
@@ -24027,9 +24024,8 @@
       "peername": "peer",
       "name": "movies",
       "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-      "path": "/map/QmayR8kf12wtGP4VTQr7fyKiCSZunjGLgriXxuPfUZf9h5",
+      "path": "/map/QmV8H7KjK3u3tVfJEeUqTR42Tbia7oQo1hMfeZjmkBQZQn",
       "dataset": {
-        "abstract": "/map/Qmb3n8FvgDbLoU9d7e3vo1UAyVkwV1RnqXUqPKC3Rj2Ej7",
         "commit": {
           "qri": "cm:0",
           "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",

--- a/api/testdata/removeResponseByPath.json
+++ b/api/testdata/removeResponseByPath.json
@@ -3,9 +3,8 @@
     "peername": "peer",
     "name": "family_relationships",
     "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-    "path": "/map/QmY5Rm6HjXd2buGVbA5LLj7EPuMcbTiXoh9KRBRGEHxwvA",
+    "path": "/map/QmdbJGpmZKsbKpBGQbWS7PjodGtrXX3hAHvxdgUsuf9a3N",
     "dataset": {
-      "abstract": "/map/Qmb3n8FvgDbLoU9d7e3vo1UAyVkwV1RnqXUqPKC3Rj2Ej7",
       "commit": {
         "qri": "cm:0",
         "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",

--- a/api/testdata/removeResponseWithPath.json
+++ b/api/testdata/removeResponseWithPath.json
@@ -3,9 +3,8 @@
     "peername": "peer",
     "name": "cities",
     "peerID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-    "path": "/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV",
+    "path": "/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC",
     "dataset": {
-      "abstract": "/map/Qmb3n8FvgDbLoU9d7e3vo1UAyVkwV1RnqXUqPKC3Rj2Ej7",
       "commit": {
         "message": "\t- modified title\n",
         "qri": "cm:0",
@@ -27,7 +26,7 @@
         "qri": "md:0",
         "title": "Updated Title"
       },
-      "previousPath": "/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA",
+      "previousPath": "/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM",
       "qri": "ds:0",
       "structure": {
         "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",

--- a/api/testdata/renameResponse.json
+++ b/api/testdata/renameResponse.json
@@ -2,9 +2,8 @@
   "data": {
     "peername": "peer",
     "name": "movies_new",
-    "path": "/map/QmayR8kf12wtGP4VTQr7fyKiCSZunjGLgriXxuPfUZf9h5",
+    "path": "/map/QmV8H7KjK3u3tVfJEeUqTR42Tbia7oQo1hMfeZjmkBQZQn",
     "dataset": {
-      "abstract": "/map/Qmb3n8FvgDbLoU9d7e3vo1UAyVkwV1RnqXUqPKC3Rj2Ej7",
       "commit": {
         "qri": "cm:0",
         "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",

--- a/api/testdata/saveMetaResponse.json
+++ b/api/testdata/saveMetaResponse.json
@@ -2,19 +2,8 @@
   "data": {
     "peername": "me",
     "name": "cities",
-    "path": "/map/QmUC8bnchH1TjWTxzvPzLkksdH7cX4EpvNkXmeK1GSqStV",
+    "path": "/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC",
     "dataset": {
-      "abstract": {
-        "qri": "ds:0",
-        "structure": {
-          "errCount": 0,
-          "format": "csv",
-          "formatConfig": {
-            "headerRow": true
-          },
-          "qri": "st:0"
-        }
-      },
       "commit": {
         "message": "\t- modified title\n",
         "qri": "cm:0",
@@ -36,7 +25,7 @@
         "qri": "md:0",
         "title": "Updated Title"
       },
-      "previousPath": "/map/QmYeLPcKPZEyvQzhVgCDcJ8kWjAipwbuw5bB4kFAkrCnmA",
+      "previousPath": "/map/QmdvEDH2hNqasqWtWwJn6Jwdvi56jGoxT5u5DsSHbtSPYM",
       "qri": "ds:0",
       "structure": {
         "checksum": "QmY3dTEQLQFe3VTMi646N5NK2TRijPtCS2fi85z72owHPD",

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -270,7 +270,7 @@ func defaultCfgBytes() []byte {
 		// these hashes should always/highly available
 		DefaultDatasets: []string{
 			// fivethirtyeight comic characters
-			"me/comic_characters@/ipfs/QmcqkHFA2LujZxY38dYZKmxsUstN4unk95azBjwEhwrnM6/dataset.json",
+			// "me/comic_characters@/ipfs/QmcqkHFA2LujZxY38dYZKmxsUstN4unk95azBjwEhwrnM6/dataset.json",
 		},
 	}
 

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -21,6 +21,7 @@ import (
 // use these for first-round bootstrapping.
 var DefaultBootstrapAddresses = []string{
 	"/ip4/130.211.198.23/tcp/4001/ipfs/QmNX9nSos8sRFvqGTwdEme6LQ8R1eJ8EuFgW32F9jjp2Pb", // mojo
+	"/ip4/35.193.162.149/tcp/4001/ipfs/QmTZxETL4YCCzB1yFx4GT1te68henVHD1XPQMkHZ1N22mm", // epa
 }
 
 // Bootstrap samples a subset of peers & requests their peers list


### PR DESCRIPTION
Annnnnd that's the last thing we need for 0.2.

Let's ignore codecov for now, instead focus on maintaining coverage this week, and increasing it next.

closes #261 