### PR TITLE
refactor(fsrepo): remove profile.json storage, fix peerstore invalid marshaling.

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -51,27 +51,8 @@ func New(r repo.Repo, options ...func(*config.Config)) (s *Server, err error) {
 	s.qriNode, err = p2p.NewQriNode(r, func(c *config.P2P) {
 		*c = *cfg.P2P
 	})
-	// func(p2pcfg *config.P2P) {
-	// p2pcfg.Online = s.cfg.Online
-	// if cfg.BoostrapAddrs != nil {
-	// 	p2pcfg.QriBootstrapAddrs = cfg.BoostrapAddrs
-	// }
-	// })
 	if err != nil {
 		return s, err
-	}
-
-	// bootstrapped := false
-	peerBootstrapped := func(peerId string) {
-		// if cfg.PostP2POnlineHook != nil && !bootstrapped {
-		// go cfg.PostP2POnlineHook(s.qriNode)
-		// bootstrapped = true
-		// }
-	}
-
-	err = s.qriNode.StartOnlineServices(peerBootstrapped)
-	if err != nil {
-		return nil, fmt.Errorf("error starting P2P service: %s", err.Error())
 	}
 
 	return s, nil
@@ -84,6 +65,26 @@ func (s *Server) Serve() (err error) {
 
 	go s.ServeRPC()
 	go s.ServeWebapp()
+
+	// func(p2pcfg *config.P2P) {
+	// p2pcfg.Online = s.cfg.Online
+	// if cfg.BoostrapAddrs != nil {
+	// 	p2pcfg.QriBootstrapAddrs = cfg.BoostrapAddrs
+	// }
+	// })
+
+	// bootstrapped := false
+	peerBootstrapped := func(peerId string) {
+		// if cfg.PostP2POnlineHook != nil && !bootstrapped {
+		// go cfg.PostP2POnlineHook(s.qriNode)
+		// bootstrapped = true
+		// }
+	}
+
+	err = s.qriNode.StartOnlineServices(peerBootstrapped)
+	if err != nil {
+		return fmt.Errorf("error starting P2P service: %s", err.Error())
+	}
 
 	if node, err := s.qriNode.IPFSNode(); err == nil {
 		go func() {

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,7 +20,21 @@ import (
 	"github.com/qri-io/qri/repo/test"
 )
 
+func confirmQriNotRunning() error {
+	l, err := net.Listen("tcp", ":"+config.DefaultAPIPort)
+	if err != nil {
+		return fmt.Errorf("it looks like a qri server is already running on port %s, please close before running tests", config.DefaultAPIPort)
+	}
+
+	l.Close()
+	return nil
+}
+
 func TestServerRoutes(t *testing.T) {
+	if err := confirmQriNotRunning(); err != nil {
+		t.Skip(err.Error())
+	}
+
 	// bump up log level to keep test output clean
 	golog.SetLogLevel("qriapi", "error")
 	defer golog.SetLogLevel("qriapi", "info")
@@ -189,6 +204,10 @@ func TestServerRoutes(t *testing.T) {
 }
 
 func TestServerReadOnlyRoutes(t *testing.T) {
+	if err := confirmQriNotRunning(); err != nil {
+		t.Skip(err.Error())
+	}
+
 	// bump up log level to keep test output clean
 	golog.SetLogLevel("qriapi", "error")
 	defer golog.SetLogLevel("qriapi", "info")

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -126,6 +126,7 @@ func initDataset(name repo.DatasetRef) {
 	ref := repo.DatasetRef{}
 	err = req.Init(p, &ref)
 	ExitIfErr(err)
+
 	if ref.Dataset.Structure.ErrCount > 0 {
 		printWarning(fmt.Sprintf("this dataset has %d validation errors", ref.Dataset.Structure.ErrCount))
 		if addDsShowValidation {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,14 +2,27 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/qri-io/qri/config"
 	"github.com/spf13/cobra"
 )
+
+func confirmQriNotRunning() error {
+	l, err := net.Listen("tcp", ":"+config.DefaultAPIPort)
+	if err != nil {
+		return fmt.Errorf("it looks like a qri server is already running on port %s, please close before running tests", config.DefaultAPIPort)
+	}
+
+	l.Close()
+	return nil
+}
 
 func executeCommand(root *cobra.Command, args ...string) (output string, err error) {
 	_, output, err = executeCommandC(root, args...)
@@ -80,6 +93,10 @@ const profileData = `
 
 // This is a basic integration test that makes sure basic happy paths work on the CLI
 func TestCommandsIntegration(t *testing.T) {
+	if err := confirmQriNotRunning(); err != nil {
+		t.Skip(err.Error())
+	}
+
 	path := filepath.Join(os.TempDir(), "qri_test_commands_integration")
 	// t.Logf("temp path: %s", path)
 	log.Info(path)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/qri/config"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -111,6 +112,13 @@ Sorry, we know this is not exactly a great experience, from this point forward
 we won't be shipping changes that require starting over.
 `
 		err = fmt.Errorf(str, err.Error(), QriRepoPath)
+	}
+
+	// configure logging straight away
+	if cfg != nil && cfg.Logging != nil {
+		for name, level := range cfg.Logging.Levels {
+			golog.SetLogLevel(name, level)
+		}
 	}
 
 	return err

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -92,14 +92,16 @@ peers & swapping data.`,
 }
 
 func init() {
-	connectCmd.Flags().StringVarP(&connectCmdAPIPort, "api-port", "", config.DefaultAPIPort, "port to start api on")
-	connectCmd.Flags().StringVarP(&connectCmdRPCPort, "rpc-port", "", config.DefaultRPCPort, "port to start rpc listener on")
-	connectCmd.Flags().StringVarP(&connectCmdWebappPort, "webapp-port", "", config.DefaultWebappPort, "port to serve webapp on")
-	connectCmd.Flags().BoolVarP(&connectSetup, "setup", "", false, "run setup if necessary, reading options from enviornment variables")
+	connectCmd.Flags().StringVarP(&connectCmdAPIPort, "api-port", "", "", "port to start api on")
+	connectCmd.Flags().StringVarP(&connectCmdRPCPort, "rpc-port", "", "", "port to start rpc listener on")
+	connectCmd.Flags().StringVarP(&connectCmdWebappPort, "webapp-port", "", "", "port to serve webapp on")
+
 	connectCmd.Flags().BoolVarP(&disableAPI, "disable-api", "", false, "disables api, overrides the api-port flag")
 	connectCmd.Flags().BoolVarP(&disableRPC, "disable-rpc", "", false, "disables rpc, overrides the rpc-port flag")
 	connectCmd.Flags().BoolVarP(&disableWebapp, "disable-webapp", "", false, "disables webapp, overrides the webapp-port flag")
 	connectCmd.Flags().BoolVarP(&disableP2P, "disable-p2p", "", false, "disable peer-2-peer networking")
+
+	connectCmd.Flags().BoolVarP(&connectSetup, "setup", "", false, "run setup if necessary, reading options from enviornment variables")
 	connectCmd.Flags().BoolVarP(&connectReadOnly, "read-only", "", false, "run qri in read-only mode, limits the api endpoints")
 	RootCmd.AddCommand(connectCmd)
 }

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -35,7 +35,7 @@ func getRepo(online bool) repo.Repo {
 	ExitIfErr(err)
 
 	fs := getIpfsFilestore(online)
-	r, err := fsrepo.NewRepo(fs, QriRepoPath, cfg.Profile.ID)
+	r, err := fsrepo.NewRepo(fs, cfg.Profile, QriRepoPath)
 	r.SetPrivateKey(pk)
 	r.SetProfile(pro)
 
@@ -148,7 +148,7 @@ func repoOrClient(online bool) (repo.Repo, *rpc.Client, error) {
 		// cfg, err := readConfigFile()
 		// ExitIfErr(err)
 
-		r, err := fsrepo.NewRepo(fs, QriRepoPath, cfg.Profile.ID)
+		r, err := fsrepo.NewRepo(fs, cfg.Profile, QriRepoPath)
 		ExitIfErr(err)
 
 		// c, _ := json.MarshalIndent(cfg, "", "  ")
@@ -193,7 +193,7 @@ func qriNode(online bool) (node *p2p.QriNode, err error) {
 	// 	return
 	// }
 
-	r, err = fsrepo.NewRepo(fs, QriRepoPath, cfg.Profile.ID)
+	r, err = fsrepo.NewRepo(fs, cfg.Profile, QriRepoPath)
 	if err != nil {
 		return
 	}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -126,13 +126,6 @@ overwrite this info.`,
 
 		err = cfg.WriteToFile(configFilepath())
 		ExitIfErr(err)
-
-		// call SetProfile to give repo a chance to save updated profile data
-		pro, err := cfg.Profile.DecodeProfile()
-		ExitIfErr(err)
-		getRepo(false).SetProfile(pro)
-
-		ExitIfErr(err)
 	},
 }
 

--- a/config/api.go
+++ b/config/api.go
@@ -28,7 +28,7 @@ func (API) Default() *API {
 		Port:    DefaultAPIPort,
 		TLS:     false,
 		AllowedOrigins: []string{
-			"http://localhost:2505",
+			"http://localhost:" + DefaultWebappPort,
 		},
 	}
 }

--- a/config/logging.go
+++ b/config/logging.go
@@ -11,6 +11,7 @@ func (Logging) Default() *Logging {
 	return &Logging{
 		Levels: map[string]string{
 			"qriapi": "info",
+			"qrip2p": "info",
 		},
 	}
 }

--- a/config/p2p.go
+++ b/config/p2p.go
@@ -105,13 +105,6 @@ func (cfg *P2P) DecodePeerID() (peer.ID, error) {
 // 	if r == nil {
 // 		return fmt.Errorf("need a qri Repo to create a qri node")
 // 	}
-// 	// if r == nil && cfg.RepoPath != "" {
-// 	//  repo, err := fs_repo.NewRepo(store, cfg.RepoPath, cfg.canonicalPeerId(store))
-// 	//  if err != nil {
-// 	//    return err
-// 	//  }
-// 	//  cfg.Repo = repo
-// 	// }
 
 // 	// If no listening addresses are set, allocate
 // 	// a tcp multiaddress on local host bound to the default port

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -29,7 +29,7 @@ func (n *QriNode) Bootstrap(boostrapAddrs []string, boostrapPeers chan pstore.Pe
 			log.Infof("boostrapping to: %s", p.ID.Pretty())
 			if err := n.Host.Connect(context.Background(), p); err == nil {
 				if err = n.AddQriPeer(p); err != nil {
-					log.Infof("error adding peer: %s", err.Error())
+					log.Errorf("error adding peer: %s", err.Error())
 				} else {
 					boostrapPeers <- p
 				}

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -16,8 +16,6 @@ const qriSupportKey = "qri-support"
 // StartDiscovery initiates peer discovery, allocating a discovery
 // services if one doesn't exist, then registering to be notified on peer discovery
 func (n *QriNode) StartDiscovery(bootstrapPeers chan pstore.PeerInfo) error {
-	log.Info("starting peer discovery")
-
 	if n.Discovery == nil {
 		service, err := discovery.NewMdnsService(context.Background(), n.Host, time.Second*5, QriServiceTag)
 		if err != nil {

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -16,6 +16,8 @@ const qriSupportKey = "qri-support"
 // StartDiscovery initiates peer discovery, allocating a discovery
 // services if one doesn't exist, then registering to be notified on peer discovery
 func (n *QriNode) StartDiscovery(bootstrapPeers chan pstore.PeerInfo) error {
+	log.Info("starting peer discovery")
+
 	if n.Discovery == nil {
 		service, err := discovery.NewMdnsService(context.Background(), n.Host, time.Second*5, QriServiceTag)
 		if err != nil {
@@ -40,23 +42,24 @@ func (n *QriNode) StartDiscovery(bootstrapPeers chan pstore.PeerInfo) error {
 // HandlePeerFound deals with the discovery of a peer that may or may not support
 // the qri protocol
 func (n *QriNode) HandlePeerFound(pinfo pstore.PeerInfo) {
-
 	// first check to see if we've seen this peer before
 	if _, err := n.Host.Peerstore().Get(pinfo.ID, qriSupportKey); err == nil {
 		return
 	} else if support, err := n.SupportsQriProtocol(pinfo.ID); err == nil {
 		if err := n.Host.Peerstore().Put(pinfo.ID, qriSupportKey, support); err != nil {
-			fmt.Println("error setting qri support flag", err.Error())
+			log.Errorf("error setting qri support flag", err.Error())
 			return
 		}
 
 		if support {
 			if err := n.AddQriPeer(pinfo); err != nil {
-				fmt.Println(err.Error())
+				log.Errorf("error adding qri peer: %s", err.Error())
+			} else {
+				log.Infof("discovered qri peer: %s", pinfo.ID)
 			}
 		}
 	} else if err != nil && err != errNoProtos {
-		fmt.Println("error checking for qri support:", err.Error())
+		log.Errorf("error checking for qri support:", err.Error())
 	}
 }
 

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -206,56 +206,6 @@ func (n *QriNode) EncapsulatedAddresses() []ma.Multiaddr {
 	return res
 }
 
-// Peers returns a list of currently connected peer IDs
-func (n *QriNode) Peers() []peer.ID {
-	if n.Host == nil {
-		return []peer.ID{}
-	}
-	conns := n.Host.Network().Conns()
-	seen := make(map[peer.ID]struct{})
-	peers := make([]peer.ID, 0, len(conns))
-
-	for _, c := range conns {
-		p := c.LocalPeer()
-		if _, found := seen[p]; found {
-			continue
-		}
-
-		seen[p] = struct{}{}
-		peers = append(peers, p)
-	}
-
-	return peers
-}
-
-// AddQriPeer negotiates a connection with a peer to get their profile details
-// and peer list.
-func (n *QriNode) AddQriPeer(pinfo pstore.PeerInfo) error {
-	// add this peer to our store
-	n.QriPeers.AddAddrs(pinfo.ID, pinfo.Addrs, pstore.TempAddrTTL)
-
-	if _, err := n.RequestProfile(pinfo.ID); err != nil {
-		log.Debug(err.Error())
-		return err
-	}
-
-	return nil
-}
-
-// ConnectedPeers lists all IPFS connected peers
-func (n *QriNode) ConnectedPeers() []string {
-	if n.Host == nil {
-		return []string{}
-	}
-	conns := n.Host.Network().Conns()
-	peers := make([]string, len(conns))
-	for i, c := range conns {
-		peers[i] = c.RemotePeer().Pretty()
-	}
-
-	return peers
-}
-
 // ConnectedQriProfiles lists all connected peers that support the qri protocol
 func (n *QriNode) ConnectedQriProfiles() map[profile.ID]*profile.Profile {
 	if n.Host == nil {
@@ -270,32 +220,6 @@ func (n *QriNode) ConnectedQriProfiles() map[profile.ID]*profile.Profile {
 		}
 	}
 	return peers
-}
-
-// ConnectToPeer takes a raw peer ID & tries to work out a route to that
-// peer, explicitly connecting to them.
-func (n *QriNode) ConnectToPeer(pid peer.ID) error {
-	// first check for local peer info
-	if pinfo := n.Host.Peerstore().PeerInfo(pid); pinfo.ID.String() != "" {
-		_, err := n.RequestProfile(pinfo.ID)
-		return err
-	}
-
-	// attempt to use ipfs routing table to discover peer
-	ipfsnode, err := n.IPFSNode()
-	if err != nil {
-		log.Debug(err.Error())
-		return err
-	}
-
-	pinfo, err := ipfsnode.Routing.FindPeer(context.Background(), pid)
-	if err != nil {
-		log.Debug(err.Error())
-		return err
-	}
-
-	_, err = n.RequestProfile(pinfo.ID)
-	return err
 }
 
 // Context returns this node's context

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -1,6 +1,4 @@
 // Package p2p implements qri peer-to-peer communication.
-// This is very, very early days, with message passing sorely in need of a
-// rewrite, but hey it's a start.
 package p2p
 
 import (
@@ -12,7 +10,7 @@ import (
 	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
 )
 
-var log = golog.Logger("p2p")
+var log = golog.Logger("qrip2p")
 
 // QriProtocolID is the top level Protocol Identifier
 const QriProtocolID = protocol.ID("/qri")
@@ -21,7 +19,7 @@ const QriProtocolID = protocol.ID("/qri")
 const QriServiceTag = "qri/0.2.1"
 
 func init() {
-	// golog.SetLogLevel("p2p", "debug")
+	// golog.SetLogLevel("qrip2p", "debug")
 
 	// ipfs core includes a client version. seems like a good idea.
 	// TODO - understand where & how client versions are used

--- a/repo/fs/files.go
+++ b/repo/fs/files.go
@@ -38,8 +38,6 @@ const (
 	// FileInfo stores information about this repository
 	// like version number, size of repo, etc.
 	FileInfo
-	// FileProfile is this node's user profile
-	FileProfile
 	// FileConfig holds configuration specific to this repo
 	FileConfig
 	// FileDatasets holds the list of datasets
@@ -67,7 +65,6 @@ var paths = map[File]string{
 	FileUnknown:        "",
 	FileLockfile:       "/repo.lock",
 	FileInfo:           "/info.json",
-	FileProfile:        "/profile.json",
 	FileConfig:         "/config.json",
 	FileDatasets:       "/datasets.json",
 	FileEventLogs:      "/events.json",

--- a/repo/fs/fs_test.go
+++ b/repo/fs/fs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/qri-io/cafs"
+	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/test"
 )
@@ -19,7 +20,7 @@ func TestRepo(t *testing.T) {
 			t.Errorf("error removing files: %s", err.Error())
 		}
 
-		r, err := NewRepo(cafs.NewMapstore(), path, "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt")
+		r, err := NewRepo(cafs.NewMapstore(), config.Profile{}.Default(), path)
 		if err != nil {
 			t.Errorf("error creating repo: %s", err.Error())
 		}

--- a/repo/profile/id.go
+++ b/repo/profile/id.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ID is a distinct thing form a peer.ID. They are *NOT* meant to be interchangable
-// but the mechanics of peer.ID & profile.ID are exactly the same (for now).
+// but the mechanics of peer.ID & profile.ID are exactly the same
 type ID peer.ID
 
 // String implements the stringer interface for ID


### PR DESCRIPTION
makes inroads on #336

Summary:
* fsrepo no longer keeps `profile.json`, it instead relies on being provided a `config.Profile` when `NewRepo` is called
* added a check to the test suite to make sure it wouldn't interfere with an already-running repo
* I _think_ fsrepo's peerstore might have been writing invalid json, but that might have been b/c of this tests/live server footgun I found. I'll investigate further later & PR if necessary