### PR TITLE
feat(cmd.Config): added qri config export command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	golog "github.com/ipfs/go-log"
@@ -15,6 +18,8 @@ var (
 	cfg *config.Config
 	// setting ignoreCfg to true will prevent loadConfig from doing anything
 	ignoreCfg bool
+
+	getConfigFilepath, setConfigFilepath string
 )
 
 // configCmd represents commands that read & modify configuration settings
@@ -22,20 +27,22 @@ var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "get and set local configuration information",
 	Long: `
-config is a bit of a cheat right now. we’re going to break profile out into 
-proper parameter-based commands later on, but for now we’re hoping you can edit 
-a YAML file of configuration information. 
+config encapsulates all settings that control the behaviour of qri.
+This includes all kinds of stuff: your profile details; enabling & disabling 
+different services; what kind of output qri logs to; 
+which ports on qri serves on; etc.
 
-For now running qri config get will write a file called config.yaml containing 
-current configuration info. Edit that file and run config set <file> to write 
-configuration details back.
+Configuration is stored as a .yaml file kept at $QRI_PATH, or provided at CLI 
+runtime via command a line argument.`,
+	Example: `  # get your profile information
+  $ qri config get profile
 
-Expect the config command to change in future releases.`,
+  # set your api port to 4444
+  $ qri config set api.port 4444
+
+  # disable rpc connections:
+  $ qri config set rpc.enabled false`,
 }
-
-var (
-	getConfigFilepath, setConfigFilepath string
-)
 
 var configGetCommand = &cobra.Command{
 	Use:   "get",
@@ -75,18 +82,65 @@ var configSetCommand = &cobra.Command{
 	},
 }
 
-func configFilepath() string {
-	return filepath.Join(QriRepoPath, "config.yaml")
+var configExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "export configuration settings",
+	Long: `export outputs your current configuration file with private keys 
+removed by default.
+export makes it easier to share your qri configuration settings.
+
+We've added the --with-private-keys option to include private keys in the export
+PLEASE PLEASE PLEASE NEVER SHARE YOUR PRIVATE KEYS WITH ANYONE. EVER.
+Anyone with your private keys can impersonate you on qri.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var (
+			data []byte
+			err  error
+		)
+
+		wpk, err := cmd.Flags().GetBool("with-private-keys")
+		ExitIfErr(err)
+		format, err := cmd.Flags().GetString("format")
+		ExitIfErr(err)
+		pretty, err := cmd.Flags().GetBool("pretty")
+		ExitIfErr(err)
+		output, err := cmd.Flags().GetString("output")
+		ExitIfErr(err)
+
+		if !wpk {
+			if cfg.Profile != nil {
+				cfg.Profile.PrivKey = ""
+			}
+			if cfg.P2P != nil {
+				cfg.P2P.PrivKey = ""
+			}
+		}
+
+		switch format {
+		case "json":
+			if pretty {
+				data, err = json.MarshalIndent(cfg, "", "  ")
+			} else {
+				data, err = json.Marshal(cfg)
+			}
+		case "yaml":
+			data, err = yaml.Marshal(cfg)
+		}
+		ExitIfErr(err)
+
+		if output != "" {
+			err = ioutil.WriteFile(output, data, os.ModePerm)
+			ExitIfErr(err)
+			printSuccess("config file written to: %s", output)
+			return
+		}
+
+		fmt.Println(string(data))
+	},
 }
 
-func init() {
-	configGetCommand.Flags().StringVarP(&getConfigFilepath, "file", "f", "", "file to save YAML config info to")
-	configCmd.AddCommand(configGetCommand)
-
-	configSetCommand.Flags().StringVarP(&setConfigFilepath, "file", "f", "", "filepath to *complete* yaml config info file")
-	configCmd.AddCommand(configSetCommand)
-
-	RootCmd.AddCommand(configCmd)
+func configFilepath() string {
+	return filepath.Join(QriRepoPath, "config.yaml")
 }
 
 func loadConfig() (err error) {
@@ -121,4 +175,20 @@ we won't be shipping changes that require starting over.
 	}
 
 	return err
+}
+
+func init() {
+	configGetCommand.Flags().StringVarP(&getConfigFilepath, "file", "f", "", "file to save YAML config info to")
+	configCmd.AddCommand(configGetCommand)
+
+	configSetCommand.Flags().StringVarP(&setConfigFilepath, "file", "f", "", "filepath to *complete* yaml config info file")
+	configCmd.AddCommand(configSetCommand)
+
+	configExportCmd.Flags().Bool("with-private-keys", false, "include private keys in export")
+	configExportCmd.Flags().BoolP("pretty", "p", false, "pretty-print output")
+	configExportCmd.Flags().StringP("format", "f", "json", "data format to export. either json or yaml")
+	configExportCmd.Flags().StringP("output", "o", "", "path to export to")
+	configCmd.AddCommand(configExportCmd)
+
+	RootCmd.AddCommand(configCmd)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -56,7 +56,6 @@ var configSetCommand = &cobra.Command{
 	Short: "Set a configuration option",
 	Run: func(cmd *cobra.Command, args []string) {
 		// var err error
-
 		if len(args)%2 != 0 {
 			ErrExit(fmt.Errorf("wrong number of arguments. arguments must be in the form: [path value]"))
 		}

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -215,6 +215,9 @@ func inputText(message, defaultText string) string {
 		message = "enter text:"
 	}
 	input := prompt(fmt.Sprintf("%s [%s]: ", message, defaultText))
+	if input == "" {
+		input = defaultText
+	}
 
 	return input
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -76,6 +76,9 @@ overwrite this info.`,
 			err := readAtFile(&setupConfigData)
 			ExitIfErr(err)
 			err = json.Unmarshal([]byte(setupConfigData), cfg)
+			if cfg.Profile != nil {
+				setupPeername = cfg.Profile.Peername
+			}
 			ExitIfErr(err)
 		}
 
@@ -87,9 +90,7 @@ overwrite this info.`,
 
 		if setupPeername != "" {
 			cfg.Profile.Peername = setupPeername
-		}
-
-		if cfg.Profile.Peername == doggos.DoggoNick(cfg.Profile.ID) && !anon {
+		} else if cfg.Profile.Peername == doggos.DoggoNick(cfg.Profile.ID) && !anon {
 			cfg.Profile.Peername = inputText("choose a peername:", doggos.DoggoNick(cfg.Profile.ID))
 			printSuccess(cfg.Profile.Peername)
 		}

--- a/config/profile.go
+++ b/config/profile.go
@@ -48,7 +48,11 @@ type Profile struct {
 // private key, peer.ID, and nickname
 func (Profile) Default() *Profile {
 	r := rand.Reader
-	p := &Profile{}
+	now := time.Now()
+	p := &Profile{
+		Created: now,
+		Updated: now,
+	}
 
 	// Generate a key pair for this host. We will use it at least
 	// to obtain a valid host ID.


### PR DESCRIPTION
while testing out enviorment variable configuration I needed a quick way to get config an existing config as JSON, and realized it may be helpful in other places. This adds export as a subcommand of
config that by default prints a json blob of the current config file with private keys removed. I've added --with-private-keys to add in the private keys, and a few other flags to switch format to yaml or pick an output file.