### PR TITLE
fix(webapp): hide webapp hash behind vanity url

### DIFF
--- a/api/root.go
+++ b/api/root.go
@@ -18,11 +18,6 @@ type RootHandler struct {
 	ph  *PeerHandlers
 }
 
-// WebappHandler renders the home page
-func (s *Server) WebappHandler(w http.ResponseWriter, r *http.Request) {
-	renderTemplate(s.cfg.Webapp, w, "webapp")
-}
-
 // NewRootHandler creates a new RootHandler
 func NewRootHandler(dsh *DatasetHandlers, ph *PeerHandlers) *RootHandler {
 	return &RootHandler{dsh, ph}

--- a/api/templates.go
+++ b/api/templates.go
@@ -18,7 +18,7 @@ func init() {
 // templateRenderer returns a func "renderTemplate" that renders a template, using the values of a Config
 func renderTemplate(c *config.Webapp, w http.ResponseWriter, tmpl string) {
 	err := templates.ExecuteTemplate(w, tmpl, map[string]interface{}{
-		"webappScripts": c.Scripts,
+		"port": c.Port,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -33,8 +33,6 @@ const webapptmpl = `
 </head>
 <body>
   <div id="root"></div>
-  {{ range .webappScripts }}
-    <script type="text/javascript" src="{{ . }}"></script>
-  {{ end }}
+  <script type="text/javascript" src="/webapp.js"></script>
 </body>
 </html>`

--- a/api/webapp.go
+++ b/api/webapp.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// ServeWebapp launches a webapp server on s.cfg.Webapp.Port
+func (s *Server) ServeWebapp() {
+	if !s.cfg.Webapp.Enabled || s.cfg.Webapp.Port == "" {
+		return
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%s", s.cfg.Webapp.Port))
+	if err != nil {
+		log.Infof("Webapp listen on port %s error: %s", s.cfg.Webapp.Port, err)
+		return
+	}
+
+	m := http.NewServeMux()
+	m.Handle("/", s.middleware(s.WebappHandler))
+	m.Handle("/webapp.js", s.WebappJSHandler())
+	webappserver := &http.Server{Handler: m}
+	webappserver.Serve(listener)
+	return
+}
+
+// WebappJSHandler attempts to resolve an update
+func (s *Server) WebappJSHandler() http.Handler {
+	var webappPath = s.cfg.Webapp.EntrypointHash
+	go s.resolveWebappPath(&webappPath)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.fetchIPFSPath(webappPath, w, r)
+	})
+}
+
+func (s *Server) resolveWebappPath(path *string) {
+	node, err := s.qriNode.IPFSNode()
+	if err != nil {
+		log.Infof("no IPFS node present to resolve webapp address: %s", err.Error())
+		return
+	}
+
+	p, err := node.Namesys.Resolve(context.Background(), "/ipns/webapp.qri.io")
+	if err != nil {
+		log.Infof("error resolving IPNS Name: %s", err.Error())
+		return
+	}
+	*path = p.String()
+}
+
+// WebappHandler renders the home page
+func (s *Server) WebappHandler(w http.ResponseWriter, r *http.Request) {
+	renderTemplate(s.cfg.Webapp, w, "webapp")
+}

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -153,15 +153,13 @@ func repoOrClient(online bool) (repo.Repo, *rpc.Client, error) {
 
 		// c, _ := json.MarshalIndent(cfg, "", "  ")
 		// printSuccess("%s", c)
-		pk, err := cfg.Profile.DecodePrivateKey()
-		ExitIfErr(err)
-
-		r.SetPrivateKey(pk)
+		// pk, err := cfg.Profile.DecodePrivateKey()
+		// ExitIfErr(err)
+		// r.SetPrivateKey(pk)
 		return r, nil, err
 
 	} else if strings.Contains(err.Error(), "lock") {
-		// TODO - bad bad hardcode
-		conn, err := net.Dial("tcp", ":2504")
+		conn, err := net.Dial("tcp", ":"+cfg.RPC.Port)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/config/webapp.go
+++ b/config/webapp.go
@@ -9,21 +9,18 @@ type Webapp struct {
 	Port    string
 	// token for analytics tracking
 	AnalyticsToken string
-	// Scripts is a list of script tags to include the webapp page, useful for using alternative / beta
-	// versions of the qri frontend
-	Scripts []string
+	// EntrypointHash is a hash of the compiled webapp (the output of running webpack https://github.com/qri-io/frontend)
+	// this is fetched and replaced via dnslink when the webapp server starts
+	// the value provided here is just a sensible fallback for when dnslink lookup fails,
+	// pointing to a known prior version of the the webapp
+	EntrypointHash string
 }
 
 // Default creates a new default Webapp configuration
 func (Webapp) Default() *Webapp {
 	return &Webapp{
-		Enabled: true,
-		Port:    DefaultWebappPort,
-		Scripts: []string{
-			// this is fetched and replaced via dnslink when the webapp server starts
-			// the value provided here is just a sensible fallback for when dnslink lookup fails,
-			// pointing to a known prior version of the the webapp
-			"http://localhost:2503/ipfs/QmewSfmnridhYdwLc9nGVwFNhMofAjPf4vxMMUYC6QDEjm",
-		},
+		Enabled:        true,
+		Port:           DefaultWebappPort,
+		EntrypointHash: "QmewSfmnridhYdwLc9nGVwFNhMofAjPf4vxMMUYC6QDEjm",
 	}
 }

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -23,11 +23,12 @@ func init() {
 
 // Repo is a filesystem-based implementation of the Repo interface
 type Repo struct {
+	basepath
+
 	profile *profile.Profile
 	pk      crypto.PrivKey
 
 	store cafs.Filestore
-	basepath
 	graph map[string]*dsgraph.Node
 
 	Refstore


### PR DESCRIPTION
using the compiled app delivered as a hash causes sad emoji when the api is up in read-only mode b/c then the user can't access the `/ipfs` endpoint on the api. To fix this I've cleaned up our webapp code a bit in the api package and now the frontend just loads "webapp.js", with new logic in the backend that knows what to do with that.