### PR TITLE
fix(connect): fix errors caused by running connect with setup

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/rpc"
+	"time"
 
 	"github.com/datatogether/api/apiutil"
 	"github.com/ipfs/go-datastore"
@@ -102,6 +103,15 @@ func (s *Server) Serve() (err error) {
 		info = fmt.Sprintf("%s\n  %s", info, a.String())
 	}
 	log.Info(info)
+
+	if s.cfg.API.DisconnectAfter != 0 {
+		log.Infof("disconnecting after %d seconds", s.cfg.API.DisconnectAfter)
+		go func(s *http.Server, t int) {
+			<-time.After(time.Second * time.Duration(t))
+			log.Infof("disconnecting")
+			s.Close()
+		}(server, s.cfg.API.DisconnectAfter)
+	}
 
 	// http.ListenAndServe will not return unless there's an error
 	return StartServer(s.cfg.API, server)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,6 +6,27 @@ import (
 	"path/filepath"
 )
 
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	// Catch errors & pretty-print.
+	// comment this out to get stack traces back.
+	// defer func() {
+	// 	if r := recover(); r != nil {
+	// 		if err, ok := r.(error); ok {
+	// 			fmt.Println(err.Error())
+	// 		} else {
+	// 			fmt.Println(r)
+	// 		}
+	// 	}
+	// }()
+
+	if err := RootCmd.Execute(); err != nil {
+		printErr(err)
+		os.Exit(-1)
+	}
+}
+
 // ErrExit writes an error to stdout & exits
 func ErrExit(err error) {
 	printErr(err)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -98,7 +98,11 @@ func TestCommandsIntegration(t *testing.T) {
 	}
 
 	path := filepath.Join(os.TempDir(), "qri_test_commands_integration")
+
 	t.Logf("temp path: %s", path)
+	os.Setenv("IPFS_PATH", filepath.Join(path, "ipfs"))
+	os.Setenv("QRI_PATH", filepath.Join(path, "qri"))
+
 	//clean up if previous cleanup failed
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		os.RemoveAll(path)
@@ -132,9 +136,6 @@ func TestCommandsIntegration(t *testing.T) {
 		t.Errorf("error profile json file: %s", err.Error())
 		return
 	}
-
-	os.Setenv("IPFS_PATH", filepath.Join(path, "ipfs"))
-	os.Setenv("QRI_PATH", filepath.Join(path, "qri"))
 
 	commands := [][]string{
 		{"help"},

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConnect(t *testing.T) {
+
+	if err := confirmQriNotRunning(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	path := filepath.Join(os.TempDir(), "qri_test_commands_connect")
+	t.Logf("temp path: %s", path)
+	os.Setenv("IPFS_PATH", filepath.Join(path, "ipfs"))
+	os.Setenv("QRI_PATH", filepath.Join(path, "qri"))
+
+	//clean up if previous cleanup failed
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		os.RemoveAll(path)
+	}
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		t.Errorf("error creating test path: %s", err.Error())
+		return
+	}
+	defer os.RemoveAll(path)
+
+	args := []string{"connect", "--setup", "--disconnect-after=3"}
+
+	// defer func() {
+	// 	if e := recover(); e != nil {
+	// 		t.Errorf("unexpected panic:\n%s\n%s", strings.Join(args, " "), e)
+	// 		return
+	// 	}
+	// }()
+
+	_, err := executeCommand(RootCmd, args...)
+	if err != nil {
+		t.Errorf("unexpected error executing command\n%s\n%s", strings.Join(args, " "), err.Error())
+		return
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -35,27 +34,6 @@ https://qri.io
 
 Feedback, questions, bug reports, and contributions are welcome!
 https://github.com/qri-io/qri/issues`,
-}
-
-// Execute adds all child commands to the root command sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	// Catch errors & pretty-print.
-	// comment this out to get stack traces back.
-	defer func() {
-		if r := recover(); r != nil {
-			if err, ok := r.(error); ok {
-				fmt.Println(err.Error())
-			} else {
-				fmt.Println(r)
-			}
-		}
-	}()
-
-	if err := RootCmd.Execute(); err != nil {
-		printErr(err)
-		os.Exit(-1)
-	}
 }
 
 func init() {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	setupAnonymous      bool
 	setupOverwrite      bool
 	setupIPFS           bool
 	setupPeername       string
@@ -42,8 +43,10 @@ overwrite this info.`,
 	Example: `  run setup with a peername of your choosing:
 	$ qri setup --peername=your_great_peername`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// var cfgData []byte
-		var cfg *config.Config
+		var (
+			cfg *config.Config
+			err error
+		)
 
 		if QRIRepoInitialized() && !setupOverwrite {
 			// use --overwrite to overwrite this repo, erasing all data and deleting your account for good
@@ -83,12 +86,10 @@ overwrite this info.`,
 		if cfg.Profile == nil {
 			cfg.Profile = config.DefaultProfile()
 		}
-		anon, err := cmd.Flags().GetBool("anonymous")
-		ExitIfErr(err)
 
 		if setupPeername != "" {
 			cfg.Profile.Peername = setupPeername
-		} else if cfg.Profile.Peername == doggos.DoggoNick(cfg.Profile.ID) && !anon {
+		} else if cfg.Profile.Peername == doggos.DoggoNick(cfg.Profile.ID) && !setupAnonymous {
 			cfg.Profile.Peername = inputText("choose a peername:", doggos.DoggoNick(cfg.Profile.ID))
 			printSuccess(cfg.Profile.Peername)
 		}
@@ -101,7 +102,6 @@ overwrite this info.`,
 		}
 
 		if setupIPFS {
-
 			tmpIPFSConfigPath := ""
 			if setupIPFSConfigData != "" {
 				err = readAtFile(&setupIPFSConfigData)
@@ -136,7 +136,7 @@ overwrite this info.`,
 
 func init() {
 	RootCmd.AddCommand(setupCmd)
-	setupCmd.Flags().BoolP("anonymous", "a", false, "use an auto-generated peername")
+	setupCmd.Flags().BoolVarP(&setupAnonymous, "anonymous", "a", false, "use an auto-generated peername")
 	setupCmd.Flags().BoolVarP(&setupOverwrite, "overwrite", "", false, "overwrite repo if one exists")
 	setupCmd.Flags().BoolVarP(&setupIPFS, "init-ipfs", "", true, "initialize an IPFS repo if one isn't present")
 	setupCmd.Flags().StringVarP(&setupPeername, "peername", "", "", "choose your desired peername")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,7 +3,7 @@ package cmd
 import "github.com/spf13/cobra"
 
 // VersionNumber is the current version qri
-const VersionNumber = "0.3.0"
+const VersionNumber = "0.3.1-dev"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/config/api.go
+++ b/config/api.go
@@ -19,6 +19,9 @@ type API struct {
 	URLRoot string `json:"urlroot"`
 	// TLS enables https via letsEyncrypt
 	TLS bool `json:"tls"`
+	// Time in seconds to stop the server after,
+	// default 0 means keep alive indefinitely
+	DisconnectAfter int `json:"disconnectafter,omitempty"`
 	// if true, requests that have X-Forwarded-Proto: http will be redirected
 	// to their https variant
 	ProxyForceHTTPS bool `json:"proxyforcehttps"`
@@ -54,6 +57,10 @@ func (a API) Validate() error {
       "tls": {
         "description": "Enables https via letsEncrypt",
         "type": "boolean"
+      },
+      "disconnectafter": {
+        "description": "time in seconds to stop the server after",
+        "type": "integer"
       },
       "proxyforcehttps": {
         "description": "When true, requests that have X-Forwarded-Proto: http will be redirected to their https variant",


### PR DESCRIPTION
Version 0.3.0 went out the door with a bug that breaks the default
docker image command, sad! The problem was caused by switching the
"anonymous" flag from a cobra.BoolVarP to a cobra.BoolP.

When connect is run with --setup, we cheat heavily & just manually
invoke the setup cobra command on the spot. The problem with this
cheat is the setup command hasn't been properly allocated by cobra,
and so any flag set without a global variable reference isn't assigned
when commands are invoked in this manual way. In the long run we should
move away from this method entirely. The short solution would be to move
the contents of setupCmd.Run into a private func "doSetup", the better
way to do this would be to create a new setup core method.

To smooth the transition through these refactorings, I've added a test
for the connect command that confirms it's behaving.

The only problem with testing the connect command is connect is designed
to be a long-running process.

 So to get around this I've added a new configuration option to
API config, and argument to connect for "disconnect after", which
tells the server to shutdown after a designated number of seconds.

We might be able to use this in other places, I'm thinking of cron
jobs that spin up with a very long disconnect-after to ensure they
don't run forever, terminiting before the disconnect-after deadline
when their work is confirmed finished.