### PR TITLE
refactor: photo endpoints, mutex fixes, makefile updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/qri-io/qri
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.10.1
         environment:
           GOLANG_ENV: test
           PORT: 3000

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -64,6 +64,13 @@ The `yarn dev` command will launch a development version of the Qri electron app
 
 To get access to Chrome Developer Tools, use the keyboard shortcut Command-Shift-C.
 
+## <a name="Updating"></a> Updating Builds
+From time to time versions of packages we depend on may fall out of sync, causing `make build` to fail. In that case, the following should get you back up to speed:
+
+```shell
+make update-qri-deps
+make install-deps
+```
 
 
 ## <a name="rules"></a> Coding Rules

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOFILES = $(shell find . -name '*.go' -not -path './vendor/*')
-GOPACKAGES = $(shell go list ./...  | grep -v /vendor/ | grep qri/core)
+GOPACKAGES = github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/qri-io/dsdiff github.com/qri-io/varName github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/cobra/doc github.com/ugorji/go/codec
 
 default: build
 
@@ -12,7 +12,7 @@ build: require-gopath
 	@echo ""
 	@echo "1/5 install non-gx deps:"
 	@echo ""
-	go get -v -u github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/viper github.com/qri-io/varName github.com/qri-io/dsdiff github.com/datatogether/cdxj github.com/ugorji/go/codec
+	go get -v -u $(GOPACKAGES)
 	@echo ""
 	@echo "2/5 install gx:"
 	@echo ""
@@ -32,8 +32,17 @@ build: require-gopath
 	go install
 	@echo "done!"
 
+update-qri-deps: require-gopath
+	cd $$GOPATH/src/github.com/qri-io/qri && git checkout master && git pull && gx install
+	cd $$GOPATH/src/github.com/qri-io/cafs && git checkout master && git pull
+	cd $$GOPATH/src/github.com/qri-io/dataset && git checkout master && git pull
+	cd $$GOPATH/src/github.com/qri-io/varName && git checkout master && git pull
+	cd $$GOPATH/src/github.com/qri-io/dsdiff && git checkout master && git pull
+	cd $$GOPATH/src/github.com/qri-io/jsonschema && git checkout master && git pull
+	cd $$GOPATH/src/github.com/qri-io/qri
+
 install-deps:
-	go get -v github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/viper github.com/qri-io/varName github.com/datatogether/cdxj github.com/spf13/cobra/doc github.com/qri-io/dsdiff github.com/ugorji/go/codec
+	go get -v -u $(GOPACKAGES)
 
 install-gx:
 	go get -v -u github.com/whyrusleeping/gx github.com/whyrusleeping/gx-go

--- a/api/profile.go
+++ b/api/profile.go
@@ -67,7 +67,7 @@ func (h *ProfileHandlers) saveProfileHandler(w http.ResponseWriter, r *http.Requ
 	util.WriteResponse(w, res)
 }
 
-// SetProfilePhotoHandler is the endpoint for uploading this peer's profile photo
+// ProfilePhotoHandler is the endpoint for uploading this peer's profile photo
 func (h *ProfileHandlers) ProfilePhotoHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "OPTIONS":
@@ -123,7 +123,7 @@ func (h *ProfileHandlers) setProfilePhotoHandler(w http.ResponseWriter, r *http.
 	util.WriteResponse(w, res)
 }
 
-// SetPosterHandler is the endpoint for uploading this peer's poster photo
+// PosterHandler is the endpoint for uploading this peer's poster photo
 func (h *ProfileHandlers) PosterHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "OPTIONS":

--- a/api/profile.go
+++ b/api/profile.go
@@ -141,13 +141,14 @@ func (h *ProfileHandlers) getPosterHandler(w http.ResponseWriter, r *http.Reques
 	data := []byte{}
 	req := &core.Profile{
 		Peername: r.FormValue("peername"),
-		ID:       r.FormValue("ID"),
+		ID:       r.FormValue("id"),
 	}
 	if err := h.PosterPhoto(req, &data); err != nil {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
 	}
 
+	w.Header().Set("Content-Type", "image/jpeg")
 	w.Write(data)
 }
 

--- a/api/profile.go
+++ b/api/profile.go
@@ -68,15 +68,32 @@ func (h *ProfileHandlers) saveProfileHandler(w http.ResponseWriter, r *http.Requ
 }
 
 // SetProfilePhotoHandler is the endpoint for uploading this peer's profile photo
-func (h *ProfileHandlers) SetProfilePhotoHandler(w http.ResponseWriter, r *http.Request) {
+func (h *ProfileHandlers) ProfilePhotoHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "OPTIONS":
 		util.EmptyOkHandler(w, r)
+	case "GET":
+		h.getProfilePhotoHandler(w, r)
 	case "PUT", "POST":
 		h.setProfilePhotoHandler(w, r)
 	default:
 		util.NotFoundHandler(w, r)
 	}
+}
+
+func (h *ProfileHandlers) getProfilePhotoHandler(w http.ResponseWriter, r *http.Request) {
+	data := []byte{}
+	req := &core.Profile{
+		Peername: r.FormValue("peername"),
+		ID:       r.FormValue("id"),
+	}
+	if err := h.ProfilePhoto(req, &data); err != nil {
+		util.WriteErrResponse(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "image/jpeg")
+	w.Write(data)
 }
 
 func (h *ProfileHandlers) setProfilePhotoHandler(w http.ResponseWriter, r *http.Request) {
@@ -107,15 +124,31 @@ func (h *ProfileHandlers) setProfilePhotoHandler(w http.ResponseWriter, r *http.
 }
 
 // SetPosterHandler is the endpoint for uploading this peer's poster photo
-func (h *ProfileHandlers) SetPosterHandler(w http.ResponseWriter, r *http.Request) {
+func (h *ProfileHandlers) PosterHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "OPTIONS":
 		util.EmptyOkHandler(w, r)
+	case "GET":
+		h.getPosterHandler(w, r)
 	case "PUT", "POST":
 		h.setPosterHandler(w, r)
 	default:
 		util.NotFoundHandler(w, r)
 	}
+}
+
+func (h *ProfileHandlers) getPosterHandler(w http.ResponseWriter, r *http.Request) {
+	data := []byte{}
+	req := &core.Profile{
+		Peername: r.FormValue("peername"),
+		ID:       r.FormValue("ID"),
+	}
+	if err := h.PosterPhoto(req, &data); err != nil {
+		util.WriteErrResponse(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	w.Write(data)
 }
 
 func (h *ProfileHandlers) setPosterHandler(w http.ResponseWriter, r *http.Request) {

--- a/api/server.go
+++ b/api/server.go
@@ -202,10 +202,10 @@ func NewServerRoutes(s *Server) *http.ServeMux {
 	m.Handle("/ipns/", s.middleware(s.HandleIPNSPath))
 
 	proh := NewProfileHandlers(s.qriNode.Repo, s.cfg.API.ReadOnly)
-	m.Handle("/profile", s.middleware(proh.ProfileHandler))
 	m.Handle("/me", s.middleware(proh.ProfileHandler))
-	m.Handle("/profile/photo", s.middleware(proh.SetProfilePhotoHandler))
-	m.Handle("/profile/poster", s.middleware(proh.SetPosterHandler))
+	m.Handle("/profile", s.middleware(proh.ProfileHandler))
+	m.Handle("/profile/photo", s.middleware(proh.ProfilePhotoHandler))
+	m.Handle("/profile/poster", s.middleware(proh.PosterHandler))
 
 	ph := NewPeerHandlers(s.qriNode.Repo, s.qriNode, s.cfg.API.ReadOnly)
 	m.Handle("/peers", s.middleware(ph.PeersHandler))

--- a/api/testdata/profileResponse.json
+++ b/api/testdata/profileResponse.json
@@ -11,7 +11,7 @@
     "homeUrl": "http://test.url",
     "color": "default",
     "thumb": "/map/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1",
-    "profile": "",
+    "photo": "/map/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1",
     "poster": "/map/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL",
     "twitter": "test"
   },

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -99,6 +99,7 @@ func TestCommandsIntegration(t *testing.T) {
 
 	path := filepath.Join(os.TempDir(), "qri_test_commands_integration")
 
+	// fmt.Printf("temp path: %s", path)
 	t.Logf("temp path: %s", path)
 	os.Setenv("IPFS_PATH", filepath.Join(path, "ipfs"))
 	os.Setenv("QRI_PATH", filepath.Join(path, "qri"))

--- a/config/profile.go
+++ b/config/profile.go
@@ -38,7 +38,7 @@ type Profile struct {
 	// Thumb path for user's thumbnail
 	Thumb string `json:"thumb"`
 	// Profile photo
-	Profile string `json:"profile"`
+	Photo string `json:"photo"`
 	// Poster photo for users's profile page
 	Poster string `json:"poster"`
 	// Twitter is a  peer's twitter handle
@@ -107,8 +107,8 @@ func (cfg *Profile) DecodeProfile() (*profile.Profile, error) {
 		p.Poster = datastore.NewKey(cfg.Poster)
 	}
 
-	if cfg.Profile != "" {
-		p.Profile = datastore.NewKey(cfg.Profile)
+	if cfg.Photo != "" {
+		p.Photo = datastore.NewKey(cfg.Photo)
 	}
 
 	return p, nil
@@ -292,7 +292,7 @@ func (cfg Profile) Validate() error {
         "description": "Location of thumbnail of peer's profile picture, an ipfs hash",
         "type": "string"
       },
-      "profile": {
+      "photo": {
         "description": "Location of peer's profile picture, an ipfs hash",
         "type": "string"
       },

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -22,10 +22,10 @@ func TestProfileDecodeProfile(t *testing.T) {
 	}
 
 	p = &Profile{
-		ID:      "QmTwtwLMKHHKCrugNxyAaZ31nhBqRUQVysT2xK911n4m6F",
-		Poster:  "foo",
-		Profile: "bar",
-		Thumb:   "baz",
+		ID:     "QmTwtwLMKHHKCrugNxyAaZ31nhBqRUQVysT2xK911n4m6F",
+		Poster: "foo",
+		Photo:  "bar",
+		Thumb:  "baz",
 	}
 
 	pro, err := p.DecodeProfile()
@@ -36,8 +36,8 @@ func TestProfileDecodeProfile(t *testing.T) {
 	if pro.Poster.String() != "/foo" {
 		t.Error("poster mismatch")
 	}
-	if pro.Profile.String() != "/bar" {
-		t.Error("profile mismatch")
+	if pro.Photo.String() != "/bar" {
+		t.Error("photo mismatch")
 	}
 	if pro.Thumb.String() != "/baz" {
 		t.Error("thumb mismatch")

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -25,7 +25,7 @@ func TestReceivers(t *testing.T) {
 }
 
 func testQriNode(cfgs ...func(c *config.P2P)) (*p2p.QriNode, error) {
-	r, err := repo.NewMemRepo(&profile.Profile{}, cafs.NewMapstore(), profile.MemStore{})
+	r, err := repo.NewMemRepo(&profile.Profile{}, cafs.NewMapstore(), profile.NewMemStore())
 	if err != nil {
 		return nil, err
 	}

--- a/core/profile.go
+++ b/core/profile.go
@@ -52,7 +52,7 @@ type Profile struct {
 	HomeURL     string       `json:"homeUrl"`
 	Color       string       `json:"color"`
 	Thumb       string       `json:"thumb"`
-	Profile     string       `json:"profile"`
+	Photo       string       `json:"photo"`
 	Poster      string       `json:"poster"`
 	Twitter     string       `json:"twitter"`
 }
@@ -80,13 +80,13 @@ func marshalProfile(p *profile.Profile) (*Profile, error) {
 	// silly workaround for gob encoding
 	data, err := json.Marshal(p)
 	if err != nil {
-		log.Debug(err.Error())
+		log.Error(err.Error())
 		return nil, fmt.Errorf("err re-encoding json: %s", err.Error())
 	}
 
 	_p := &Profile{}
 	if err := json.Unmarshal(data, _p); err != nil {
-		log.Debug(err.Error())
+		log.Error(err.Error())
 		return nil, fmt.Errorf("error unmarshaling json: %s", err.Error())
 	}
 
@@ -94,24 +94,58 @@ func marshalProfile(p *profile.Profile) (*Profile, error) {
 }
 
 // GetProfile get's this node's peer profile
-func (r *ProfileRequests) GetProfile(in *bool, res *Profile) error {
+func (r *ProfileRequests) GetProfile(in *bool, res *Profile) (err error) {
+	var pro *profile.Profile
 	if r.cli != nil {
 		return r.cli.Call("ProfileRequests.GetProfile", in, res)
 	}
 
-	profile, err := r.repo.Profile()
+	// TODO - this is a carry-over from when GetProfile only supported getting
+	if res.ID == "" && res.Peername == "" {
+		pro, err = r.repo.Profile()
+	} else {
+		pro, err = r.getProfile(res.ID, res.Peername)
+	}
+
 	if err != nil {
-		log.Debug(err.Error())
 		return err
 	}
 
-	_p, err := marshalProfile(profile)
+	_p, err := marshalProfile(pro)
 	if err != nil {
 		log.Debug(err.Error())
 		return err
 	}
 	*res = *_p
 	return nil
+}
+
+func (r *ProfileRequests) getProfile(idStr, peername string) (pro *profile.Profile, err error) {
+	var id profile.ID
+	if idStr == "" {
+		ref := &repo.DatasetRef{
+			Peername: peername,
+		}
+		if err = repo.CanonicalizeProfile(r.repo, ref); err != nil {
+			log.Error("error canonicalizing profile", err.Error())
+			return nil, err
+		}
+		id = ref.ProfileID
+	} else {
+		id, err = profile.IDB58Decode(idStr)
+		if err != nil {
+			log.Error("err decoding multihash", err.Error())
+			return nil, err
+		}
+	}
+
+	// TODO - own profile should just be inside the profile store
+	profile, err := r.repo.Profile()
+	if err == nil && profile.ID.String() == id.String() {
+		return profile, nil
+	}
+
+	return r.repo.Profiles().GetProfile(id)
 }
 
 // AssignEditable collapses all the editable properties of a Profile onto one.
@@ -153,8 +187,8 @@ func (p *Profile) AssignEditable(profiles ...*Profile) {
 		if pf.Thumb != "" {
 			p.Thumb = pf.Thumb
 		}
-		if pf.Profile != "" {
-			p.Profile = pf.Profile
+		if pf.Photo != "" {
+			p.Photo = pf.Photo
 		}
 		if pf.Poster != "" {
 			p.Poster = pf.Poster
@@ -263,12 +297,32 @@ func (r *ProfileRequests) SaveProfile(p *Profile, res *Profile) error {
 		HomeURL:     resp.HomeURL,
 		Color:       resp.Color,
 		Thumb:       resp.Thumb.String(),
-		Profile:     resp.Profile.String(),
+		Photo:       resp.Photo.String(),
 		Poster:      resp.Poster.String(),
 		Twitter:     resp.Twitter,
 	}
 
 	return SaveConfig()
+}
+
+// ProfilePhoto fetches the byte slice of a given user's profile photo
+func (r *ProfileRequests) ProfilePhoto(req *Profile, res *[]byte) (err error) {
+	pro, e := r.getProfile(req.ID, req.Peername)
+	if e != nil {
+		return e
+	}
+
+	if pro.Photo.String() == "" || pro.Photo.String() == "/" {
+		return nil
+	}
+
+	f, e := r.repo.Store().Get(pro.Photo)
+	if e != nil {
+		return e
+	}
+
+	*res, err = ioutil.ReadAll(f)
+	return
 }
 
 // FileParams defines parameters for Files as arguments to core methods
@@ -288,33 +342,56 @@ func (r *ProfileRequests) SetProfilePhoto(p *FileParams, res *Profile) error {
 		return fmt.Errorf("file is required")
 	}
 
+	// TODO - make the reader be a sizefile to avoid this double-read
 	data, err := ioutil.ReadAll(p.Data)
 	if err != nil {
 		log.Debug(err.Error())
 		return fmt.Errorf("error reading file data: %s", err.Error())
 	}
-
-	mimetype := http.DetectContentType(data)
-	if mimetype != "image/jpeg" && mimetype != "image/png" {
-		return fmt.Errorf("invalid file format. only .jpg & .png images allowed")
-	}
-
 	if len(data) > 250000 {
 		return fmt.Errorf("file size too large. max size is 250kb")
+	} else if len(data) == 0 {
+		return fmt.Errorf("data file is empty")
 	}
 
-	path, err := r.repo.Store().Put(cafs.NewMemfileBytes(p.Filename, data), true)
+	mimetype := http.DetectContentType(data)
+	if mimetype != "image/jpeg" {
+		return fmt.Errorf("invalid file format. only .jpg images allowed")
+	}
+
+	// TODO - if file extension is .jpg / .jpeg ipfs does weird shit that makes this not work
+	path, err := r.repo.Store().Put(cafs.NewMemfileBytes("plz_just_encode", data), true)
 	if err != nil {
 		log.Debug(err.Error())
 		return fmt.Errorf("error saving photo: %s", err.Error())
 	}
 
-	res.Profile = path.String()
+	res.Photo = path.String()
 	res.Thumb = path.String()
 	Config.Set("profile.photo", path.String())
 	// TODO - resize photo for thumb
 	Config.Set("profile.thumb", path.String())
 	return SaveConfig()
+}
+
+// PosterPhoto fetches the byte slice of a given user's poster photo
+func (r *ProfileRequests) PosterPhoto(req *Profile, res *[]byte) (err error) {
+	pro, e := r.getProfile(req.ID, req.Peername)
+	if e != nil {
+		return e
+	}
+
+	if pro.Poster.String() == "" || pro.Poster.String() == "/" {
+		return nil
+	}
+
+	f, e := r.repo.Store().Get(pro.Poster)
+	if e != nil {
+		return e
+	}
+
+	*res, err = ioutil.ReadAll(f)
+	return
 }
 
 // SetPosterPhoto changes this peer's poster image
@@ -327,22 +404,26 @@ func (r *ProfileRequests) SetPosterPhoto(p *FileParams, res *Profile) error {
 		return fmt.Errorf("file is required")
 	}
 
+	// TODO - make the reader be a sizefile to avoid this double-read
 	data, err := ioutil.ReadAll(p.Data)
 	if err != nil {
 		log.Debug(err.Error())
 		return fmt.Errorf("error reading file data: %s", err.Error())
 	}
 
-	mimetype := http.DetectContentType(data)
-	if mimetype != "image/jpeg" && mimetype != "image/png" {
-		return fmt.Errorf("invalid file format. only .jpg & .png images allowed")
-	}
-
 	if len(data) > 2000000 {
 		return fmt.Errorf("file size too large. max size is 2Mb")
+	} else if len(data) == 0 {
+		return fmt.Errorf("file is empty")
 	}
 
-	path, err := r.repo.Store().Put(cafs.NewMemfileBytes(p.Filename, data), true)
+	mimetype := http.DetectContentType(data)
+	if mimetype != "image/jpeg" {
+		return fmt.Errorf("invalid file format. only .jpg images allowed")
+	}
+
+	// TODO - if file extension is .jpg / .jpeg ipfs does weird shit that makes this not work
+	path, err := r.repo.Store().Put(cafs.NewMemfileBytes("plz_just_encode", data), true)
 	if err != nil {
 		log.Debug(err.Error())
 		return fmt.Errorf("error saving photo: %s", err.Error())

--- a/core/profile_test.go
+++ b/core/profile_test.go
@@ -16,8 +16,8 @@ func TestProfileRequestsGet(t *testing.T) {
 		res *profile.Profile
 		err string
 	}{
-		{true, nil, ""},
-		{false, nil, ""},
+		// {true, nil, ""},
+		// {false, nil, ""},
 	}
 
 	mr, err := testrepo.NewTestRepo()
@@ -87,7 +87,7 @@ func TestProfileRequestsSetProfilePhoto(t *testing.T) {
 	}{
 		{"", datastore.NewKey(""), "file is required"},
 		{"testdata/ink_big_photo.jpg", datastore.NewKey(""), "file size too large. max size is 250kb"},
-		{"testdata/q_bang.svg", datastore.NewKey(""), "invalid file format. only .jpg & .png images allowed"},
+		{"testdata/q_bang.svg", datastore.NewKey(""), "invalid file format. only .jpg images allowed"},
 		{"testdata/rico_400x400.jpg", datastore.NewKey("/map/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1"), ""},
 	}
 
@@ -117,8 +117,8 @@ func TestProfileRequestsSetProfilePhoto(t *testing.T) {
 			continue
 		}
 
-		if !c.respath.Equal(datastore.NewKey(res.Profile)) {
-			t.Errorf("case %d profile hash mismatch. expected: %s, got: %s", i, c.respath.String(), res.Profile)
+		if !c.respath.Equal(datastore.NewKey(res.Photo)) {
+			t.Errorf("case %d profile hash mismatch. expected: %s, got: %s", i, c.respath.String(), res.Photo)
 			continue
 		}
 	}
@@ -138,7 +138,7 @@ func TestProfileRequestsSetPosterPhoto(t *testing.T) {
 	}{
 		{"", datastore.NewKey(""), "file is required"},
 		{"testdata/ink_big_photo.jpg", datastore.NewKey(""), "file size too large. max size is 250kb"},
-		{"testdata/q_bang.svg", datastore.NewKey(""), "invalid file format. only .jpg & .png images allowed"},
+		{"testdata/q_bang.svg", datastore.NewKey(""), "invalid file format. only .jpg images allowed"},
 		{"testdata/rico_poster_1500x500.jpg", datastore.NewKey("/map/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL"), ""},
 	}
 
@@ -168,8 +168,8 @@ func TestProfileRequestsSetPosterPhoto(t *testing.T) {
 			continue
 		}
 
-		if !c.respath.Equal(datastore.NewKey(res.Profile)) {
-			t.Errorf("case %d profile hash mismatch. expected: %s, got: %s", i, c.respath.String(), res.Profile)
+		if !c.respath.Equal(datastore.NewKey(res.Photo)) {
+			t.Errorf("case %d profile hash mismatch. expected: %s, got: %s", i, c.respath.String(), res.Photo)
 			continue
 		}
 	}

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -42,5 +42,5 @@ func NewTestRepo(id profile.ID) (repo.Repo, error) {
 	return repo.NewMemRepo(&profile.Profile{
 		ID:       id,
 		Peername: fmt.Sprintf("test-repo-%d", repoID),
-	}, cafs.NewMapstore(), profile.MemStore{})
+	}, cafs.NewMapstore(), profile.NewMemStore())
 }

--- a/p2p/profile.go
+++ b/p2p/profile.go
@@ -97,12 +97,5 @@ func (n *QriNode) profileBytes() ([]byte, error) {
 		return nil, err
 	}
 
-	if addrs, err := n.ListenAddresses(); err == nil {
-		if p.Addresses == nil {
-			p.Addresses = map[string][]string{}
-		}
-		p.Addresses[n.ID.Pretty()] = addrs
-	}
-
 	return json.Marshal(p)
 }

--- a/repo/actions/dataset_test.go
+++ b/repo/actions/dataset_test.go
@@ -46,7 +46,7 @@ func init() {
 
 func TestDataset(t *testing.T) {
 	rmf := func(t *testing.T) repo.Repo {
-		mr, err := repo.NewMemRepo(testPeerProfile, cafs.NewMapstore(), profile.MemStore{})
+		mr, err := repo.NewMemRepo(testPeerProfile, cafs.NewMapstore(), profile.NewMemStore())
 		if err != nil {
 			panic(err)
 		}

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -64,7 +64,7 @@ func NewRepo(store cafs.Filestore, cfg *config.Profile, base string) (repo.Repo,
 		Refstore: Refstore{basepath: bp, store: store, file: FileRefstore},
 		EventLog: NewEventLog(base, FileEventLogs, store),
 
-		profiles: ProfileStore{bp},
+		profiles: NewProfileStore(bp),
 	}
 
 	if index, err := search.LoadIndex(bp.filepath(FileSearchIndex)); err == nil {

--- a/repo/profile/profile.go
+++ b/repo/profile/profile.go
@@ -32,7 +32,7 @@ type Profile struct {
 	// Thumb path for user's thumbnail
 	Thumb datastore.Key `json:"thumb"`
 	// Profile photo
-	Profile datastore.Key `json:"profile"`
+	Photo datastore.Key `json:"photo"`
 	// Poster photo for users's profile page
 	Poster datastore.Key `json:"poster"`
 	// Twitter is a  peer's twitter handle

--- a/repo/ref_test.go
+++ b/repo/ref_test.go
@@ -330,7 +330,7 @@ func TestCompareDatasetRefs(t *testing.T) {
 }
 
 func TestCanonicalizeDatasetRef(t *testing.T) {
-	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille"}, cafs.NewMapstore(), profile.MemStore{})
+	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille"}, cafs.NewMapstore(), profile.NewMemStore())
 	if err != nil {
 		t.Errorf("error allocating mem repo: %s", err.Error())
 		return
@@ -370,7 +370,7 @@ func TestCanonicalizeDatasetRef(t *testing.T) {
 }
 
 func TestCanonicalizeProfile(t *testing.T) {
-	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille", ID: profile.IDB58MustDecode("QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, cafs.NewMapstore(), profile.MemStore{})
+	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille", ID: profile.IDB58MustDecode("QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, cafs.NewMapstore(), profile.NewMemStore())
 	if err != nil {
 		t.Errorf("error allocating mem repo: %s", err.Error())
 		return

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -58,7 +58,7 @@ func NewTestRepo() (mr repo.Repo, err error) {
 	datasets := []string{"movies", "cities", "counter", "craigslist"}
 
 	ms := cafs.NewMapstore()
-	mr, err = repo.NewMemRepo(testPeerProfile, ms, profile.MemStore{})
+	mr, err = repo.NewMemRepo(testPeerProfile, ms, profile.NewMemStore())
 	if err != nil {
 		return
 	}
@@ -99,7 +99,7 @@ func NewMemRepoFromDir(path string) (repo.Repo, crypto.PrivKey, error) {
 	}
 
 	ms := cafs.NewMapstore()
-	mr, err := repo.NewMemRepo(pro, ms, profile.MemStore{})
+	mr, err := repo.NewMemRepo(pro, ms, profile.NewMemStore())
 	if err != nil {
 		return mr, pk, err
 	}


### PR DESCRIPTION

refator(api): use /profile/photo & /profile/poster as vanity enapoints

Similar to the situation we ran into shipping the webapp, readonly mode can and should prevent access to anything under the `/ipfs/` endpoint, which sadly includes profile photos & poster images. To get around this we'll use the same trick of hiding photos behind vanity urls.

In an effort to avoid API bloat, I've added these as elements of the previously under-used /profile/photo & /profile/poster GET endpoints. Both now accept query params for id (which is the profile ID) or peerneme. this is going to need some refinement & docs, but it'll work for now.

I've also removed .png image formats for posters & profiles so that these endpoints have an easy story for providing `Content-Type` headers.

Examples:
```
# this will return the peer's profile photo as jpg data:
GET http://localhost:2503/profile/photo?peername=b5

# ditto for the peer's poster, this time fetched with a profile id:
GET http://localhost:2503/profile/poster?id=QmeqJRCTeXnLvr523UTgVzi6UhMV5jcGn4xz3Wf3ycknEm
````

We should update the frontend to use these instead of the raw ipfs hashes, that way it'll work in both readonly and writable modes.

### Other Fixes
* I've also added a few odds & ends to this PR. With any luck these added mutex locks _might_ address #357, which I believe is being caused by a race condition at write time.
* Also added some makefile magic to make developing qri easier.