### PR TITLE
fix(fsrepo.Profiles): add file lock for peers.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOFILES = $(shell find . -name '*.go' -not -path './vendor/*')
-GOPACKAGES = github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/qri-io/dsdiff github.com/qri-io/varName github.com/qri-io/registry/regclient github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/cobra/doc github.com/ugorji/go/codec
+GOPACKAGES = github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/qri-io/dsdiff github.com/qri-io/varName github.com/qri-io/registry/regclient github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/cobra/doc github.com/ugorji/go/codec github.com/theckman/go-flock
 
 default: build
 

--- a/p2p/profile.go
+++ b/p2p/profile.go
@@ -37,7 +37,7 @@ func (n *QriNode) RequestProfile(pid peer.ID) (*profile.Profile, error) {
 	}
 
 	res := <-replies
-	log.Debug(res)
+	log.Debugf("profile response for message: %s", res.ID)
 
 	cp := &profile.CodingProfile{}
 	if err := json.Unmarshal(res.Body, cp); err != nil {
@@ -68,20 +68,7 @@ func (n *QriNode) handleProfile(ws *WrappedStream, msg Message) (hangup bool) {
 		return
 	}
 
-	// pids, err := pro.PeerIDs()
-	// if err != nil {
-	// 	log.Debug(err.Error())
-	// 	return
-	// }
-
 	pro.Updated = time.Now()
-	n.Repo.Profiles().PutProfile(pro)
-
-	// log.Debugf("adding peer: %s", pid.Pretty())
-	// if err := n.Repo.Profiles().PutPeer(pid, pro); err != nil {
-	// 	log.Debug(err.Error())
-	// 	return
-	// }
 
 	data, err := n.profileBytes()
 	if err != nil {


### PR DESCRIPTION
we've been getting all sorts of bad json from not guarding peers.json from concurrent reads & writes. This makes some initial inroads on the problem, but isn't to be trusted until comprehensive tests are written.

makes more inroads on #357