### PR TITLE
chore(makefile): escape dollar sign so error displays correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: build
 
 require-gopath:
 ifndef GOPATH
-	$(error $GOPATH must be set. plz check: https://github.com/golang/go/wiki/SettingGOPATH)
+	$(error $$GOPATH must be set. plz check: https://github.com/golang/go/wiki/SettingGOPATH)
 endif
 
 build: require-gopath


### PR DESCRIPTION
Current error renders as:

    Makefile:8: *** OPATH must be set

Since the shell will treat $G as a variable to evaluate, concatenating the result to `OPATH`.