### PR TITLE
refactor(infoCommand): make info command only work for datasets

### DIFF
--- a/cmd/data.go
+++ b/cmd/data.go
@@ -33,11 +33,8 @@ Data reads records from a dataset`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		loadConfig()
 	},
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			fmt.Println("please specify a dataset name to retrieve data")
-			return
-		}
 		requireNotRPC(cmd.Name())
 
 		r := getRepo(false)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 
 	"github.com/qri-io/dataset"
-	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/repo"
-	"github.com/qri-io/qri/repo/profile"
 	"github.com/spf13/cobra"
 )
 
@@ -42,23 +40,7 @@ var infoCmd = &cobra.Command{
 			}
 		}
 
-		online := false
-		// check to see if we're all local
-		r := getRepo(false)
-		for _, arg := range args {
-			ref, err := repo.ParseDatasetRef(arg)
-			ExitIfErr(err)
-			err = repo.CanonicalizeDatasetRef(r, &ref)
-			ExitIfErr(err)
-			if ref.Path == "" {
-				online = true
-			}
-		}
-
-		pr, err := peerRequests(online)
-		ExitIfErr(err)
-
-		req, err := datasetRequests(online)
+		req, err := datasetRequests(false)
 		ExitIfErr(err)
 
 		for i, arg := range args {
@@ -66,25 +48,7 @@ var infoCmd = &cobra.Command{
 			ExitIfErr(err)
 
 			if ref.IsPeerRef() {
-				err = repo.CanonicalizeProfile(r, &ref)
-				ExitIfErr(err)
-				p := &core.PeerInfoParams{
-					Peername: ref.Peername,
-				}
-				res := &profile.CodingProfile{}
-				err := pr.Info(p, res)
-				if err != nil {
-					printSuccess(err.Error())
-				}
-				ExitIfErr(err)
-
-				if outformat == "" {
-					printPeerInfo(0, res)
-				} else {
-					data, err := json.MarshalIndent(res, "", "  ")
-					ExitIfErr(err)
-					fmt.Printf("%s", string(data))
-				}
+				printWarning("please specify a dataset for peer %s", ref.Peername)
 			} else {
 				res := repo.DatasetRef{}
 				err = req.Get(&ref, &res)

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
@@ -11,7 +9,7 @@ import (
 var datasetRenameCmd = &cobra.Command{
 	Use:     "rename",
 	Aliases: []string{"mv"},
-	Short:   "show the history of changes to a dataset",
+	Short:   "change the name of a dataset",
 	Long: `
 Rename changes the name of a dataset. So, uh, it’s worth noting that this can 
 break lots of stuff for other people, especially in these early days of qri. 
@@ -24,11 +22,8 @@ with it, especially if you want other people to like your datasets.`,
 	Annotations: map[string]string{
 		"group": "dataset",
 	},
+	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 2 {
-			ErrExit(fmt.Errorf("please provide current & new dataset names"))
-		}
-
 		current, err := repo.ParseDatasetRef(args[0])
 		ExitIfErr(err)
 


### PR DESCRIPTION
Logic surrounding the info command is just too convoluted right now. In the future it'd be great to get this working properly, but will require some pretty major refactoring at lower levels before that can be the case, so for now let's just turn it off.