### PR TITLE
fix(setup): fix config not loading if already found

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -60,6 +60,8 @@ peers & swapping data.`,
 			ExitIfErr(err)
 		} else if !QRIRepoInitialized() {
 			ErrExit(fmt.Errorf("no qri repo exists"))
+		} else {
+			loadConfig()
 		}
 
 		r = getRepo(true)

--- a/config/api.go
+++ b/config/api.go
@@ -85,6 +85,7 @@ func DefaultAPI() *API {
 		Port:    DefaultAPIPort,
 		TLS:     false,
 		AllowedOrigins: []string{
+			"electron://local.qri.io",
 			fmt.Sprintf("http://localhost:%d", DefaultWebappPort),
 			"http://app.qri.io",
 			"https://app.qri.io",


### PR DESCRIPTION
we missed a condition where `--setup` flag is provided but configuration details already exist.