### PR TITLE
feat(api/config): refactor cmd/config.go and add api/config.go

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -140,11 +140,9 @@ var configSetCommand = &cobra.Command{
 			}
 		}
 
-		err = core.Config.Validate()
+		err = core.SetConfig(core.Config)
 		ExitIfErr(err)
 
-		err = core.Config.WriteToFile(core.ConfigFilepath)
-		ExitIfErr(err)
 		printSuccess("config updated")
 	},
 }

--- a/config/api.go
+++ b/config/api.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/qri-io/jsonschema"
 )
 
@@ -91,4 +93,22 @@ func DefaultAPI() *API {
 			"https://app.qri.io",
 		},
 	}
+}
+
+// Copy returns a deep copy of an API struct
+func (a *API) Copy() *API {
+	res := &API{
+		Enabled:         a.Enabled,
+		Port:            a.Port,
+		ReadOnly:        a.ReadOnly,
+		URLRoot:         a.URLRoot,
+		TLS:             a.TLS,
+		DisconnectAfter: a.DisconnectAfter,
+		ProxyForceHTTPS: a.ProxyForceHTTPS,
+	}
+	if a.AllowedOrigins != nil {
+		res.AllowedOrigins = make([]string, len(a.AllowedOrigins))
+		reflect.Copy(reflect.ValueOf(res.AllowedOrigins), reflect.ValueOf(a.AllowedOrigins))
+	}
+	return res
 }

--- a/config/api_test.go
+++ b/config/api_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,5 +9,25 @@ func TestAPIValidate(t *testing.T) {
 	err := DefaultAPI().Validate()
 	if err != nil {
 		t.Errorf("error validating default api: %s", err)
+	}
+}
+
+func TestAPICopy(t *testing.T) {
+	cases := []struct {
+		api *API
+	}{
+		{DefaultAPI()},
+	}
+	for i, c := range cases {
+		cpy := c.api.Copy()
+		if !reflect.DeepEqual(cpy, c.api) {
+			t.Errorf("API Copy test case %v, api structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.api)
+			continue
+		}
+		cpy.AllowedOrigins[0] = ""
+		if reflect.DeepEqual(cpy, c.api) {
+			t.Errorf("API Copy test case %v, editing one api struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.api)
+			continue
+		}
 	}
 }

--- a/config/cli.go
+++ b/config/cli.go
@@ -31,3 +31,21 @@ func (c CLI) Validate() error {
   }`)
 	return validate(schema, &c)
 }
+
+// Copy returns a deep copy of a CLI struct
+func (c *CLI) Copy() *CLI {
+	res := &CLI{
+		ColorizeOutput: c.ColorizeOutput,
+	}
+	return res
+}
+
+// WithPrivateValues returns a deep copy of CLI struct all the privates values of the receiver added to the *CLI param
+func (c *CLI) WithPrivateValues(p *CLI) *CLI {
+	return p.Copy()
+}
+
+// WithoutPrivateValues returns a deep copy of an CLI struct with all the private values removed
+func (c *CLI) WithoutPrivateValues() *CLI {
+	return c.Copy()
+}

--- a/config/cli_test.go
+++ b/config/cli_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,5 +9,20 @@ func TestCLIValidate(t *testing.T) {
 	err := DefaultCLI().Validate()
 	if err != nil {
 		t.Errorf("error validating default cli: %s", err)
+	}
+}
+
+func TestCLICopy(t *testing.T) {
+	cases := []struct {
+		cli *CLI
+	}{
+		{DefaultCLI()},
+	}
+	for i, c := range cases {
+		cpy := c.cli.Copy()
+		if !reflect.DeepEqual(cpy, c.cli) {
+			t.Errorf("CLI Copy test case %v, cli structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.cli)
+			continue
+		}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -254,3 +254,62 @@ func (cfg Config) Validate() error {
 	}
 	return cfg.Logging.Validate()
 }
+
+// Copy returns a deep copy of the Config struct
+func (cfg *Config) Copy() *Config {
+	res := &Config{}
+
+	if cfg.Profile != nil {
+		res.Profile = cfg.Profile.Copy()
+	}
+	if cfg.Repo != nil {
+		res.Repo = cfg.Repo.Copy()
+	}
+	if cfg.Store != nil {
+		res.Store = cfg.Store.Copy()
+	}
+	if cfg.P2P != nil {
+		res.P2P = cfg.P2P.Copy()
+	}
+	if cfg.Registry != nil {
+		res.Registry = cfg.Registry.Copy()
+	}
+	if cfg.CLI != nil {
+		res.CLI = cfg.CLI.Copy()
+	}
+	if cfg.API != nil {
+		res.API = cfg.API.Copy()
+	}
+	if cfg.Webapp != nil {
+		res.Webapp = cfg.Webapp.Copy()
+	}
+	if cfg.RPC != nil {
+		res.RPC = cfg.RPC.Copy()
+	}
+	if cfg.Logging != nil {
+		res.Logging = cfg.Logging.Copy()
+	}
+
+	return res
+}
+
+// WithoutPrivateValues returns a deep copy of the receiver with the private values removed
+func (cfg *Config) WithoutPrivateValues() *Config {
+	res := cfg.Copy()
+
+	res.Profile.PrivKey = ""
+	res.P2P.PrivKey = ""
+
+	return res
+}
+
+// WithPrivateValues returns a deep copy of the receiver with the private values from
+// the *Config passed in from the params
+func (cfg *Config) WithPrivateValues(p *Config) *Config {
+	res := cfg.Copy()
+
+	res.Profile.PrivKey = p.Profile.PrivKey
+	res.P2P.PrivKey = p.P2P.PrivKey
+
+	return res
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"github.com/sergi/go-diff/diffmatchpatch"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 func TestReadFromFile(t *testing.T) {
@@ -198,5 +199,25 @@ func TestConfigValidate(t *testing.T) {
 	l.Logging.Levels["qriapi"] = "badType"
 	if err := l.Validate(); err == nil {
 		t.Error("When given bad input in Logging, config.Validate did not catch the error.")
+	}
+}
+
+func TestConfigCopy(t *testing.T) {
+	cases := []struct {
+		config *Config
+	}{
+		{DefaultConfig()},
+	}
+	for i, c := range cases {
+		cpy := c.config.Copy()
+		if !reflect.DeepEqual(cpy, c.config) {
+			t.Errorf("Config Copy test case %v, config structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.config)
+			continue
+		}
+		cpy.API.AllowedOrigins[0] = ""
+		if reflect.DeepEqual(cpy, c.config) {
+			t.Errorf("Config Copy test case %v, editing one config struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.config)
+			continue
+		}
 	}
 }

--- a/config/logging.go
+++ b/config/logging.go
@@ -46,3 +46,15 @@ func (l Logging) Validate() error {
   }`)
 	return validate(schema, &l)
 }
+
+// Copy returns a deep copy of a Logging struct
+func (l *Logging) Copy() *Logging {
+	res := &Logging{}
+	if l.Levels != nil {
+		res.Levels = map[string]string{}
+		for key, value := range l.Levels {
+			res.Levels[key] = value
+		}
+	}
+	return res
+}

--- a/config/logging_test.go
+++ b/config/logging_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,5 +9,25 @@ func TestLoggingValidate(t *testing.T) {
 	err := DefaultLogging().Validate()
 	if err != nil {
 		t.Errorf("error validating default logging: %s", err)
+	}
+}
+
+func TestLoggingCopy(t *testing.T) {
+	cases := []struct {
+		logging *Logging
+	}{
+		{DefaultLogging()},
+	}
+	for i, c := range cases {
+		cpy := c.logging.Copy()
+		if !reflect.DeepEqual(cpy, c.logging) {
+			t.Errorf("Logging Copy test case %v, logging structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.logging)
+			continue
+		}
+		cpy.Levels["qriapi"] = "error"
+		if reflect.DeepEqual(cpy, c.logging) {
+			t.Errorf("Logging Copy test case %v, editing one logging struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.logging)
+			continue
+		}
 	}
 }

--- a/config/p2p.go
+++ b/config/p2p.go
@@ -42,7 +42,7 @@ type P2P struct {
 	ProfileReplication string `json:"profilereplication"`
 
 	// list of addresses to bootsrap qri peers on
-	BoostrapAddrs []string `json:"bootstrapaddrs"`
+	BootstrapAddrs []string `json:"bootstrapaddrs"`
 }
 
 // DefaultP2P generates sensible settings for p2p, generating a new randomized

--- a/config/p2p.go
+++ b/config/p2p.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 
 	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
 	peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
@@ -164,6 +165,30 @@ func (cfg P2P) Validate() error {
     }
   }`)
 	return validate(schema, &cfg)
+}
+
+// Copy returns a deep copy of a p2p struct
+func (cfg *P2P) Copy() *P2P {
+	res := &P2P{
+		Enabled:            cfg.Enabled,
+		PeerID:             cfg.PeerID,
+		PubKey:             cfg.PubKey,
+		PrivKey:            cfg.PrivKey,
+		Port:               cfg.Port,
+		ProfileReplication: cfg.ProfileReplication,
+	}
+
+	if cfg.QriBootstrapAddrs != nil {
+		res.QriBootstrapAddrs = make([]string, len(cfg.QriBootstrapAddrs))
+		reflect.Copy(reflect.ValueOf(res.QriBootstrapAddrs), reflect.ValueOf(cfg.QriBootstrapAddrs))
+	}
+
+	if cfg.BootstrapAddrs != nil {
+		res.BootstrapAddrs = make([]string, len(cfg.BootstrapAddrs))
+		reflect.Copy(reflect.ValueOf(res.BootstrapAddrs), reflect.ValueOf(cfg.BootstrapAddrs))
+	}
+
+	return res
 }
 
 // // Validate confirms that the given settings will work, returning an error if not.

--- a/config/p2p_test.go
+++ b/config/p2p_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -38,5 +39,25 @@ func TestP2PValidate(t *testing.T) {
 	err := DefaultP2P().Validate()
 	if err != nil {
 		t.Errorf("error validating default p2p: %s", err)
+	}
+}
+
+func TestP2PCopy(t *testing.T) {
+	cases := []struct {
+		p2p *P2P
+	}{
+		{DefaultP2P()},
+	}
+	for i, c := range cases {
+		cpy := c.p2p.Copy()
+		if !reflect.DeepEqual(cpy, c.p2p) {
+			t.Errorf("P2P Copy test case %v, p2p structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.p2p)
+			continue
+		}
+		cpy.QriBootstrapAddrs[0] = ""
+		if reflect.DeepEqual(cpy, c.p2p) {
+			t.Errorf("P2P Copy test case %v, editing one p2p struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.p2p)
+			continue
+		}
 	}
 }

--- a/config/profile.go
+++ b/config/profile.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"reflect"
 	"time"
 
 	"github.com/libp2p/go-libp2p-crypto"
@@ -205,4 +206,34 @@ func (cfg ProfilePod) Validate() error {
     ]
   }`)
 	return validate(schema, &cfg)
+}
+
+// Copy makes a deep copy of the ProfilePod struct
+func (cfg *ProfilePod) Copy() *ProfilePod {
+	res := &ProfilePod{
+		ID:          cfg.ID,
+		PrivKey:     cfg.PrivKey,
+		Peername:    cfg.Peername,
+		Created:     cfg.Created,
+		Updated:     cfg.Updated,
+		Type:        cfg.Type,
+		Email:       cfg.Email,
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		HomeURL:     cfg.HomeURL,
+		Color:       cfg.Color,
+		Thumb:       cfg.Thumb,
+		Photo:       cfg.Photo,
+		Poster:      cfg.Poster,
+		Twitter:     cfg.Twitter,
+	}
+	if cfg.Addresses != nil {
+		res.Addresses = map[string][]string{}
+		for key, value := range cfg.Addresses {
+			res.Addresses[key] = make([]string, len(value))
+			reflect.Copy(reflect.ValueOf(res.Addresses[key]), reflect.ValueOf(value))
+		}
+	}
+
+	return res
 }

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,5 +9,31 @@ func TestProfileValidate(t *testing.T) {
 	err := DefaultProfile().Validate()
 	if err != nil {
 		t.Errorf("error validating default profile: %s", err)
+	}
+}
+
+func TestProfileCopy(t *testing.T) {
+	// build off DefaultProfile so we can test that the profile Copy
+	// actually copies over correctly (ie, deeply)
+	p := DefaultProfile()
+	p.Addresses = map[string][]string{}
+	p.Addresses["test"] = []string{"1", "2", "3"}
+
+	cases := []struct {
+		profile *ProfilePod
+	}{
+		{p},
+	}
+	for i, c := range cases {
+		cpy := c.profile.Copy()
+		if !reflect.DeepEqual(cpy, c.profile) {
+			t.Errorf("ProfilePod Copy test case %v, profile structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.profile)
+			continue
+		}
+		cpy.Addresses["test"][0] = ""
+		if reflect.DeepEqual(cpy, c.profile) {
+			t.Errorf("ProfilePod Copy test case %v, editing one profile struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.profile)
+			continue
+		}
 	}
 }

--- a/config/registry.go
+++ b/config/registry.go
@@ -34,3 +34,11 @@ func (cfg Registry) Validate() error {
   }`)
 	return validate(schema, &cfg)
 }
+
+// Copy makes a deep copy of the Registry struct
+func (cfg *Registry) Copy() *Registry {
+	res := &Registry{
+		Location: cfg.Location,
+	}
+	return res
+}

--- a/config/registry_test.go
+++ b/config/registry_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRegistryValidate(t *testing.T) {
+	err := DefaultRegistry().Validate()
+	if err != nil {
+		t.Errorf("error validating default registry: %s", err)
+	}
+}
+
+func TestRegistryCopy(t *testing.T) {
+	cases := []struct {
+		registry *Registry
+	}{
+		{DefaultRegistry()},
+	}
+	for i, c := range cases {
+		cpy := c.registry.Copy()
+		if !reflect.DeepEqual(cpy, c.registry) {
+			t.Errorf("Registry Copy test case %v, registry structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.registry)
+			continue
+		}
+		cpy.Location = "different/location"
+		if reflect.DeepEqual(cpy, c.registry) {
+			t.Errorf("Registry Copy test case %v, editing one registry struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.registry)
+			continue
+		}
+	}
+}

--- a/config/repo.go
+++ b/config/repo.go
@@ -1,6 +1,10 @@
 package config
 
-import "github.com/qri-io/jsonschema"
+import (
+	"reflect"
+
+	"github.com/qri-io/jsonschema"
+)
 
 // Repo configures a qri repo
 type Repo struct {
@@ -42,4 +46,17 @@ func (cfg Repo) Validate() error {
     }
   }`)
 	return validate(schema, &cfg)
+}
+
+// Copy returns a deep copy of the Repo struct
+func (cfg *Repo) Copy() *Repo {
+	res := &Repo{
+		Type: cfg.Type,
+	}
+	if cfg.Middleware != nil {
+		res.Middleware = make([]string, len(cfg.Middleware))
+		reflect.Copy(reflect.ValueOf(res.Middleware), reflect.ValueOf(cfg.Middleware))
+	}
+
+	return res
 }

--- a/config/repo_test.go
+++ b/config/repo_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,5 +9,30 @@ func TestRepoValidate(t *testing.T) {
 	err := DefaultRepo().Validate()
 	if err != nil {
 		t.Errorf("error validating default repo: %s", err)
+	}
+}
+
+func TestRepoCopy(t *testing.T) {
+	// build off DefaultRepo so we can test that the repo Copy
+	// actually copies over correctly (ie, deeply)
+	r := DefaultRepo()
+	r.Middleware = []string{"firstMiddleware"}
+
+	cases := []struct {
+		repo *Repo
+	}{
+		{r},
+	}
+	for i, c := range cases {
+		cpy := c.repo.Copy()
+		if !reflect.DeepEqual(cpy, c.repo) {
+			t.Errorf("Repo Copy test case %v, repo structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.repo)
+			continue
+		}
+		cpy.Middleware[0] = "differentMiddleware"
+		if reflect.DeepEqual(cpy, c.repo) {
+			t.Errorf("Repo Copy test case %v, editing one repo struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.repo)
+			continue
+		}
 	}
 }

--- a/config/rpc.go
+++ b/config/rpc.go
@@ -41,3 +41,13 @@ func (cfg RPC) Validate() error {
   }`)
 	return validate(schema, &cfg)
 }
+
+// Copy makes a deep copy of the RPC struct
+func (cfg *RPC) Copy() *RPC {
+	res := &RPC{
+		Enabled: cfg.Enabled,
+		Port:    cfg.Port,
+	}
+
+	return res
+}

--- a/config/rpc_test.go
+++ b/config/rpc_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,5 +9,25 @@ func TestRPCValidate(t *testing.T) {
 	err := DefaultRPC().Validate()
 	if err != nil {
 		t.Errorf("error validating default rpc: %s", err)
+	}
+}
+
+func TestRPCCopy(t *testing.T) {
+	cases := []struct {
+		rpc *RPC
+	}{
+		{DefaultRPC()},
+	}
+	for i, c := range cases {
+		cpy := c.rpc.Copy()
+		if !reflect.DeepEqual(cpy, c.rpc) {
+			t.Errorf("RPC Copy test case %v, rpc structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.rpc)
+			continue
+		}
+		cpy.Enabled = false
+		if reflect.DeepEqual(cpy, c.rpc) {
+			t.Errorf("RPC Copy test case %v, editing one rpc struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.rpc)
+			continue
+		}
 	}
 }

--- a/config/store.go
+++ b/config/store.go
@@ -34,3 +34,12 @@ func (cfg Store) Validate() error {
   }`)
 	return validate(schema, &cfg)
 }
+
+// Copy returns a deep copy of the Store struct
+func (cfg *Store) Copy() *Store {
+	res := &Store{
+		Type: cfg.Type,
+	}
+
+	return res
+}

--- a/config/store_test.go
+++ b/config/store_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,5 +9,25 @@ func TestStoreValidate(t *testing.T) {
 	err := DefaultStore().Validate()
 	if err != nil {
 		t.Errorf("error validating default store: %s", err)
+	}
+}
+
+func TestStoreCopy(t *testing.T) {
+	cases := []struct {
+		store *Store
+	}{
+		{DefaultStore()},
+	}
+	for i, c := range cases {
+		cpy := c.store.Copy()
+		if !reflect.DeepEqual(cpy, c.store) {
+			t.Errorf("Store Copy test case %v, store structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.store)
+			continue
+		}
+		cpy.Type = ""
+		if reflect.DeepEqual(cpy, c.store) {
+			t.Errorf("Store Copy test case %v, editing one store struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.store)
+			continue
+		}
 	}
 }

--- a/config/webapp.go
+++ b/config/webapp.go
@@ -64,3 +64,15 @@ func (cfg Webapp) Validate() error {
   }`)
 	return validate(schema, &cfg)
 }
+
+// Copy returns a deep copy of the Webapp struct
+func (cfg *Webapp) Copy() *Webapp {
+	res := &Webapp{
+		Enabled:                 cfg.Enabled,
+		Port:                    cfg.Port,
+		AnalyticsToken:          cfg.AnalyticsToken,
+		EntrypointUpdateAddress: cfg.EntrypointUpdateAddress,
+		EntrypointHash:          cfg.EntrypointHash,
+	}
+	return res
+}

--- a/config/webapp_test.go
+++ b/config/webapp_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,5 +9,25 @@ func TestWebappValidate(t *testing.T) {
 	err := DefaultWebapp().Validate()
 	if err != nil {
 		t.Errorf("error validating default webapp: %s", err)
+	}
+}
+
+func TestWebappCopy(t *testing.T) {
+	cases := []struct {
+		webapp *Webapp
+	}{
+		{DefaultWebapp()},
+	}
+	for i, c := range cases {
+		cpy := c.webapp.Copy()
+		if !reflect.DeepEqual(cpy, c.webapp) {
+			t.Errorf("Webapp Copy test case %v, webapp structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.webapp)
+			continue
+		}
+		cpy.Port = 0
+		if reflect.DeepEqual(cpy, c.webapp) {
+			t.Errorf("Webapp Copy test case %v, editing one webapp struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.webapp)
+			continue
+		}
 	}
 }

--- a/core/config.go
+++ b/core/config.go
@@ -75,15 +75,10 @@ func GetConfig(p *GetConfigParams, res *[]byte) error {
 		encode interface{}
 	)
 
-	*cfg = *Config
-
 	if !p.WithPrivateKey {
-		if cfg.Profile != nil {
-			cfg.Profile.PrivKey = ""
-		}
-		if cfg.P2P != nil {
-			cfg.P2P.PrivKey = ""
-		}
+		cfg = Config.WithoutPrivateValues()
+	} else {
+		cfg = Config.Copy()
 	}
 
 	encode = cfg
@@ -118,10 +113,10 @@ func SetConfig(res *config.Config) error {
 		return fmt.Errorf("error validating config: %s", err)
 	}
 	if err := SaveConfig(); err != nil {
-		return fmt.Errorf("error saving config: &s", err)
+		return fmt.Errorf("error saving config: %s", err)
 	}
 
-	// Config = Config.WithPrivateValues(res)
+	Config = res.WithPrivateValues(Config)
 
 	return nil
 }

--- a/core/config.go
+++ b/core/config.go
@@ -1,10 +1,12 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/qri/config"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -54,4 +56,58 @@ we won't be shipping changes that require starting over.
 	Config = cfg
 
 	return err
+}
+
+// GetConfigParams are the params needed to format/specify the fields in bytes returned from the GetConfig function
+type GetConfigParams struct {
+	WithPrivateKey bool
+	Format         string
+	Concise        bool
+	Field          string
+}
+
+// GetConfig returns the Config, or one of the specified fields of the Config, as a slice of bytes
+// the bytes can be formatted as json, concise json, or yaml
+func GetConfig(params *GetConfigParams, data *[]byte) error {
+	var (
+		err    error
+		cfg    = &config.Config{}
+		encode interface{}
+	)
+
+	*cfg = *Config
+
+	if !params.WithPrivateKey {
+		if cfg.Profile != nil {
+			cfg.Profile.PrivKey = ""
+		}
+		if cfg.P2P != nil {
+			cfg.P2P.PrivKey = ""
+		}
+	}
+
+	encode = cfg
+
+	if params.Field != "" {
+		encode, err = cfg.Get(params.Field)
+		if err != nil {
+			return fmt.Errorf("error getting %s from config: %s", params.Field, err)
+		}
+	}
+
+	switch params.Format {
+	case "json":
+		if params.Concise {
+			*data, err = json.Marshal(encode)
+		} else {
+			*data, err = json.MarshalIndent(encode, "", " ")
+		}
+	case "yaml":
+		*data, err = yaml.Marshal(encode)
+	}
+	if err != nil {
+		return fmt.Errorf("error getting config: %s", err)
+	}
+
+	return nil
 }

--- a/core/profile.go
+++ b/core/profile.go
@@ -103,7 +103,7 @@ func (r *ProfileRequests) SaveProfile(p *config.ProfilePod, res *config.ProfileP
 		return fmt.Errorf("profile required for update")
 	}
 
-	if p.Peername != "" {
+	if p.Peername != Config.Profile.Peername && p.Peername != "" {
 		// TODO - should ProfileRequests be allocated with a configuration? How should this work in relation to
 		// RPC requests?
 		if Config.Registry != nil {
@@ -163,7 +163,7 @@ func (r *ProfileRequests) SaveProfile(p *config.ProfilePod, res *config.ProfileP
 	*res = *Config.Profile
 	res.PrivKey = ""
 
-	return SaveConfig()
+	return SetConfig(Config)
 }
 
 // ProfilePhoto fetches the byte slice of a given user's profile photo
@@ -296,6 +296,7 @@ func (r *ProfileRequests) SetPosterPhoto(p *FileParams, res *config.ProfilePod) 
 	path, err := r.repo.Store().Put(cafs.NewMemfileBytes("plz_just_encode", data), true)
 	if err != nil {
 		log.Debug(err.Error())
+
 		return fmt.Errorf("error saving photo: %s", err.Error())
 	}
 

--- a/core/profile_test.go
+++ b/core/profile_test.go
@@ -101,7 +101,7 @@ func TestSaveProfile(t *testing.T) {
 	pro.Email = "test_email@example.com"
 	pro.Description = "This is only a test profile"
 	pro.HomeURL = "http://example.com"
-	pro.Color = "test_color"
+	pro.Color = "default"
 	pro.Twitter = "test_twitter"
 
 	// Save the CodingProfile.
@@ -167,7 +167,7 @@ func TestSaveProfile(t *testing.T) {
 	if got.HomeURL != "http://example.com" {
 		log.Errorf("Got Type %v", got.HomeURL)
 	}
-	if got.Color != "test_color" {
+	if got.Color != "default" {
 		log.Errorf("Got Type %v", got.Color)
 	}
 	if got.Twitter != "test_twitter" {


### PR DESCRIPTION
closes #375 
* Moves the bulk of the functionality of GetConfig from the cmd/config.go file to the core/config.go file. Adds GetConfigParams.