### PR TITLE
refactor(p2p): extract NewTestNetwork into its own p2ptest package

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -25,12 +25,8 @@ type Requests interface {
 func Receivers(node *p2p.QriNode) []Requests {
 	r := node.Repo
 
-	// TODO - horrible hack for meow
-	dsr := NewDatasetRequests(r, nil)
-	dsr.Node = node
-
 	return []Requests{
-		dsr,
+		NewDatasetRequestsWithNode(r, nil, node),
 		NewHistoryRequests(r, nil),
 		NewPeerRequests(node, nil),
 		NewProfileRequests(r, nil),

--- a/core/datasets.go
+++ b/core/datasets.go
@@ -58,6 +58,20 @@ func NewDatasetRequests(r repo.Repo, cli *rpc.Client) *DatasetRequests {
 	}
 }
 
+// NewDatasetRequestsWithNode creates a DatasetRequests pointer from either a repo
+// or an rpc.Client
+func NewDatasetRequestsWithNode(r repo.Repo, cli *rpc.Client, node *p2p.QriNode) *DatasetRequests {
+	if r != nil && cli != nil {
+		panic(fmt.Errorf("both repo and client supplied to NewDatasetRequestsWithNode"))
+	}
+
+	return &DatasetRequests{
+		repo: actions.Dataset{r},
+		cli:  cli,
+		Node: node,
+	}
+}
+
 // List returns this repo's datasets
 func (r *DatasetRequests) List(p *ListParams, res *[]repo.DatasetRef) error {
 

--- a/p2p/events_test.go
+++ b/p2p/events_test.go
@@ -5,15 +5,21 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/qri-io/qri/p2p/test"
 	"github.com/qri-io/qri/repo"
 )
 
 func TestRequestEventsList(t *testing.T) {
 	ctx := context.Background()
-	peers, err := NewTestNetwork(ctx, t, 5)
+	testPeers, err := p2ptest.NewTestNetwork(ctx, t, 5, NewTestQriNode)
 	if err != nil {
 		t.Errorf("error creating network: %s", err.Error())
 		return
+	}
+	// Convert from test nodes to non-test nodes.
+	peers := make([]*QriNode, len(testPeers))
+	for i, node := range testPeers {
+		peers[i] = node.(*QriNode)
 	}
 
 	for _, p := range peers {

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/qri-io/cafs/ipfs"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/p2p/test"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
 
@@ -67,6 +68,15 @@ type QriNode struct {
 	receivers []chan Message
 	// profileReplication sets what to do when this node sees it's own profile
 	profileReplication string
+}
+
+// Assert that conversions needed by the tests are valid.
+var _ p2ptest.TestablePeerNode = (*QriNode)(nil)
+var _ p2ptest.NodeMakerFunc = NewTestQriNode
+
+// NewTestQriNode creates a new node, as a TestablePeerNode, usable by testing utilities.
+func NewTestQriNode(r repo.Repo, options ...func(o *config.P2P)) (p2ptest.TestablePeerNode, error) {
+	return NewQriNode(r, options...)
 }
 
 // NewQriNode creates a new node, providing no arguments will use
@@ -359,6 +369,11 @@ func (n *QriNode) handleStream(ws *WrappedStream, replies chan Message) {
 			break
 		}
 	}
+}
+
+// Keys returns the KeyBook for the node.
+func (n *QriNode) Keys() pstore.KeyBook {
+	return n.QriPeers
 }
 
 // MakeHandlers generates a map of MsgTypes to their corresponding handler functions

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -1,15 +1,12 @@
 package p2p
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/qri-io/cafs"
-	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
+	"github.com/qri-io/qri/repo/test"
 
 	testutil "gx/ipfs/QmWRCn8vruNAzHx8i6SAXinuheRitKEGu8c7m26stKvsYx/go-testutil"
-	// peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 )
 
 func TestNewNode(t *testing.T) {
@@ -19,7 +16,7 @@ func TestNewNode(t *testing.T) {
 		return
 	}
 
-	r, err := NewTestRepo(profile.ID(pid))
+	r, err := test.NewTestRepoFromProfileID(profile.ID(pid))
 	if err != nil {
 		t.Errorf("error creating test repo: %s", err.Error())
 		return
@@ -33,14 +30,4 @@ func TestNewNode(t *testing.T) {
 	if node.Online != true {
 		t.Errorf("default node online flag should be true")
 	}
-}
-
-var repoID = 0
-
-func NewTestRepo(id profile.ID) (repo.Repo, error) {
-	repoID++
-	return repo.NewMemRepo(&profile.Profile{
-		ID:       id,
-		Peername: fmt.Sprintf("test-repo-%d", repoID),
-	}, cafs.NewMapstore(), profile.NewMemStore())
 }

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -2,15 +2,20 @@ package p2p
 
 import (
 	"context"
+	"github.com/qri-io/qri/p2p/test"
 	"testing"
 )
 
 func TestPing(t *testing.T) {
 	ctx := context.Background()
-	peers, err := NewTestNetwork(ctx, t, 3)
+	testPeers, err := p2ptest.NewTestNetwork(ctx, t, 3, NewTestQriNode)
 	if err != nil {
 		t.Errorf("error creating network: %s", err.Error())
 		return
+	}
+	peers := make([]*QriNode, len(testPeers))
+	for i, arg := range testPeers {
+		peers[i] = arg.(*QriNode)
 	}
 
 	if err := connectNodes(ctx, peers); err != nil {

--- a/p2p/profile_test.go
+++ b/p2p/profile_test.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"github.com/qri-io/qri/p2p/test"
 	"sync"
 	"testing"
 
@@ -10,10 +11,15 @@ import (
 
 func TestRequestProfile(t *testing.T) {
 	ctx := context.Background()
-	peers, err := NewTestNetwork(ctx, t, 5)
+	testPeers, err := p2ptest.NewTestNetwork(ctx, t, 5, NewTestQriNode)
 	if err != nil {
 		t.Errorf("error creating network: %s", err.Error())
 		return
+	}
+	// Convert from test nodes to non-test nodes.
+	peers := make([]*QriNode, len(testPeers))
+	for i, node := range testPeers {
+		peers[i] = node.(*QriNode)
 	}
 
 	if err := connectNodes(ctx, peers); err != nil {

--- a/p2p/test/p2ptest.go
+++ b/p2p/test/p2ptest.go
@@ -1,0 +1,75 @@
+package p2ptest
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/repo"
+	"github.com/qri-io/qri/repo/profile"
+	"github.com/qri-io/qri/repo/test"
+	testutil "gx/ipfs/QmVvkK7s5imCiq3JVbL3pGfnhcCnf3LrFJPF4GE2sAoGZf/go-testutil"
+	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
+	pstore "gx/ipfs/QmXauCuJzmzapetmC6W4TuDJLL1yFFrVzSHoWv8YdbmnxH/go-libp2p-peerstore"
+	"testing"
+)
+
+// TestablePeerNode is used by tests only. Implemented by QriNode, whose Keys is QriPeers.
+type TestablePeerNode interface {
+	Keys() pstore.KeyBook
+}
+
+// NodeMakerFunc is a function that constructs a Node from a Repo and options.
+type NodeMakerFunc func(repo.Repo, ...func(*config.P2P)) (TestablePeerNode, error)
+
+// NewTestNetwork constructs nodes to test p2p functionality.
+func NewTestNetwork(ctx context.Context, t *testing.T, num int, maker NodeMakerFunc) ([]TestablePeerNode, error) {
+	nodes := make([]TestablePeerNode, num)
+
+	for i := 0; i < num; i++ {
+		rid, err := testutil.RandPeerID()
+		if err != nil {
+			return nil, fmt.Errorf("error creating peer ID: %s", err.Error())
+		}
+
+		r, err := test.NewTestRepoFromProfileID(profile.ID(rid))
+		if err != nil {
+			return nil, fmt.Errorf("error creating test repo: %s", err.Error())
+		}
+
+		node, err := NewTestQriNode(r, t, maker)
+		if err != nil {
+			return nil, err
+		}
+
+		nodes[i] = node
+	}
+	return nodes, nil
+}
+
+// NewTestQriNode constructs a node for testing.
+func NewTestQriNode(r repo.Repo, t *testing.T, maker NodeMakerFunc) (TestablePeerNode, error) {
+	localnp := testutil.RandPeerNetParamsOrFatal(t)
+	data, err := localnp.PrivKey.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	privKey := base64.StdEncoding.EncodeToString(data)
+
+	node, err := maker(r, func(c *config.P2P) {
+		c.PeerID = localnp.ID.Pretty()
+		c.PrivKey = privKey
+		c.Addrs = []ma.Multiaddr{
+			localnp.Addr,
+		}
+		c.QriBootstrapAddrs = []string{}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating test node: %s", err.Error())
+	}
+	node.Keys().AddPubKey(localnp.ID, localnp.PubKey)
+	node.Keys().AddPrivKey(localnp.ID, localnp.PrivKey)
+
+	return node, err
+}

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -85,6 +85,17 @@ func NewTestRepo() (mr repo.Repo, err error) {
 	return
 }
 
+var repoID = 0
+
+// NewTestRepoFromProfileID constructs a repo from a profileID, usable for tests
+func NewTestRepoFromProfileID(id profile.ID) (repo.Repo, error) {
+	repoID++
+	return repo.NewMemRepo(&profile.Profile{
+		ID:       id,
+		Peername: fmt.Sprintf("test-repo-%d", repoID),
+	}, cafs.NewMapstore(), profile.NewMemStore())
+}
+
 func pkgPath(paths ...string) string {
 	gp := os.Getenv("GOPATH")
 	return filepath.Join(append([]string{gp, "src/github.com/qri-io/qri/repo/test"}, paths...)...)


### PR DESCRIPTION
Will enable easier testing of p2p package. Also move NewTestRepo to repo/test, and create
NewDatasetRequests constructor that can take a QriNode parameter.