### PR TITLE
feat(peer connections): single peer connection control

### DIFF
--- a/api/peers.go
+++ b/api/peers.go
@@ -143,20 +143,15 @@ func (h *PeerHandlers) peerHandler(w http.ResponseWriter, r *http.Request) {
 	util.WriteResponse(w, res)
 }
 
-func (h *PeerHandlers) namespaceHandler(w http.ResponseWriter, r *http.Request) {
-
-}
-
 func (h *PeerHandlers) connectToPeerHandler(w http.ResponseWriter, r *http.Request) {
-	b58pid := r.URL.Path[len("/connect/"):]
-
-	if b58pid == "" {
-		util.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("peer id is required"))
-		return
+	arg := r.URL.Path[len("/connect/"):]
+	if len(arg) == 0 {
+		util.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("invalid connect argument"))
 	}
+	pcpod := core.NewPeerConnectionParamsPod(arg)
 
 	res := &config.ProfilePod{}
-	if err := h.ConnectToPeer(&b58pid, res); err != nil {
+	if err := h.ConnectToPeer(pcpod, res); err != nil {
 		log.Infof("error connecting to peer: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -124,7 +124,8 @@ func init() {
 	connectCmd.Flags().BoolVarP(&disableAPI, "disable-api", "", false, "disables api, overrides the api-port flag")
 	connectCmd.Flags().BoolVarP(&disableRPC, "disable-rpc", "", false, "disables rpc, overrides the rpc-port flag")
 	connectCmd.Flags().BoolVarP(&disableWebapp, "disable-webapp", "", false, "disables webapp, overrides the webapp-port flag")
-	connectCmd.Flags().BoolVarP(&disableP2P, "disable-p2p", "", false, "disable peer-2-peer networking")
+	// TODO - not yet supported
+	// connectCmd.Flags().BoolVarP(&disableP2P, "disable-p2p", "", false, "disable peer-2-peer networking")
 
 	connectCmd.Flags().BoolVarP(&connectSetup, "setup", "", false, "run setup if necessary, reading options from enviornment variables")
 	connectCmd.Flags().BoolVarP(&connectReadOnly, "read-only", "", false, "run qri in read-only mode, limits the api endpoints")

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -11,7 +11,7 @@ import (
 
 var datasetDiffCmd = &cobra.Command{
 	Use:   "diff",
-	Short: "diff two datasets",
+	Short: "compare differences between two datasets",
 	Long: `
 Diff compares two datasets from your repo and prints a represntation 
 of the differences between them.  You can specifify the datasets

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -118,7 +118,7 @@ var peersListCmd = &cobra.Command{
 
 var peersConnectCmd = &cobra.Command{
 	Use:   "connect",
-	Short: "connect directly to a peer ID",
+	Short: "connect to a peer",
 	Args:  cobra.MinimumNArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		loadConfig()
@@ -127,10 +127,12 @@ var peersConnectCmd = &cobra.Command{
 		pr, err := peerRequests(false)
 		ExitIfErr(err)
 
+		pcpod := core.NewPeerConnectionParamsPod(args[0])
 		res := &config.ProfilePod{}
-		err = pr.ConnectToPeer(&args[0], res)
+		err = pr.ConnectToPeer(pcpod, res)
 		ExitIfErr(err)
 
+		printSuccess("successfully connected to %s", res.Peername)
 		printPeerInfo(0, res)
 	},
 }
@@ -143,7 +145,15 @@ var peersDisconnectCmd = &cobra.Command{
 		loadConfig()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		pr, err := peerRequests(false)
+		ExitIfErr(err)
 
+		pcpod := core.NewPeerConnectionParamsPod(args[0])
+		res := false
+		err = pr.DisconnectFromPeer(pcpod, &res)
+		ExitIfErr(err)
+
+		printSuccess("disconnected")
 	},
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -75,5 +75,5 @@ var searchCmd = &cobra.Command{
 func init() {
 	searchCmd.Flags().BoolVarP(&searchCmdReindex, "reindex", "r", false, "re-generate search index from scratch. might take a while.")
 	searchCmd.Flags().StringP("format", "f", "", "set output format [json]")
-	RootCmd.AddCommand(searchCmd)
+	// RootCmd.AddCommand(searchCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,7 +3,7 @@ package cmd
 import "github.com/spf13/cobra"
 
 // VersionNumber is the current version qri
-const VersionNumber = "0.3.2"
+const VersionNumber = "0.3.2-dev"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/repo/profile"
 
+	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
 	pstore "gx/ipfs/QmXauCuJzmzapetmC6W4TuDJLL1yFFrVzSHoWv8YdbmnxH/go-libp2p-peerstore"
 	peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 )
@@ -157,33 +158,88 @@ func (n *QriNode) ConnectedPeers() []string {
 	return peers
 }
 
+// PeerConnectionParams defines parameters for the ConnectToPeer command
+type PeerConnectionParams struct {
+	Peername  string
+	ProfileID profile.ID
+	PeerID    peer.ID
+	Multiaddr ma.Multiaddr
+}
+
 // ConnectToPeer takes a raw peer ID & tries to work out a route to that
 // peer, explicitly connecting to them.
-func (n *QriNode) ConnectToPeer(pid peer.ID) error {
-	// first check for local peer info
-	if pinfo := n.Host.Peerstore().PeerInfo(pid); pinfo.ID.String() != "" {
-		_, err := n.RequestProfile(pinfo.ID)
+func (n *QriNode) ConnectToPeer(ctx context.Context, p PeerConnectionParams) (*profile.Profile, error) {
+	log.Debugf("connect to peer: %v", p)
+	pinfo, err := n.peerConnectionParamsToPeerInfo(p)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := n.Host.Connect(ctx, pinfo); err != nil {
+		return nil, err
+	}
+
+	if err := n.AddQriPeer(pinfo); err != nil {
+		return nil, err
+	}
+
+	return n.Repo.Profiles().PeerProfile(pinfo.ID)
+}
+
+// DisconnectFromPeer explicitly closes a connection to a peer
+func (n *QriNode) DisconnectFromPeer(ctx context.Context, p PeerConnectionParams) error {
+	pinfo, err := n.peerConnectionParamsToPeerInfo(p)
+	if err != nil {
 		return err
+	}
+
+	return n.Host.Network().ClosePeer(pinfo.ID)
+}
+
+func (n *QriNode) peerConnectionParamsToPeerInfo(p PeerConnectionParams) (pi pstore.PeerInfo, err error) {
+	if p.Multiaddr != nil {
+		return toPeerInfos([]ma.Multiaddr{p.Multiaddr})[0], nil
+	} else if len(p.PeerID) > 0 {
+		return n.getPeerInfo(p.PeerID)
+	}
+
+	proID := p.ProfileID
+	if len(proID) == 0 && p.Peername != "" {
+		// TODO - there's lot's of possibile ambiguity around resolving peernames
+		// this naive implementation for now just checks the profile store for a
+		// matching peername
+		proID, err = n.Repo.Profiles().PeernameID(p.Peername)
+		if err != nil {
+			return
+		}
+	}
+
+	ids, err := n.Repo.Profiles().PeerIDs(proID)
+	if err != nil {
+		return
+	}
+	if len(ids) == 0 {
+		return pstore.PeerInfo{}, fmt.Errorf("no network info for %s", proID)
+	}
+
+	// TODO - there's ambiguity here that we should address, for now
+	// we'll just by default connect to the first peer
+	return n.getPeerInfo(ids[0])
+}
+
+func (n *QriNode) getPeerInfo(pid peer.ID) (pstore.PeerInfo, error) {
+	// first check for local peer info
+	if pinfo := n.Host.Peerstore().PeerInfo(pid); len(pinfo.ID) > 0 {
+		// _, err := n.RequestProfile(pinfo.ID)
+		return pinfo, nil
 	}
 
 	// attempt to use ipfs routing table to discover peer
 	ipfsnode, err := n.IPFSNode()
 	if err != nil {
 		log.Debug(err.Error())
-		return err
+		return pstore.PeerInfo{}, err
 	}
 
-	pinfo, err := ipfsnode.Routing.FindPeer(context.Background(), pid)
-	if err != nil {
-		log.Debug(err.Error())
-		return err
-	}
-
-	s, err := n.Host.NewStream(n.Context(), pinfo.ID, QriProtocolID)
-	if err != nil {
-		return fmt.Errorf("error opening stream: %s", err.Error())
-	}
-	s.Close()
-
-	return nil
+	return ipfsnode.Routing.FindPeer(context.Background(), pid)
 }

--- a/repo/profile/store.go
+++ b/repo/profile/store.go
@@ -48,8 +48,8 @@ func (m MemStore) PutProfile(profile *Profile) error {
 
 // PeernameID gives the ID for a given peername
 func (m MemStore) PeernameID(peername string) (ID, error) {
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
 	for id, profile := range m.store {
 		if profile.Peername == peername {
@@ -63,8 +63,8 @@ func (m MemStore) PeernameID(peername string) (ID, error) {
 // TODO - this func implies that peer.ID's are only ever connected to the same
 // profile. That could cause trouble.
 func (m MemStore) PeerProfile(id peer.ID) (*Profile, error) {
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
 	// str := fmt.Sprintf("/ipfs/%s", id.Pretty())
 
@@ -81,8 +81,8 @@ func (m MemStore) PeerProfile(id peer.ID) (*Profile, error) {
 
 // PeerIDs gives the peer.IDs list for a given peername
 func (m MemStore) PeerIDs(id ID) ([]peer.ID, error) {
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
 	for proid, profile := range m.store {
 		if id == proid {
@@ -95,8 +95,8 @@ func (m MemStore) PeerIDs(id ID) ([]peer.ID, error) {
 
 // List hands the full list of peers back
 func (m MemStore) List() (map[ID]*Profile, error) {
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
 	res := map[ID]*Profile{}
 	for id, p := range m.store {
@@ -107,8 +107,8 @@ func (m MemStore) List() (map[ID]*Profile, error) {
 
 // GetProfile give's peer info from the store for a given peer.ID
 func (m MemStore) GetProfile(id ID) (*Profile, error) {
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
 	if m.store[id] == nil {
 		return nil, ErrNotFound


### PR DESCRIPTION
We've been lacking proper peer connection control for a while now, this upgrades the `qri peers connect` command to accept:

* `/ipfs/QmPeerId`
* qri profile ID
* peernames (must exist in cache)
* a full multiaddr string (same as our bootstrap addresses)

So all of the following should be valid:
* `qri peers connect /ipfs/QmTZxETL4YCCzB1yFx4GT1te68henVHD1XPQMkHZ1N22mm`
* `qr peers connect b5` _(only if you've seen peer b5 before)_
*  `qri peers connect QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W` (b5's profileID)
* `qri peers connect /ip4/130.211.198.23/tcp/4001/ipfs/QmNX9nSos8sRFvqGTwdEme6LQ8R1eJ8EuFgW32F9jjp2Pb`

the same for a new disconnect command, which explicitly closes a connection.

All of the above also applies to the api `/connect` endpoint, so:
* `/connect/ipfs/QmTZxETL4YCCzB1yFx4GT1te68henVHD1XPQMkHZ1N22mm`
* `/connect/b5` _(only if you've seen peer b5 before)_
*  `/connect/QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W` (b5's profileID)
* `/connect/ip4/130.211.198.23/tcp/4001/ipfs/QmNX9nSos8sRFvqGTwdEme6LQ8R1eJ8EuFgW32F9jjp2Pb`

From here on in I think we should be sewing context params into lots of these network-oriented functions, so starting into that here.

ALL OF THIS STUFF NEEDS TESTS. V EXPERIMENTAL.