### PR TITLE
feat(Profile Info, Connections): verbose profile info, better explicit conn mgmt

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -16,9 +16,9 @@ var (
 )
 
 var datasetLogCmd = &cobra.Command{
-	Use: "log",
-	// Aliases: []string{"ls"},
-	Short: "show log of dataset history",
+	Use:     "log",
+	Aliases: []string{"history"},
+	Short:   "show log of dataset history",
 	Long: `
 log prints a list of changes to a dataset over time. Each entry in the log is a 
 snapshot of a dataset taken at the moment it was saved that keeps exact details 

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -26,17 +26,17 @@ var peersInfoCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		loadConfig()
 	},
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 {
-			ErrExit(fmt.Errorf("peer name is required"))
-		}
+		req, err := peerRequests(false)
+		ExitIfErr(err)
 
-		printInfo("searching for peer %s...", args[0])
-		req, err := peerRequests(true)
+		v, err := cmd.Flags().GetBool("verbose")
 		ExitIfErr(err)
 
 		p := &core.PeerInfoParams{
 			Peername: args[0],
+			Verbose:  v,
 		}
 
 		res := &config.ProfilePod{}
@@ -132,7 +132,7 @@ var peersConnectCmd = &cobra.Command{
 		err = pr.ConnectToPeer(pcpod, res)
 		ExitIfErr(err)
 
-		printSuccess("successfully connected to %s", res.Peername)
+		printSuccess("successfully connected to %s:\n", res.Peername)
 		printPeerInfo(0, res)
 	},
 }
@@ -158,6 +158,8 @@ var peersDisconnectCmd = &cobra.Command{
 }
 
 func init() {
+	peersInfoCmd.Flags().BoolP("verbose", "v", false, "show verbose profile info")
+
 	// peersListCmd.Flags().StringP("format", "f", "", "set output format [json]")
 	peersListCmd.Flags().StringP("network", "n", "", "list peers from connected networks. currently only accepts \"ipfs\"")
 	peersListCmd.Flags().BoolP("cached", "c", false, "show peers that aren't online, but previously seen")

--- a/config/profile.go
+++ b/config/profile.go
@@ -48,6 +48,9 @@ type ProfilePod struct {
 	// where QmSy... is a peer identifier on the IPFS peer-to-peer network
 	// Should not serialize to config.yaml
 	PeerIDs []string `json:"peerIDs,omitempty" yaml:"peerIDs,omitempty"`
+	// NetworkAddrs keeps a list of locations for this profile on the network as multiaddr strings
+	// Should not serialize to config.yaml
+	NetworkAddrs []string `json:"networkAddrs,omitempty" yaml:"networkAddrs,omitempty"`
 }
 
 // DefaultProfile gives a new default profile configuration, generating a new random

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -97,7 +97,11 @@ func connectNodes(ctx context.Context, nodes []*QriNode) error {
 func connectQriPeerNodes(ctx context.Context, nodes []*QriNode) error {
 	var wg sync.WaitGroup
 	connect := func(a, b *QriNode) error {
-		if err := a.AddQriPeer(b.PeerInfo()); err != nil {
+		bpi := pstore.PeerInfo{
+			ID:    b.Host.ID(),
+			Addrs: b.Host.Addrs(),
+		}
+		if err := a.AddQriPeer(bpi); err != nil {
 			return err
 		}
 		wg.Done()

--- a/repo/profile/profile.go
+++ b/repo/profile/profile.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/qri/config"
-	// ma "gx/ipfs/QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji/go-multiaddr"
+
+	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
 	peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 )
 
@@ -49,6 +50,8 @@ type Profile struct {
 	// PeerIDs lists any network PeerIDs associated with this profile
 	// in the form /network/peerID
 	PeerIDs []peer.ID `json:"peerIDs"`
+	// NetworkAddrs keeps a list of locations for this profile on the network as multiaddr strings
+	NetworkAddrs []ma.Multiaddr `json:"networkAddrs,omitempty"`
 }
 
 // NewProfile allocates a profile from a CodingProfile
@@ -118,6 +121,12 @@ func (p *Profile) Decode(sp *config.ProfilePod) error {
 		pro.Photo = datastore.NewKey(sp.Photo)
 	}
 
+	for _, addrStr := range sp.NetworkAddrs {
+		if maddr, err := ma.NewMultiaddr(addrStr); err == nil {
+			pro.NetworkAddrs = append(pro.NetworkAddrs, maddr)
+		}
+	}
+
 	*p = pro
 	return nil
 }
@@ -128,23 +137,28 @@ func (p Profile) Encode() (*config.ProfilePod, error) {
 	for i, pid := range p.PeerIDs {
 		pids[i] = fmt.Sprintf("/ipfs/%s", pid.Pretty())
 	}
+	var addrs []string
+	for _, maddr := range p.NetworkAddrs {
+		addrs = append(addrs, maddr.String())
+	}
 	pp := &config.ProfilePod{
-		ID:          p.ID.String(),
-		Type:        p.Type.String(),
-		Peername:    p.Peername,
-		Created:     p.Created,
-		Updated:     p.Updated,
-		Email:       p.Email,
-		Name:        p.Name,
-		Description: p.Description,
-		HomeURL:     p.HomeURL,
-		Color:       p.Color,
-		Twitter:     p.Twitter,
-		Poster:      p.Poster.String(),
-		Photo:       p.Photo.String(),
-		Thumb:       p.Thumb.String(),
-		Online:      p.Online,
-		PeerIDs:     pids,
+		ID:           p.ID.String(),
+		Type:         p.Type.String(),
+		Peername:     p.Peername,
+		Created:      p.Created,
+		Updated:      p.Updated,
+		Email:        p.Email,
+		Name:         p.Name,
+		Description:  p.Description,
+		HomeURL:      p.HomeURL,
+		Color:        p.Color,
+		Twitter:      p.Twitter,
+		Poster:       p.Poster.String(),
+		Photo:        p.Photo.String(),
+		Thumb:        p.Thumb.String(),
+		Online:       p.Online,
+		PeerIDs:      pids,
+		NetworkAddrs: addrs,
 	}
 	return pp, nil
 }


### PR DESCRIPTION
Added a series of tweaks & refinements surrounding `qri peers connect` & `qri peers disconnect`:
* Made disconnect close *all* open connections (so disconnect actually works) 
* removed dial backoff checks from explicit connections
* added a -verbose flag to `qri peers info` that'll yank network addresses from the host Peerstore, which is useful for debugging how peers found each other.