### PR TITLE
test(registry): switch to mock registery server package

### DIFF
--- a/api/profile_test.go
+++ b/api/profile_test.go
@@ -19,8 +19,7 @@ import (
 	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/repo/profile"
 	"github.com/qri-io/qri/repo/test"
-	"github.com/qri-io/registry"
-	"github.com/qri-io/registry/regserver/handlers"
+	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
 func TestProfileHandler(t *testing.T) {
@@ -33,7 +32,7 @@ func TestProfileHandler(t *testing.T) {
 	defer golog.SetLogLevel("qriapi", "info")
 
 	// use a test registry server
-	registryServer := httptest.NewServer(handlers.NewRoutes(registry.NewProfiles()))
+	registryServer := regmock.NewMockServer()
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp
@@ -108,7 +107,7 @@ func TestProfilePhotoHandler(t *testing.T) {
 	defer golog.SetLogLevel("qriapi", "info")
 
 	// use a test registry server
-	registryServer := httptest.NewServer(handlers.NewRoutes(registry.NewProfiles()))
+	registryServer := regmock.NewMockServer()
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp
@@ -199,7 +198,7 @@ func TestProfilePosterHandler(t *testing.T) {
 	defer golog.SetLogLevel("qriapi", "info")
 
 	// use a test registry server
-	registryServer := httptest.NewServer(handlers.NewRoutes(registry.NewProfiles()))
+	registryServer := regmock.NewMockServer()
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -21,8 +21,7 @@ import (
 	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/repo/profile"
 	"github.com/qri-io/qri/repo/test"
-	"github.com/qri-io/registry"
-	"github.com/qri-io/registry/regserver/handlers"
+	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
 func confirmQriNotRunning() error {
@@ -45,7 +44,7 @@ func TestServerRoutes(t *testing.T) {
 	defer golog.SetLogLevel("qriapi", "info")
 
 	// use a test registry server
-	registryServer := httptest.NewServer(handlers.NewRoutes(registry.NewProfiles()))
+	registryServer := regmock.NewMockServer()
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -5,15 +5,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/qri-io/qri/config"
-	"github.com/qri-io/registry"
-	"github.com/qri-io/registry/regserver/handlers"
+	regmock "github.com/qri-io/registry/regserver/mock"
 	"github.com/spf13/cobra"
 )
 
@@ -100,7 +98,7 @@ func TestCommandsIntegration(t *testing.T) {
 		t.Skip(err.Error())
 	}
 
-	registryServer := httptest.NewServer(handlers.NewRoutes(registry.NewProfiles()))
+	registryServer := regmock.NewMockServer()
 
 	path := filepath.Join(os.TempDir(), "qri_test_commands_integration")
 	t.Logf("test filepath: %s", path)

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -1,19 +1,17 @@
 package cmd
 
 import (
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/qri-io/registry"
-	"github.com/qri-io/registry/regserver/handlers"
+	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
 func TestConnect(t *testing.T) {
 
-	registryServer := httptest.NewServer(handlers.NewRoutes(registry.NewProfiles()))
+	registryServer := regmock.NewMockServer()
 
 	if err := confirmQriNotRunning(); err != nil {
 		t.Skip(err.Error())

--- a/core/setup_test.go
+++ b/core/setup_test.go
@@ -1,18 +1,16 @@
 package core
 
 import (
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/qri-io/qri/config"
-	"github.com/qri-io/registry"
-	"github.com/qri-io/registry/regserver/handlers"
+	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
 func TestSetupTeardown(t *testing.T) {
-	registryServer := httptest.NewServer(handlers.NewRoutes(registry.NewProfiles()))
+	registryServer := regmock.NewMockServer()
 
 	path := filepath.Join(os.TempDir(), "test_core_setup_teardown")
 	cfg1 := config.DefaultConfig()


### PR DESCRIPTION
quick update to work with new registry code. This further decouples the two codebases so we should have to do this less in the future (at least on the testing frontier)