### PR TITLE
feat(render): add render command for executing templates against datasets

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/qri-io/qri/core"
+	"github.com/spf13/cobra"
+)
+
+// renderCmd represents the render command
+var renderCmd = &cobra.Command{
+	Use:   "render",
+	Short: "execute a template against a dataset",
+	Long:  `the most common use for render is to generate html from a qri dataset`,
+	Example: `  render a dataset called me/schools:
+  $ qri render -o=schools.html me/schools
+
+  render a dataset with a custom template:
+  $ qri render --template=template.html me/schools`,
+	Annotations: map[string]string{
+		"group": "dataset",
+	},
+	PreRun: func(cmd *cobra.Command, args []string) {
+		loadConfig()
+	},
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var template []byte
+
+		fp, err := cmd.Flags().GetString("template")
+		ExitIfErr(err)
+		out, err := cmd.Flags().GetString("output")
+		ExitIfErr(err)
+		limit, err := cmd.Flags().GetInt("limit")
+		ExitIfErr(err)
+		offset, err := cmd.Flags().GetInt("offset")
+		ExitIfErr(err)
+		all, err := cmd.Flags().GetBool("all")
+		ExitIfErr(err)
+
+		req, err := renderRequests(false)
+		ExitIfErr(err)
+
+		if fp != "" {
+			template, err = ioutil.ReadFile(fp)
+			ExitIfErr(err)
+		}
+
+		p := &core.RenderParams{
+			Ref:            args[0],
+			Template:       template,
+			TemplateFormat: "html",
+			All:            all,
+			Limit:          limit,
+			Offset:         offset,
+		}
+
+		res := []byte{}
+		err = req.Render(p, &res)
+		ExitIfErr(err)
+
+		if out == "" {
+			fmt.Print(string(res))
+		} else {
+			ioutil.WriteFile(out, res, 0777)
+		}
+	},
+}
+
+func init() {
+	renderCmd.Flags().StringP("template", "t", "", "path to template file")
+	renderCmd.Flags().StringP("output", "o", "", "path to write output file")
+	renderCmd.Flags().BoolP("all", "a", false, "read all dataset entries (overrides limit, offest)")
+	renderCmd.Flags().IntP("limit", "l", 50, "max number of records to read")
+	renderCmd.Flags().IntP("offset", "s", 0, "number of records to skip")
+
+	RootCmd.AddCommand(renderCmd)
+}

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -102,6 +102,29 @@ func datasetRequests(online bool) (*core.DatasetRequests, error) {
 	return req, nil
 }
 
+func renderRequests(online bool) (*core.RenderRequests, error) {
+  if cli := rpcConn(); cli != nil {
+    return core.NewRenderRequests(nil, cli), nil
+  }
+
+  if !online {
+    // TODO - make this not terrible
+    r, cli, err := repoOrClient(online)
+    if err != nil {
+      return nil, err
+    }
+    return core.NewRenderRequests(r, cli), nil
+  }
+
+  n, err := qriNode(online)
+  if err != nil {
+    return nil, err
+  }
+
+  req := core.NewRenderRequests(n.Repo, nil)
+  return req, nil
+}
+
 func profileRequests(online bool) (*core.ProfileRequests, error) {
 	r, cli, err := repoOrClient(online)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	Webapp  *Webapp
 	RPC     *RPC
 	Logging *Logging
+
+	Render *Render
 }
 
 // DefaultConfig gives a new default qri configuration
@@ -43,6 +45,8 @@ func DefaultConfig() *Config {
 		Webapp:  DefaultWebapp(),
 		RPC:     DefaultRPC(),
 		Logging: DefaultLogging(),
+
+		Render: DefaultRender(),
 	}
 }
 
@@ -214,16 +218,17 @@ func (cfg Config) Validate() error {
     "title": "config",
     "description": "qri configuration",
     "type": "object",
-    "required": ["Profile", "Repo", "Store", "P2P", "CLI", "API", "Webapp", "RPC"],
+    "required": ["Profile", "Repo", "Store", "P2P", "CLI", "API", "Webapp", "RPC", "Render"],
     "properties" : {
-    	"Profile" : { "type":"object" },
-    	"Repo" : { "type":"object" },
-    	"Store" : { "type":"object" },
-    	"P2P" : { "type":"object" },
-    	"CLI" : { "type":"object" },
-    	"API" : { "type":"object" },
-    	"Webapp" : { "type":"object" },
-    	"RPC" : { "type":"object" }
+			"Profile" : { "type":"object" },
+			"Repo" : { "type":"object" },
+			"Store" : { "type":"object" },
+			"P2P" : { "type":"object" },
+			"CLI" : { "type":"object" },
+			"API" : { "type":"object" },
+			"Webapp" : { "type":"object" },
+			"RPC" : { "type":"object" },
+			"Render" : { "type":"object" }
     }
   }`)
 	if err := validate(schema, &cfg); err != nil {
@@ -290,6 +295,9 @@ func (cfg *Config) Copy() *Config {
 	}
 	if cfg.Logging != nil {
 		res.Logging = cfg.Logging.Copy()
+	}
+	if cfg.Render != nil {
+		res.Render = cfg.Render.Copy()
 	}
 
 	return res

--- a/config/p2p.go
+++ b/config/p2p.go
@@ -35,6 +35,10 @@ type P2P struct {
 	// QriBootstrapAddrs lists addresses to bootstrap qri node from
 	QriBootstrapAddrs []string `json:"qribootstrapaddrs"`
 
+	// HTTPGatewayAddr is an address that qri can use to resolve p2p assets
+	// over HTTP, represented as a url. eg: https://ipfs.io
+	HTTPGatewayAddr string `json:"httpgatewayaddr"`
+
 	// ProfileReplication determines what to do when this peer sees messages
 	// broadcast by it's own profile (from another peer instance). setting
 	// ProfileReplication == "full" will cause this peer to automatically pin
@@ -50,7 +54,8 @@ type P2P struct {
 func DefaultP2P() *P2P {
 	r := rand.Reader
 	p2p := &P2P{
-		Enabled: true,
+		Enabled:         true,
+		HTTPGatewayAddr: "https://ipfs.io",
 		// DefaultBootstrapAddresses follows the pattern of IPFS boostrapping off known "gateways".
 		// This boostrapping is specific to finding qri peers, which are IPFS peers that also
 		// support the qri protocol.
@@ -106,7 +111,7 @@ func (cfg P2P) Validate() error {
     "title": "P2P",
     "description": "Config for the p2p",
     "type": "object",
-    "required": ["enabled", "peerid", "pubkey", "privkey", "port", "addrs", "qribootstrapaddrs", "profilereplication", "bootstrapaddrs"],
+    "required": ["enabled", "peerid", "pubkey", "privkey", "port", "addrs", "httpgatewayaddr", "qribootstrapaddrs", "profilereplication", "bootstrapaddrs"],
     "properties": {
       "enabled": {
         "description": "When true, peer to peer communication is allowed",
@@ -137,6 +142,10 @@ func (cfg P2P) Validate() error {
         "items": {
           "type": "string"
         }
+      },
+      "httpgatewayaddr": {
+        "description" : "address that qri can use to resolve p2p assets over HTTP",
+        "type" : "string"
       },
       "qribootstrapaddrs": {
         "description": "List of addresses to bootstrap the qri node from",
@@ -176,6 +185,7 @@ func (cfg *P2P) Copy() *P2P {
 		PrivKey:            cfg.PrivKey,
 		Port:               cfg.Port,
 		ProfileReplication: cfg.ProfileReplication,
+		HTTPGatewayAddr:    cfg.HTTPGatewayAddr,
 	}
 
 	if cfg.QriBootstrapAddrs != nil {

--- a/config/render.go
+++ b/config/render.go
@@ -1,0 +1,54 @@
+package config
+
+import "github.com/qri-io/jsonschema"
+
+// Render configures the qri render command
+type Render struct {
+	// TemplateUpdateAddress is currently an IPNS location to check for updates. api.Server starts
+	// this address is checked, and if the hash there differs from DefaultTemplateHash, it'll use that instead
+	TemplateUpdateAddress string `json:"templateUpdateAddress"`
+	// DefaultTemplateHash is a hash of the compiled template
+	// this is fetched and replaced via dnslink when the render server starts
+	// the value provided here is just a sensible fallback for when dnslink lookup fails,
+	// pointing to a known prior version of the the render
+	DefaultTemplateHash string `json:"defaultTemplateHash"`
+}
+
+// DefaultRender creates a new default Render configuration
+func DefaultRender() *Render {
+	return &Render{
+		TemplateUpdateAddress: "/ipns/defaulttmpl.qri.io",
+		DefaultTemplateHash:   "/ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw",
+	}
+}
+
+// Validate validates all fields of render returning all errors found.
+func (cfg Render) Validate() error {
+	schema := jsonschema.Must(`{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Render",
+    "description": "Render for the render",
+    "type": "object",
+    "required": ["templateUpdateAddress", "defaultTemplateHash"],
+    "properties": {
+      "templateUpdateAddress": {
+        "description": "address to check for app updates",
+        "type": "string"
+      },
+      "defaultTemplateHash": {
+        "description": "A hash of the compiled render. This is fetched and replaced via dsnlink when the render server starts. The value provided here is just a sensible fallback for when dnslink lookup fails.",
+        "type": "string"
+      }
+    }
+  }`)
+	return validate(schema, &cfg)
+}
+
+// Copy returns a deep copy of the Render struct
+func (cfg *Render) Copy() *Render {
+	res := &Render{
+		TemplateUpdateAddress: cfg.TemplateUpdateAddress,
+		DefaultTemplateHash:   cfg.DefaultTemplateHash,
+	}
+	return res
+}

--- a/config/render_test.go
+++ b/config/render_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRenderValidate(t *testing.T) {
+	err := DefaultRender().Validate()
+	if err != nil {
+		t.Errorf("error validating default render: %s", err)
+	}
+}
+
+func TestRenderCopy(t *testing.T) {
+	cases := []struct {
+		render *Render
+	}{
+		{DefaultRender()},
+	}
+	for i, c := range cases {
+		cpy := c.render.Copy()
+		if !reflect.DeepEqual(cpy, c.render) {
+			t.Errorf("Render Copy test case %v, render structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.render)
+			continue
+		}
+		cpy.DefaultTemplateHash = "foo"
+		if reflect.DeepEqual(cpy, c.render) {
+			t.Errorf("Render Copy test case %v, editing one render struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.render)
+			continue
+		}
+	}
+}

--- a/config/testdata/default.yaml
+++ b/config/testdata/default.yaml
@@ -28,6 +28,7 @@ p2p:
   online: true
   selfreplication: full
   boostrapaddrs: []
+  httpgatewayaddr: https://ipfs.io
 webapp:
   enabled: true
   port: 2505
@@ -39,3 +40,6 @@ rpc:
   port: 2504
 logging:
   levels: {}
+render:
+  templateupdateaddress: /ipns/defaulttmpl.qri.io
+  defaulttemplatehash:   /ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw

--- a/config/testdata/simple.yaml
+++ b/config/testdata/simple.yaml
@@ -23,3 +23,4 @@ api: null
 webapp: null
 rpc: null
 logging: null
+render: null

--- a/core/core.go
+++ b/core/core.go
@@ -31,5 +31,6 @@ func Receivers(node *p2p.QriNode) []Requests {
 		NewPeerRequests(node, nil),
 		NewProfileRequests(r, nil),
 		NewSearchRequests(r, nil),
+		NewRenderRequests(r, nil),
 	}
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -18,8 +18,8 @@ func TestReceivers(t *testing.T) {
 	}
 
 	reqs := Receivers(node)
-	if len(reqs) != 5 {
-		t.Errorf("unexpected number of receivers returned. expected: %d. got: %d", 5, len(reqs))
+	if len(reqs) != 6 {
+		t.Errorf("unexpected number of receivers returned. expected: %d. got: %d", 6, len(reqs))
 		return
 	}
 }

--- a/core/render.go
+++ b/core/render.go
@@ -1,0 +1,197 @@
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/rpc"
+	"strings"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/qri-io/dataset/dsfs"
+	"github.com/qri-io/dataset/dsio"
+	"github.com/qri-io/jsonschema"
+	"github.com/qri-io/qri/repo"
+)
+
+// RenderRequests encapsulates business logic for this node's
+// user profile
+type RenderRequests struct {
+	cli  *rpc.Client
+	repo repo.Repo
+}
+
+// NewRenderRequests creates a RenderRequests pointer from either a repo
+// or an rpc.Client
+func NewRenderRequests(r repo.Repo, cli *rpc.Client) *RenderRequests {
+	if r != nil && cli != nil {
+		panic(fmt.Errorf("both repo and client supplied to NewRenderRequests"))
+	}
+
+	return &RenderRequests{
+		cli:  cli,
+		repo: r,
+	}
+}
+
+// CoreRequestsName implements the Requets interface
+func (RenderRequests) CoreRequestsName() string { return "render" }
+
+// RenderParams defines parameters for the Render method
+type RenderParams struct {
+	Ref            string
+	Template       []byte
+	TemplateFormat string
+	All            bool
+	Limit, Offset  int
+}
+
+// Render executes a template against a template
+func (r *RenderRequests) Render(p *RenderParams, res *[]byte) error {
+	if r.cli != nil {
+		return r.cli.Call("RenderRequests.Render", p, res)
+	}
+
+	ref, err := repo.ParseDatasetRef(p.Ref)
+	if err != nil {
+		return err
+	}
+
+	err = repo.CanonicalizeDatasetRef(r.repo, &ref)
+	if err != nil {
+		log.Debug(err.Error())
+		return err
+	}
+
+	store := r.repo.Store()
+
+	if p.Template == nil && Config.Render != nil && Config.Render.DefaultTemplateHash != "" {
+		log.Debugf("using default hash: %s", Config.Render.DefaultTemplateHash)
+		var rdr io.Reader
+		file, err := store.Get(datastore.NewKey(Config.Render.DefaultTemplateHash))
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") && Config.P2P != nil && Config.P2P.HTTPGatewayAddr != "" {
+				log.Debugf("fetching %d from ipfs gateway", Config.Render.DefaultTemplateHash)
+				var res *http.Response
+				res, err = http.Get(fmt.Sprintf("%s%s", Config.P2P.HTTPGatewayAddr, Config.Render.DefaultTemplateHash))
+				if err != nil {
+					return err
+				}
+				defer res.Body.Close()
+				rdr = res.Body
+			} else {
+				return fmt.Errorf("loading default template: %s", err.Error())
+			}
+		} else {
+			rdr = file
+		}
+
+		p.Template, err = ioutil.ReadAll(rdr)
+		if err != nil {
+			return fmt.Errorf("reading template: %s", err.Error())
+		}
+	}
+
+	tmpl, err := template.New("template").Parse(string(p.Template))
+	if err != nil {
+		return fmt.Errorf("parsing template: %s", err.Error())
+	}
+
+	ds, err := dsfs.LoadDataset(store, datastore.NewKey(ref.Path))
+	if err != nil {
+		log.Debug(err.Error())
+		return err
+	}
+
+	file, err := dsfs.LoadData(store, ds)
+	if err != nil {
+		log.Debug(err.Error())
+		return err
+	}
+
+	var (
+		array []interface{}
+		obj   = map[string]interface{}{}
+		read  = 0
+	)
+
+	sm, err := schemaScanMode(ds.Structure.Schema)
+	if err != nil {
+		return err
+	}
+
+	rr, err := dsio.NewEntryReader(ds.Structure, file)
+	if err != nil {
+		return fmt.Errorf("error allocating data reader: %s", err)
+	}
+
+	for i := 0; i >= 0; i++ {
+		val, err := rr.ReadEntry()
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return fmt.Errorf("row iteration error: %s", err.Error())
+		}
+		if !p.All && i < p.Offset {
+			continue
+		}
+
+		if sm == "object" {
+			obj[val.Key] = val.Value
+		} else {
+			array = append(array, val.Value)
+		}
+
+		read++
+		if read == p.Limit {
+			break
+		}
+	}
+
+	enc := ds.Encode()
+	// TODO - repo.DatasetRef should be refactored into this newly expanded DatasetPod,
+	// once that's done these values should be populated by ds.Encode(), removing the need
+	// for these assignments
+	enc.Peername = ref.Peername
+	enc.ProfileID = ref.ProfileID.String()
+	enc.Name = ref.Name
+
+	if sm == "object" {
+		enc.Data = obj
+	} else {
+		enc.Data = array
+	}
+
+	tmplBuf := &bytes.Buffer{}
+	if err := tmpl.Execute(tmplBuf, enc); err != nil {
+		return err
+	}
+
+	*res = tmplBuf.Bytes()
+	return nil
+}
+
+// TODO - this is stolen from dataset/dsio, dsio should probably export this
+// schemaScanMode determines weather the top level is an array or object
+func schemaScanMode(sc *jsonschema.RootSchema) (string, error) {
+	if vt, ok := sc.Validators["type"]; ok {
+		// TODO - lol go PR jsonschema to export access to this instead of this
+		// silly validation hack
+		obj := []jsonschema.ValError{}
+		arr := []jsonschema.ValError{}
+		vt.Validate("", map[string]interface{}{}, &obj)
+		vt.Validate("", []interface{}{}, &arr)
+		if len(obj) == 0 {
+			return "object", nil
+		} else if len(arr) == 0 {
+			return "array", nil
+		}
+	}
+	err := fmt.Errorf("invalid schema. root must be either an array or object type")
+	log.Debug(err.Error())
+	return "object", err
+}

--- a/core/render_test.go
+++ b/core/render_test.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/rpc"
+	"testing"
+
+	testrepo "github.com/qri-io/qri/repo/test"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+func TestNewRenderRequests(t *testing.T) {
+	defer func() {
+		if err := recover(); err == nil {
+			t.Errorf("expected NewRenderRequests to panic")
+		}
+	}()
+
+	tr, err := testrepo.NewTestRepo()
+	if err != nil {
+		t.Errorf("error allocating test repo: %s", err.Error())
+		return
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write([]byte{}) }))
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Errorf("error allocating listener: %s", err.Error())
+		return
+	}
+
+	reqs := NewRenderRequests(tr, nil)
+	if reqs.CoreRequestsName() != "render" {
+		t.Errorf("invalid requests name. expected: '%s', got: '%s'", "render", reqs.CoreRequestsName())
+	}
+
+	// this should panic:
+	NewRenderRequests(tr, rpc.NewClient(conn))
+}
+
+func TestRenderRequestsRender(t *testing.T) {
+	mockGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tmpl := `<html><h1>{{.Peername}}/{{.Name}}</h1></html>`
+		w.Write([]byte(tmpl))
+	}))
+
+	Config.P2P.HTTPGatewayAddr = mockGateway.URL
+
+	cases := []struct {
+		params *RenderParams
+		expect []byte
+		err    string
+	}{
+		{&RenderParams{}, nil, "cannot parse empty string as dataset reference"},
+		{&RenderParams{Ref: "foo/invalid_ref"}, nil, "error fetching peer from store: profile: not found"},
+		{&RenderParams{Ref: "me/movies", Template: []byte("{{ .Meta.Title }}")}, []byte("example movie data"), ""},
+		{&RenderParams{Ref: "me/movies", Template: []byte("{{ .BadTemplateBooPlzFail }}")}, nil, `template: template:1:3: executing "template" at <.BadTemplateBooPlzFa...>: can't evaluate field BadTemplateBooPlzFail in type *dataset.DatasetPod`},
+		{&RenderParams{Ref: "me/movies", Template: []byte("{{ .BadTemplateBooPlzFail")}, nil, `parsing template: template: template:1: unclosed action`},
+		{&RenderParams{Ref: "me/movies"}, []byte("<html><h1>peer/movies</h1></html>"), ""},
+		{&RenderParams{Ref: "me/sitemap"}, []byte("<html><h1>peer/sitemap</h1></html>"), ""},
+		{&RenderParams{Ref: "me/sitemap", Limit: 4, Offset: 4}, []byte("<html><h1>peer/sitemap</h1></html>"), ""},
+	}
+
+	tr, err := testrepo.NewTestRepo()
+	if err != nil {
+		t.Errorf("error allocating test repo: %s", err.Error())
+		return
+	}
+
+	reqs := NewRenderRequests(tr, nil)
+
+	for i, c := range cases {
+		got := []byte{}
+		err := reqs.Render(c.params, &got)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			return
+		}
+
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(string(got), string(c.expect), false)
+		if len(diffs) > 1 {
+			t.Log(dmp.DiffPrettyText(diffs))
+			t.Errorf("case %d failed to match.", i)
+		}
+	}
+}

--- a/core/self_update.go
+++ b/core/self_update.go
@@ -19,25 +19,25 @@ import (
  */
 
 var (
-	// lastPubVerHash is a hard-coded reference the gx "lastpubver" file of the previous release
-	lastPubVerHash = "/ipfs/QmcXZCLAgUdvXpt1fszjNGVGn6WnhsrJahkQXY3JJqxUWJ"
-	// prevIPNSName is the dnslink address to check for version agreement
-	prevIPNSName = "/ipns/cli.previous.qri.io"
+	// LastPubVerHash is a hard-coded reference the gx "lastpubver" file of the previous release
+	LastPubVerHash = "/ipfs/QmcXZCLAgUdvXpt1fszjNGVGn6WnhsrJahkQXY3JJqxUWJ"
+	// PrevIPNSName is the dnslink address to check for version agreement
+	PrevIPNSName = "/ipns/cli.previous.qri.io"
 	// ErrUpdateRequired means this version of qri is out of date
 	ErrUpdateRequired = fmt.Errorf("update required")
 )
 
 // CheckVersion uses a name resolver to lookup prevIPNSName, checking if the hard-coded lastPubVerHash
 // and the returned lookup match. If they don't, CheckVersion returns ErrUpdateRequired
-func CheckVersion(ctx context.Context, res namesys.Resolver) error {
-	p, err := res.Resolve(ctx, prevIPNSName)
+func CheckVersion(ctx context.Context, res namesys.Resolver, lookupAddr, localHash string) (latest string, err error) {
+	p, err := res.Resolve(ctx, lookupAddr)
 	if err != nil {
 		log.Debug(err.Error())
-		return fmt.Errorf("error resolving name: %s", err.Error())
+		return "", fmt.Errorf("error resolving name: %s", err.Error())
 	}
 
-	if p.String() != lastPubVerHash {
-		return ErrUpdateRequired
+	if p.String() != localHash {
+		return p.String(), ErrUpdateRequired
 	}
-	return nil
+	return "", nil
 }

--- a/core/self_update_test.go
+++ b/core/self_update_test.go
@@ -8,18 +8,18 @@ import (
 )
 
 func TestCheckVersion(t *testing.T) {
-	name := prevIPNSName
-	ver := lastPubVerHash
+	name := PrevIPNSName
+	ver := LastPubVerHash
 	defer func() {
-		prevIPNSName = name
-		lastPubVerHash = ver
+		PrevIPNSName = name
+		LastPubVerHash = ver
 	}()
 
 	res := namesys.NewDNSResolver()
 
-	prevIPNSName = "foo"
+	PrevIPNSName = "foo"
 	expect := "error resolving name: not a valid domain name"
-	if err := CheckVersion(context.Background(), res); err != nil && err.Error() != expect {
+	if _, err := CheckVersion(context.Background(), res, name, ver); err != nil && err.Error() != expect {
 		t.Errorf("error mismatch. epxected: '%s', got: '%s'", expect, err.Error())
 		return
 	}

--- a/repo/actions/dataset.go
+++ b/repo/actions/dataset.go
@@ -2,13 +2,14 @@ package actions
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsfs"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
-	"strings"
 )
 
 // Dataset wraps a repo.Repo, adding actions related to working


### PR DESCRIPTION
Pumped about this one. I've realized we can get a long way by just executing templates against qri datasets, which have a rigid structure that makes templating much easier. So with that, I'd like to introduce a new command: `qri render`. `qri render` accepts a dataset name, executes a HTML template, using the specified dataset to populate template data. It has a few features:

* render uses the `template/html` package from golang. users of the Hugo static site generator will feel at home with this syntax
* users can provide custom templates with the --template argument
* if no template is specified, qri uses a default "stock" template that is resolved over IPFS
* this stock template is updated using IPNS, similar to the way we distribute app updates
* template fetching falls back to a P2P gateway over HTTP if configured correctly
* render automatically loads data using the same logic as the `qri data` command, accepting --limit, --offset, and --all params to control data loading
* writes to stdout by default, to a file with --output flag

To get this to work I had to introduce some other new stuff:
* render section in config: this holds the place to lookup default template IPNS addresses
* config.P2P.HTTPGatewayAddr: url of a gateway to resolve content-addressed hashes with qri isn't connected to the p2p network

This opens up a whole world of possiblities, users can use `qri render` to create custom representations of data that suites their needs, and leverage qri to generate these assets as they go

### Limitations:
* currently the template must be loaded as a single file, in the future we should add support for partials & stuff
* currently HTML templates only. I've added a "TemplateFormat" param that currently does nothing, but in the future we can use this to expand to other common template output formats (raw text, PDF?)