### PR TITLE
feat(registry.Datasets): initial dataset registry integration

### DIFF
--- a/api/profile_test.go
+++ b/api/profile_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/repo/profile"
 	"github.com/qri-io/qri/repo/test"
-	"github.com/qri-io/registry/regclient"
 	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
@@ -32,12 +31,8 @@ func TestProfileHandler(t *testing.T) {
 	golog.SetLogLevel("qriapi", "error")
 	defer golog.SetLogLevel("qriapi", "info")
 
-	// use a test registry server
-	registryServer := regmock.NewMockServer()
-	// and test registry client
-	rc := regclient.NewClient(&regclient.Config{Location: registryServer.URL})
-
-	// in order to have consistent responses
+	// use a test registry server & client & client
+	rc, registryServer := regmock.NewMockServer()
 	// we need to artificially specify the timestamp
 	// we use the dsfs.Timestamp func variable to override
 	// the actual time
@@ -109,10 +104,8 @@ func TestProfilePhotoHandler(t *testing.T) {
 	golog.SetLogLevel("qriapi", "error")
 	defer golog.SetLogLevel("qriapi", "info")
 
-	// use a test registry server
-	registryServer := regmock.NewMockServer()
-	// and test registry client
-	rc := regclient.NewClient(&regclient.Config{Location: registryServer.URL})
+	// use a test registry server & client
+	rc, registryServer := regmock.NewMockServer()
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp
@@ -202,10 +195,8 @@ func TestProfilePosterHandler(t *testing.T) {
 	golog.SetLogLevel("qriapi", "error")
 	defer golog.SetLogLevel("qriapi", "info")
 
-	// use a test registry server
-	registryServer := regmock.NewMockServer()
-	// and test registry client
-	rc := regclient.NewClient(&regclient.Config{Location: registryServer.URL})
+	// use a test registry server & client
+	rc, registryServer := regmock.NewMockServer()
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp

--- a/api/profile_test.go
+++ b/api/profile_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/repo/profile"
 	"github.com/qri-io/qri/repo/test"
+	"github.com/qri-io/registry/regclient"
 	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
@@ -33,6 +34,8 @@ func TestProfileHandler(t *testing.T) {
 
 	// use a test registry server
 	registryServer := regmock.NewMockServer()
+	// and test registry client
+	rc := regclient.NewClient(&regclient.Config{Location: registryServer.URL})
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp
@@ -42,7 +45,7 @@ func TestProfileHandler(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r, err := test.NewTestRepo()
+	r, err := test.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -108,6 +111,8 @@ func TestProfilePhotoHandler(t *testing.T) {
 
 	// use a test registry server
 	registryServer := regmock.NewMockServer()
+	// and test registry client
+	rc := regclient.NewClient(&regclient.Config{Location: registryServer.URL})
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp
@@ -117,7 +122,7 @@ func TestProfilePhotoHandler(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r, err := test.NewTestRepo()
+	r, err := test.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -199,6 +204,8 @@ func TestProfilePosterHandler(t *testing.T) {
 
 	// use a test registry server
 	registryServer := regmock.NewMockServer()
+	// and test registry client
+	rc := regclient.NewClient(&regclient.Config{Location: registryServer.URL})
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp
@@ -208,7 +215,7 @@ func TestProfilePosterHandler(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r, err := test.NewTestRepo()
+	r, err := test.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/repo/profile"
 	"github.com/qri-io/qri/repo/test"
-	"github.com/qri-io/registry/regclient"
 	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
@@ -44,10 +43,8 @@ func TestServerRoutes(t *testing.T) {
 	golog.SetLogLevel("qriapi", "error")
 	defer golog.SetLogLevel("qriapi", "info")
 
-	// use a test registry server
-	registryServer := regmock.NewMockServer()
-	// and test registry client
-	rc := regclient.NewClient(&regclient.Config{Location: registryServer.URL})
+	// use a test registry server & client
+	rc, registryServer := regmock.NewMockServer()
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/qri-io/qri/core"
 	"github.com/qri-io/qri/repo/profile"
 	"github.com/qri-io/qri/repo/test"
+	"github.com/qri-io/registry/regclient"
 	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
@@ -45,6 +46,8 @@ func TestServerRoutes(t *testing.T) {
 
 	// use a test registry server
 	registryServer := regmock.NewMockServer()
+	// and test registry client
+	rc := regclient.NewClient(&regclient.Config{Location: registryServer.URL})
 
 	// in order to have consistent responses
 	// we need to artificially specify the timestamp
@@ -56,7 +59,7 @@ func TestServerRoutes(t *testing.T) {
 
 	client := &http.Client{}
 
-	r, err := test.NewTestRepo()
+	r, err := test.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -253,7 +256,7 @@ func TestServerReadOnlyRoutes(t *testing.T) {
 
 	client := &http.Client{}
 
-	r, err := test.NewTestRepo()
+	r, err := test.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -98,7 +98,7 @@ func TestCommandsIntegration(t *testing.T) {
 		t.Skip(err.Error())
 	}
 
-	registryServer := regmock.NewMockServer()
+	_, registryServer := regmock.NewMockServer()
 
 	path := filepath.Join(os.TempDir(), "qri_test_commands_integration")
 	t.Logf("test filepath: %s", path)

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestConnect(t *testing.T) {
 
-	registryServer := regmock.NewMockServer()
+	_, registryServer := regmock.NewMockServer()
 
 	if err := confirmQriNotRunning(); err != nil {
 		t.Skip(err.Error())

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -25,7 +25,7 @@ func TestReceivers(t *testing.T) {
 }
 
 func testQriNode(cfgs ...func(c *config.P2P)) (*p2p.QriNode, error) {
-	r, err := repo.NewMemRepo(&profile.Profile{}, cafs.NewMapstore(), profile.NewMemStore())
+	r, err := repo.NewMemRepo(&profile.Profile{}, cafs.NewMapstore(), profile.NewMemStore(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/core/datasets_test.go
+++ b/core/datasets_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/qri-io/qri/p2p/test"
 	"github.com/qri-io/qri/repo"
 	testrepo "github.com/qri-io/qri/repo/test"
+	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
 func TestDatasetRequestsInit(t *testing.T) {
@@ -189,7 +190,8 @@ func TestDatasetRequestsListP2p(t *testing.T) {
 }
 
 func TestDatasetRequestsGet(t *testing.T) {
-	mr, err := testrepo.NewTestRepo(nil)
+	rc, _ := regmock.NewMockServer()
+	mr, err := testrepo.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -211,8 +213,8 @@ func TestDatasetRequestsGet(t *testing.T) {
 		res *dataset.Dataset
 		err string
 	}{
-		//TODO: probably delete some of these
-		{repo.DatasetRef{Peername: "peer", Path: "abc", Name: "ABC"}, nil, "error loading dataset: error getting file bytes: datastore: key not found"},
+		// TODO: probably delete some of these
+		{repo.DatasetRef{Peername: "peer", Path: "abc", Name: "ABC"}, nil, "repo: not found"},
 		{repo.DatasetRef{Peername: "peer", Path: ref.Path, Name: "ABC"}, nil, ""},
 		{repo.DatasetRef{Peername: "peer", Path: ref.Path, Name: "movies"}, moviesDs, ""},
 		{repo.DatasetRef{Peername: "peer", Path: ref.Path, Name: "cats"}, moviesDs, ""},
@@ -233,7 +235,8 @@ func TestDatasetRequestsGet(t *testing.T) {
 }
 
 func TestDatasetRequestsSave(t *testing.T) {
-	mr, err := testrepo.NewTestRepo(nil)
+	rc, _ := regmock.NewMockServer()
+	mr, err := testrepo.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -246,7 +249,7 @@ func TestDatasetRequestsSave(t *testing.T) {
 		// {&SaveParams{Path: datastore.NewKey("abc"), Name: "ABC", Hash: "123"}, nil, "error loading dataset: error getting file bytes: datastore: key not found"},
 		// {&SaveParams{Path: path, Name: "ABC", Hash: "123"}, nil, ""},
 		{&SaveParams{Name: "movies", Peername: "peer", MetadataFilename: "meta.json", Metadata: bytes.NewReader([]byte(`{"title":"movies!"}`))}, ""},
-		{&SaveParams{Name: "unknown_dataset", Peername: "peer"}, "error getting previous dataset: error loading dataset: error getting file bytes: datastore: key not found"},
+		{&SaveParams{Name: "unknown_dataset", Peername: "peer"}, "error getting previous dataset: repo: not found"},
 		// {&SaveParams{Path: path, Name: "cats"}, moviesDs, ""},
 	}
 
@@ -265,7 +268,8 @@ func TestDatasetRequestsSave(t *testing.T) {
 }
 
 func TestDatasetRequestsRename(t *testing.T) {
-	mr, err := testrepo.NewTestRepo(nil)
+	rc, _ := regmock.NewMockServer()
+	mr, err := testrepo.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -300,7 +304,8 @@ func TestDatasetRequestsRename(t *testing.T) {
 }
 
 func TestDatasetRequestsRemove(t *testing.T) {
-	mr, err := testrepo.NewTestRepo(nil)
+	rc, _ := regmock.NewMockServer()
+	mr, err := testrepo.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -334,8 +339,8 @@ func TestDatasetRequestsRemove(t *testing.T) {
 }
 
 func TestDatasetRequestsStructuredData(t *testing.T) {
-
-	mr, err := testrepo.NewTestRepo(nil)
+	rc, _ := regmock.NewMockServer()
+	mr, err := testrepo.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -496,7 +501,8 @@ Pirates of the Caribbean: At World's End ,foo
 }
 
 func TestDataRequestsDiff(t *testing.T) {
-	mr, err := testrepo.NewTestRepo(nil)
+	rc, _ := regmock.NewMockServer()
+	mr, err := testrepo.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return

--- a/core/datasets_test.go
+++ b/core/datasets_test.go
@@ -50,7 +50,7 @@ func TestDatasetRequestsInit(t *testing.T) {
 		{&InitParams{DataFilename: jobsByAutomationFile.FileName(), Peername: "peer", Data: jobsByAutomationFile}, nil, ""},
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -73,7 +73,7 @@ func TestDatasetRequestsList(t *testing.T) {
 		movies, counter, cities, craigslist, sitemap repo.DatasetRef
 	)
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -189,7 +189,7 @@ func TestDatasetRequestsListP2p(t *testing.T) {
 }
 
 func TestDatasetRequestsGet(t *testing.T) {
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -233,7 +233,7 @@ func TestDatasetRequestsGet(t *testing.T) {
 }
 
 func TestDatasetRequestsSave(t *testing.T) {
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -265,7 +265,7 @@ func TestDatasetRequestsSave(t *testing.T) {
 }
 
 func TestDatasetRequestsRename(t *testing.T) {
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -300,7 +300,7 @@ func TestDatasetRequestsRename(t *testing.T) {
 }
 
 func TestDatasetRequestsRemove(t *testing.T) {
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -335,7 +335,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 func TestDatasetRequestsStructuredData(t *testing.T) {
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -413,7 +413,7 @@ func TestDatasetRequestsAdd(t *testing.T) {
 		{&repo.DatasetRef{Name: "abc", Path: "hash###"}, nil, "this store cannot fetch from remote sources"},
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -472,7 +472,7 @@ Pirates of the Caribbean: At World's End ,foo
 		{ValidateDatasetParams{Schema: schemaf2, DataFilename: "data.csv", Data: dataf2}, 1, ""},
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -496,7 +496,7 @@ Pirates of the Caribbean: At World's End ,foo
 }
 
 func TestDataRequestsDiff(t *testing.T) {
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return

--- a/core/history_test.go
+++ b/core/history_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestHistoryRequestsLog(t *testing.T) {
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return

--- a/core/peers_test.go
+++ b/core/peers_test.go
@@ -23,7 +23,7 @@ func TestPeerRequestsList(t *testing.T) {
 		// TODO - need a test that confirms that this node's identity is never present in peers list
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return

--- a/core/profile_test.go
+++ b/core/profile_test.go
@@ -23,7 +23,7 @@ func TestProfileRequestsGet(t *testing.T) {
 		// {false, nil, ""},
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -58,7 +58,7 @@ func TestProfileRequestsSave(t *testing.T) {
 		// TODO - moar tests
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -105,7 +105,7 @@ func TestSaveProfile(t *testing.T) {
 	pro.Twitter = "test_twitter"
 
 	// Save the CodingProfile.
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -193,7 +193,7 @@ func TestProfileRequestsSetProfilePhoto(t *testing.T) {
 		{"testdata/rico_400x400.jpg", datastore.NewKey("/map/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1"), ""},
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -244,7 +244,7 @@ func TestProfileRequestsSetPosterPhoto(t *testing.T) {
 		{"testdata/rico_poster_1500x500.jpg", datastore.NewKey("/map/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL"), ""},
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return

--- a/core/render_test.go
+++ b/core/render_test.go
@@ -18,7 +18,7 @@ func TestNewRenderRequests(t *testing.T) {
 		}
 	}()
 
-	tr, err := testrepo.NewTestRepo()
+	tr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -63,7 +63,7 @@ func TestRenderRequestsRender(t *testing.T) {
 		{&RenderParams{Ref: "me/sitemap", Limit: 4, Offset: 4}, []byte("<html><h1>peer/sitemap</h1></html>"), ""},
 	}
 
-	tr, err := testrepo.NewTestRepo()
+	tr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return

--- a/core/search_test.go
+++ b/core/search_test.go
@@ -16,7 +16,7 @@ func TestSearch(t *testing.T) {
 		{&repo.SearchParams{}, nil, "this repo doesn't support search"},
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return
@@ -48,7 +48,7 @@ func TestReindex(t *testing.T) {
 		{&ReindexSearchParams{}, false, "search reindexing is currently only supported on file-system repos"},
 	}
 
-	mr, err := testrepo.NewTestRepo()
+	mr, err := testrepo.NewTestRepo(nil)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())
 		return

--- a/core/setup_test.go
+++ b/core/setup_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSetupTeardown(t *testing.T) {
-	registryServer := regmock.NewMockServer()
+	_, registryServer := regmock.NewMockServer()
 
 	path := filepath.Join(os.TempDir(), "test_core_setup_teardown")
 	cfg1 := config.DefaultConfig()

--- a/repo/actions/dataset_test.go
+++ b/repo/actions/dataset_test.go
@@ -46,7 +46,7 @@ func init() {
 
 func TestDataset(t *testing.T) {
 	rmf := func(t *testing.T) repo.Repo {
-		mr, err := repo.NewMemRepo(testPeerProfile, cafs.NewMapstore(), profile.NewMemStore())
+		mr, err := repo.NewMemRepo(testPeerProfile, cafs.NewMapstore(), profile.NewMemStore(), nil)
 		if err != nil {
 			panic(err)
 		}

--- a/repo/actions/merge_events_test.go
+++ b/repo/actions/merge_events_test.go
@@ -23,11 +23,11 @@ func createReposAndLogs() (repo.Repo, repo.Repo, *repo.MemEventLog, *repo.MemEve
 	aRepo, _ := repo.NewMemRepo(&profile.Profile{
 		ID:       profile.ID(profileAID),
 		Peername: "test-peer-0",
-	}, cafs.NewMapstore(), profile.MemStore{})
+	}, cafs.NewMapstore(), profile.MemStore{}, nil)
 	bRepo, _ := repo.NewMemRepo(&profile.Profile{
 		ID:       profile.ID(profileBID),
 		Peername: "test-peer-0",
-	}, cafs.NewMapstore(), profile.MemStore{})
+	}, cafs.NewMapstore(), profile.MemStore{}, nil)
 	aLog := aRepo.(*repo.MemRepo).MemEventLog
 	bLog := bRepo.(*repo.MemRepo).MemEventLog
 	return aRepo, bRepo, aLog, bLog

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -2,6 +2,7 @@ package fsrepo
 
 import (
 	"fmt"
+	"github.com/qri-io/registry/regclient"
 	"os"
 
 	golog "github.com/ipfs/go-log"
@@ -35,10 +36,12 @@ type Repo struct {
 
 	profiles ProfileStore
 	index    search.Index
+
+	registry *regclient.Client
 }
 
 // NewRepo creates a new file-based repository
-func NewRepo(store cafs.Filestore, pro *profile.Profile, base string) (repo.Repo, error) {
+func NewRepo(store cafs.Filestore, pro *profile.Profile, rc *regclient.Client, base string) (repo.Repo, error) {
 	if err := os.MkdirAll(base, os.ModePerm); err != nil {
 		return nil, err
 	}
@@ -155,6 +158,11 @@ func (r *Repo) UpdateSearchIndex(store cafs.Filestore) error {
 // Profiles returns this repo's Peers implementation
 func (r *Repo) Profiles() profile.Store {
 	return r.profiles
+}
+
+// Registry returns a client for interacting with a federated registry if one exists, otherwise nil
+func (r *Repo) Registry() *regclient.Client {
+	return r.registry
 }
 
 // Destroy destroys this repository

--- a/repo/fs/fs_test.go
+++ b/repo/fs/fs_test.go
@@ -26,7 +26,7 @@ func TestRepo(t *testing.T) {
 			t.Error(err.Error())
 		}
 
-		r, err := NewRepo(cafs.NewMapstore(), pro, path)
+		r, err := NewRepo(cafs.NewMapstore(), pro, nil, path)
 		if err != nil {
 			t.Errorf("error creating repo: %s", err.Error())
 		}

--- a/repo/graph_test.go
+++ b/repo/graph_test.go
@@ -142,7 +142,7 @@ func makeTestRepo() (Repo, error) {
 	store := cafs.NewMapstore()
 	p := &profile.Profile{}
 
-	r, err := NewMemRepo(p, store, nil)
+	r, err := NewMemRepo(p, store, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating test repo: %s", err.Error())
 	}

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -5,6 +5,7 @@ import (
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset/dsgraph"
 	"github.com/qri-io/qri/repo/profile"
+	"github.com/qri-io/registry/regclient"
 )
 
 // MemRepo is an in-memory implementation of the Repo interface
@@ -17,10 +18,11 @@ type MemRepo struct {
 	*MemEventLog
 	profile  *profile.Profile
 	profiles profile.Store
+	registry *regclient.Client
 }
 
 // NewMemRepo creates a new in-memory repository
-func NewMemRepo(p *profile.Profile, store cafs.Filestore, ps profile.Store) (Repo, error) {
+func NewMemRepo(p *profile.Profile, store cafs.Filestore, ps profile.Store, rc *regclient.Client) (Repo, error) {
 	return &MemRepo{
 		store:       store,
 		MemRefstore: &MemRefstore{},
@@ -71,4 +73,9 @@ func (r *MemRepo) SetProfile(p *profile.Profile) error {
 // Profiles gives this repo's Peer interface implementation
 func (r *MemRepo) Profiles() profile.Store {
 	return r.profiles
+}
+
+// Registry returns a client for interacting with a federated registry if one exists, otherwise nil
+func (r *MemRepo) Registry() *regclient.Client {
+	return r.registry
 }

--- a/repo/ref_test.go
+++ b/repo/ref_test.go
@@ -330,7 +330,7 @@ func TestCompareDatasetRefs(t *testing.T) {
 }
 
 func TestCanonicalizeDatasetRef(t *testing.T) {
-	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille"}, cafs.NewMapstore(), profile.NewMemStore())
+	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille"}, cafs.NewMapstore(), profile.NewMemStore(), nil)
 	if err != nil {
 		t.Errorf("error allocating mem repo: %s", err.Error())
 		return
@@ -370,7 +370,7 @@ func TestCanonicalizeDatasetRef(t *testing.T) {
 }
 
 func TestCanonicalizeProfile(t *testing.T) {
-	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille", ID: profile.IDB58MustDecode("QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, cafs.NewMapstore(), profile.NewMemStore())
+	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille", ID: profile.IDB58MustDecode("QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y")}, cafs.NewMapstore(), profile.NewMemStore(), nil)
 	if err != nil {
 		t.Errorf("error allocating mem repo: %s", err.Error())
 		return

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset/dsgraph"
 	"github.com/qri-io/qri/repo/profile"
+	"github.com/qri-io/registry/regclient"
 )
 
 var (
@@ -73,6 +74,9 @@ type Repo interface {
 	// TODO - should rename this to "profiles" to separate from the networking
 	// concept of a peer
 	Profiles() profile.Store
+	// Registry returns a client for interacting with a federated registry
+	// if one exists, otherwise nil
+	Registry() *regclient.Client
 }
 
 // SearchParams encapsulates parameters provided to Searchable.Search

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/registry/regclient"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
@@ -56,11 +57,11 @@ func ProfileConfig() *config.ProfilePod {
 }
 
 // NewTestRepo generates a repository usable for testing purposes
-func NewTestRepo() (mr repo.Repo, err error) {
+func NewTestRepo(rc *regclient.Client) (mr repo.Repo, err error) {
 	datasets := []string{"movies", "cities", "counter", "craigslist", "sitemap"}
 
 	ms := cafs.NewMapstore()
-	mr, err = repo.NewMemRepo(testPeerProfile, ms, profile.NewMemStore())
+	mr, err = repo.NewMemRepo(testPeerProfile, ms, profile.NewMemStore(), rc)
 	if err != nil {
 		return
 	}
@@ -96,7 +97,7 @@ func NewTestRepoFromProfileID(id profile.ID, dataIndex int) (repo.Repo, error) {
 	r, err := repo.NewMemRepo(&profile.Profile{
 		ID:       id,
 		Peername: fmt.Sprintf("test-repo-%d", globalRepoID),
-	}, cafs.NewMapstore(), profile.NewMemStore())
+	}, cafs.NewMapstore(), profile.NewMemStore(), nil)
 	if err != nil {
 		return r, err
 	}
@@ -138,7 +139,7 @@ func NewMemRepoFromDir(path string) (repo.Repo, crypto.PrivKey, error) {
 	}
 
 	ms := cafs.NewMapstore()
-	mr, err := repo.NewMemRepo(pro, ms, profile.NewMemStore())
+	mr, err := repo.NewMemRepo(pro, ms, profile.NewMemStore(), nil)
 	if err != nil {
 		return mr, pk, err
 	}


### PR DESCRIPTION
we gave registries a few new tricks, and have started integrating them here. If a qri repo is configured with a registry, it will fire off notifications to the registry server within goroutines on dataset creation & deletion, which will start to build up a list of datasets on the registry side. This comes back to help users on core.datasetRequests.Get, which now includes a parallel check
to both p2p network *and* registries if we don't have a local copy.

The upside here is we can use registries to do checks if we aren't connect to p2p. If this goes as expected the next place to expand is adding search on the registry side, and then move on to tracking who has pinned what.

*might* make some inroads on #397