### PR TITLE
refactor(datasets): Use Copy and PagedReader. Rename StructuredData.

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -655,7 +655,7 @@ func (h DatasetHandlers) dataHandler(w http.ResponseWriter, r *http.Request) {
 		err = nil
 	}
 
-	p := &core.StructuredDataParams{
+	p := &core.LookupParams{
 		Path:   d.Path,
 		Format: dataset.JSONDataFormat,
 		Limit:  limit,
@@ -663,16 +663,16 @@ func (h DatasetHandlers) dataHandler(w http.ResponseWriter, r *http.Request) {
 		All:    r.FormValue("all") == "true" && limit == defaultDataLimit && offset == 0,
 	}
 
-	data := &core.StructuredData{}
-	if err := h.StructuredData(p, data); err != nil {
+	result := &core.LookupResult{}
+	if err := h.LookupBody(p, result); err != nil {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
 	}
 
 	page := util.PageFromRequest(r)
 	dataResponse := DataResponse{
-		Path: data.Path,
-		Data: json.RawMessage(data.Data),
+		Path: result.Path,
+		Data: json.RawMessage(result.Data),
 	}
 	if err := util.WritePageResponse(w, dataResponse, r, page); err != nil {
 		log.Infof("error writing repsonse: %s", err.Error())

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -52,7 +52,7 @@ Data reads records from a dataset`,
 		df, err := dataset.ParseDataFormatString(dataCmdFormat)
 		ExitIfErr(err)
 
-		p := &core.StructuredDataParams{
+		p := &core.LookupParams{
 			Format: df,
 			Path:   ds.Path,
 			Limit:  dataCmdLimit,
@@ -60,15 +60,15 @@ Data reads records from a dataset`,
 			All:    dataCmdAll,
 		}
 
-		sd := &core.StructuredData{}
+		result := &core.LookupResult{}
 
-		if err := req.StructuredData(p, sd); err != nil {
+		if err := req.LookupBody(p, result); err != nil {
 			ErrExit(err)
 		}
 
-		data := sd.Data
+		data := result.Data
 		if p.Format == dataset.CBORDataFormat {
-			data = []byte(hex.EncodeToString(sd.Data))
+			data = []byte(hex.EncodeToString(result.Data))
 		}
 
 		path := cmd.Flag("output").Value.String()

--- a/core/datasets_test.go
+++ b/core/datasets_test.go
@@ -438,7 +438,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 	}
 }
 
-func TestDatasetRequestsStructuredData(t *testing.T) {
+func TestDatasetRequestsLookupBody(t *testing.T) {
 	rc, _ := regmock.NewMockServer()
 	mr, err := testrepo.NewTestRepo(rc)
 	if err != nil {
@@ -463,23 +463,23 @@ func TestDatasetRequestsStructuredData(t *testing.T) {
 
 	var df1 = dataset.JSONDataFormat
 	cases := []struct {
-		p        *StructuredDataParams
+		p        *LookupParams
 		resCount int
 		err      string
 	}{
-		{&StructuredDataParams{}, 0, "error loading dataset: error getting file bytes: datastore: key not found"},
-		{&StructuredDataParams{Format: df1, Path: moviesRef.Path, Limit: 5, Offset: 0, All: false}, 5, ""},
-		{&StructuredDataParams{Format: df1, Path: moviesRef.Path, Limit: -5, Offset: -100, All: false}, 0, "invalid limit / offset settings"},
-		{&StructuredDataParams{Format: df1, Path: moviesRef.Path, Limit: -5, Offset: -100, All: true}, 0, "invalid limit / offset settings"},
-		{&StructuredDataParams{Format: df1, Path: clRef.Path, Limit: 0, Offset: 0, All: true}, 0, ""},
-		{&StructuredDataParams{Format: df1, Path: clRef.Path, Limit: 2, Offset: 0, All: false}, 2, ""},
-		{&StructuredDataParams{Format: df1, Path: sitemapRef.Path, Limit: 3, Offset: 0, All: false}, 3, ""},
+		{&LookupParams{}, 0, "error loading dataset: error getting file bytes: datastore: key not found"},
+		{&LookupParams{Format: df1, Path: moviesRef.Path, Limit: 5, Offset: 0, All: false}, 5, ""},
+		{&LookupParams{Format: df1, Path: moviesRef.Path, Limit: -5, Offset: -100, All: false}, 0, "invalid limit / offset settings"},
+		{&LookupParams{Format: df1, Path: moviesRef.Path, Limit: -5, Offset: -100, All: true}, 0, "invalid limit / offset settings"},
+		{&LookupParams{Format: df1, Path: clRef.Path, Limit: 0, Offset: 0, All: true}, 0, ""},
+		{&LookupParams{Format: df1, Path: clRef.Path, Limit: 2, Offset: 0, All: false}, 2, ""},
+		{&LookupParams{Format: df1, Path: sitemapRef.Path, Limit: 3, Offset: 0, All: false}, 3, ""},
 	}
 
 	req := NewDatasetRequests(mr, nil)
 	for i, c := range cases {
-		got := &StructuredData{}
-		err := req.StructuredData(c.p, got)
+		got := &LookupResult{}
+		err := req.LookupBody(c.p, got)
 
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch: expected: %s, got: %s", i, c.err, err)


### PR DESCRIPTION
Use new utilities Copy and PagedReader instead of copying entries manually. Rename StructuredData (the method) to LookupBody, rename StructuredData (the struct) to LookupResult.