### PR TITLE
feat(cmd/export): specify data format using --data-format flag

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -161,7 +161,7 @@ func TestCommandsIntegration(t *testing.T) {
 		{"log", "me/movies"},
 		{"diff", "me/movies", "me/movies2", "-d", "detail"},
 		{"export", "--dataset", "-o" + path, "me/movies"},
-		{"export", "--all", "-o" + path, "--format=json", "me/movies"},
+		{"export", "--all", "-o" + path, "--format=json", "--data-format=json", "me/movies"},
 		{"rename", "me/movies", "me/movie"},
 		{"data", "--limit=1", "--data-format=cbor", "me/movie"},
 		{"validate", "me/movie"},

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -22,7 +22,7 @@ var (
 	exportCmdDataset    bool
 	exportCmdMeta       bool
 	exportCmdStructure  bool
-	exportCmdData       bool
+	exportCmdNoData     bool
 	exportCmdTransform  bool
 	exportCmdVis        bool
 	exportCmdAll        bool
@@ -105,7 +105,7 @@ To export everything about a dataset, use the --dataset flag.`,
 			ExitIfErr(err)
 			return
 		} else if exportCmdAll {
-			exportCmdData = true
+			exportCmdNoData = false
 			exportCmdDataset = true
 			exportCmdMeta = true
 			exportCmdStructure = true
@@ -198,8 +198,7 @@ To export everything about a dataset, use the --dataset flag.`,
 			printSuccess("exported structure file to: %s", stPath)
 		}
 
-		if exportCmdData {
-
+		if !exportCmdNoData {
 			src, err := dsfs.LoadData(r.Store(), ds)
 			ExitIfErr(err)
 
@@ -270,13 +269,13 @@ func init() {
 	exportCmd.Flags().StringP("output", "o", "", "path to write to, default is current directory")
 	exportCmd.Flags().StringP("format", "f", "yaml", "format for all exported files, except for data. yaml is the default format. options: yaml, json")
 	exportCmd.Flags().StringP("data-format", "", "", "format for data file. default is the original data format. options: json, csv, cbor")
-	exportCmd.Flags().BoolVarP(&exportCmdZipped, "zip", "z", false, "compress export as zip archive")
+	exportCmd.Flags().BoolVarP(&exportCmdZipped, "zip", "z", false, "compress export as zip archive, export all parts of dataset, data in original format")
 	exportCmd.Flags().BoolVarP(&exportCmdAll, "all", "a", false, "export full dataset package")
 	exportCmd.Flags().BoolVarP(&exportCmdAll, "namespaced", "n", false, "export to a peer name namespaced directory")
 	exportCmd.Flags().BoolVarP(&exportCmdDataset, "dataset", "", false, "export root dataset")
 	exportCmd.Flags().BoolVarP(&exportCmdMeta, "meta", "m", false, "export dataset metadata file")
 	exportCmd.Flags().BoolVarP(&exportCmdStructure, "structure", "s", false, "export dataset structure file")
-	exportCmd.Flags().BoolVarP(&exportCmdData, "data", "d", true, "export dataset data file")
+	exportCmd.Flags().BoolVarP(&exportCmdNoData, "no-data", "", false, "don't include dataset data file in export")
 	// exportCmd.Flags().BoolVarP(&exportCmdTransform, "transform", "t", false, "export dataset transform file")
 	// exportCmd.Flags().BoolVarP(&exportCmdVis, "vis-conf", "c", false, "export viz config file")
 

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -33,15 +33,18 @@ var saveCmd = &cobra.Command{
 	Long: `
 Save is how you change a dataset, updating one or more of data, metadata, and 
 structure. You can also update your data via url. Every time you run save, 
-an entry is added to your dataset’s log 
-(which you can see by running “qri log [ref]”). Every time you save, you can 
-provide a message about what you changed and why. If you don’t provide a message 
+an entry is added to your dataset’s log (which you can see by running “qri log 
+[ref]”). Every time you save, you can provide a message about what you changed 
+and why. If you don’t provide a message 
 qri will automatically generate one for you.
 
 Currently you can only save changes to datasets that you control. Tools for 
 collaboration are in the works. Sit tight sportsfans.`,
 	Example: `  save updated data to dataset annual_pop:
-  $ qri --data /path/to/data.csv me/annual_pop`,
+  $ qri --data /path/to/data.csv me/annual_pop
+
+  save updated dataset (no data) to annual_pop:
+  $ qri --file /path/to/dataset.yaml me/annual_pop`,
 	Annotations: map[string]string{
 		"group": "dataset",
 	},


### PR DESCRIPTION
closes #435 

Also replaces redundant --data flag with --no-data flag (data is always exported by default, and if there are no flags then just the data will export)