### PR TITLE
feat(transform secrets): supply secrets to transforms

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -67,3 +67,15 @@ func loadFileIfPath(path string) (file *os.File, err error) {
 
 	return os.Open(path)
 }
+
+// parseSecrets turns a key,value sequence into a map[string]string
+func parseSecrets(secrets ...string) (map[string]string, error) {
+	if len(secrets)%2 != 0 {
+		return nil, fmt.Errorf("expected even number of (key,value) pairs for secrets")
+	}
+	s := map[string]string{}
+	for i := 0; i < len(secrets); i = i + 2 {
+		s[secrets[i]] = secrets[i+1]
+	}
+	return s, nil
+}

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -207,15 +207,30 @@ func prompt(msg string) string {
 }
 
 func inputText(message, defaultText string) string {
-	if message == "" {
-		message = "enter text:"
-	}
 	input := prompt(fmt.Sprintf("%s [%s]: ", message, defaultText))
 	if input == "" {
 		input = defaultText
 	}
 
 	return input
+}
+
+func confirm(message string, def bool) bool {
+	if noPrompt {
+		return def
+	}
+
+	yellow := color.New(color.FgYellow).SprintFunc()
+	defaultText := "y/N"
+	if def {
+		defaultText = "Y/n"
+	}
+	input := prompt(fmt.Sprintf("%s [%s]: ", yellow(message), defaultText))
+	if input == "" {
+		return def
+	}
+	input = strings.TrimSpace(strings.ToLower(input))
+	return (input == "y" || input == "yes") == def
 }
 
 func printDiffs(diffText string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ var (
 	cfgFile string
 	// setting noLoadConfig to true will skip the the default call to LoadConfig
 	noLoadConfig bool
+	noPrompt     bool
 	// global pagination variables
 	pageNum  int
 	pageSize int
@@ -42,6 +43,7 @@ func init() {
 	// RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $QRI_PATH/config.yaml)")
 	// RootCmd.PersistentFlags().BoolVarP(&noColor, "no-color", "c", false, "disable colorized output")
 	RootCmd.SetUsageTemplate(rootUsageTemplate)
+	RootCmd.PersistentFlags().BoolVarP(&noPrompt, "no-prompt", "", false, "disable all interactive prompts")
 	for _, cmd := range RootCmd.Commands() {
 		cmd.SetUsageTemplate(defaultUsageTemplate)
 	}

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -23,6 +23,7 @@ var (
 	savePassive        bool
 	saveRescursive     bool
 	saveShowValidation bool
+	saveSecrets        []string
 )
 
 // saveCmd represents the save command
@@ -97,6 +98,18 @@ collaboration are in the works. Sit tight sportsfans.`,
 			dsp.DataPath = saveDataPath
 		}
 
+		if dsp.Transform != nil && saveSecrets != nil {
+			if !confirm(`
+Warning: You are providing secrets to a dataset transformation.
+Never provide secrets to a transformation you do not trust.
+continue?`, true) {
+				return
+			}
+
+			dsp.Transform.Secrets, err = parseSecrets(addDsSecrets...)
+			ExitIfErr(err)
+		}
+
 		p := &core.SaveParams{
 			Dataset: dsp,
 			Private: false,
@@ -136,5 +149,6 @@ func init() {
 	saveCmd.Flags().StringVarP(&saveMessage, "message", "m", "", "commit message for save")
 	saveCmd.Flags().StringVarP(&saveDataPath, "data", "", "", "path to file or url to initialize from")
 	saveCmd.Flags().BoolVarP(&saveShowValidation, "show-validation", "s", false, "display a list of validation errors upon adding")
+	saveCmd.Flags().StringSliceVar(&saveSecrets, "secrets", nil, "transform secrets as comma separated key,value,key,value,... sequence")
 	RootCmd.AddCommand(saveCmd)
 }

--- a/repo/actions/dataset.go
+++ b/repo/actions/dataset.go
@@ -19,7 +19,7 @@ type Dataset struct {
 }
 
 // CreateDataset initializes a dataset from a dataset pointer and data file
-func (act Dataset) CreateDataset(name string, ds *dataset.Dataset, data cafs.File, pin bool) (ref repo.DatasetRef, err error) {
+func (act Dataset) CreateDataset(name string, ds *dataset.Dataset, data cafs.File, secrets map[string]string, pin bool) (ref repo.DatasetRef, err error) {
 	log.Debugf("CreateDataset: %s", name)
 	var (
 		path datastore.Key
@@ -32,7 +32,7 @@ func (act Dataset) CreateDataset(name string, ds *dataset.Dataset, data cafs.Fil
 
 	if ds.Transform != nil {
 		log.Info("running transformation...")
-		data, err = act.ExecTransform(ds, data)
+		data, err = act.ExecTransform(ds, data, secrets)
 		if err != nil {
 			return
 		}

--- a/repo/actions/dataset_test.go
+++ b/repo/actions/dataset_test.go
@@ -92,7 +92,7 @@ func createDataset(t *testing.T, rmf RepoMakerFunc) (repo.Repo, repo.DatasetRef)
 		return r, repo.DatasetRef{}
 	}
 
-	ref, err := act.CreateDataset(tc.Name, tc.Input, tc.DataFile(), true)
+	ref, err := act.CreateDataset(tc.Name, tc.Input, tc.DataFile(), nil, true)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -169,7 +169,7 @@ func testDatasetPinning(t *testing.T, rmf RepoMakerFunc) {
 		return
 	}
 
-	ref2, err := act.CreateDataset(tc.Name, tc.Input, tc.DataFile(), false)
+	ref2, err := act.CreateDataset(tc.Name, tc.Input, tc.DataFile(), nil, false)
 	if err != nil {
 		t.Error(err.Error())
 		return

--- a/repo/actions/transform.go
+++ b/repo/actions/transform.go
@@ -12,9 +12,19 @@ import (
 )
 
 // ExecTransform executes a designated transformation
-func (act Dataset) ExecTransform(ds *dataset.Dataset, infile cafs.File) (file cafs.File, err error) {
+func (act Dataset) ExecTransform(ds *dataset.Dataset, infile cafs.File, secrets map[string]string) (file cafs.File, err error) {
 	filepath := ds.Transform.ScriptPath
-	rr, err := skytf.ExecFile(ds, filepath, infile)
+	rr, err := skytf.ExecFile(ds, filepath, infile, func(o *skytf.ExecOpts) {
+		if secrets != nil {
+			// convert to map[string]interface{}, which the lower-level skytf supports
+			// until we're sure map[string]string is going to work in the majority of use cases
+			s := map[string]interface{}{}
+			for key, val := range secrets {
+				s[key] = val
+			}
+			o.Secrets = s
+		}
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/repo/test/test_dataset_actions.go
+++ b/repo/test/test_dataset_actions.go
@@ -40,7 +40,7 @@ func createDataset(t *testing.T, rmf RepoMakerFunc) (repo.Repo, repo.DatasetRef)
 		return r, repo.DatasetRef{}
 	}
 
-	ref, err := act.CreateDataset(tc.Name, tc.Input, tc.DataFile(), true)
+	ref, err := act.CreateDataset(tc.Name, tc.Input, tc.DataFile(), nil, true)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -109,7 +109,7 @@ func testDatasetPinning(t *testing.T, rmf RepoMakerFunc) {
 		return
 	}
 
-	ref2, err := act.CreateDataset(tc.Name, tc.Input, tc.DataFile(), false)
+	ref2, err := act.CreateDataset(tc.Name, tc.Input, tc.DataFile(), nil, false)
 	if err != nil {
 		t.Error(err.Error())
 		return

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -79,7 +79,7 @@ func NewTestRepo(rc *regclient.Client) (mr repo.Repo, err error) {
 
 		datafile := cafs.NewMemfileBytes(tc.DataFilename, tc.Data)
 
-		if _, err = act.CreateDataset(tc.Name, tc.Input, datafile, true); err != nil {
+		if _, err = act.CreateDataset(tc.Name, tc.Input, datafile, nil, true); err != nil {
 			return nil, fmt.Errorf("%s error creating dataset: %s", k, err.Error())
 		}
 	}
@@ -114,7 +114,7 @@ func NewTestRepoFromProfileID(id profile.ID, peerNum int, dataIndex int) (repo.R
 	}
 
 	datafile := cafs.NewMemfileBytes(tc.DataFilename, tc.Data)
-	if _, err = act.CreateDataset(tc.Name, tc.Input, datafile, true); err != nil {
+	if _, err = act.CreateDataset(tc.Name, tc.Input, datafile, nil, true); err != nil {
 		return nil, fmt.Errorf("error creating dataset: %s", err.Error())
 	}
 
@@ -149,7 +149,7 @@ func NewMemRepoFromDir(path string) (repo.Repo, crypto.PrivKey, error) {
 	}
 
 	for _, c := range tc {
-		if _, err := act.CreateDataset(c.Name, c.Input, c.DataFile(), true); err != nil {
+		if _, err := act.CreateDataset(c.Name, c.Input, c.DataFile(), nil, true); err != nil {
 			return mr, pk, err
 		}
 	}


### PR DESCRIPTION
At some point someone isn't going to read the documentation on how transform.config works, not realize that we record all configuration details, create a script that asks a user to put API keys into a config slot, and qri will dox those keys. This will make me sad.

To prevent this I'm adding in an explicit codepath for secrets, one that currently only works with the
command line, and comes with a warning if the user tries to provide secrets to `qri add` or `qri save`.
By providing explicit features & docs on how to interact with secret information, and throwing warnings
around the use of this information, I believe we'll reduce the chances people will misuse features like
config. @osterbit pointed to the "danger zone" on github repo settings as a good example of warning users when they're about to do something potentially dangerous, I see this as a nice analogy.

Secrets will never be recorded, and will need to be provided on each run of a transform. Later on we can think about some sort of secure store of secrets that can be auto-provided to scripts, which we can then plumb up into UI.

Because users are required to interactively confirm when providing secrets, I've also added a `--no-prompt` flag to skip any prompts. Advanced users will need this for scripting purposes. I've intentionally left off a shortcut so that users must explicitly type "no-prompt".