### PR TITLE
fix(config): set map values with config set command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,6 +51,7 @@ PLEASE PLEASE PLEASE NEVER SHARE YOUR PRIVATE KEYS WITH ANYONE. EVER.
 Anyone with your private keys can impersonate you on qri.`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ExitIfErr(o.Complete(f))
 			ExitIfErr(o.Get(args))
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -126,6 +126,7 @@ func TestConfigSet(t *testing.T) {
 		{"p2p.enabled", false, ""},
 		{"p2p.qribootstrapaddrs.0", "wahoo", ""},
 		{"p2p.qribootstrapaddrs.0", false, "invalid type for config path p2p.qribootstrapaddrs.0, expected: string, got: bool"},
+		{"logging.levels.qriapi", "debug", ""},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
updated config Set method to support setting map[string]interface{} values

closes #450