### PR TITLE
feat(use, get): added use and get commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/qri-io/qri
     docker:
-      - image: circleci/golang:1.10.1
+      - image: circleci/golang:1.10.3
         environment:
           GOLANG_ENV: test
           PORT: 3000

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -54,6 +54,7 @@ type DataOptions struct {
 
 	UsingRPC        bool
 	DatasetRequests *lib.DatasetRequests
+	Repo            repo.Repo
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -61,6 +62,10 @@ func (o *DataOptions) Complete(f Factory, args []string) (err error) {
 	o.Ref = args[0]
 	o.UsingRPC = f.RPC() != nil
 	o.DatasetRequests, err = f.DatasetRequests()
+	if err != nil {
+		return
+	}
+	o.Repo, err = f.Repo()
 	return
 }
 
@@ -72,6 +77,10 @@ func (o *DataOptions) Run() error {
 
 	dsr, err := repo.ParseDatasetRef(o.Ref)
 	if err != nil {
+		return err
+	}
+
+	if err = lib.DefaultSelectedRef(o.Repo, &dsr); err != nil {
 		return err
 	}
 

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -29,6 +29,7 @@ type Factory interface {
 	ProfileRequests() (*lib.ProfileRequests, error)
 	SearchRequests() (*lib.SearchRequests, error)
 	RenderRequests() (*lib.RenderRequests, error)
+	SelectionRequests() (*lib.SelectionRequests, error)
 }
 
 // PathFactory is a function that returns paths to qri & ipfs repos

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"github.com/qri-io/qri/lib"
+	"github.com/qri-io/qri/repo"
+	"github.com/spf13/cobra"
+)
+
+// NewGetCommand creates a new `qri search` command that searches for datasets
+func NewGetCommand(f Factory, ioStreams IOStreams) *cobra.Command {
+	o := &GetOptions{IOStreams: ioStreams}
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "get elements of qri datasets",
+		Long:  ``,
+		Annotations: map[string]string{
+			"group": "dataset",
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			ExitIfErr(o.Complete(f, args))
+			ExitIfErr(o.Run())
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.Format, "format", "f", "yaml", "set output format [json, yaml]")
+	cmd.Flags().BoolVar(&o.Concise, "concise", false, "print output without indentation, only applies to json format")
+
+	return cmd
+}
+
+// GetOptions encapsulates state for the search command
+type GetOptions struct {
+	IOStreams
+
+	Refs    []string
+	Path    string
+	Format  string
+	Concise bool
+
+	DatasetRequests *lib.DatasetRequests
+}
+
+// Complete adds any missing configuration that can only be added just before calling Run
+func (o *GetOptions) Complete(f Factory, args []string) (err error) {
+	if len(args) != 0 {
+		o.Path = args[0]
+		o.Refs = args[1:]
+	}
+	o.DatasetRequests, err = f.DatasetRequests()
+	return
+}
+
+// Run executes the search command
+func (o *GetOptions) Run() (err error) {
+	var refs []repo.DatasetRef
+	for _, refstr := range o.Refs {
+		ref, err := repo.ParseDatasetRef(refstr)
+		if err != nil {
+			return err
+		}
+		refs = append(refs, ref)
+	}
+
+	p := &lib.SelectParams{
+		Path:    o.Path,
+		Format:  o.Format,
+		Concise: o.Concise,
+	}
+
+	res := []byte{}
+	if err = o.DatasetRequests.Select(p, &res); err != nil {
+		return err
+	}
+
+	_, err = o.Out.Write(res)
+	return err
+}

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -52,6 +52,7 @@ https://github.com/qri-io/qri/issues`,
 		NewBodyCommand(opt, ioStreams),
 		NewDiffCommand(opt, ioStreams),
 		NewExportCommand(opt, ioStreams),
+		NewGetCommand(opt, ioStreams),
 		NewInfoCommand(opt, ioStreams),
 		NewListCommand(opt, ioStreams),
 		NewLogCommand(opt, ioStreams),
@@ -63,6 +64,7 @@ https://github.com/qri-io/qri/issues`,
 		NewSaveCommand(opt, ioStreams),
 		NewSearchCommand(opt, ioStreams),
 		NewSetupCommand(opt, ioStreams),
+		NewUseCommand(opt, ioStreams),
 		NewValidateCommand(opt, ioStreams),
 		NewVersionCommand(opt, ioStreams),
 	)
@@ -236,6 +238,14 @@ func (o *QriOptions) ProfileRequests() (*lib.ProfileRequests, error) {
 		return nil, err
 	}
 	return lib.NewProfileRequests(o.repo, o.rpc), nil
+}
+
+// SelectionRequests creates a lib.SelectionRequests from internal state
+func (o *QriOptions) SelectionRequests() (*lib.SelectionRequests, error) {
+	if err := o.init(); err != nil {
+		return nil, err
+	}
+	return lib.NewSelectionRequests(o.repo, o.rpc), nil
 }
 
 // SearchRequests generates a lib.SearchRequests from internal state

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -62,6 +62,11 @@ func (o *UseOptions) Run() (err error) {
 		return err
 	}
 
+	if len(refs) == 0 {
+		printInfo(o.Out, "cleared selected datasets")
+		return nil
+	}
+
 	for _, ref := range refs {
 		fmt.Fprintln(o.Out, ref.String())
 	}

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/qri-io/qri/lib"
+	"github.com/qri-io/qri/repo"
+	"github.com/spf13/cobra"
+)
+
+// NewUseCommand creates a new `qri search` command that searches for datasets
+func NewUseCommand(f Factory, ioStreams IOStreams) *cobra.Command {
+	o := &UseOptions{IOStreams: ioStreams}
+	cmd := &cobra.Command{
+		Use:   "use",
+		Short: "select datasets for use with other commands",
+		Long:  ``,
+		Annotations: map[string]string{
+			"group": "dataset",
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			ExitIfErr(o.Complete(f, args))
+			ExitIfErr(o.Run())
+		},
+	}
+
+	return cmd
+}
+
+// UseOptions encapsulates state for the search command
+type UseOptions struct {
+	IOStreams
+
+	Refs []string
+
+	SelectionRequests *lib.SelectionRequests
+}
+
+// Complete adds any missing configuration that can only be added just before calling Run
+func (o *UseOptions) Complete(f Factory, args []string) (err error) {
+	o.Refs = args
+	o.SelectionRequests, err = f.SelectionRequests()
+	return
+}
+
+// Run executes the search command
+func (o *UseOptions) Run() (err error) {
+	var (
+		refs []repo.DatasetRef
+		res  bool
+	)
+
+	for _, refstr := range o.Refs {
+		ref, err := repo.ParseDatasetRef(refstr)
+		if err != nil {
+			return err
+		}
+		refs = append(refs, ref)
+	}
+
+	if err = o.SelectionRequests.SetSelectedRefs(&refs, &res); err != nil {
+		return err
+	}
+
+	for _, ref := range refs {
+		fmt.Fprintln(o.Out, ref.String())
+	}
+	return nil
+}

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -184,11 +184,8 @@ func (r *DatasetRequests) Select(p *SelectParams, res *[]byte) (err error) {
 		return r.cli.Call("DatasetRequests.Select", p, res)
 	}
 
-	if len(p.Refs) == 0 {
-		var done bool
-		if err := NewSelectionRequests(r.repo.Repo, nil).SelectedRefs(&done, &p.Refs); err != nil {
-			return err
-		}
+	if err = DefaultSelectedRefs(r.repo.Repo, &p.Refs); err != nil {
+		return err
 	}
 
 	encode := map[string]interface{}{}
@@ -770,6 +767,10 @@ type ValidateDatasetParams struct {
 func (r *DatasetRequests) Validate(p *ValidateDatasetParams, errors *[]jsonschema.ValError) (err error) {
 	if r.cli != nil {
 		return r.cli.Call("DatasetRequests.Validate", p, errors)
+	}
+
+	if err = DefaultSelectedRef(r.repo, &p.Ref); err != nil {
+		return
 	}
 
 	if p.Ref.IsEmpty() && p.Data == nil {

--- a/lib/history.go
+++ b/lib/history.go
@@ -46,6 +46,10 @@ func (d *HistoryRequests) Log(params *LogParams, res *[]repo.DatasetRef) (err er
 	}
 
 	ref := params.Ref
+	if err = DefaultSelectedRef(d.repo, &ref); err != nil {
+		return
+	}
+
 	err = repo.CanonicalizeDatasetRef(d.repo, &ref)
 	if err != nil {
 		log.Debug(err.Error())

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -30,5 +30,6 @@ func Receivers(node *p2p.QriNode) []Requests {
 		NewProfileRequests(r, nil),
 		NewSearchRequests(r, nil),
 		NewRenderRequests(r, nil),
+		NewSelectionRequests(r, nil),
 	}
 }

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -18,8 +18,8 @@ func TestReceivers(t *testing.T) {
 	}
 
 	reqs := Receivers(node)
-	if len(reqs) != 7 {
-		t.Errorf("unexpected number of receivers returned. expected: %d. got: %d\nhave you added/removed a receiver?", 7, len(reqs))
+	if len(reqs) != 8 {
+		t.Errorf("unexpected number of receivers returned. expected: %d. got: %d\nhave you added/removed a receiver?", 8, len(reqs))
 		return
 	}
 }

--- a/lib/render.go
+++ b/lib/render.go
@@ -59,6 +59,10 @@ func (r *RenderRequests) Render(p *RenderParams, res *[]byte) error {
 		return err
 	}
 
+	if err := DefaultSelectedRef(r.repo, &ref); err != nil {
+		return err
+	}
+
 	err = repo.CanonicalizeDatasetRef(r.repo, &ref)
 	if err != nil {
 		log.Debug(err.Error())

--- a/lib/selection.go
+++ b/lib/selection.go
@@ -1,0 +1,55 @@
+package lib
+
+import (
+	"fmt"
+	"net/rpc"
+
+	"github.com/qri-io/qri/repo"
+)
+
+// SelectionRequests encapsulates business logic for the qri search
+// command
+type SelectionRequests struct {
+	cli  *rpc.Client
+	repo repo.Repo
+}
+
+// NewSelectionRequests creates a SelectionRequests pointer from either a repo
+// or an rpc.Client
+func NewSelectionRequests(r repo.Repo, cli *rpc.Client) *SelectionRequests {
+	if r != nil && cli != nil {
+		panic(fmt.Errorf("both repo and client supplied to NewSelectionRequests"))
+	}
+	return &SelectionRequests{
+		cli:  cli,
+		repo: r,
+	}
+}
+
+// CoreRequestsName implements the requests
+func (r SelectionRequests) CoreRequestsName() string { return "selection" }
+
+// SetSelectedRefs sets the current set of selected references
+func (r *SelectionRequests) SetSelectedRefs(sel *[]repo.DatasetRef, done *bool) error {
+	if r.cli != nil {
+		return r.cli.Call("SelectionRequests.SetSelectedRefs", sel, done)
+	}
+
+	if rs, ok := r.repo.(repo.RefSelector); ok {
+		return rs.SetSelectedRefs(*sel)
+	}
+	return fmt.Errorf("selection not supported")
+}
+
+// SelectedRefs gets the current set of selected references
+func (r *SelectionRequests) SelectedRefs(done *bool, sel *[]repo.DatasetRef) (err error) {
+	if r.cli != nil {
+		return r.cli.Call("SelectionRequests.SelectedRefs", done, sel)
+	}
+
+	if rs, ok := r.repo.(repo.RefSelector); ok {
+		*sel, err = rs.SelectedRefs()
+		return
+	}
+	return fmt.Errorf("selection not supported")
+}

--- a/lib/selection_test.go
+++ b/lib/selection_test.go
@@ -34,3 +34,87 @@ func TestSelectionRequestsSelectedRefs(t *testing.T) {
 		}
 	}
 }
+
+func TestDefaultSelectedRefs(t *testing.T) {
+	mr, err := testrepo.NewTestRepo(nil)
+	if err != nil {
+		t.Fatalf("allocating test repo: %s", err)
+	}
+
+	refs := []repo.DatasetRef{}
+	if err := DefaultSelectedRefs(mr, &refs); err != nil {
+		t.Error(err.Error())
+	}
+	if len(refs) != 0 {
+		t.Error("expected 0 references")
+	}
+
+	sr := NewSelectionRequests(mr, nil)
+	var done bool
+	a := []repo.DatasetRef{{Peername: "a"}, {Peername: "b"}}
+	if err := sr.SetSelectedRefs(&a, &done); err != nil {
+		t.Errorf("setting selected refs: %s", err.Error())
+	}
+
+	if err := DefaultSelectedRefs(mr, &refs); err != nil {
+		t.Error(err.Error())
+	}
+	if len(refs) != 2 {
+		t.Error("expected 2 references")
+	}
+
+	refs = []repo.DatasetRef{}
+	b := []repo.DatasetRef{}
+	if err := sr.SetSelectedRefs(&b, &done); err != nil {
+		t.Errorf("setting selected refs: %s", err.Error())
+	}
+	if err := DefaultSelectedRefs(mr, &refs); err != nil {
+		t.Error(err.Error())
+	}
+	if len(refs) != 0 {
+		t.Error("expected 0 references")
+	}
+
+}
+
+func TestDefaultSelectedRef(t *testing.T) {
+	mr, err := testrepo.NewTestRepo(nil)
+	if err != nil {
+		t.Fatalf("allocating test repo: %s", err)
+	}
+
+	ref := &repo.DatasetRef{}
+	if err := DefaultSelectedRef(mr, ref); err != nil {
+		t.Error(err.Error())
+	}
+	if !ref.IsEmpty() {
+		t.Error("expected ref to be empty")
+	}
+
+	sr := NewSelectionRequests(mr, nil)
+	var done bool
+	a := []repo.DatasetRef{{Peername: "a"}, {Peername: "b"}}
+	if err := sr.SetSelectedRefs(&a, &done); err != nil {
+		t.Errorf("setting selected refs: %s", err.Error())
+	}
+
+	if err := DefaultSelectedRef(mr, ref); err != nil {
+		t.Error(err.Error())
+	}
+	if ref.IsEmpty() {
+		t.Error("expected ref not to be empty")
+	}
+
+	ref = &repo.DatasetRef{}
+	b := []repo.DatasetRef{}
+	if err := sr.SetSelectedRefs(&b, &done); err != nil {
+		t.Errorf("setting selected refs: %s", err.Error())
+	}
+	if err := DefaultSelectedRef(mr, ref); err != nil {
+		t.Error(err.Error())
+	}
+	if !ref.IsEmpty() {
+		t.Error("expected ref to be empty")
+	}
+
+}

--- a/lib/selection_test.go
+++ b/lib/selection_test.go
@@ -1,0 +1,36 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/qri-io/qri/repo"
+	testrepo "github.com/qri-io/qri/repo/test"
+)
+
+func TestSelectionRequestsSelectedRefs(t *testing.T) {
+	mr, err := testrepo.NewTestRepo(nil)
+	if err != nil {
+		t.Fatalf("error allocating test repo: %s", err.Error())
+	}
+
+	sr := NewSelectionRequests(mr, nil)
+	var done bool
+	a := []repo.DatasetRef{{Peername: "a"}}
+	if err := sr.SetSelectedRefs(&a, &done); err != nil {
+		t.Errorf("setting selected refs: %s", err.Error())
+	}
+
+	b := []repo.DatasetRef{}
+	if err := sr.SelectedRefs(&done, &b); err != nil {
+		t.Errorf("selected refs: %s", err.Error())
+	}
+
+	if len(a) != len(b) {
+		t.Errorf("repsonse len mismatch. expected: %d. got: %d", len(a), len(b))
+	}
+	for i, ar := range a {
+		if err := repo.CompareDatasetRef(ar, b[i]); err != nil {
+			t.Errorf("case selection %d error: %s", i, err)
+		}
+	}
+}

--- a/repo/actions/dataset_test.go
+++ b/repo/actions/dataset_test.go
@@ -43,6 +43,7 @@ func init() {
 		panic(fmt.Errorf("error unmarshaling private key: %s", err.Error()))
 		return
 	}
+	testPeerProfile.PrivKey = privKey
 }
 
 func TestDataset(t *testing.T) {
@@ -53,7 +54,7 @@ func TestDataset(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		mr.SetPrivateKey(privKey)
+		// mr.SetPrivateKey(privKey)
 		return mr
 	}
 	DatasetTests(t, rmf)
@@ -82,7 +83,6 @@ func testCreateDataset(t *testing.T, rmf RepoMakerFunc) {
 func createDataset(t *testing.T, rmf RepoMakerFunc) (repo.Repo, repo.DatasetRef) {
 	r := rmf(t)
 	r.SetProfile(testPeerProfile)
-	r.SetPrivateKey(privKey)
 	act := Dataset{r}
 
 	tc, err := dstest.NewTestCaseFromDir(testdataPath("cities"))

--- a/repo/actions/select.go
+++ b/repo/actions/select.go
@@ -1,0 +1,68 @@
+package actions
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/dataset/dsfs"
+	"github.com/qri-io/qri/repo"
+)
+
+// Select loads a dataset value specified by case.Sensitve.dot.separated.paths
+func (act Dataset) Select(ref repo.DatasetRef, path string) (interface{}, error) {
+	ds, err := dsfs.LoadDataset(act.Store(), datastore.NewKey(ref.Path))
+	if err != nil {
+		return nil, err
+	}
+
+	if path == "" {
+		return ds.Encode(), nil
+	}
+
+	v, err := pathValue(ds.Encode(), path)
+	if err != nil {
+		return nil, err
+	}
+	return v.Interface(), nil
+}
+
+func pathValue(ds *dataset.DatasetPod, path string) (elem reflect.Value, err error) {
+	elem = reflect.ValueOf(ds)
+
+	for _, sel := range strings.Split(path, ".") {
+		if elem.Kind() == reflect.Ptr {
+			elem = elem.Elem()
+		}
+
+		switch elem.Kind() {
+		case reflect.Struct:
+			elem = elem.FieldByNameFunc(func(str string) bool {
+				return strings.ToLower(str) == sel
+			})
+		case reflect.Slice:
+			index, err := strconv.Atoi(sel)
+			if err != nil {
+				return elem, fmt.Errorf("invalid index value: %s", sel)
+			}
+			elem = elem.Index(index)
+		case reflect.Map:
+			for _, key := range elem.MapKeys() {
+				// we only support strings as keys
+				if strings.ToLower(key.String()) == sel {
+					return elem.MapIndex(key), nil
+				}
+			}
+			return elem, fmt.Errorf("invalid selection path: %s", path)
+		}
+
+		if elem.Kind() == reflect.Invalid {
+			return elem, fmt.Errorf("invalid selection path: %s", path)
+		}
+	}
+
+	return elem, nil
+}

--- a/repo/fs/files.go
+++ b/repo/fs/files.go
@@ -53,6 +53,8 @@ const (
 	FileAnalytics
 	// FileSearchIndex is the path to a search index
 	FileSearchIndex
+	// FileSelectedRefs is the path to the current ref selection
+	FileSelectedRefs
 	// FileChangeRequests is a file of change requests
 	FileChangeRequests
 )
@@ -68,6 +70,7 @@ var paths = map[File]string{
 	FilePeers:          "/peers.json",
 	FileAnalytics:      "/analytics.json",
 	FileSearchIndex:    "/index.bleve",
+	FileSelectedRefs:   "/selected_refs.json",
 	FileChangeRequests: "/change_requests.json",
 }
 

--- a/repo/fs/fs_test.go
+++ b/repo/fs/fs_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/qri-io/qri/repo/test"
 )
 
+var _ repo.RefSelector = (*Repo)(nil)
+
 func TestRepo(t *testing.T) {
 	path := filepath.Join(os.TempDir(), "qri_repo_test")
 	t.Log(path)

--- a/repo/graph_test.go
+++ b/repo/graph_test.go
@@ -115,10 +115,10 @@ func makeTestRepo() (Repo, error) {
 		return nil, err
 	}
 
-	r.SetPrivateKey(privKey)
 	r.SetProfile(&profile.Profile{
 		ID:       "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
 		Peername: "peer",
+		PrivKey:  privKey,
 	})
 
 	data1f := cafs.NewMemfileBytes("data1", []byte("dataset_1"))

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -1,8 +1,6 @@
 package repo
 
 import (
-	"fmt"
-
 	"github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset/dsgraph"
@@ -12,12 +10,14 @@ import (
 
 // MemRepo is an in-memory implementation of the Repo interface
 type MemRepo struct {
-	pk       crypto.PrivKey
-	store    cafs.Filestore
-	graph    map[string]*dsgraph.Node
-	refCache *MemRefstore
 	*MemRefstore
 	*MemEventLog
+
+	store        cafs.Filestore
+	graph        map[string]*dsgraph.Node
+	refCache     *MemRefstore
+	selectedRefs []DatasetRef
+
 	profile  *profile.Profile
 	profiles profile.Store
 	registry *regclient.Client
@@ -39,15 +39,6 @@ func NewMemRepo(p *profile.Profile, store cafs.Filestore, ps profile.Store, rc *
 // Store returns the underlying cafs.Filestore for this repo
 func (r *MemRepo) Store() cafs.Filestore {
 	return r.store
-}
-
-// SetPrivateKey sets this repos's internal private key reference
-func (r *MemRepo) SetPrivateKey(pk crypto.PrivKey) error {
-	if r.profile == nil {
-		return fmt.Errorf("no profile")
-	}
-	r.profile.PrivKey = pk
-	return nil
 }
 
 // PrivateKey returns this repo's private key
@@ -77,6 +68,17 @@ func (r *MemRepo) Profile() (*profile.Profile, error) {
 func (r *MemRepo) SetProfile(p *profile.Profile) error {
 	r.profile = p
 	return nil
+}
+
+// SetSelectedRefs sets the current reference selection
+func (r *MemRepo) SetSelectedRefs(sel []DatasetRef) error {
+	r.selectedRefs = sel
+	return nil
+}
+
+// SelectedRefs gives the current reference selection
+func (r *MemRepo) SelectedRefs() ([]DatasetRef, error) {
+	return r.selectedRefs, nil
 }
 
 // Profiles gives this repo's Peer interface implementation

--- a/repo/ref.go
+++ b/repo/ref.go
@@ -21,6 +21,14 @@ type Refstore interface {
 	RefCount() (int, error)
 }
 
+// RefSelector is an interface for supporting reference selection
+// a reference selection is a slice of references intended for using
+// in dataset operations
+type RefSelector interface {
+	SetSelectedRefs([]DatasetRef) error
+	SelectedRefs() ([]DatasetRef, error)
+}
+
 // ProfileRef encapsulates a reference to a peer profile
 // It's main job is to connect peernames / profile ID's to profiles
 type ProfileRef struct {

--- a/repo/ref.go
+++ b/repo/ref.go
@@ -21,6 +21,9 @@ type Refstore interface {
 	RefCount() (int, error)
 }
 
+// ErrRefSelectionNotSupported is the expected error for when RefSelector interface is *not* implemented
+var ErrRefSelectionNotSupported = fmt.Errorf("selection not supported")
+
 // RefSelector is an interface for supporting reference selection
 // a reference selection is a slice of references intended for using
 // in dataset operations

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -53,12 +53,8 @@ type Repo interface {
 	// A repository must maintain profile information about the owner of this dataset.
 	// The value returned by Profile() should represent the peer.
 	Profile() (*profile.Profile, error)
-	// It must be possible to alter profile information.
+	// SetProfile sets this repo's current profile. Profiles must contain a private key
 	SetProfile(*profile.Profile) error
-	// SetPrivateKey sets an internal reference to the private key for this profile.
-	// PrivateKey is used to tie peer actions to this profile. Repo implementations must
-	// never expose this private key once set.
-	SetPrivateKey(pk crypto.PrivKey) error
 	// PrivateKey hands over this repo's private key
 	// TODO - this is needed to create action structs, any way we can make this
 	// privately-negotiated or created at init?

--- a/repo/test/test.go
+++ b/repo/test/test.go
@@ -23,6 +23,7 @@ func testdataPath(path string) string {
 func RunRepoTests(t *testing.T, rmf RepoMakerFunc) {
 	tests := []repoTestFunc{
 		testProfile,
+		testRefSelector,
 		// testRefstore,
 		// DatasetActions,
 	}
@@ -47,4 +48,29 @@ func testProfile(t *testing.T, rmf RepoMakerFunc) {
 		return
 	}
 
+}
+
+func testRefSelector(t *testing.T, rmf RepoMakerFunc) {
+	r := rmf(t)
+	if rs, ok := r.(repo.RefSelector); ok {
+		sel := []repo.DatasetRef{
+			{Peername: "foo"},
+		}
+
+		err := rs.SetSelectedRefs(sel)
+		if err != nil {
+			t.Errorf("Error setting selection: %s", err)
+		}
+
+		got, err := rs.SelectedRefs()
+		if len(sel) != len(got) {
+			t.Errorf("Selected length mismatch. Expected: %d. Got: %d.", len(sel), len(got))
+		}
+
+		for i, a := range sel {
+			if err := repo.CompareDatasetRef(a, got[i]); err != nil {
+				t.Errorf("comparing selected reference %d: %s", i, err)
+			}
+		}
+	}
 }

--- a/repo/test/test_dataset_actions.go
+++ b/repo/test/test_dataset_actions.go
@@ -31,7 +31,6 @@ func testCreateDataset(t *testing.T, rmf RepoMakerFunc) {
 func createDataset(t *testing.T, rmf RepoMakerFunc) (repo.Repo, repo.DatasetRef) {
 	r := rmf(t)
 	r.SetProfile(testPeerProfile)
-	r.SetPrivateKey(privKey)
 	act := actions.Dataset{r}
 
 	tc, err := dstest.NewTestCaseFromDir(testdataPath("cities"))


### PR DESCRIPTION
Two things showed up while working on tutorials:
1. We haven't built a way to actually _get_ dataset info from the command line. Currently we have `qri info`, which only displays a summary.
2. constantly retyping dataset names has officially gotten too irritating.

### Reference Selection & `qri use`
For the retyping problem, I think we should steal the concept of "USE" from database land to set the current dataset. For example, in postgres's `psql` tool, the command `USE [database_name]` sets the current database you're interacting with. So for us I've first plumbed the concept of a "Reference Selection" as an opt-in interface in the repo package:

```golang
// RefSelector is an interface for supporting reference selection
// a reference selection is a slice of references intended for using
// in dataset operations
type RefSelector interface {
	SetSelectedRefs([]DatasetRef) error
	SelectedRefs() ([]DatasetRef, error)
}
```

It's a simple setter-getter interface. Notice reference selections are a a slice of references. Having this be an opt-in interface means not all interfaces may implement reference selection. This PR adds reference selection for both `MemRepo` and `Fs` repo.

Now that we have a way to store a selection of datasets, I've plumed this up into a new `qri use` command that takes any number of dataset references as arguments (a raw `qri use` with no args clears the selection). Once a user has set a selection with `qri use`, they become the default dataset names when no selection is made. So:
```shell
$ qri use osterbit/list_of_shas
osterbit/list_of_shas

$ qri info
1  osterbit/list_of_shas
    /ipfs/QmNhUwFjFa1j6kKS9LebDPS7KLr6ovhYgRgLEHjfNB9GAX
    113 Shorthand Abstractions/Mental Models
    source: https://www.fs.blog/mental-models

$ qri use

$ qri info
requires at least 1 arg(s), only received 0
```

From the CLI this'll dramatically cut down on typing, and abate the need for tab completions. We can also plumb this up into the API & frontend as needed.

### `qri get`

Ok, so I'm _really_ into `qri config get`. There's something so lovely about being able to hold a mental model of the configuration file in my head and using dot selectors to isolate bits of configuration info. This PR adds a new command `qri get` that does the same thing for datasets:

```bash
$ qri get meta osterbit/list_of_shas
osterbit/list_of_shas@QmRGAvfLoRcx2nTExZLaPajh6KNH8bDSUZvYDVsUVJSxEe/ipfs/QmNhUwFjFa1j6kKS9LebDPS7KLr6ovhYgRgLEHjfNB9GAX:
  citations: []
  contributors: []
  description: "source: https://www.fs.blog/mental-models/\nadded because \n- lists
    of these are sorta interesting\n- example of a simple dataset that could be organized/represented
    a few different different hierarchical formats or as a table\n\ncitations:\nCharlie
    Munger, https://www.fs.blog/mental-models/\n\nNOTE - have noticed some errors
    in the data from the original parsing\nTODO: fix"
  homePath: https://www.fs.blog/mental-models/
  language:
  - english
  qri: md:0
  readmePath: https://www.fs.blog/mental-models/
  theme:
  - special interest
  title: '113 Shorthand Abstractions/Mental Models '
```

Default output is YAML, switchable with the same `--format` flag that `qri config` uses. But the more interesting thing shows up when `qri get` is used on _multiple datasets_:
```shell
$ qri get meta osterbit/census_acs5_2010_tag b5/schools
b5/schools@QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W/ipfs/QmSies9e7YEWUpT27RniNULJ4rxSD5zZd1aAe5d8BBEfji:
  accrualPeriodicity: R/P1W
  downloadPath: https://code.org/schools.json
  qri: md:0
osterbit/census_acs5_2010_tag@QmRGAvfLoRcx2nTExZLaPajh6KNH8bDSUZvYDVsUVJSxEe/ipfs/QmbDbPMbnsYHYtTPXE2Jv1EfwzY3y28hu93By9UiYpikCk:
  accrualPeriodicity: R/P1W
  downloadPath: https://api.census.gov/data/2010/acs5/tags.json
  qri: md:0
```

combined with `qri use` this makes for what I think is a pleasant experience:
```shell
$ qri use osterbit/census_acs5_2010_tag b5/schools
osterbit/census_acs5_2010_tag 
b5/schools

$ qri get meta.title -f json
{
 "b5/schools@QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W/ipfs/QmSies9e7YEWUpT27RniNULJ4rxSD5zZd1aAe5d8BBEfji": "",
 "osterbit/census_acs5_2010_tag@QmRGAvfLoRcx2nTExZLaPajh6KNH8bDSUZvYDVsUVJSxEe/ipfs/QmbDbPMbnsYHYtTPXE2Jv1EfwzY3y28hu93By9UiYpikCk": ""
}
```

To me we clearly need some work on the lengthy name that's output, but this points to the _inherent compatibility_ of qri datasets. I'm very excited to fold some limit/offset tools that apply to everything, but especially `qri body`, where datasets that are meant to kinda "go together" can now be conjoined with `qri use` to return data that combines a number of dataset bodies quickly & easily. I'm also very excited about reduced complexity of a mental model that `qri get` implies.

### Next Steps
* merge the `qri body` command into `qri get`
* Let's consider the format of the top level output. Should it just be an array of arrays? I'm assuming we should add parameters for this
* Let's consider adding some sort of selection syntax that extends this dot notation with pattern matching (let's take our time with this one)