### PR TITLE
fix(cmd): Improve how DatasetRefs are parsed for better cmd behavior.

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -40,10 +40,10 @@ Once you’ve added data, you can use the export command to pull the data out of
 qri, change the data outside of qri, and use the save command to record those 
 changes to qri.`,
 		Example: `  add a new dataset named annual_pop:
-  $ qri add --data data.csv me/annual_pop
+  $ qri add --body data.csv me/annual_pop
 
 create a dataset with a dataset data file:
-  $ qri add --file dataset.yaml --data comics.csv me/comic_characters`,
+  $ qri add --file dataset.yaml --body comics.csv me/comic_characters`,
 		Run: func(cmd *cobra.Command, args []string) {
 			ExitIfErr(o.Complete(f))
 			ExitIfErr(o.Run(args))
@@ -146,7 +146,7 @@ func (o *AddOptions) InitDataset(name repo.DatasetRef) error {
 		}
 	}
 
-	if name.Peername != "" {
+	if name.Name != "" {
 		dsp.Name = name.Name
 	}
 	if name.Peername != "" {

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -34,7 +34,7 @@ qri will automatically generate one for you.
 Currently you can only save changes to datasets that you control. Tools for 
 collaboration are in the works. Sit tight sportsfans.`,
 		Example: `  save updated data to dataset annual_pop:
-  $ qri --data /path/to/data.csv me/annual_pop
+  $ qri --body /path/to/data.csv me/annual_pop
 
   save updated dataset (no data) to annual_pop:
   $ qri --file /path/to/dataset.yaml me/annual_pop`,

--- a/repo/ref.go
+++ b/repo/ref.go
@@ -177,15 +177,16 @@ func ParseDatasetRef(ref string) (DatasetRef, error) {
 
 	} else {
 
-		var peername, datasetname, pid bool
+		var hasFirst, hasSecond, hasPid bool
+		var first, second string
 		toks := strings.Split(ref, "/")
 
 		for i, tok := range toks {
 			if isBase58Multihash(tok) {
 				// first hash we encounter is a peerID
-				if !pid {
+				if !hasPid {
 					dsr.ProfileID, _ = profile.IDB58Decode(tok)
-					pid = true
+					hasPid = true
 					continue
 				}
 
@@ -197,20 +198,27 @@ func ParseDatasetRef(ref string) (DatasetRef, error) {
 				break
 			}
 
-			if !peername {
-				dsr.Peername = tok
-				peername = true
+			if !hasFirst {
+				first = tok
+				hasFirst = true
 				continue
 			}
 
-			if !datasetname {
-				dsr.Name = tok
-				datasetname = true
+			if !hasSecond {
+				second = tok
+				hasSecond = true
 				continue
 			}
 
 			dsr.Path = strings.Join(toks[i:], "/")
 			break
+		}
+
+		if hasFirst && !hasSecond {
+			dsr.Name = first
+		} else if hasFirst && hasSecond {
+			dsr.Peername = first
+			dsr.Name = second
 		}
 	}
 

--- a/repo/ref_test.go
+++ b/repo/ref_test.go
@@ -90,6 +90,10 @@ func TestParseDatasetRef(t *testing.T) {
 		Name:     "datasetname",
 	}
 
+	justNameDatasetRef := DatasetRef{
+		Name:     "datasetname",
+	}
+
 	peerIDDatasetRef := DatasetRef{
 		ProfileID: profile.IDB58MustDecode("QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y"),
 	}
@@ -142,7 +146,7 @@ func TestParseDatasetRef(t *testing.T) {
 	}{
 		{"", DatasetRef{}, "cannot parse empty string as dataset reference"},
 		{"peername/", peernameDatasetRef, ""},
-		{"peername", peernameDatasetRef, ""},
+		{"datasetname", justNameDatasetRef, ""},
 
 		{"QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/", peerIDDatasetRef, ""},
 		{"/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", peerIDDatasetRef, ""},
@@ -160,7 +164,7 @@ func TestParseDatasetRef(t *testing.T) {
 		{"peername/datasetname@/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", fullDatasetRef, ""},
 
 		{"/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idFullDatasetRef, ""},
-		{"/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idFullDatasetRef, ""}, // 15
+		{"/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idFullDatasetRef, ""},
 		{"/datasetname/@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idFullIPFSDatasetRef, ""},
 		{"/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idFullDatasetRef, ""},
 
@@ -170,23 +174,7 @@ func TestParseDatasetRef(t *testing.T) {
 
 		{"peername/datasetname/@/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", fullDatasetRef, ""},
 		{"peername/datasetname/@/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", fullIPFSDatasetRef, ""},
-
-		// TODO - restore. These have been removed b/c I didn't have time to make dem work properly - @b5
-		// {"peername/datasetname@/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", fullIPFSDatasetRef, ""},
-		// {"peername/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", fullIPFSDatasetRef, ""},
-		// {"@/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", pathOnlyDatasetRef, ""},
-		// {"@network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", pathOnlyDatasetRef, ""},
-		// {"@/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", ipfsOnlyDatasetRef, ""},
-		// {"@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D96w1L5qAhUM5Y/junk/junk/...", ipfsOnlyDatasetRef, ""},
-
-		// {"peername/datasetname@network/bad_hash", DatasetRef{}, "invalid ProfileID: profile.IDB58MustDecode('network'"}),
-		// {"peername/datasetname@bad_hash/junk/junk..", DatasetRef{}, "invalid ProfileID: profile.IDB58MustDecode('bad_hash'"}),
-		// {"peername/datasetname@bad_hash", DatasetRef{}, "invalid ProfileID: profile.IDB58MustDecode('bad_hash'"}),
-
-		// {"@///*(*)/", DatasetRef{}, "malformed DatasetRef string: @///*(*)/"},
-		// {"///*(*)/", DatasetRef{}, "malformed DatasetRef string: ///*(*)/"},
-		// {"@", DatasetRef{}, ""},
-		// {"///@////", DatasetRef{}, ""},
+		{"@/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", pathOnlyDatasetRef, ""},
 	}
 
 	for i, c := range cases {
@@ -410,8 +398,8 @@ func TestCanonicalizeProfile(t *testing.T) {
 		expect          DatasetRef
 		err             string
 	}{
-		{"me", DatasetRef{}, lucille, ""},
-		{"lucille", DatasetRef{}, lucille, ""},
+		{"me/", DatasetRef{}, lucille, ""},
+		{"lucille/", DatasetRef{}, lucille, ""},
 		{"QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", DatasetRef{}, lucille, ""},
 		{"me/ball@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", DatasetRef{}, ball, ""},
 		{"/ball@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", DatasetRef{}, ball, ""},


### PR DESCRIPTION
This command-line invocation:

    qri add --body=some_rows.json new_dataset

would previously act as follows:

    added new dataset me/some_rowsjson@QmBlahBlah/ipfs/QmBlahBlah

but now acts like:

    added new dataset me/new_dataset@QmBlahBlah/ipfs/QmBlahBlah