### PR TITLE
fix(cmd): Wrap how DatasetRefs are parsed for better cmd behavior.

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -40,10 +40,10 @@ Once you’ve added data, you can use the export command to pull the data out of
 qri, change the data outside of qri, and use the save command to record those 
 changes to qri.`,
 		Example: `  add a new dataset named annual_pop:
-  $ qri add --data data.csv me/annual_pop
+  $ qri add --body data.csv me/annual_pop
 
 create a dataset with a dataset data file:
-  $ qri add --file dataset.yaml --data comics.csv me/comic_characters`,
+  $ qri add --file dataset.yaml --body comics.csv me/comic_characters`,
 		Run: func(cmd *cobra.Command, args []string) {
 			ExitIfErr(o.Complete(f))
 			ExitIfErr(o.Run(args))
@@ -97,12 +97,12 @@ func (o *AddOptions) Run(args []string) error {
 		if len(args) == 1 {
 			arg = args[0]
 		}
-		ref, _ := repo.ParseDatasetRef(arg)
+		ref, _ := parseCmdLineDatasetRef(arg)
 		return o.InitDataset(ref)
 	}
 
 	for _, arg := range args {
-		ref, err := repo.ParseDatasetRef(arg)
+		ref, err := parseCmdLineDatasetRef(arg)
 		if err != nil {
 			return err
 		}
@@ -146,7 +146,7 @@ func (o *AddOptions) InitDataset(name repo.DatasetRef) error {
 		}
 	}
 
-	if name.Peername != "" {
+	if name.Name != "" {
 		dsp.Name = name.Name
 	}
 	if name.Peername != "" {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -86,7 +86,7 @@ func parseSecrets(secrets ...string) (map[string]string, error) {
 
 // parseCmdLineDatasetRef parses DatasetRefs, assuming peer "me" if none given.
 func parseCmdLineDatasetRef(ref string) (repo.DatasetRef, error) {
-	if strings.Index(ref, "@") == -1 && strings.Index(ref, "/") == -1 {
+	if !strings.ContainsAny(ref, "@/") {
 		ref = "me/" + ref
 	}
 	return repo.ParseDatasetRef(ref)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/qri-io/qri/repo"
 )
 
 // Execute adds all child commands to the root command sets flags appropriately.
@@ -79,4 +82,12 @@ func parseSecrets(secrets ...string) (map[string]string, error) {
 		s[secrets[i]] = secrets[i+1]
 	}
 	return s, nil
+}
+
+// parseCmdLineDatasetRef parses DatasetRefs, assuming peer "me" if none given.
+func parseCmdLineDatasetRef(ref string) (repo.DatasetRef, error) {
+	if strings.Index(ref, "@") == -1 && strings.Index(ref, "/") == -1 {
+		ref = "me/" + ref
+	}
+	return repo.ParseDatasetRef(ref)
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/qri-io/qri/lib"
-	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
 )
 
@@ -65,7 +64,7 @@ func (o *RemoveOptions) Run() error {
 	}
 
 	for _, arg := range o.Args {
-		ref, err := repo.ParseDatasetRef(arg)
+		ref, err := parseCmdLineDatasetRef(arg)
 		if err != nil {
 			return err
 		}

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -34,7 +34,7 @@ qri will automatically generate one for you.
 Currently you can only save changes to datasets that you control. Tools for 
 collaboration are in the works. Sit tight sportsfans.`,
 		Example: `  save updated data to dataset annual_pop:
-  $ qri --data /path/to/data.csv me/annual_pop
+  $ qri --body /path/to/data.csv me/annual_pop
 
   save updated dataset (no data) to annual_pop:
   $ qri --file /path/to/dataset.yaml me/annual_pop`,

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -92,7 +92,7 @@ func (o *SaveOptions) Run() (err error) {
 		return fmt.Errorf("please provide the name of an existing dataset to save updates to, or specify a dataset --file with name and peername")
 	}
 
-	ref, err := repo.ParseDatasetRef(o.Ref)
+	ref, err := parseCmdLineDatasetRef(o.Ref)
 	if err != nil && o.FilePath == "" {
 		return err
 	}


### PR DESCRIPTION
This command-line invocation:

  qri add --body=some_rows.json new_dataset

would previously act as follows:

  added new dataset me/some_rowsjson@QmBlahBlah/ipfs/QmBlahBlah

but now acts like:

  added new dataset me/new_dataset@QmBlahBlah/ipfs/QmBlahBlah