### PR TITLE
feat: Pin on publish

### DIFF
--- a/api/testdata/statusResponse.json
+++ b/api/testdata/statusResponse.json
@@ -1,1 +1,1 @@
-{ "meta": { "code": 200, "status": "ok" }, "data": [] }
+{ "meta": { "code": 200, "status": "ok" }, "data": null }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -105,11 +105,14 @@ func TestCommandsIntegration(t *testing.T) {
 	_, registryServer := regmock.NewMockServer()
 
 	path := filepath.Join(os.TempDir(), "qri_test_commands_integration")
+	fmt.Println(path)
 	t.Logf("test filepath: %s", path)
 
 	//clean up if previous cleanup failed
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		os.RemoveAll(path)
+		if err := os.RemoveAll(path); err != nil {
+			t.Fatalf("failed to cleanup from previous test execution: %s", err.Error())
+		}
 	}
 	if err := os.MkdirAll(path, os.ModePerm); err != nil {
 		t.Errorf("error creating test path: %s", err.Error())

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -105,7 +105,6 @@ func TestCommandsIntegration(t *testing.T) {
 	_, registryServer := regmock.NewMockServer()
 
 	path := filepath.Join(os.TempDir(), "qri_test_commands_integration")
-	fmt.Println(path)
 	t.Logf("test filepath: %s", path)
 
 	//clean up if previous cleanup failed

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -81,7 +81,7 @@ func (o *ConnectOptions) Complete(f Factory, args []string) (err error) {
 	qriPath := f.QriRepoPath()
 
 	if o.Setup && !QRIRepoInitialized(qriPath) {
-		so := &SetupOptions{IOStreams: o.IOStreams, IPFS: true}
+		so := &SetupOptions{IOStreams: o.IOStreams, IPFS: true, Registry: o.Registry}
 		if err = so.Complete(f, args); err != nil {
 			return err
 		}

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -213,7 +213,11 @@ func (o *QriOptions) RegistryRequests() (*lib.RegistryRequests, error) {
 	if err := o.init(); err != nil {
 		return nil, err
 	}
-	return lib.NewRegistryRequests(o.repo, o.rpc), nil
+	req := lib.NewRegistryRequests(o.repo, o.rpc)
+	if o.node != nil {
+		req.SetQriNode(o.node)
+	}
+	return req, nil
 }
 
 // HistoryRequests generates a lib.HistoryRequests from internal state

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -205,7 +205,7 @@ func (o *QriOptions) DatasetRequests() (*lib.DatasetRequests, error) {
 	if err := o.init(); err != nil {
 		return nil, err
 	}
-	return lib.NewDatasetRequests(o.repo, o.rpc), nil
+	return lib.NewDatasetRequestsWithNode(o.repo, o.rpc, o.node), nil
 }
 
 // RegistryRequests generates a lib.RegistryRequests from internal state
@@ -213,11 +213,7 @@ func (o *QriOptions) RegistryRequests() (*lib.RegistryRequests, error) {
 	if err := o.init(); err != nil {
 		return nil, err
 	}
-	req := lib.NewRegistryRequests(o.repo, o.rpc)
-	if o.node != nil {
-		req.SetQriNode(o.node)
-	}
-	return req, nil
+	return lib.NewRegistryRequestsWithNode(o.repo, o.rpc, o.node), nil
 }
 
 // HistoryRequests generates a lib.HistoryRequests from internal state

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -96,7 +96,12 @@ func (o *RegistryOptions) Publish() error {
 			return err
 		}
 
-		if err = o.RegistryRequests.Publish(&ref, &res); err != nil {
+		p := &lib.PublishParams{
+			Ref: ref,
+			Pin: true,
+		}
+
+		if err = o.RegistryRequests.Publish(p, &res); err != nil {
 			return err
 		}
 		printInfo(o.Out, "published dataset %s", ref)

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -12,7 +12,7 @@ func TestRemoveComplete(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return
@@ -99,7 +99,7 @@ func TestRemoveRun(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return

--- a/cmd/rename_test.go
+++ b/cmd/rename_test.go
@@ -10,7 +10,7 @@ func TestRenameComplete(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return
@@ -100,7 +100,7 @@ func TestRenameRun(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -11,7 +11,7 @@ func TestRenderComplete(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return
@@ -90,7 +90,7 @@ func TestRenderRun(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -54,7 +54,7 @@ collaboration are in the works. Sit tight sportsfans.`,
 	cmd.Flags().StringVarP(&o.BodyPath, "body", "", "", "path to file or url of data to add as dataset contents")
 	// cmd.Flags().BoolVarP(&o.ShowValidation, "show-validation", "s", false, "display a list of validation errors upon adding")
 	cmd.Flags().StringSliceVar(&o.Secrets, "secrets", nil, "transform secrets as comma separated key,value,key,value,... sequence")
-	cmd.Flags().BoolVarP(&o.NoRegistry, "no-registry", "n", false, "don't publish this dataset to the registry")
+	cmd.Flags().BoolVarP(&o.Publish, "publish", "p", false, "publish this dataset to the registry")
 
 	return cmd
 }
@@ -71,7 +71,7 @@ type SaveOptions struct {
 	Passive        bool
 	Rescursive     bool
 	ShowValidation bool
-	NoRegistry     bool
+	Publish        bool
 	Secrets        []string
 
 	DatasetRequests *lib.DatasetRequests
@@ -161,7 +161,7 @@ continue?`, true) {
 	p := &lib.SaveParams{
 		Dataset: dsp,
 		Private: false,
-		Publish: !o.NoRegistry,
+		Publish: o.Publish,
 	}
 
 	res := &repo.DatasetRef{}

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -1,16 +1,19 @@
 package cmd
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/qri-io/qri/lib"
+	"github.com/qri-io/registry/regclient"
 )
 
 func TestSearchComplete(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return
@@ -89,7 +92,14 @@ func TestSearchRun(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	// mock registry server that returns fake response data
+	var mockResponse = []byte(`{"data":[{"Type":"","ID":"ramfox/test","Value":null},{"Type":"","ID":"b5/test","Value":{"commit":{"path":"/","signature":"JI/VSNqMuFGYVEwm3n8ZMjZmey+W2mhkD5if2337wDp+kaYfek9DntOyZiILXocW5JuOp48EqcsWf/BwhejQiYZ2utaIzR8VcMPo7u7c5nz2G6JTsoW+u9UUaKRVtl30jh6Kg1O2bnhYh9v4qW9VQgxOYfdhBl6zT4cYcjm1UkrblEe/wh494k9NziM5Bi2ATGRE2m71Lsf/TEDoNI549SebLQ1dsWXr1kM7lCeFqlDVjgbKQmGXowqcK/P9v+RBIRCnArnwFe/BQq4i1wmmnMEqpuUnfWR3xfJTE1DUMVaAid7U0jTWGVxROUdKk6mmTzlb1PiNdfruP+SFhjyQwQ==","timestamp":"2018-05-25T13:44:54.692493401Z","title":"created dataset"},"meta":{"citations":[{"url":"https://api.github.com/repos/qri-io/qri/releases"}],"qri":"md:0"},"path":"/ipfs/QmPi5wrPsY4xPwy2oRr7NRZyfFxTeupfmnrVDubzoABLNP","qri":"","structure":{"checksum":"QmQXfdYYubCvr9ePJtgABpp7N1fNsAnnywUJPYAJTvDhrn","errCount":0,"entries":7,"format":"json","length":19116,"qri":"","schema":{"type":"array"}},"transform":{"config":{"org":"qri-io","repo":"qri"},"path":"/","syntax":"skylark"},"Handle":"b5","Name":"test","PublicKey":"CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/W17VPFX+pjyM1MHI1CsvIe+JYQX45MJNITTd7hZZDX2rRWVavGXhsccmVDGU6ubeN3t6ewcBlgCxvyewwKhmZKCAs3/0xNGKXK/YMyZpRVjTWw9yPU9gOzjd9GuNJtL7d1Hl7dPt9oECa7WBCh0W9u2IoHTda4g8B2mK92awLOZTjXeA7vbhKKX+QVHKDxEI0U2/ooLYJUVxEoHRc+DUYNPahX5qRgJ1ZDP4ep1RRRoZR+HjGhwgJP+IwnAnO5cRCWUbZvE1UBJUZDvYMqW3QvDp+TtXwqUWVvt69tp8EnlBgfyXU91A58IEQtLgZ7klOzdSEJDP+S8HIwhG/vbTAgMBAAE="}},{"Type":"","ID":"EDGI/fib_6","Value":{"commit":{"path":"/","signature":"dG6NoEFlQ9ILFjVDrecSDlUbDPRSiwK9kFQ3vjTh/4tpfgrT5EOw6eGDx75lklx0DWx51s3AC2Qqytll2JwwCB6SMVVl0I9qnZJ4XQVG+MX4hGeIJ4crGCSts85unDvmiQCfc4EVqPYZKLzaVqjXa43zv5mJPfRA2ktTew3VGkOcg8RmyU6e2XWrZpkILcZg1jt2apKs5qHslx4klKBVPtQIr53/U61OW4tzME9kz08FYrk2F7I5FHWy45W7VU8DpzCbhw6kxJXu2KYD1QstsZGCKH93sZY3agP4XGY15HeEOTib465LK6+nsoBtrsroQSOTBHzVgyUZACNom5SUvQ==","timestamp":"2018-05-23T19:50:03.307982846Z","title":"created dataset"},"meta":{"description":"test of skylark as a transformation language","qri":"md:0","title":"Fibonacci(6)"},"path":"/ipfs/QmS6jJSEJYxZvCeo8cZqzVa7Ybu9yNQeFYfNZAHxM4eyDK","qri":"","structure":{"checksum":"QmdhDDZTAWoifKCWwFrZqzKUyXM6rN7ThdP1u67rkeJvTj","errCount":0,"entries":6,"format":"cbor","length":7,"qri":"","schema":{"type":"array"}},"transform":{"syntax":"skylark"},"Handle":"EDGI","Name":"fib_6","PublicKey":"CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCmTFRx/6dKmoxje8AG+jFv94IcGUGnjrupa7XEr12J/c4ZLn3aPrD8F0tjRbstt1y/J+bO7Qb69DGiu2iSIqyE21nl2oex5+14jtxbupRq9jRTbpUHRj+y9I7uUDwl0E2FS1IQpBBfEGzDPIBVavxbhguC3O3XA7Aq7vea2lpJ1tWpr0GDRYSNmJAybkHS6k7dz1eVXFK+JE8FGFJi/AThQZKWRijvWFdlZvb8RyNFRHzpbr9fh38bRMTqhZpw/YGO5Ly8PNSiOOE4Y5cNUHLEYwG2/lpT4l53iKScsaOazlRkJ6NmkM1il7riCa55fcIAQZDtaAx+CT5ZKfmek4P5AgMBAAE="}}],"meta":{"code":200}}`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(mockResponse)
+	}))
+	rc := regclient.NewClient(&regclient.Config{Location: server.URL})
+
+	f, err := NewTestFactory(rc)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return

--- a/cmd/test_factory.go
+++ b/cmd/test_factory.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"net/rpc"
 
 	"github.com/qri-io/qri/config"
@@ -29,12 +27,11 @@ type TestFactory struct {
 }
 
 // NewTestFactory creates TestFactory object with an in memory test repo
-func NewTestFactory() (tf TestFactory, err error) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(mockResponse)
-	}))
-	rc := regclient.NewClient(&regclient.Config{Location: server.URL})
-	repo, err := test.NewTestRepo(rc)
+// with an optional registry client. In tests users can create mock registry
+// servers and pass in a client connected to that mock, or omit the registry
+// client entirely for testing without a designated registry
+func NewTestFactory(c *regclient.Client) (tf TestFactory, err error) {
+	repo, err := test.NewTestRepo(c)
 	if err != nil {
 		return
 	}
@@ -116,5 +113,3 @@ func (t TestFactory) SearchRequests() (*lib.SearchRequests, error) {
 func (t TestFactory) RenderRequests() (*lib.RenderRequests, error) {
 	return lib.NewRenderRequests(t.repo, t.rpc), nil
 }
-
-var mockResponse = []byte(`{"data":[{"Type":"","ID":"ramfox/test","Value":null},{"Type":"","ID":"b5/test","Value":{"commit":{"path":"/","signature":"JI/VSNqMuFGYVEwm3n8ZMjZmey+W2mhkD5if2337wDp+kaYfek9DntOyZiILXocW5JuOp48EqcsWf/BwhejQiYZ2utaIzR8VcMPo7u7c5nz2G6JTsoW+u9UUaKRVtl30jh6Kg1O2bnhYh9v4qW9VQgxOYfdhBl6zT4cYcjm1UkrblEe/wh494k9NziM5Bi2ATGRE2m71Lsf/TEDoNI549SebLQ1dsWXr1kM7lCeFqlDVjgbKQmGXowqcK/P9v+RBIRCnArnwFe/BQq4i1wmmnMEqpuUnfWR3xfJTE1DUMVaAid7U0jTWGVxROUdKk6mmTzlb1PiNdfruP+SFhjyQwQ==","timestamp":"2018-05-25T13:44:54.692493401Z","title":"created dataset"},"meta":{"citations":[{"url":"https://api.github.com/repos/qri-io/qri/releases"}],"qri":"md:0"},"path":"/ipfs/QmPi5wrPsY4xPwy2oRr7NRZyfFxTeupfmnrVDubzoABLNP","qri":"","structure":{"checksum":"QmQXfdYYubCvr9ePJtgABpp7N1fNsAnnywUJPYAJTvDhrn","errCount":0,"entries":7,"format":"json","length":19116,"qri":"","schema":{"type":"array"}},"transform":{"config":{"org":"qri-io","repo":"qri"},"path":"/","syntax":"skylark"},"Handle":"b5","Name":"test","PublicKey":"CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/W17VPFX+pjyM1MHI1CsvIe+JYQX45MJNITTd7hZZDX2rRWVavGXhsccmVDGU6ubeN3t6ewcBlgCxvyewwKhmZKCAs3/0xNGKXK/YMyZpRVjTWw9yPU9gOzjd9GuNJtL7d1Hl7dPt9oECa7WBCh0W9u2IoHTda4g8B2mK92awLOZTjXeA7vbhKKX+QVHKDxEI0U2/ooLYJUVxEoHRc+DUYNPahX5qRgJ1ZDP4ep1RRRoZR+HjGhwgJP+IwnAnO5cRCWUbZvE1UBJUZDvYMqW3QvDp+TtXwqUWVvt69tp8EnlBgfyXU91A58IEQtLgZ7klOzdSEJDP+S8HIwhG/vbTAgMBAAE="}},{"Type":"","ID":"EDGI/fib_6","Value":{"commit":{"path":"/","signature":"dG6NoEFlQ9ILFjVDrecSDlUbDPRSiwK9kFQ3vjTh/4tpfgrT5EOw6eGDx75lklx0DWx51s3AC2Qqytll2JwwCB6SMVVl0I9qnZJ4XQVG+MX4hGeIJ4crGCSts85unDvmiQCfc4EVqPYZKLzaVqjXa43zv5mJPfRA2ktTew3VGkOcg8RmyU6e2XWrZpkILcZg1jt2apKs5qHslx4klKBVPtQIr53/U61OW4tzME9kz08FYrk2F7I5FHWy45W7VU8DpzCbhw6kxJXu2KYD1QstsZGCKH93sZY3agP4XGY15HeEOTib465LK6+nsoBtrsroQSOTBHzVgyUZACNom5SUvQ==","timestamp":"2018-05-23T19:50:03.307982846Z","title":"created dataset"},"meta":{"description":"test of skylark as a transformation language","qri":"md:0","title":"Fibonacci(6)"},"path":"/ipfs/QmS6jJSEJYxZvCeo8cZqzVa7Ybu9yNQeFYfNZAHxM4eyDK","qri":"","structure":{"checksum":"QmdhDDZTAWoifKCWwFrZqzKUyXM6rN7ThdP1u67rkeJvTj","errCount":0,"entries":6,"format":"cbor","length":7,"qri":"","schema":{"type":"array"}},"transform":{"syntax":"skylark"},"Handle":"EDGI","Name":"fib_6","PublicKey":"CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCmTFRx/6dKmoxje8AG+jFv94IcGUGnjrupa7XEr12J/c4ZLn3aPrD8F0tjRbstt1y/J+bO7Qb69DGiu2iSIqyE21nl2oex5+14jtxbupRq9jRTbpUHRj+y9I7uUDwl0E2FS1IQpBBfEGzDPIBVavxbhguC3O3XA7Aq7vea2lpJ1tWpr0GDRYSNmJAybkHS6k7dz1eVXFK+JE8FGFJi/AThQZKWRijvWFdlZvb8RyNFRHzpbr9fh38bRMTqhZpw/YGO5Ly8PNSiOOE4Y5cNUHLEYwG2/lpT4l53iKScsaOazlRkJ6NmkM1il7riCa55fcIAQZDtaAx+CT5ZKfmek4P5AgMBAAE="}}],"meta":{"code":200}}`)

--- a/cmd/use_test.go
+++ b/cmd/use_test.go
@@ -11,7 +11,7 @@ func TestUseComplete(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return
@@ -99,7 +99,7 @@ func TestUseRun(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -11,7 +11,7 @@ func TestValidateComplete(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return
@@ -99,7 +99,7 @@ func TestValidateRun(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
-	f, err := NewTestFactory()
+	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
 		return

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -422,7 +422,8 @@ func (r *DatasetRequests) Init(p *SaveParams, res *repo.DatasetRef) (err error) 
 	if p.Publish {
 		// fmt.Println("posting dataset to registry ...")
 		var done bool
-		if err = NewRegistryRequests(r.repo, nil).Publish(res, &done); err != nil {
+
+		if err = NewRegistryRequests(r.repo, nil).Publish(&PublishParams{Ref: *res, Pin: true}, &done); err != nil {
 			return err
 		}
 		// fmt.Println("done")
@@ -540,7 +541,7 @@ func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) 
 	if p.Publish {
 		fmt.Println("posting dataset to registry ...")
 		var done bool
-		if err = NewRegistryRequests(r.repo, nil).Publish(&ref, &done); err != nil {
+		if err = NewRegistryRequests(r.repo.Repo, nil).Publish(&PublishParams{Ref: ref, Pin: true}, &done); err != nil {
 			return err
 		}
 		fmt.Println("done")

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -533,7 +533,7 @@ func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) 
 
 	ref, err := r.repo.CreateDataset(dsp.Name, ds, dataFile, secrets, true)
 	if err != nil {
-		log.Errorf("create ds error: %s\n", err.Error())
+		log.Debugf("create ds error: %s\n", err.Error())
 		return err
 	}
 	ref.Dataset = ds.Encode()

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -47,7 +47,7 @@ func TestDatasetRequestsInit(t *testing.T) {
 		w.Write([]byte(`\\\{"json":"data"}`))
 	}))
 
-	rc, _ := regmock.NewMockServer()
+	rc, _ := regmock.NewMockServerWithMemPinset()
 	mr, err := testrepo.NewTestRepo(rc)
 	if err != nil {
 		t.Errorf("error allocating test repo: %s", err.Error())

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -21,7 +21,7 @@ type RegistryRequests struct {
 // CoreRequestsName implements the Requests interface
 func (RegistryRequests) CoreRequestsName() string { return "registry" }
 
-// NewRegistryRequests creates a DatasetRequests pointer from either a repo
+// NewRegistryRequests creates a RegistryRequests pointer from either a repo
 // or an rpc.Client
 func NewRegistryRequests(r repo.Repo, cli *rpc.Client) *RegistryRequests {
 	if r != nil && cli != nil {
@@ -34,9 +34,17 @@ func NewRegistryRequests(r repo.Repo, cli *rpc.Client) *RegistryRequests {
 	}
 }
 
-// SetQriNode assigns the unexported qri node pointer
-func (r *RegistryRequests) SetQriNode(node *p2p.QriNode) {
-	r.node = node
+// NewRegistryRequestsWithNode creates a RegistryRequests and a QriNode
+func NewRegistryRequestsWithNode(r repo.Repo, cli *rpc.Client, node *p2p.QriNode) *RegistryRequests {
+	if r != nil && cli != nil {
+		panic(fmt.Errorf("both repo and client supplied to NewDatasetRequestsWithNode"))
+	}
+
+	return &RegistryRequests{
+		repo: actions.Registry{r},
+		cli:  cli,
+		node: node,
+	}
 }
 
 // PublishParams encapsulates arguments to the publish method
@@ -66,11 +74,9 @@ func (r *RegistryRequests) Publish(p *PublishParams, done *bool) (err error) {
 			if err != nil {
 				return err
 			}
+		}
 
-			if err := node.StartOnlineServices(func(string) {}); err != nil {
-				return err
-			}
-		} else if !node.Online {
+		if !node.Online {
 			if err := node.StartOnlineServices(func(string) {}); err != nil {
 				return err
 			}

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"net/rpc"
 
+	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/actions"
+	"github.com/qri-io/registry"
 )
 
 // RegistryRequests defines business logic for working with registries
 type RegistryRequests struct {
+	node *p2p.QriNode
 	repo actions.Registry
 	cli  *rpc.Client
 }
@@ -30,12 +34,65 @@ func NewRegistryRequests(r repo.Repo, cli *rpc.Client) *RegistryRequests {
 	}
 }
 
+// SetQriNode assigns the unexported qri node pointer
+func (r *RegistryRequests) SetQriNode(node *p2p.QriNode) {
+	r.node = node
+}
+
+// PublishParams encapsulates arguments to the publish method
+type PublishParams struct {
+	Ref repo.DatasetRef
+	Pin bool
+}
+
 // Publish a dataset to a registry
-func (r *RegistryRequests) Publish(ref *repo.DatasetRef, done *bool) error {
+func (r *RegistryRequests) Publish(p *PublishParams, done *bool) (err error) {
 	if r.cli != nil {
-		return r.cli.Call("RegistryRequests.Publish", ref, done)
+		return r.cli.Call("RegistryRequests.Publish", p, done)
 	}
-	return r.repo.Publish(*ref)
+
+	ref := p.Ref
+
+	if p.Pin {
+		log.Info("pinning dataset...")
+		node := r.node
+
+		if node == nil {
+			// if we don't have an online node, create one and connect
+			node, err = p2p.NewQriNode(r.repo.Repo, func(c *config.P2P) {
+				*c = *Config.P2P
+				c.Enabled = true
+			})
+			if err != nil {
+				return err
+			}
+
+			if err := node.StartOnlineServices(func(string) {}); err != nil {
+				return err
+			}
+		} else if !node.Online {
+			if err := node.StartOnlineServices(func(string) {}); err != nil {
+				return err
+			}
+		}
+
+		var addrs []string
+		for _, maddr := range node.EncapsulatedAddresses() {
+			addrs = append(addrs, maddr.String())
+		}
+
+		if err = r.repo.Pin(ref, addrs); err != nil {
+			if err == registry.ErrPinsetNotSupported {
+				log.Info("this registry does not support pinning, dataset not pinned.")
+			} else {
+				return err
+			}
+		} else {
+			log.Info("done")
+		}
+	}
+
+	return r.repo.Publish(ref)
 }
 
 // Unpublish a dataset from a registry

--- a/lib/search.go
+++ b/lib/search.go
@@ -49,9 +49,13 @@ func (sr *SearchRequests) Search(p *SearchParams, results *[]SearchResult) error
 	if sr.cli != nil {
 		return sr.cli.Call("SearchRequests.Search", p, results)
 	}
-	reg := sr.repo.Registry()
 	if p == nil {
 		return fmt.Errorf("error: search params cannot be nil")
+	}
+
+	reg := sr.repo.Registry()
+	if reg == nil {
+		return repo.ErrNoRegistry
 	}
 	params := &regclient.SearchParams{p.QueryString, nil, p.Limit, p.Offset}
 

--- a/repo/actions/registry.go
+++ b/repo/actions/registry.go
@@ -12,6 +12,11 @@ import (
 	"github.com/qri-io/registry/regclient"
 )
 
+// MaxDatasetSize is the maximum size a dataset body can be
+// before it cannot be uploaded to a registry
+// TODO - this should be dictated by registries
+const MaxDatasetSize = 1000000 * 250
+
 // Registry wraps a repo.Repo, adding actions related to working
 // with registries
 type Registry struct {
@@ -54,7 +59,7 @@ func (act Registry) Pin(ref repo.DatasetRef, addrs []string) (err error) {
 	}
 
 	// TODO - better test for this
-	if ds.Structure.Length > 1000000*250 {
+	if ds.Structure.Length > MaxDatasetSize {
 		return fmt.Errorf("dataset size exceeds 250Mb limit for pinning")
 	}
 

--- a/repo/actions/registry.go
+++ b/repo/actions/registry.go
@@ -77,7 +77,7 @@ func (act Registry) Unpin(ref repo.DatasetRef, addrs []string) (err error) {
 // dsParams is a convenience func that collects params for registry dataset interaction
 func (act Registry) dsParams(ref *repo.DatasetRef) (cli *regclient.Client, pub crypto.PubKey, ds *dataset.Dataset, err error) {
 	if cli = act.Registry(); cli == nil {
-		err = fmt.Errorf("no configured registry")
+		err = repo.ErrNoRegistry
 		return
 	}
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -31,6 +31,8 @@ var (
 	ErrRepoEmpty = fmt.Errorf("repo: this repo contains no datasets")
 	// ErrNotPinner is for when the repo doesn't have the concept of pinning as a feature
 	ErrNotPinner = fmt.Errorf("repo: backing store doesn't support pinning")
+	// ErrNoRegistry indicates no regsitry is currently configured
+	ErrNoRegistry = fmt.Errorf("no configured registry")
 )
 
 // Repo is the interface for working with a qri repository qri repos are stored


### PR DESCRIPTION
Over on the registry repo we've added interfaces for registries to accept requests to pin data. Profiles that are connected to the registry can sign a request that the registry copy the data.

This PR adapts `qri registry publish` to also submit a request to pin if a registry is present. The process works like this:
1. User needs a local dataset they've created. They run `qri registry publish me/foo`
2. the user isn't connected to the p2p network, qri connects, and write's down it's local addresses
3. qri adds the full datasetRef of `me/foo` (most importantly, the `/ipfs/QmFooHash` bit), and those local addresses into a call to `regclient.Pin`. Those are sent to the registry server. In a request that'll take a little time...
4. Over on the registry side, an ipfs node is asked to pin the hash `/ipfs/QmFooHash`. To make the process quicker, that ipfs node is told to connect directly to the peer addresses that came with the request.
5. Once the hash is pinned, the request will finish, and the `regclient.Pin` request will return `200`.
6. Data is now pinned in a remote, always on location.

Lots of work to do here, but this is the general gist.