### PR TITLE
fix(rpc): Register types with gob to avoid "reading body EOF" errors

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -154,9 +154,7 @@ func TestServerRoutes(t *testing.T) {
 		{"DELETE", "/registry/me/counter", "", "unpublishResponse.json", 200},
 
 		// search
-		// TODO(dlong): Disabled for now due to non-determinism between local runs vs
-		// circleci runs vs qri connect running vs not running.
-		//{"GET", "/search", "searchRequest.json", "searchResponse.json", 200},
+		{"GET", "/search", "searchRequest.json", "searchResponse.json", 200},
 
 		{"GET", "/connect/", "", "", 400},
 

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -44,9 +44,6 @@ func (r *DatasetRequests) Repo() repo.Repo {
 // CoreRequestsName implements the Requets interface
 func (DatasetRequests) CoreRequestsName() string { return "datasets" }
 
-// ErrReadBodyEOF is an error message returned by net/rpc when it can't deserialize data
-const ErrReadBodyEOF = "reading body EOF"
-
 // NewDatasetRequests creates a DatasetRequests pointer from either a repo
 // or an rpc.Client
 func NewDatasetRequests(r repo.Repo, cli *rpc.Client) *DatasetRequests {
@@ -745,16 +742,7 @@ func (r *DatasetRequests) LookupBody(p *LookupParams, data *LookupResult) (err e
 // Add adds an existing dataset to a peer's repository
 func (r *DatasetRequests) Add(ref *repo.DatasetRef, res *repo.DatasetRef) (err error) {
 	if r.cli != nil {
-		err = r.cli.Call("DatasetRequests.Add", ref, res)
-		if err.Error() == ErrReadBodyEOF {
-			// This isn't actually an error, it just means that the response from
-			// the net/rpc client could not be unserialized. That it a separate problem
-			// that should be fixed, but it does not mean that the Add operation itself
-			// has failed.
-			log.Debug("ignoring EOF error")
-			err = nil
-		}
-		return
+		return r.cli.Call("DatasetRequests.Add", ref, res)
 	}
 
 	if err := repo.CanonicalizeDatasetRef(r.repo, ref); err != nil {

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -4,6 +4,7 @@
 package lib
 
 import (
+	"encoding/gob"
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/qri/p2p"
 )
@@ -18,6 +19,14 @@ type Requests interface {
 	// CoreRequestsName confirms participation in the CoreRequests interface while
 	// also giving a human readable string for logging purposes
 	CoreRequestsName() string
+}
+
+func init() {
+	// Fields like dataset.Structure.Schema contain data of arbitrary types,
+	// registering with the gob package prevents errors when sending them
+	// over net/rpc calls.
+	gob.Register([]interface{}{})
+	gob.Register(map[string]interface{}{})
 }
 
 // Receivers returns a slice of CoreRequests that defines the full local


### PR DESCRIPTION
By registering interface array and interface map types with gob, we should hopefully avoid all future gob encoding erorrs. Revert commit d9f78058adb which added a work-around for this error; it isn't needed anymore.