### PR TITLE
refactor(render): replace template lookup with hardcoded template

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"regexp"
+
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
@@ -28,7 +30,7 @@ func NewGetCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	return cmd
 }
 
-// GetOptions encapsulates state for the search command
+// GetOptions encapsulates state for the get command
 type GetOptions struct {
 	IOStreams
 
@@ -40,17 +42,23 @@ type GetOptions struct {
 	DatasetRequests *lib.DatasetRequests
 }
 
+// isDatasetField checks if a string is a dataset field or not
+var isDatasetField = regexp.MustCompile("(?i)commit|structure|body|meta|viz|transform")
+
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *GetOptions) Complete(f Factory, args []string) (err error) {
-	if len(args) != 0 {
-		o.Path = args[0]
-		o.Refs = args[1:]
+	if len(args) > 0 {
+		if isDatasetField.MatchString(args[0]) {
+			o.Path = args[0]
+			args = args[1:]
+		}
 	}
+	o.Refs = args
 	o.DatasetRequests, err = f.DatasetRequests()
 	return
 }
 
-// Run executes the search command
+// Run executes the get command
 func (o *GetOptions) Run() (err error) {
 	var refs []repo.DatasetRef
 	for _, refstr := range o.Refs {

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestGetComplete(t *testing.T) {
+	streams, in, out, errs := NewTestIOStreams()
+	setNoColor(true)
+
+	f, err := NewTestFactory(nil)
+	if err != nil {
+		t.Errorf("error creating new test factory: %s", err)
+		return
+	}
+
+	cases := []struct {
+		args []string
+		path string
+		refs []string
+		err  string
+	}{
+		{[]string{}, "", []string{}, ""},
+		{[]string{"one arg"}, "", []string{"one arg"}, ""},
+		{[]string{"commit", "peer/ds"}, "commit", []string{"peer/ds"}, ""},
+		{[]string{"peer/ds_two", "peer/ds"}, "", []string{"peer/ds_two", "peer/ds"}, ""},
+		{[]string{"foo", "peer/ds"}, "", []string{"foo", "peer/ds"}, ""},
+		{[]string{"structure"}, "structure", []string{}, ""},
+	}
+
+	for i, c := range cases {
+		opt := &GetOptions{
+			IOStreams: streams,
+		}
+
+		opt.Complete(f, c.args)
+
+		if c.err != errs.String() {
+			t.Errorf("case %d, error mismatch. Expected: '%s', Got: '%s'", i, c.err, errs.String())
+			ioReset(in, out, errs)
+			continue
+		}
+
+		if !testSliceEqual(c.refs, opt.Refs) {
+			t.Errorf("case %d, opt.Refs not set correctly. Expected: '%s', Got: '%s'", i, c.refs, opt.Refs)
+			ioReset(in, out, errs)
+			continue
+		}
+
+		if c.path != opt.Path {
+			t.Errorf("case %d, opt.Path not set correctly. Expected: '%s', Got: '%s'", i, c.path, opt.Path)
+			ioReset(in, out, errs)
+			continue
+		}
+
+		if opt.DatasetRequests == nil {
+			t.Errorf("case %d, opt.DatasetRequests not set.", i)
+			ioReset(in, out, errs)
+			continue
+		}
+		ioReset(in, out, errs)
+	}
+}

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -90,6 +90,12 @@ func TestRenderRun(t *testing.T) {
 	streams, in, out, errs := NewTestIOStreams()
 	setNoColor(true)
 
+	// set Default Template to something easier to work with, then
+	// cleanup when test completes
+	prevDefaultTemplate := lib.DefaultTemplate
+	lib.DefaultTemplate = `<html><h1>{{.Peername}}/{{.Name}}</h1></html>`
+	defer func() { lib.DefaultTemplate = prevDefaultTemplate }()
+
 	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Errorf("error creating new test factory: %s", err)
@@ -134,7 +140,7 @@ func TestRenderRun(t *testing.T) {
 		msg      string
 	}{
 		{"peer/bad_dataset", "", "", false, 10, 0, "", "repo: not found", "could not find dataset 'peer/bad_dataset'"},
-		{"peer/cities", "", "", false, 10, 0, "<html><h2>peer/cities</h2></html>", "", ""},
+		{"peer/cities", "", "", false, 10, 0, "<html><h1>peer/cities</h1></html>", "", ""},
 		{"peer/cities", "testdata/template.html", "", false, 2, 0, "<html><h2>peer/cities</h2><tbody><tr><td>toronto</td><td>40000000</td><td>55.5</td><td>false</td></tr><tr><td>new york</td><td>8500000</td><td>44.4</td><td>true</td></tr></tbody></html>", "", ""},
 		{"peer/cities", "testdata/template.html", "", false, 1, 2, "<html><h2>peer/cities</h2><tbody><tr><td>chicago</td><td>300000</td><td>44.4</td><td>true</td></tr></tbody></html>", "", ""},
 	}

--- a/config/p2p.go
+++ b/config/p2p.go
@@ -67,6 +67,7 @@ func DefaultP2P() *P2P {
 			"/ip4/130.211.198.23/tcp/4001/ipfs/QmNX9nSos8sRFvqGTwdEme6LQ8R1eJ8EuFgW32F9jjp2Pb", // mojo
 			"/ip4/35.193.162.149/tcp/4001/ipfs/QmTZxETL4YCCzB1yFx4GT1te68henVHD1XPQMkHZ1N22mm", // epa
 			"/ip4/35.226.92.45/tcp/4001/ipfs/QmP6sbnHXANXgQ7JeCCeCKdJrgpvUd8s75YNfzdkHf6Mpi",   // 538
+			"/ip4/35.192.140.245/tcp/4001/ipfs/QmUUVNiTz2K9zQSH9PxerKWXmN1p3DBo3oJXurvYziFzqh", // EDGI
 		},
 		ProfileReplication: "full",
 	}

--- a/lib/render_test.go
+++ b/lib/render_test.go
@@ -42,12 +42,11 @@ func TestNewRenderRequests(t *testing.T) {
 }
 
 func TestRenderRequestsRender(t *testing.T) {
-	mockGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tmpl := `<html><h1>{{.Peername}}/{{.Name}}</h1></html>`
-		w.Write([]byte(tmpl))
-	}))
-
-	Config.P2P.HTTPGatewayAddr = mockGateway.URL
+	// set Default Template to something easier to work with, then
+	// cleanup when test completes
+	prevDefaultTemplate := DefaultTemplate
+	DefaultTemplate = `<html><h1>{{.Peername}}/{{.Name}}</h1></html>`
+	defer func() { DefaultTemplate = prevDefaultTemplate }()
 
 	cases := []struct {
 		params *RenderParams


### PR DESCRIPTION
this change ensures we _always_ have a template to render into. Previously we were trying to keep sync on templates from the d.web but it's a little too flakie for the moment. I'd like to add default template updating at some point in the future, but for now reducing the number of external dependencies leads to software that works better. The supplied default is pretty sparse, but it's a start.

This also sneaks in a quick fix for #492