### PR TITLE
fix(cmd): Execute commands using RunE instead of Run

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -44,9 +44,14 @@ changes to qri.`,
 
 create a dataset with a dataset data file:
   $ qri add --file dataset.yaml --body comics.csv me/comic_characters`,
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f))
-			ExitIfErr(o.ErrOut, o.Run(args))
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f); err != nil {
+				return err
+			}
+			if err := o.Run(args); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -26,9 +26,14 @@ body reads records from a dataset`,
 			"group": "dataset",
 		},
 		Args: cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -33,9 +33,15 @@ func Execute() {
 	}
 
 	root := NewQriCommand(EnvPathFactory, os.Stdin, os.Stdout, os.Stderr)
+	// If the subcommand hits an error, don't show usage or the error, since we'll show
+	// the error message below, on our own. Usage is still shown if the subcommand
+	// is missing command-line arguments.
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+	// Execute the subcommand
 	if err := root.Execute(); err != nil {
 		printErr(os.Stdin, err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -52,18 +52,29 @@ The --with-private-keys option will show private keys.
 PLEASE PLEASE PLEASE NEVER SHARE YOUR PRIVATE KEYS WITH ANYONE. EVER.
 Anyone with your private keys can impersonate you on qri.`,
 		Args: cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f))
-			ExitIfErr(o.ErrOut, o.Get(args))
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f); err != nil {
+				return err
+			}
+			if err := o.Get(args); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 
 	set := &cobra.Command{
 		Use:   "set",
 		Short: "Set a configuration option",
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f))
-			ExitIfErr(o.ErrOut, o.Set(args))
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			if err := o.Complete(f); err != nil {
+				return err
+			}
+			if err := o.Set(args); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -30,9 +30,14 @@ things:
 
 When you run connect you are connecting to the distributed web, interacting with
 peers & swapping data.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -27,9 +27,14 @@ either by name or by their hash`,
 			"group": "dataset",
 		},
 		Args: cobra.MinimumNArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -35,9 +35,14 @@ To export everything about a dataset, use the --dataset flag.`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -18,9 +18,14 @@ func NewGetCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -31,9 +31,14 @@ func NewInfoCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 			"group": "dataset",
 		},
 		Args: cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,9 +27,14 @@ qri repository.`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -30,9 +30,14 @@ working backwards in time.`,
 			"group": "dataset",
 		},
 		Args: cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -33,9 +33,14 @@ format is yaml.`,
   show info in json:
   $ qri peers info b5 --format json`,
 		Args: cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Info())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Info(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 
@@ -54,9 +59,14 @@ command in the background or in another terminal window.
   to ensure you get a cached version of the list:
   $ qri peers list --cached`,
 		Aliases: []string{"ls"},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.List())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.List(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 
@@ -64,9 +74,14 @@ command in the background or in another terminal window.
 		Use:   "connect",
 		Short: "connect to a peer",
 		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Connect())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Connect(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 
@@ -74,9 +89,14 @@ command in the background or in another terminal window.
 		Use:   "disconnect",
 		Short: "explicitly close a connection to a peer",
 		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Disconnect())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Disconnect(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -48,9 +48,14 @@ $ qri config set registry.location ""`,
 		Example: `  Publish a dataset you've created to the registry:
   $ qri registry publish me/dataset_name`,
 		Args: cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Publish())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Publish(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 
@@ -61,9 +66,14 @@ $ qri config set registry.location ""`,
 		Example: `  Remove a dataset from the registry:
   $ qri registry unpublish me/dataset_name`,
 		Args: cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Unpublish())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Unpublish(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -32,9 +32,14 @@ both qri & IPFS. Promise.`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -26,9 +26,14 @@ renames to a minimum.`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -24,10 +24,17 @@ func NewRenderCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Validate())
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -41,10 +41,17 @@ collaboration are in the works. Sit tight sportsfans.`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Validate())
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -19,10 +19,17 @@ func NewSearchCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 		Annotations: map[string]string{
 			"group": "network",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Validate())
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -37,9 +37,14 @@ overwrite this info.`,
 		Annotations: map[string]string{
 			"group": "other",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Run(f))
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Run(f); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -26,10 +26,17 @@ func NewUseCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Validate())
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -51,10 +51,17 @@ will affect a dataset before saving changes to a dataset.
 Note: --body and --schema flags will override the dataset if both flags are provided.`,
 		Example: `  show errors in an existing dataset:
   $ qri validate b5/comics`,
-		Run: func(cmd *cobra.Command, args []string) {
-			ExitIfErr(o.ErrOut, o.Complete(f, args))
-			ExitIfErr(o.ErrOut, o.Validate())
-			ExitIfErr(o.ErrOut, o.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,8 +15,9 @@ For updates & further information check https://github.com/qri-io/qri/releases`,
 		Annotations: map[string]string{
 			"group": "other",
 		},
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			printInfo(ioStreams.Out, lib.VersionNumber)
+			return nil
 		},
 	}
 	return cmd


### PR DESCRIPTION
In order to better understand why cmd tests fail, use RunE. This returns an err and avoids calling os.Exit, which is bad since it silences test output. Other behavior, like failing when a command is given invalid arguments, stays the same even with this change.