### PR TITLE
refactor(dataset): Change CanonicalizeDatasetRef's return semantics.

### DIFF
--- a/cmd/rename_test.go
+++ b/cmd/rename_test.go
@@ -116,7 +116,7 @@ func TestRenameRun(t *testing.T) {
 		{"", "", "", "cannot parse empty string as dataset reference", ""},
 		{"me/from", "", "", "cannot parse empty string as dataset reference", ""},
 		{"", "me/to", "", "cannot parse empty string as dataset reference", ""},
-		{"me/bad_name", "me/bad_name_too", "", "error getting dataset: repo: not found", ""},
+		{"me/bad_name", "me/bad_name_too", "", "error with existing reference: repo: not found", ""},
 		{"me/cities", "me/cities_too", "renamed dataset cities_too\n", "", ""},
 	}
 

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -137,7 +137,7 @@ func TestSaveRun(t *testing.T) {
 		err      string
 		msg      string
 	}{
-		{"me/bad_dataset", "", "", "", "", false, "", "error getting previous dataset: repo: not found", ""},
+		{"me/bad_dataset", "", "", "", "", false, "", "error with previous reference: repo: not found", ""},
 		{"me/cities", "bad/filpath.json", "", "", "", false, "", "open bad/filpath.json: no such file or directory", ""},
 		{"me/cities", "", "bad/bodypath.csv", "", "", false, "", "reading body file: open bad/bodypath.csv: no such file or directory", ""},
 		{"me/movies", "testdata/movies/dataset.json", "testdata/movies/body_ten.csv", "", "", true, "dataset saved: peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmcQxYfLwwAzkbHcFRGFGQbvawSB2u2vKnS3eqEe9vBdUj\nthis dataset has 1 validation errors\n", "", ""},

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -191,9 +191,9 @@ sarnia,550000,55.65,false
 	}{
 		{nil, nil, "dataset is required"},
 		{&dataset.DatasetPod{}, nil, "peername & name are required to update dataset"},
-		{&dataset.DatasetPod{Peername: "foo", Name: "bar"}, nil, "canonicalizing previous dataset reference: error fetching peer from store: profile: not found"},
+		{&dataset.DatasetPod{Peername: "foo", Name: "bar"}, nil, "error with previous reference: error fetching peer from store: profile: not found"},
 		{&dataset.DatasetPod{Peername: "bad", Name: "path", Commit: &dataset.CommitPod{Qri: "qri:st"}}, nil, "decoding dataset: invalid commit 'qri' value: qri:st"},
-		{&dataset.DatasetPod{Peername: "bad", Name: "path", BodyPath: "/bad/path"}, nil, "canonicalizing previous dataset reference: error fetching peer from store: profile: not found"},
+		{&dataset.DatasetPod{Peername: "bad", Name: "path", BodyPath: "/bad/path"}, nil, "error with previous reference: error fetching peer from store: profile: not found"},
 		{&dataset.DatasetPod{Peername: "me", Name: "cities", BodyPath: "http://localhost:999999/bad/url"}, nil, "fetching body url: Get http://localhost:999999/bad/url: dial tcp: address 999999: invalid port"},
 
 		{&dataset.DatasetPod{Peername: "me", Name: "cities", Meta: &dataset.Meta{Title: "updated name of movies dataset"}}, nil, ""},
@@ -459,7 +459,7 @@ func TestDatasetRequestsRename(t *testing.T) {
 		{&RenameParams{}, "", "current name is required to rename a dataset"},
 		{&RenameParams{Current: repo.DatasetRef{Peername: "peer", Name: "movies"}, New: repo.DatasetRef{Peername: "peer", Name: "new movies"}}, "", "error: illegal name 'new movies', names must start with a letter and consist of only a-z,0-9, and _. max length 144 characters"},
 		{&RenameParams{Current: repo.DatasetRef{Peername: "peer", Name: "movies"}, New: repo.DatasetRef{Peername: "peer", Name: "new_movies"}}, "new_movies", ""},
-		{&RenameParams{Current: repo.DatasetRef{Peername: "peer", Name: "new_movies"}, New: repo.DatasetRef{Peername: "peer", Name: "new_movies"}}, "", "dataset 'peer/new_movies' already exists"},
+		{&RenameParams{Current: repo.DatasetRef{Peername: "peer", Name: "cities"}, New: repo.DatasetRef{Peername: "peer", Name: "sitemap"}}, "", "dataset 'peer/sitemap' already exists"},
 	}
 
 	req := NewDatasetRequests(mr, nil)

--- a/lib/render.go
+++ b/lib/render.go
@@ -64,14 +64,12 @@ func (r *RenderRequests) Render(p *RenderParams, res *[]byte) error {
 	err := repo.CanonicalizeDatasetRef(r.repo, &p.Ref)
 	if err != nil {
 		log.Debug(err.Error())
+		if err == repo.ErrNotFound {
+			return NewError(err, fmt.Sprintf("could not find dataset '%s/%s'", p.Ref.Peername, p.Ref.Name))
+		}
 		return err
 	}
-
-	ref, err := r.repo.GetRef(p.Ref)
-	if err != nil {
-		log.Debug(err.Error())
-		return NewError(err, fmt.Sprintf("could not find dataset '%s/%s'", p.Ref.Peername, p.Ref.Name))
-	}
+	ref := p.Ref
 
 	store := r.repo.Store()
 

--- a/repo/actions/merge_events_test.go
+++ b/repo/actions/merge_events_test.go
@@ -28,8 +28,8 @@ func createReposAndLogs() (repo.Repo, repo.Repo, *repo.MemEventLog, *repo.MemEve
 		ID:       profile.ID(profileBID),
 		Peername: "test-peer-0",
 	}, cafs.NewMapstore(), profile.MemStore{}, nil)
-	aLog := aRepo.(*repo.MemRepo).MemEventLog
-	bLog := bRepo.(*repo.MemRepo).MemEventLog
+	aLog := aRepo.MemEventLog
+	bLog := bRepo.MemEventLog
 	return aRepo, bRepo, aLog, bLog
 }
 

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -24,7 +24,7 @@ type MemRepo struct {
 }
 
 // NewMemRepo creates a new in-memory repository
-func NewMemRepo(p *profile.Profile, store cafs.Filestore, ps profile.Store, rc *regclient.Client) (Repo, error) {
+func NewMemRepo(p *profile.Profile, store cafs.Filestore, ps profile.Store, rc *regclient.Client) (*MemRepo, error) {
 	return &MemRepo{
 		store:       store,
 		MemRefstore: &MemRefstore{},

--- a/repo/ref_test.go
+++ b/repo/ref_test.go
@@ -331,22 +331,28 @@ func TestCompareDatasetRefs(t *testing.T) {
 }
 
 func TestCanonicalizeDatasetRef(t *testing.T) {
-	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille"}, cafs.NewMapstore(), profile.NewMemStore(), nil)
+	repo, err := NewMemRepo(&profile.Profile{Peername: "lucille"},
+	    cafs.NewMapstore(), profile.NewMemStore(), nil)
 	if err != nil {
 		t.Errorf("error allocating mem repo: %s", err.Error())
 		return
 	}
+	mr := repo.MemRefstore
+	mr.PutRef(DatasetRef{Peername:"lucille", Name: "foo", Path: "/ipfs/QmTest"})
+	mr.PutRef(DatasetRef{Peername:"you",     Name: "other", Path: "/ipfs/QmTest2"})
+	mr.PutRef(DatasetRef{Peername:"lucille", Name: "ball",
+                         Path: "/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1"})
 
 	cases := []struct {
 		input  string
 		expect string
 		err    string
 	}{
-		{"me/foo", "lucille/foo", ""},
-		{"you/foo", "you/foo", ""},
+		{"me/foo", "lucille/foo@/ipfs/QmTest", ""},
+		{"you/other", "you/other@/ipfs/QmTest2", ""},
+		{"lucille/ball", "lucille/ball@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", ""},
 		{"me/ball@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "lucille/ball@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", ""},
-		// TODO - add tests that show path fulfillment
-		// {"@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "lucille/ball@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", ""},
+		{"@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "lucille/ball@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", ""},
 	}
 
 	for i, c := range cases {

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -59,7 +59,7 @@ func ProfileConfig() *config.ProfilePod {
 }
 
 // NewTestRepo generates a repository usable for testing purposes
-func NewTestRepo(rc *regclient.Client) (mr repo.Repo, err error) {
+func NewTestRepo(rc *regclient.Client) (mr *repo.MemRepo, err error) {
 	datasets := []string{"movies", "cities", "counter", "craigslist", "sitemap"}
 
 	ms := cafs.NewMapstore()


### PR DESCRIPTION
Previously, CanonicalizeDatasetRef had 2 main steps: canonicalizing the profile
(turning "me" into the user's peername), and then filling in fields from the
local repo. If the dataset did not exist in the local repo (because it was
a remote dataset), the function would ignore GetRef's error, and just continue
on. This fragile behavior led to bad things, like many callers duplicating work
such as caling GetRef after CanonicalizeDatasetRef, or certain methods
displaying non-sensical error messages.

Instead, have CanonicalizeDatasetRef return repo.ErrNotFound if the reference
is non-local. Callers can handle this error code as needed, such as displaying
a more sensible error, or succeeding anyway (in the case of `rename`, which
expects the reference to not be found), or contacting a remote host (like
`log` does to get dataset about non-local references).