### PR TITLE
docs(cmd): updating cmd documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOFILES = $(shell find . -name '*.go' -not -path './vendor/*')
-GOPACKAGES = github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/analytics github.com/qri-io/skytf github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/qri-io/dsdiff github.com/qri-io/varName github.com/qri-io/registry/regclient github.com/sergi/go-diff/diffmatchpatch github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/cobra/doc github.com/theckman/go-flock github.com/ugorji/go/codec github.com/beme/abide github.com/ghodss/yaml
+GOPACKAGES = github.com/briandowns/spinner github.com/datatogether/api/apiutil github.com/fatih/color github.com/ipfs/go-datastore github.com/olekukonko/tablewriter github.com/qri-io/skytf github.com/qri-io/bleve github.com/qri-io/dataset github.com/qri-io/doggos github.com/qri-io/dsdiff github.com/qri-io/varName github.com/qri-io/registry/regclient github.com/sergi/go-diff/diffmatchpatch github.com/sirupsen/logrus github.com/spf13/cobra github.com/spf13/cobra/doc github.com/theckman/go-flock github.com/ugorji/go/codec github.com/beme/abide github.com/ghodss/yaml
 
 default: build
 

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,7 @@ test:
 
 test-all-coverage:
 	./.circleci/cover.test.sh
+
+cli-docs:
+	go run docs/docs.go --dir temp --filename cli_commands.md
+

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -6,21 +6,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
 // TODO: Tests.
-
 
 // NewAddCommand creates an add command
 func NewAddCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &AddOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:        "add",
-		Short:      "Add a dataset",
+		Use:   "add",
+		Short: "Add a dataset from another peer",
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
 		Long: `
-Add retrieves a dataset owned by another peer and adds it to your repo.`,
+Add retrieves a dataset owned by another peer and adds it to your repo. 
+The dataset reference of the dataset will remain the same, including 
+the name of the peer that originally added the dataset.`,
 		Example: `  add a dataset named their_data, owned by other_peer:
   $ qri add other_peer/their_data`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -27,10 +27,7 @@ the name of the peer that originally added the dataset.`,
 			if err := o.Complete(f); err != nil {
 				return err
 			}
-			if err := o.Run(args); err != nil {
-				return err
-			}
-			return nil
+			return o.Run(args)
 		},
 	}
 

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -36,10 +36,7 @@ func NewBodyCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -19,7 +19,7 @@ func NewBodyCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 		Use:   "body",
 		Short: "Get the body of a dataset",
 		Long: `
-'qri body' reads records from a dataset`,
+` + "`qri body`" + ` reads entries from a dataset. Default is 50 entries, starting from the beginning of the body. You can using the ` + "`--limit`" + ` and ` + "`--offset`" + ` flags to iterate through the dataset body.`,
 		Example: `  show the first 50 rows of a dataset:
   $ qri body me/dataset_name
 

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -17,11 +17,17 @@ func NewBodyCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &BodyOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "body",
-		Short: "Get the contents of a dataset",
+		Short: "Get the body of a dataset",
 		Long: `
-body reads records from a dataset`,
+'qri body' reads records from a dataset`,
 		Example: `  show the first 50 rows of a dataset:
-  $ qri data me/dataset_name`,
+  $ qri body me/dataset_name
+
+  show the next 50 rows of a dataset:
+  $ qri body --offset 50 me/dataset_name
+
+  save the body as csv to file
+  $ qri body -o new_file.csv -f csv me/dataset_name`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,3 +1,9 @@
+// Package cmd defines the CLI interface. It relies heavily on the spf13/cobra
+// package. Much of its structure is adapted from kubernetes/kubernetes/tree/master/cmd
+// The `help` message for each command uses backticks rather than quotes when
+// refering to commands by name, even though it is cumbersome to maintain.
+// Using backticks means we can get better formatting when auto generating markdown
+// documentation from the command help messages.
 package cmd
 
 import (

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,18 +20,21 @@ func NewConfigCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := ConfigOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "get and set local configuration information",
+		Short: "Get and set local configuration information",
 		Annotations: map[string]string{
 			"group": "other",
 		},
 		Long: `
-config encapsulates all settings that control the behaviour of qri.
+'qri config' encapsulates all settings that control the behaviour of qri.
 This includes all kinds of stuff: your profile details; enabling & disabling 
 different services; what kind of output qri logs to; 
 which ports on qri serves on; etc.
 
 Configuration is stored as a .yaml file kept at $QRI_PATH, or provided at CLI 
-runtime via command a line argument.`,
+runtime via command a line argument.
+
+For details on each config field checkout: 
+https://github.com/qri-io/qri/blob/master/config/readme.md`,
 		Example: `  # get your profile information
   $ qri config get profile
 
@@ -48,9 +51,21 @@ runtime via command a line argument.`,
 		Long: `get outputs your current configuration file with private keys 
 removed by default, making it easier to share your qri configuration settings.
 
+You can get particular parts of the config by using dot notation to
+traverse the config object. For details on each config field checkout: 
+https://github.com/qri-io/qri/blob/master/config/readme.md
+
 The --with-private-keys option will show private keys.
 PLEASE PLEASE PLEASE NEVER SHARE YOUR PRIVATE KEYS WITH ANYONE. EVER.
 Anyone with your private keys can impersonate you on qri.`,
+		Example: `  # get the entire config
+  qri config get
+
+  # get the config profile
+  qri config get profile
+
+  # get the profile description
+  qri config get profile.description`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f); err != nil {
@@ -65,7 +80,24 @@ Anyone with your private keys can impersonate you on qri.`,
 
 	set := &cobra.Command{
 		Use:   "set",
-		Short: "Set a configuration option",
+		Short: "Set configuration options",
+		Long: `'qri config set' allows you to set configuration options. You can set 
+particular parts of the config by using dot notation to traverse the 
+config object. 
+
+While the 'qri config get' command allows you to view the whole config,
+or only parts of it, the 'qri config set' command is more specific.
+
+If the config object were a tree and each field a branch, you can only
+set the leaves of the branches. In other words, the you cannot set a 
+field that is itself an object or array. For details on each config 
+field checkout: https://github.com/qri-io/qri/blob/master/config/readme.md`,
+		Example: `  # set a profile description
+  qri config set profile.description "This is my new description that I
+  am very proud of and want displayed in my profile"
+
+  # disable rpc communication
+  qri config set rpc.enabled false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			if err := o.Complete(f); err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -71,10 +71,7 @@ Anyone with your private keys can impersonate you on qri.`,
 			if err := o.Complete(f); err != nil {
 				return err
 			}
-			if err := o.Get(args); err != nil {
-				return err
-			}
-			return nil
+			return o.Get(args)
 		},
 	}
 
@@ -103,10 +100,7 @@ field checkout: https://github.com/qri-io/qri/blob/master/config/readme.md`,
 			if err := o.Complete(f); err != nil {
 				return err
 			}
-			if err := o.Set(args); err != nil {
-				return err
-			}
-			return nil
+			return o.Set(args)
 		},
 	}
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -14,12 +14,12 @@ func NewConnectCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := ConnectOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "connect",
-		Short: "connect to the distributed web, start a local API server",
+		Short: "Connect to the distributed web by spinning up a Qri node",
 		Annotations: map[string]string{
 			"group": "network",
 		},
 		Long: `
-While it’s not totally accurate, connect is like starting a server. running 
+While it’s not totally accurate, connect is like starting a server. Running 
 connect will start a process and stay there until you exit the process 
 (ctrl+c from the terminal, or killing the process using tools like activity 
 monitor on the mac, or the aptly-named “kill” command). Connect does three main 
@@ -52,7 +52,7 @@ peers & swapping data.`,
 	// TODO - not yet supported
 	// cmd.Flags().BoolVarP(&o.DisableP2P, "disable-p2p", "", false, "disable peer-2-peer networking")
 
-	cmd.Flags().BoolVarP(&o.Setup, "setup", "", false, "run setup if necessary, reading options from enviornment variables")
+	cmd.Flags().BoolVarP(&o.Setup, "setup", "", false, "run setup if necessary, reading options from environment variables")
 	cmd.Flags().BoolVarP(&o.ReadOnly, "read-only", "", false, "run qri in read-only mode, limits the api endpoints")
 	cmd.Flags().StringVarP(&o.Registry, "registry", "", "", "specify registry to setup with. only works when --setup is true")
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -34,10 +34,7 @@ peers & swapping data.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -12,11 +12,12 @@ func NewDiffCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := DiffOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "diff",
-		Short: "compare differences between two datasets",
+		Short: "Compare differences between two datasets",
 		Long: `
 Diff compares two datasets from your repo and prints a representation 
 of the differences between them.  You can specifify the datasets
-either by name or by their hash`,
+either by name or by their hash. You can compare different versions of 
+the same dataset.`,
 		Example: `  show diff between two versions of the same dataset:
   $ qri diff me/annual_pop@/ipfs/QmcBZoEQ7ot4UYKn1JM3gwd4LHorj6FJ4Ep19rfLBT3VZ8 
   me/annual_pop@/ipfs/QmVvqsge5wqp4piJbLArwVB6iJSTrdM8ZRpHY7fikASrr8

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -32,10 +32,7 @@ the same dataset.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -49,10 +49,7 @@ new dataset, use --blank.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -26,12 +26,22 @@ func NewExportCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &ExportOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "export",
-		Short: "copy datasets to your local filesystem",
+		Short: "Copy datasets to your local filesystem",
 		Long: `
-Export gets datasets out of qri. By default it exports only a dataset’s data to 
-the path [current directory]/[peername]/[dataset name]/[data file]. 
+Export gets datasets out of qri. By default it exports only the dataset body. 
 
-To export everything about a dataset, use the --dataset flag.`,
+To export to a specific directory, use the --output flag.
+
+If you want an empty dataset that can be filled in with details to create a
+new dataset, use --blank.`,
+		Example: `  # export dataset
+  qri export me/annual_pop
+
+  # export without the body of the dataset
+  qri export --no-body me/annual_pop
+
+  # export to a specific directory
+  qri export -o ~/new_directory me/annual_pop`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -13,8 +13,28 @@ func NewGetCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &GetOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "get",
-		Short: "get elements of qri datasets",
-		Long:  ``,
+		Short: "Get elements of qri datasets",
+		Long: `Get the qri dataset (except for the body). You can also get portions of 
+the dataset: meta, structure, viz, transform, and commit. To narrow down
+further to specific fields in each section, use dot notation. The get 
+command prints to the console in yaml format, by default.
+
+You can get pertinent information on multiple datasets at the same time
+by supplying more than one dataset reference.
+
+Check out https://qri.io/docs/reference/dataset/ to learn about each section of the 
+dataset and its fields.`,
+		Example: `  # print the entire dataset to the console
+  qri get me/annual_pop
+
+  # print the meta to the console
+  qri get meta me/annual_pop
+
+  # print the dataset body size to the console
+  qri get structure.length me/annual_pop
+
+  # print the dataset body size for two different datasets
+  qri get structure.length me/annual_pop me/annual_gdp`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -42,10 +42,7 @@ dataset and its fields.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -53,10 +53,7 @@ terminal window.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -17,16 +17,34 @@ func NewInfoCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 		Use:     "info",
 		Aliases: []string{"get", "describe"},
 		Short:   "show summarized description of a dataset",
-		Long:    `info describes datasets`,
-		Example: `  get info for b5/comics:
-  $ qri info b5/comics
+		Long: `Info describes datasets. By default, it will return the peername, dataset name, 
+the network, the dataset hash, the file size, the length of the datasets, 
+and the validation errors.
 
-  get info for a dataset at a specific version:
-  $ qri info me@/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn
+Using the ` + "`--format`" + ` flag, you can get output in json. This will return a json
+representation of the dataset, without the dataset body, identical to 
+` + "`qri get --format json`" + `.
+
+To get info on a peer's dataset, you must be running ` + "`qri connect`" + ` in a separate 
+terminal window.`,
+		Example: `  # get info for my dataset:
+  qri info me/annual_pop
+
+  # get info for a dataset at a specific version:
+  qri info me@/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn
 
   or
 
-  $ qri info me/comics@/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`,
+  qri info me/comics@/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn
+
+  # get info in json format
+  qri info -f json me/annual_pop
+
+  # to get info on a peer's dataset, spin up your qri node
+  qri connect
+
+  # then, in a separate window, request the info from peer b5
+  qri info b5/comics`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -16,7 +16,7 @@ func NewInfoCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "info",
 		Aliases: []string{"get", "describe"},
-		Short:   "show summarized description of a dataset",
+		Short:   "Show summarized description of a dataset",
 		Long: `Info describes datasets. By default, it will return the peername, dataset name, 
 the network, the dataset hash, the file size, the length of the datasets, 
 and the validation errors.

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -16,14 +16,24 @@ func NewListCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "show a list of datasets",
+		Short:   "Show a list of datasets",
 		Long: `
-list shows lists of datasets, including names and current hashes. 
+List shows lists of datasets, including names and current hashes. 
 
 The default list is the latest version of all datasets you have on your local 
-qri repository.`,
-		Example: `  show all of your datasets:
-  $ qri list`,
+qri repository.
+
+When used in conjuction with ` + "`qri connect`" + `, list can list a peer's dataset. You
+must have ` + "`qri connect`" + ` running in a separate terminal window.`,
+		Example: `  # show all of your datasets:
+  qri list
+
+  # to view the list of your peer's dataset,
+  # in one terminal window:
+  qri connect
+
+  # in a separate terminal window, to show all of b5's datasets:
+  qri list b5`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -41,10 +41,7 @@ must have ` + "`qri connect`" + ` running in a separate terminal window.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -14,9 +14,9 @@ func NewLogCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "log",
 		Aliases: []string{"history"},
-		Short:   "show log of dataset history",
+		Short:   "Show log of dataset history",
 		Long: `
-log prints a list of changes to a dataset over time. Each entry in the log is a 
+` + "`qri log`" + ` prints a list of changes to a dataset over time. Each entry in the log is a 
 snapshot of a dataset taken at the moment it was saved that keeps exact details 
 about how that dataset looked at at that point in time. 
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -34,10 +34,7 @@ working backwards in time.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -48,10 +48,7 @@ You must have ` + "`qri connect`" + ` running in another terminal.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Info(); err != nil {
-				return err
-			}
-			return nil
+			return o.Info()
 		},
 	}
 
@@ -78,10 +75,7 @@ connected, use the ` + "`--cached`" + ` flag.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.List(); err != nil {
-				return err
-			}
-			return nil
+			return o.List()
 		},
 	}
 
@@ -107,10 +101,7 @@ the most sure-fire way to connect to a peer. `,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Connect(); err != nil {
-				return err
-			}
-			return nil
+			return o.Connect()
 		},
 	}
 
@@ -138,10 +129,7 @@ You must have ` + "`qri connect`" + ` running in another terminal.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Disconnect(); err != nil {
-				return err
-			}
-			return nil
+			return o.Disconnect()
 		},
 	}
 

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -15,7 +15,14 @@ func NewPeersCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &PeersOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "peers",
-		Short: "commands for working with peers",
+		Short: "Commands for working with peers",
+		Long: `
+The ` + "`peers`" + ` commands allow you to interact with other peers on the Qri network.
+In order for these commands to work, you must be running a Qri node. This 
+node allows you to communicate on the network. To spin up a Qri node, run
+` + "`qri connect`" + ` in a separate terminal. This will connect you to the network, 
+until you choose to close the connection by ending the session or closing 
+the terminal.`,
 		Annotations: map[string]string{
 			"group": "network",
 		},
@@ -23,10 +30,14 @@ func NewPeersCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 
 	info := &cobra.Command{
 		Use:   "info",
-		Short: `Get info on a qri peer`,
+		Short: `Get info on a Qri peer`,
 		Long: `
 The peers info command returns a peer's profile information. The default
-format is yaml.`,
+format is yaml.
+
+Using the ` + "`--verbose`" + ` flag, you can also view a peer's network information.
+
+You must have ` + "`qri connect`" + ` running in another terminal.`,
 		Example: `  show info on a peer named "b5":
   $ qri peers info b5
 
@@ -46,18 +57,22 @@ format is yaml.`,
 
 	list := &cobra.Command{
 		Use:   "list",
-		Short: "list known qri peers",
+		Short: "List known qri peers",
 		Long: `
-lists the peers your qri node has seen before. The peers list command will
-show the cached list of peers, unless you are currently running the connect
-command in the background or in another terminal window.
+Lists the peers to which your Qri node is connected. 
 
-(run 'qri help connect' for more information about the connect command) `,
-		Example: `  to list qri peers:
-  $ qri peers list
+You must have ` + "`qri connect`" + ` running in another terminal.
 
-  to ensure you get a cached version of the list:
-  $ qri peers list --cached`,
+To find peers that are not online, but to which your node has previously been 
+connected, use the ` + "`--cached`" + ` flag.`,
+		Example: `  # spin up a Qri node
+  qri connect
+
+  # thenin a separate terminal, to list qri peers:
+  qri peers list
+
+  # to ensure you get a cached version of the list:
+  qri peers list --cached`,
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
@@ -72,8 +87,22 @@ command in the background or in another terminal window.
 
 	connect := &cobra.Command{
 		Use:   "connect",
-		Short: "connect to a peer",
-		Args:  cobra.MinimumNArgs(1),
+		Short: "Connect to a peer",
+		Long: `
+Connect to a peer using a peername, peer ID, or multiaddress. Qri will use this name, id, or address
+to find a peer to which it has not automatically connected. 
+
+You must have a Qri node running (` + "`qri connect`" + `) in a separate terminal. You will only be able 
+to connect to a peer that also has spun up it's own Qri node.
+
+A multiaddress, or multiaddr, is the most specific way to refer to a peer's location, and is therefore
+the most sure-fire way to connect to a peer. `,
+		Example: `  # spin up a Qri node
+  qri connect
+
+  # in a separate terminal, connect to a specific peer
+  qri peers connect /ip4/192.168.0.194/tcp/4001/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -87,8 +116,24 @@ command in the background or in another terminal window.
 
 	disconnect := &cobra.Command{
 		Use:   "disconnect",
-		Short: "explicitly close a connection to a peer",
+		Short: "Explicitly close a connection to a peer",
 		Args:  cobra.MinimumNArgs(1),
+		Long: `
+Explicitly close a connection to a peer using a peername, peer id, or multiaddress. 
+
+You can close all connections to the Qri network by ending your Qri node session. 
+
+Use the disconnect command when you want to stay connected to the network, but want to 
+close your connection to a specific peer. This could be because that connection is hung,
+the connection is pulling too many resources, or because you simply no longer need an
+explicit connection.  This is not the same as blocking a peer or connection.
+
+Once you close a connection to a peer, you or that peer can immediately open another 
+connection.
+
+You must have ` + "`qri connect`" + ` running in another terminal.`,
+		Example: `  # disconnect from a peer using a multiaddr
+  qri peers disconnect /ip4/192.168.0.194/tcp/4001/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -56,10 +56,7 @@ Datasets are by default published to the registry when they are created.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Publish(); err != nil {
-				return err
-			}
-			return nil
+			return o.Publish()
 		},
 	}
 
@@ -80,10 +77,7 @@ This dataset will no longer show up in search results.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Unpublish(); err != nil {
-				return err
-			}
-			return nil
+			return o.Unpublish()
 		},
 	}
 

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -16,7 +16,7 @@ func NewRegistryCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 Registries are federated public records of datasets and peers.
 These records form a public facing central lookup for your datasets, so others
 can find them through search tools and via web links. You can use registry 
-commands to control how your datasets are published to registries, opting out
+commands to control how your datasets are published to registries, opting in or out
 on a dataset-by-dataset basis.
 
 Unpublished dataset info will be held locally so you can still interact

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -44,7 +44,15 @@ $ qri config set registry.location ""`,
 	// publishCmd represents the publish command
 	publish := &cobra.Command{
 		Use:   "publish",
-		Short: "publish dataset info to the registry",
+		Short: "Publish dataset info to the registry",
+		Long: `
+Publishes the dataset information onto the registry. There will be a record
+of your dataset on the registry, and if your dataset is less than 20mbs, 
+Qri will back your dataset up onto the registry.
+
+Published datasets can be found by other peers using the ` + "`qri search`" + ` command.
+
+Datasets are by default published to the registry when they are created.`,
 		Example: `  Publish a dataset you've created to the registry:
   $ qri registry publish me/dataset_name`,
 		Args: cobra.MinimumNArgs(1),
@@ -63,6 +71,12 @@ $ qri config set registry.location ""`,
 	unpublish := &cobra.Command{
 		Use:   "unpublish",
 		Short: "remove dataset info from the registry",
+		Long: `
+Unpublish will remove the reference to your dataset from the registry. If 
+you dataset was previously backed up onto the registry, this backup will 
+be removed.
+
+This dataset will no longer show up in search results.`,
 		Example: `  Remove a dataset from the registry:
   $ qri registry unpublish me/dataset_name`,
 		Args: cobra.MinimumNArgs(1),

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -11,17 +11,13 @@ func NewRegistryCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &RegistryOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "registry",
-		Short: "commands for working with a qri registry",
-		Long: `Registries are federated public records of datasets and peers.
+		Short: "Commands for working with a qri registry",
+		Long: `
+Registries are federated public records of datasets and peers.
 These records form a public facing central lookup for your datasets, so others
 can find them through search tools and via web links. You can use registry 
 commands to control how your datasets are published to registries, opting out
 on a dataset-by-dataset basis.
-
-By default qri is configured to publish to https://registry.qri.io,
-the main public collection of datasets & peers. "qri add" and "qri update"
-default to publishing to a registry as part of dataset creation unless run 
-with the "no-registry" flag.
 
 Unpublished dataset info will be held locally so you can still interact
 with it. And your datasets will be available to others peers when you run 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -13,7 +13,7 @@ func NewRemoveCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "remove",
 		Aliases: []string{"rm", "delete"},
-		Short:   "remove a dataset from your local repository",
+		Short:   "Remove a dataset from your local repository",
 		Long: `
 Remove gets rid of a dataset from your qri node. After running remove, qri will 
 no longer list your dataset as being available locally. By default, remove frees

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -36,10 +36,7 @@ both qri & IPFS. Promise.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -30,10 +30,7 @@ renames to a minimum.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -12,7 +12,7 @@ func NewRenameCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rename",
 		Aliases: []string{"mv"},
-		Short:   "change the name of a dataset",
+		Short:   "Change the name of a dataset",
 		Long: `
 Rename changes the name of a dataset.
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -39,10 +39,7 @@ provided, Qri will render the dataset with a default template.`,
 			if err := o.Validate(); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -14,7 +14,7 @@ func NewRenderCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &RenderOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "render",
-		Short: "execute a template against a dataset",
+		Short: "Execute a template against a dataset",
 		Long: `
 You can use html templates, formatted in the go/html template style, 
 to render visualizations from your dataset. These visualizations can be charts, 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -15,7 +15,15 @@ func NewRenderCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "render",
 		Short: "execute a template against a dataset",
-		Long:  `the most common use for render is to generate html from a qri dataset`,
+		Long: `
+You can use html templates, formatted in the go/html template style, 
+to render visualizations from your dataset. These visualizations can be charts, 
+graphs, or just display your dataset in a different format.
+
+Use the ` + "`--output`" + ` flag to save the rendered html to a file.
+
+Use the ` + "`--template`" + ` flag to use a custom template. If no template is
+provided, Qri will render the dataset with a default template.`,
 		Example: `  render a dataset called me/schools:
   $ qri render -o=schools.html me/schools
 

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -22,7 +22,7 @@ func NewSaveCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "save",
 		Aliases: []string{"update", "commit"},
-		Short:   "save changes to a dataset",
+		Short:   "Save changes to a dataset",
 		Long: `
 Save is how you change a dataset, updating one or more of data, metadata, and structure. 
 You can also update your data via url. Every time you run save, an entry is added to 

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -52,10 +52,7 @@ to the save.`,
 			if err := o.Validate(); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -24,20 +24,24 @@ func NewSaveCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 		Aliases: []string{"update", "commit"},
 		Short:   "save changes to a dataset",
 		Long: `
-Save is how you change a dataset, updating one or more of data, metadata, and 
-structure. You can also update your data via url. Every time you run save, 
-an entry is added to your dataset’s log (which you can see by running “qri log 
-[ref]”). Every time you save, you can provide a message about what you changed 
-and why. If you don’t provide a message 
-qri will automatically generate one for you.
+Save is how you change a dataset, updating one or more of data, metadata, and structure. 
+You can also update your data via url. Every time you run save, an entry is added to 
+your dataset’s log (which you can see by running ` + "`qri log <dataset_reference>`" + `). 
 
-Currently you can only save changes to datasets that you control. Tools for 
-collaboration are in the works. Sit tight sportsfans.`,
-		Example: `  save updated data to dataset annual_pop:
-  $ qri --body /path/to/data.csv me/annual_pop
+Every time you save, you can provide a message about what 
+you changed and why. If you don’t provide a message 
+Qri will automatically generate one for you.
 
-  save updated dataset (no data) to annual_pop:
-  $ qri --file /path/to/dataset.yaml me/annual_pop`,
+When you make an update and save a dataset that you originally added from a different
+peer, the dataset gets renamed from ` + "`peers_name/dataset_name`" + ` to ` + "`my_name/dataset_name`" + `.
+
+The ` + "`--message`" + `" and ` + "`--title`" + ` flags allow you to add a commit message and title 
+to the save.`,
+		Example: `  # save updated data to dataset annual_pop:
+  qri --body /path/to/data.csv me/annual_pop
+
+  # save updated dataset (no data) to annual_pop:
+  qri --file /path/to/dataset.yaml me/annual_pop`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -32,10 +32,7 @@ Any dataset that has been published to the registry is available for search.`,
 			if err := o.Validate(); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -15,7 +15,10 @@ func NewSearchCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search",
 		Short: "Search qri",
-		Long:  `Search datasets & peers that match your query. Search pings the qri registry. Any dataset that has been published to the registry is available for search.`,
+		Long: `
+Search datasets & peers that match your query. Search pings the qri registry. 
+
+Any dataset that has been published to the registry is available for search.`,
 		Example: `
   # search 
   $ qri search "annual population"`,

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -15,7 +15,10 @@ func NewSearchCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search",
 		Short: "Search qri",
-		Long:  `Search datasets & peers that match your query`,
+		Long:  `Search datasets & peers that match your query. Search pings the qri registry. Any dataset that has been published to the registry is available for search.`,
+		Example: `
+  # search 
+  $ qri search "annual population"`,
 		Annotations: map[string]string{
 			"group": "network",
 		},

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -44,10 +44,7 @@ including all your datasets, and de-registers your peername from the registry.`,
 			if err := o.Complete(f, args); err != nil {
 				return err
 			}
-			if err := o.Run(f); err != nil {
-				return err
-			}
-			return nil
+			return o.Run(f)
 		},
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -19,7 +19,7 @@ func NewSetupCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &SetupOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "initialize qri and IPFS repositories, provision a new qri ID",
+		Short: "Initialize qri and IPFS repositories, provision a new qri ID",
 		Long: `
 Setup is the first command you run to get a fresh install of Qri. If you’ve 
 never run qri before, you’ll need to run setup before you can do anything. 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -21,7 +21,7 @@ func NewSetupCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 		Use:   "setup",
 		Short: "initialize qri and IPFS repositories, provision a new qri ID",
 		Long: `
-Setup is the first command you run to get a fresh install of qri. If you’ve 
+Setup is the first command you run to get a fresh install of Qri. If you’ve 
 never run qri before, you’ll need to run setup before you can do anything. 
 
 Setup does a few things:
@@ -29,9 +29,12 @@ Setup does a few things:
 - provisions a new qri ID
 - create an IPFS repository if one doesn’t exist
 
-This command is automatically run if you invoke any qri command without first 
-running setup. If setup has already been run, by default qri won’t let you 
-overwrite this info.`,
+This command is automatically run if you invoke any Qri command without first 
+running setup. If setup has already been run, by default Qri won’t let you 
+overwrite this info.
+
+Use the ` + "`--remove`" + ` to remove your Qri repo. This deletes your entire repo, 
+including all your datasets, and de-registers your peername from the registry.`,
 		Example: `  run setup with a peername of your choosing:
   $ qri setup --peername=your_great_peername`,
 		Annotations: map[string]string{

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -13,16 +13,16 @@ func NewUseCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &UseOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "use",
-		Short: "select datasets for use with other commands",
-		Example: `  use dataset me/dataset_name, then get meta.title:
-  $ qri data me/dataset_name
-  $ qri get meta.title
+		Short: "Select datasets for use with the qri get command",
+		Example: `  # use dataset me/dataset_name, then get meta.title:
+  qri use me/dataset_name
+  qri get meta.title
 
-  clear current selection:
-  $ qri use --clear
+  # clear current selection:
+  qri use --clear
 
-  show current selected dataset references:
-  $ qri use --list`,
+  # show current selected dataset references:
+  qri use --list`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -14,6 +14,13 @@ func NewUseCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "use",
 		Short: "Select datasets for use with the qri get command",
+		Long: `
+Run the ` + "`use`" + ` command to have Qri remember references to a specific datasets. 
+These datasets will be referenced for future commands, if no dataset reference 
+is explicitly given for those commands.
+
+We created this command to ease the typing/copy and pasting burden while using
+Qri to explore a dataset.`,
 		Example: `  # use dataset me/dataset_name, then get meta.title:
   qri use me/dataset_name
   qri get meta.title
@@ -22,7 +29,10 @@ func NewUseCommand(f Factory, ioStreams IOStreams) *cobra.Command {
   qri use --clear
 
   # show current selected dataset references:
-  qri use --list`,
+  qri use --list
+
+  # add multiple references to the remembered list
+  qri use me/population_2017 me/population_2018`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -33,10 +33,7 @@ func NewUseCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 			if err := o.Validate(); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -48,9 +48,18 @@ schema for dataset "me/foo"
 Using validate this way is a great way to see how changes to data or schema
 will affect a dataset before saving changes to a dataset.
 
+You can get the current schema of a dataset by running the ` + "`qri get structure.schema`" + `
+command.
+
 Note: --body and --schema flags will override the dataset if both flags are provided.`,
-		Example: `  show errors in an existing dataset:
-  $ qri validate b5/comics`,
+		Example: `  # show errors in an existing dataset:
+  qri validate b5/comics
+
+  # validate a new body against an existing schema
+  qri validate --body new_data.csv me/annual_pop
+
+  # validate data against a new schema
+  qri validate --body data.csv --schema schema.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -17,7 +17,7 @@ func NewValidateCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 	o := &ValidateOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "validate",
-		Short: "show schema validation errors",
+		Short: "Show schema validation errors",
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
@@ -67,10 +67,7 @@ Note: --body and --schema flags will override the dataset if both flags are prov
 			if err := o.Validate(); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-			return nil
+			return o.Run()
 		},
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,8 +9,10 @@ import (
 func NewVersionCommand(_ Factory, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "print the version number",
-		Long: `qri uses semantic versioning.
+		Short: "Print the version number",
+		Long: `
+Qri uses semantic versioning.
+
 For updates & further information check https://github.com/qri-io/qri/releases`,
 		Annotations: map[string]string{
 			"group": "other",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	qri "github.com/qri-io/qri/cmd"
+	"github.com/spf13/cobra/doc"
+)
+
+func main() {
+	var (
+		dir        string
+		merge      string
+		filenames  []string
+		aggregator []byte
+	)
+
+	flag.StringVar(&dir, "dir", "docs", "path to the docs directory")
+	flag.StringVar(&merge, "filename", "", "docs will be merged into one markdown file with this filename. default extension: markdown")
+
+	flag.Parse()
+
+	// generate markdown filenames
+	root := qri.NewQriCommand(qri.EnvPathFactory, os.Stdin, ioutil.Discard, ioutil.Discard)
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		err = os.MkdirAll(dir, 0755)
+		if err != nil {
+			log.Fatal(err)
+			os.Exit(1)
+		}
+	}
+
+	fileList := func(name string) string {
+		name = filepath.Base(name)
+		filenames = append(filenames, name)
+		return "<a id='" + name[:len(name)-len(filepath.Ext(name))] + "'></a>\n"
+	}
+
+	err := doc.GenMarkdownTreeCustom(root, dir, fileList, func(string) string { return "" })
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// if we are supplied with a filename, merge docs into one file and save with that filename
+	if merge != "" {
+
+		data := []byte(`---
+title: "CLI commands"
+description: "qri command line reference"
+date: 2018-01-30T00:00:00-04:00
+section: reference
+draft: false
+---
+
+# Qri CLI command line reference 
+
+
+Qri ("query") is a global dataset version control system 
+on the distributed web.
+
+
+|Command | Description |
+|--------|-------------|
+|[qri add](#qri_add)  | Add a dataset from another peer   |
+|[qri body](#qri_body)  | Get the body of a dataset   |
+|[qri config](#qri_config)  | Get and set local configuration information   |
+|[qri connect](#qri_connect)  | Connect to the distributed web by spinning up a Qri node   |
+|[qri diff](#qri_diff)  | Compare differences between two datasets   |
+|[qri export](#qri_export)  | Copy datasets to your local filenamesystem   |
+|[qri get](#qri_get)  | Get elements of qri datasets   |
+|[qri info](#qri_info)  | Show summarized description of a dataset   |
+|[qri list](#qri_list)  | Show a list of datasets   |
+|[qri log](#qri_log)  | Show log of dataset history   |
+|[qri new](#qri_new)  | Create a new dataset   |
+|[qri peers](#qri_peers)  | Commands for working with peers   |
+|[qri registry](#qri_registry)  | Commands for working with a qri registry   |
+|[qri remove](#qri_remove)  | Remove a dataset from your local repository   |
+|[qri rename](#qri_rename)  | Change the name of a dataset   |
+|[qri render](#qri_render)  | Execute a template against a dataset   |
+|[qri save](#qri_save)  | Save changes to a dataset   |
+|[qri search](#qri_search)  | Search qri   |
+|[qri setup](#qri_setup)  | Initialize qri and IPFS repositories, provision a new qri ID   |
+|[qri use](#qri_use)  | Select datasets for use with the qri get command   |
+|[qri validate](#qri_validate)  | Show schema validation errors   |
+|[qri version](#qri_version)  | Print the version number   |
+
+________
+
+`)
+
+		aggregator = append(aggregator, data...)
+
+		for _, file := range filenames {
+
+			if file == "qri.md" {
+				continue
+			}
+
+			data, err = ioutil.ReadFile(filepath.Join(dir, file))
+			if err != nil {
+				panic(err)
+			}
+
+			index := strings.Index(string(data), "### SEE ALSO")
+			if index < 0 {
+				index = len(data)
+			}
+			aggregator = append(aggregator, data[:index]...)
+			aggregator = append(aggregator, []byte("\n\n________\n\n")...)
+		}
+
+		if filepath.Ext(merge) == "" {
+			merge += ".md"
+		}
+
+		err = ioutil.WriteFile(filepath.Join(dir, merge), aggregator, 0777)
+		if err != nil {
+			panic(err)
+		}
+
+	}
+}

--- a/repo/search/search.go
+++ b/repo/search/search.go
@@ -1,12 +1,7 @@
 package search
 
 import (
-	"strings"
-
 	"github.com/qri-io/bleve"
-	//_ "github.com/qri-io/bleve/config"
-	"github.com/ipfs/go-datastore/query"
-	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/repo"
 )
 
@@ -27,39 +22,5 @@ func Search(i Index, p repo.SearchParams) ([]repo.DatasetRef, error) {
 		res[i] = repo.DatasetRef{Path: hit.ID}
 	}
 
-	// fmt.Println(searchResults)
 	return res, nil
-}
-
-// NewDatasetQuery generates a query for datastes from a query string, limit, and offset
-func NewDatasetQuery(q string, limit, offset int) query.Query {
-	return query.Query{
-		Filters: []query.Filter{
-			DatasetSearchFilter{query: q, lowered: strings.ToLower(q)},
-		},
-		Limit:  limit,
-		Offset: offset,
-	}
-}
-
-// DatasetSearchFilter conforms to the bleve Filter interface
-type DatasetSearchFilter struct {
-	query   string
-	lowered string
-}
-
-// Filter filters entries that don't match
-func (f DatasetSearchFilter) Filter(e query.Entry) bool {
-	ds, ok := e.Value.(*dataset.Dataset)
-	if !ok {
-		return false
-	}
-
-	q := f.lowered
-	if strings.Contains(strings.ToLower(ds.Meta.Title), q) ||
-		strings.Contains(strings.ToLower(ds.Meta.Description), q) {
-		return true
-	}
-
-	return false
 }


### PR DESCRIPTION
While writing the [RFC CLI commands](qri-io/rfcs#14) document, I figured I would go through and update the documentation on the CLI commands, if any are outdated.