### PR TITLE
fix(p2p): Avoid generating p2p keys in DefaultP2P, for faster tests

### DIFF
--- a/p2p/node.go
+++ b/p2p/node.go
@@ -80,9 +80,15 @@ func NewTestQriNode(r repo.Repo, options ...func(o *config.P2P)) (p2ptest.Testab
 // NewQriNode creates a new node, providing no arguments will use
 // default configuration
 func NewQriNode(r repo.Repo, options ...func(o *config.P2P)) (node *QriNode, err error) {
-	cfg := config.DefaultP2P()
+	cfg := config.NewP2P()
 	for _, opt := range options {
 		opt(cfg)
+	}
+	if len(cfg.PrivKey) == 0 {
+		err = cfg.GeneratePrivateKeyAndPeerID()
+		if err != nil {
+			return nil, err
+		}
 	}
 	// if err := cfg.Validate(r); err != nil {
 	// 	return nil, err


### PR DESCRIPTION
Currently, the p2p tests (as well as some tests in lib) spend a lot of time
generating actual crypto keys due to calling DefaultP2P, which are then
replaced by test keys from the libp2p package. Avoiding this useless work
speeds up the p2p tests by about 5x.

Performance numbers from before this change, taken from https://github.com/qri-io/dataset/pull/141:
```
Run 0
ok      github.com/qri-io/qri/api      18.428s
ok      github.com/qri-io/qri/cmd      59.639s
ok      github.com/qri-io/qri/config   46.602s
ok      github.com/qri-io/qri/lib      52.682s
ok      github.com/qri-io/qri/p2p      40.562s
Run 1
ok      github.com/qri-io/qri/api      21.280s
ok      github.com/qri-io/qri/cmd      55.533s
ok      github.com/qri-io/qri/config   51.034s
ok      github.com/qri-io/qri/lib      44.018s
ok      github.com/qri-io/qri/p2p      49.323s
Run 2
ok      github.com/qri-io/qri/api      15.110s
ok      github.com/qri-io/qri/cmd      57.857s
ok      github.com/qri-io/qri/config   43.257s
ok      github.com/qri-io/qri/lib      49.521s
ok      github.com/qri-io/qri/p2p      36.730s
```

After this change:
```
Run 0
ok      github.com/qri-io/qri/api      13.866s
ok      github.com/qri-io/qri/cmd      61.417s
ok      github.com/qri-io/qri/config   32.168s
ok      github.com/qri-io/qri/lib      32.685s
ok      github.com/qri-io/qri/p2p       8.008s
Run 1
ok      github.com/qri-io/qri/api      18.329s
ok      github.com/qri-io/qri/cmd      68.314s
ok      github.com/qri-io/qri/config   43.116s
ok      github.com/qri-io/qri/lib      32.584s
ok      github.com/qri-io/qri/p2p       6.926s
```