### PR TITLE
fix(cmd): Set number of open files limit at startup.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/qri/lib"
@@ -124,31 +123,4 @@ func currentPath() (string, bool) {
 		return "", ok
 	}
 	return path.Dir(filename), true
-}
-
-const PreferredNumOpenFiles = 10000
-
-// ensureLargeNumOpenFiles ensures that user can have a large number of open files
-func ensureLargeNumOpenFiles() {
-	// Get the number of open files currently allowed.
-	var rLimit syscall.Rlimit
-	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
-	if err != nil {
-		panic(err)
-	}
-	if rLimit.Cur >= PreferredNumOpenFiles {
-		return
-	}
-
-	// Set the number of open files that are allowed to be sufficiently large. This avoids
-	// the error "too many open files" that often occurs when running IPFS or other
-	// local database-like technologies.
-	rLimit.Cur = PreferredNumOpenFiles
-	rLimit.Max = PreferredNumOpenFiles
-
-	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
-	if err != nil {
-		fmt.Println("error setting max open files limit: %s", err)
-		return
-	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/qri/lib"
@@ -37,6 +38,8 @@ func Execute() {
 			}
 		}()
 	}
+
+	ensureLargeNumOpenFiles()
 
 	root := NewQriCommand(EnvPathFactory, os.Stdin, os.Stdout, os.Stderr)
 	// If the subcommand hits an error, don't show usage or the error, since we'll show
@@ -121,4 +124,31 @@ func currentPath() (string, bool) {
 		return "", ok
 	}
 	return path.Dir(filename), true
+}
+
+const PreferredNumOpenFiles = 10000
+
+// ensureLargeNumOpenFiles ensures that user can have a large number of open files
+func ensureLargeNumOpenFiles() {
+	// Get the number of open files currently allowed.
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		panic(err)
+	}
+	if rLimit.Cur >= PreferredNumOpenFiles {
+		return
+	}
+
+	// Set the number of open files that are allowed to be sufficiently large. This avoids
+	// the error "too many open files" that often occurs when running IPFS or other
+	// local database-like technologies.
+	rLimit.Cur = PreferredNumOpenFiles
+	rLimit.Max = PreferredNumOpenFiles
+
+	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		fmt.Println("error setting max open files limit: %s", err)
+		return
+	}
 }

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -1,0 +1,39 @@
+// +build !windows
+
+package cmd
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// preferredNumOpenFiles is the perferred number of open files that the process can have.
+// This value tends to be the recommended value for `ulimit -n`, as seen on github discussions
+// around various projects such as hugo, mongo, redis.
+const preferredNumOpenFiles = 10000
+
+// ensureLargeNumOpenFiles ensures that user can have a large number of open files
+func ensureLargeNumOpenFiles() {
+	// Get the number of open files currently allowed.
+	var rLimit unix.Rlimit
+	err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		panic(err)
+	}
+	if rLimit.Cur >= preferredNumOpenFiles {
+		return
+	}
+
+	// Set the number of open files that are allowed to be sufficiently large. This avoids
+	// the error "too many open files" that often occurs when running IPFS or other
+	// local database-like technologies.
+	rLimit.Cur = preferredNumOpenFiles
+	rLimit.Max = preferredNumOpenFiles
+
+	err = unix.Setrlimit(unix.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		fmt.Printf("error setting max open files limit: %s\n", err)
+		return
+	}
+}

--- a/cmd/system_windows.go
+++ b/cmd/system_windows.go
@@ -1,0 +1,6 @@
+package cmd
+
+// ensureLargeNumOpenFiles doesn't need to do anything on Windows
+func ensureLargeNumOpenFiles() {
+	// Nothing to do.
+}


### PR DESCRIPTION
If the user is running qri without having a sufficiently large enough value for the "open files limit", their IPFS instance can start to fill with the error "too many open files". Setting this value at startup avoids this issue.