### PR TITLE
feat(save): re-run dataset transforms, add loading indicator

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -50,6 +50,9 @@ func (o *AddOptions) Complete(f Factory) (err error) {
 
 // Run adds another peer's dataset to this user's repo
 func (o *AddOptions) Run(args []string) error {
+	spinner.Start()
+	defer spinner.Stop()
+
 	for _, arg := range args {
 		ref, err := parseCmdLineDatasetRef(arg)
 		if err != nil {

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -80,6 +80,9 @@ func (o *BodyOptions) Complete(f Factory, args []string) (err error) {
 
 // Run executes the body command
 func (o *BodyOptions) Run() error {
+	spinner.Start()
+	defer spinner.Stop()
+
 	if o.UsingRPC {
 		return usingRPCError("body")
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	// disable spinner output during testing
+	spinner.Writer = ioutil.Discard
+}
+
 func confirmQriNotRunning() error {
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", config.DefaultAPIPort))
 	if err != nil {

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -15,15 +15,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
 // TODO: Tests.
-
 
 const providingSecretWarningMessage = `
 Warning: You are providing secrets to a dataset transformation.
 Never provide secrets to a transformation you do not trust.
 continue?`
-
 
 // NewNewCommand creates a new command
 func NewNewCommand(f Factory, ioStreams IOStreams) *cobra.Command {
@@ -75,13 +72,13 @@ create a dataset with a dataset data file:
 type NewOptions struct {
 	IOStreams
 
-	File           string
-	BodyPath       string
-	Title          string
-	Message        string
-	Private        bool
-	Publish        bool
-	Secrets        []string
+	File     string
+	BodyPath string
+	Title    string
+	Message  string
+	Private  bool
+	Publish  bool
+	Secrets  []string
 
 	DatasetRequests *lib.DatasetRequests
 }
@@ -95,8 +92,9 @@ func (o *NewOptions) Complete(f Factory) (err error) {
 }
 
 // Run creates a new dataset
-func (o *NewOptions) Run(args []string) error {
-	var err error
+func (o *NewOptions) Run(args []string) (err error) {
+	spinner.Start()
+	defer spinner.Stop()
 
 	if o.File == "" && o.BodyPath == "" {
 		return fmt.Errorf("creating new dataset needs either --file or --body")

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -104,6 +104,9 @@ func (o *RegistryOptions) Complete(f Factory, args []string) (err error) {
 // Publish executes the publish command
 func (o *RegistryOptions) Publish() error {
 	var res bool
+	spinner.Start()
+	defer spinner.Stop()
+
 	for _, arg := range o.Refs {
 		ref, err := repo.ParseDatasetRef(arg)
 		if err != nil {
@@ -127,6 +130,9 @@ func (o *RegistryOptions) Publish() error {
 // Unpublish executes the unpublish command
 func (o *RegistryOptions) Unpublish() error {
 	var res bool
+	spinner.Start()
+	defer spinner.Stop()
+
 	for _, arg := range o.Refs {
 		ref, err := repo.ParseDatasetRef(arg)
 		if err != nil {

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -76,6 +76,9 @@ func (o *RenderOptions) Complete(f Factory, args []string) (err error) {
 func (o *RenderOptions) Run() (err error) {
 	var template []byte
 
+	spinner.Start()
+	defer spinner.Stop()
+
 	ref, err := repo.ParseDatasetRef(o.Ref)
 	if err != nil && err != repo.ErrEmptyRef {
 		return err

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -114,6 +114,9 @@ func (o *SaveOptions) Validate() error {
 
 // Run executes the save command
 func (o *SaveOptions) Run() (err error) {
+	spinner.Start()
+	defer spinner.Stop()
+
 	ref, err := parseCmdLineDatasetRef(o.Ref)
 	if err != nil && o.FilePath == "" {
 		return lib.NewError(lib.ErrBadArgs, "error parsing dataset reference '"+o.Ref+"'")
@@ -183,6 +186,7 @@ continue?`, true) {
 		return err
 	}
 
+	spinner.Stop()
 	printSuccess(o.Out, "dataset saved: %s", res)
 	if res.Dataset.Structure.ErrCount > 0 {
 		printWarning(o.Out, fmt.Sprintf("this dataset has %d validation errors", res.Dataset.Structure.ErrCount))

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"io/ioutil"
+
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsutil"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
-	"io/ioutil"
 )
 
 // NewSaveCommand creates a `qri save` cobra command used for saving changes
@@ -26,22 +27,27 @@ func NewSaveCommand(f Factory, ioStreams IOStreams) *cobra.Command {
 		Long: `
 Save is how you change a dataset, updating one or more of data, metadata, and structure. 
 You can also update your data via url. Every time you run save, an entry is added to 
-your dataset’s log (which you can see by running ` + "`qri log <dataset_reference>`" + `). 
+your dataset’s log (which you can see by running ` + "`qri log <dataset_reference>`" + `).
 
-Every time you save, you can provide a message about what 
-you changed and why. If you don’t provide a message 
-Qri will automatically generate one for you.
+If the dataset you're changing has defined a transform, running ` + "`qri save`" + `
+will re execute the transform. To only re-run the tranform, run save with no args.
+
+Every time you save, you can provide a message about what you changed and why. 
+If you don’t provide a message Qri will automatically generate one for you.
 
 When you make an update and save a dataset that you originally added from a different
 peer, the dataset gets renamed from ` + "`peers_name/dataset_name`" + ` to ` + "`my_name/dataset_name`" + `.
 
-The ` + "`--message`" + `" and ` + "`--title`" + ` flags allow you to add a commit message and title 
-to the save.`,
+The ` + "`--message`" + `" and ` + "`--title`" + ` flags allow you to add a 
+commit message and title to the save.`,
 		Example: `  # save updated data to dataset annual_pop:
-  qri --body /path/to/data.csv me/annual_pop
+  qri save --body /path/to/data.csv me/annual_pop
 
   # save updated dataset (no data) to annual_pop:
-  qri --file /path/to/dataset.yaml me/annual_pop`,
+  qri save --file /path/to/dataset.yaml me/annual_pop
+  
+  # re-execute a dataset that has a transform:
+  qri save me/tf_dataset`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
@@ -100,9 +106,9 @@ func (o *SaveOptions) Validate() error {
 	if o.Ref == "" {
 		return lib.NewError(lib.ErrBadArgs, "please provide the peername and dataset name you would like to update, in the format of `peername/dataset_name`\nsee `qri save --help` for more info")
 	}
-	if o.FilePath == "" && o.BodyPath == "" {
-		return lib.NewError(lib.ErrBadArgs, "please an updated/changed dataset file (--file) or body file (--body), or both\nsee `qri save --help` for more info")
-	}
+	// if o.FilePath == "" && o.BodyPath == "" {
+	// 	return lib.NewError(lib.ErrBadArgs, "please an updated/changed dataset file (--file) or body file (--body), or both\nsee `qri save --help` for more info")
+	// }
 	return nil
 }
 

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -67,7 +67,6 @@ func TestSaveValidate(t *testing.T) {
 		msg      string
 	}{
 		{"", "", "", lib.ErrBadArgs.Error(), "please provide the peername and dataset name you would like to update, in the format of `peername/dataset_name`\nsee `qri save --help` for more info"},
-		{"me/test", "", "", lib.ErrBadArgs.Error(), "please an updated/changed dataset file (--file) or body file (--body), or both\nsee `qri save --help` for more info"},
 		{"me/test", "test/path.yaml", "", "", ""},
 		{"me/test", "", "test/bodypath.yaml", "", ""},
 		{"me/test", "test/filepath.yaml", "test/bodypath.yaml", "", ""},

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -72,6 +72,8 @@ func (o *SearchOptions) Validate() error {
 
 // Run executes the search command
 func (o *SearchOptions) Run() (err error) {
+	spinner.Start()
+	defer spinner.Stop()
 
 	// TODO: add reindex option back in
 
@@ -87,6 +89,7 @@ func (o *SearchOptions) Run() (err error) {
 		return err
 	}
 
+	spinner.Stop()
 	switch o.Format {
 	case "":
 		fmt.Fprintf(o.Out, "showing %d results for '%s'\n", len(results), o.Query)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -109,6 +109,8 @@ func (o *ValidateOptions) Run() (err error) {
 		dataFile, schemaFile *os.File
 		ref                  repo.DatasetRef
 	)
+	spinner.Start()
+	defer spinner.Stop()
 
 	ref, err = repo.ParseDatasetRef(o.Ref)
 	if err != nil && err != repo.ErrEmptyRef {
@@ -147,6 +149,9 @@ func (o *ValidateOptions) Run() (err error) {
 	if err = o.DatasetRequests.Validate(p, &res); err != nil {
 		return err
 	}
+
+	spinner.Stop()
+
 	if len(res) == 0 {
 		printSuccess(o.Out, "✔ All good!")
 		return

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -21,13 +21,6 @@ type DatasetRequests struct {
 	node *p2p.QriNode
 }
 
-// Repo exposes the DatasetRequest's repo
-// TODO - this is an architectural flaw resulting from not having a clear
-// order of local > network > RPC requests figured out
-// func (r *DatasetRequests) Repo() repo.Repo {
-// 	return r.repo
-// }
-
 // CoreRequestsName implements the Requets interface
 func (DatasetRequests) CoreRequestsName() string { return "datasets" }
 


### PR DESCRIPTION
If a dataset defines a transform, running "qri save" without args should re-run that transform. The code I've added here is hacky & terrible, but we need to move. Will fix in the future.

closes #541.