### PR TITLE
fix(p2p.RequestProfile, p2p.handleProfile): receiving peer does not save profile to repo

### DIFF
--- a/p2p/connected.go
+++ b/p2p/connected.go
@@ -94,11 +94,12 @@ func (n *QriNode) handleConnected(ws *WrappedStream, msg Message) (hangup bool) 
 	}
 
 	// forward this message to all connected peers except the sender
-	pids := peerDifference(n.ConnectedQriPeerIDs(), []peer.ID{pinfo.ID})
-	if err := n.SendMessage(msg, nil, pids...); err != nil {
-		log.Debug(err.Error())
-		return
-	}
+	// TODO - this is causing concurrent iteration & write to the repo profile store. Fix
+	// pids := peerDifference(n.ConnectedQriPeerIDs(), []peer.ID{pinfo.ID})
+	// if err := n.SendMessage(msg, nil, pids...); err != nil {
+	// 	log.Debug(err.Error())
+	// 	return
+	// }
 
 	// store that we've seen this message, cleaning up after a while
 	n.msgState.Store(msg.ID, true)

--- a/p2p/dataset_test.go
+++ b/p2p/dataset_test.go
@@ -22,11 +22,7 @@ func TestRequestDatasetInfo(t *testing.T) {
 		t.Errorf("error connecting peers: %s", err.Error())
 	}
 
-	// Convert from test nodes to non-test nodes.
-	peers := make([]*QriNode, len(testPeers))
-	for i, node := range testPeers {
-		peers[i] = node.(*QriNode)
-	}
+	peers := asQriNodes(testPeers)
 
 	refs := []repo.DatasetRef{}
 	for _, c := range peers {

--- a/p2p/datasets_test.go
+++ b/p2p/datasets_test.go
@@ -21,11 +21,7 @@ func TestRequestDatasetsList(t *testing.T) {
 		t.Errorf("error connecting peers: %s", err.Error())
 	}
 
-	// Convert from test nodes to non-test nodes.
-	peers := make([]*QriNode, len(testPeers))
-	for i, node := range testPeers {
-		peers[i] = node.(*QriNode)
-	}
+	peers := asQriNodes(testPeers)
 
 	t.Logf("testing RequestDatasetList message with %d peers", len(peers))
 	var wg sync.WaitGroup

--- a/p2p/events_test.go
+++ b/p2p/events_test.go
@@ -17,11 +17,8 @@ func TestRequestEventsList(t *testing.T) {
 		t.Errorf("error creating network: %s", err.Error())
 		return
 	}
-	// Convert from test nodes to non-test nodes.
-	peers := make([]*QriNode, len(testPeers))
-	for i, node := range testPeers {
-		peers[i] = node.(*QriNode)
-	}
+
+	peers := asQriNodes(testPeers)
 
 	for _, p := range peers {
 		p.Repo.LogEvent(repo.ETDsCreated, repo.DatasetRef{})

--- a/p2p/log_test.go
+++ b/p2p/log_test.go
@@ -23,11 +23,7 @@ func TestRequestDatasetLog(t *testing.T) {
 		t.Errorf("error connecting peers: %s", err.Error())
 	}
 
-	// Convert from test nodes to non-test nodes.
-	peers := make([]*QriNode, len(testPeers))
-	for i, node := range testPeers {
-		peers[i] = node.(*QriNode)
-	}
+	peers := asQriNodes(testPeers)
 
 	tc, err := dstest.NewTestCaseFromDir("testdata/tim/craigslist")
 	if err != nil {

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -114,9 +114,9 @@ func (n *QriNode) PeerInfo(pid peer.ID) pstore.PeerInfo {
 // AddQriPeer negotiates a connection with a peer to get their profile details
 // and peer list.
 func (n *QriNode) AddQriPeer(pinfo pstore.PeerInfo) error {
-	// add this peer to our store
+	// add this peer to our store so libp2p has the provided addresses of
+	// the peer in the next call
 	n.Host.Peerstore().AddAddrs(pinfo.ID, pinfo.Addrs, pstore.TempAddrTTL)
-	n.Host.ConnManager().TagPeer(pinfo.ID, qriConnManagerTag, qriConnManagerValue)
 
 	if _, err := n.RequestProfile(pinfo.ID); err != nil {
 		log.Debug(err.Error())

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -2,8 +2,9 @@ package p2p
 
 import (
 	"context"
-	"github.com/qri-io/qri/p2p/test"
 	"testing"
+
+	"github.com/qri-io/qri/p2p/test"
 )
 
 func TestPing(t *testing.T) {
@@ -16,10 +17,7 @@ func TestPing(t *testing.T) {
 	}
 
 	// Convert from test nodes to non-test nodes.
-	peers := make([]*QriNode, len(testPeers))
-	for i, arg := range testPeers {
-		peers[i] = arg.(*QriNode)
-	}
+	peers := asQriNodes(testPeers)
 
 	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
 		t.Errorf("error connecting peers: %s", err.Error())

--- a/p2p/profile.go
+++ b/p2p/profile.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"encoding/json"
 	"fmt"
+
 	// "time"
 
 	"github.com/qri-io/qri/config"

--- a/p2p/profile.go
+++ b/p2p/profile.go
@@ -3,7 +3,7 @@ package p2p
 import (
 	"encoding/json"
 	"fmt"
-	"time"
+	// "time"
 
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/repo/profile"
@@ -31,9 +31,10 @@ func (n *QriNode) RequestProfile(pid peer.ID) (*profile.Profile, error) {
 	}
 
 	replies := make(chan Message)
-	msg := NewMessage(n.ID, MtProfile, data)
+	req := NewMessage(n.ID, MtProfile, data)
+	req = req.WithHeaders("phase", "request")
 
-	if err := n.SendMessage(msg, replies, pid); err != nil {
+	if err := n.SendMessage(req, replies, pid); err != nil {
 		log.Debugf("send profile message error: %s", err.Error())
 		return nil, err
 	}
@@ -66,24 +67,36 @@ func (n *QriNode) RequestProfile(pid peer.ID) (*profile.Profile, error) {
 func (n *QriNode) handleProfile(ws *WrappedStream, msg Message) (hangup bool) {
 	// hangup = false
 
-	pro := &profile.Profile{}
-	if err := json.Unmarshal(msg.Body, pro); err != nil {
-		log.Debug(err.Error())
-		return
+	switch msg.Header("phase") {
+	case "request":
+
+		pp := &config.ProfilePod{}
+		if err := json.Unmarshal(msg.Body, pp); err != nil {
+			log.Debug(err.Error())
+			return
+		}
+
+		pro := &profile.Profile{}
+		if err := pro.Decode(pp); err != nil {
+			log.Debug(err.Error())
+			return
+		}
+
+		if err := n.Repo.Profiles().PutProfile(pro); err != nil {
+			log.Debug(err.Error())
+			return
+		}
+
+		data, err := n.profileBytes()
+		if err != nil {
+			log.Debug(err.Error())
+			return
+		}
+
+		if err := ws.sendMessage(msg.Update(data)); err != nil {
+			log.Debugf("error sending peer info message: %s", err.Error())
+		}
 	}
-
-	pro.Updated = time.Now().UTC()
-
-	data, err := n.profileBytes()
-	if err != nil {
-		log.Debug(err.Error())
-		return
-	}
-
-	if err := ws.sendMessage(msg.Update(data)); err != nil {
-		log.Debugf("error sending peer info message: %s", err.Error())
-	}
-
 	return
 }
 

--- a/p2p/profile_test.go
+++ b/p2p/profile_test.go
@@ -60,11 +60,11 @@ func TestRequestProfileConnectNodes(t *testing.T) {
 
 				addrsP1 := p1.Host.Peerstore().Addrs(p2.ID)
 				if len(addrsP1) == 0 {
-					t.Errorf("%s (request node) should have addrs of %s (response node)", p1.ID.Pretty(), p2.ID.Pretty())
+					t.Errorf("%s (request node) should have addrs of %s (response node)", p1.ID, p2.ID)
 				}
 				addrsP2 := p2.Host.Peerstore().Addrs(p1.ID)
 				if len(addrsP2) == 0 {
-					t.Errorf("%s (request node) should have addrs of %s (response node)", p2.ID.Pretty(), p1.ID.Pretty())
+					t.Errorf("%s (request node) should have addrs of %s (response node)", p2.ID, p1.ID)
 				}
 
 				pid := pro.PeerIDs[0]
@@ -147,11 +147,11 @@ func TestRequestProfileOneWayConnection(t *testing.T) {
 
 		peerInfo2 := p1.Host.Peerstore().PeerInfo(p2.ID)
 		if len(peerInfo2.Addrs) == 0 {
-			t.Errorf("%s (request node) should have addrs of %s (response node)", p1.ID.Pretty(), p2.ID.Pretty())
+			t.Errorf("%s (request node) should have addrs of %s (response node)", p1.ID, p2.ID)
 		}
 		peerInfo1 := p2.Host.Peerstore().PeerInfo(p1.ID)
 		if len(peerInfo1.Addrs) == 0 {
-			t.Errorf("%s (request node) should have addrs of %s (response node)", p2.ID.Pretty(), p1.ID.Pretty())
+			t.Errorf("%s (response node) should have addrs of %s (request node)", p2.ID, p1.ID)
 		}
 
 		pid := pro.PeerIDs[0]

--- a/p2p/profile_test.go
+++ b/p2p/profile_test.go
@@ -20,11 +20,8 @@ func TestRequestProfileConnectNodes(t *testing.T) {
 		t.Errorf("error creating network: %s", err.Error())
 		return
 	}
-	// Convert from test nodes to non-test nodes.
-	peers := make([]*QriNode, len(testPeers))
-	for i, node := range testPeers {
-		peers[i] = node.(*QriNode)
-	}
+
+	peers := asQriNodes(testPeers)
 
 	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
 		t.Errorf("error connecting peers: %s", err.Error())
@@ -110,11 +107,7 @@ func TestRequestProfileOneWayConnection(t *testing.T) {
 		return
 	}
 
-	// Convert from test nodes to QriNodes.
-	peers := make([]*QriNode, len(testPeers))
-	for i, node := range testPeers {
-		peers[i] = node.(*QriNode)
-	}
+	peers := asQriNodes(testPeers)
 
 	p1 := peers[0]
 	peers = peers[1:]

--- a/p2p/profile_test.go
+++ b/p2p/profile_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 
 	"github.com/qri-io/qri/p2p/test"
+	// "github.com/qri-io/qri/repo/profile"
 
+	pstore "gx/ipfs/QmZR2XWVVBCtbgBWnQhWk2xcQfaR3W8faQPriAiaaj7rsr/go-libp2p-peerstore"
 	peer "gx/ipfs/QmdVrMn1LhB4ybb8hMVaMLXnA8XRSewMnK6YqXKXoTcRvN/go-libp2p-peer"
 )
 
-func TestRequestProfile(t *testing.T) {
+func TestRequestProfileConnectNodes(t *testing.T) {
 	ctx := context.Background()
 	f := p2ptest.NewTestNodeFactory(NewTestableQriNode)
 	testPeers, err := p2ptest.NewTestNetwork(ctx, f, 5)
@@ -36,10 +38,17 @@ func TestRequestProfile(t *testing.T) {
 			go func(p1, p2 *QriNode) {
 				defer wg.Done()
 
-				pro, err := p1.RequestProfile(p2.ID)
+				_, err := p1.RequestProfile(p2.ID)
 				if err != nil {
 					t.Errorf("%s -> %s error: %s", p1.ID.Pretty(), p2.ID.Pretty(), err.Error())
 				}
+
+				pro, err := p1.Repo.Profiles().PeerProfile(p2.ID)
+				if err != nil {
+					t.Errorf("error getting profile from profile store: %s", err.Error())
+					return
+				}
+
 				if pro == nil {
 					t.Error("profile shouldn't be nil")
 					return
@@ -47,6 +56,15 @@ func TestRequestProfile(t *testing.T) {
 				if len(pro.PeerIDs) == 0 {
 					t.Error("profile should have peer IDs")
 					return
+				}
+
+				addrsP1 := p1.Host.Peerstore().Addrs(p2.ID)
+				if len(addrsP1) == 0 {
+					t.Errorf("%s (request node) should have addrs of %s (response node)", p1.ID.Pretty(), p2.ID.Pretty())
+				}
+				addrsP2 := p2.Host.Peerstore().Addrs(p1.ID)
+				if len(addrsP2) == 0 {
+					t.Errorf("%s (request node) should have addrs of %s (response node)", p2.ID.Pretty(), p1.ID.Pretty())
 				}
 
 				pid := pro.PeerIDs[0]
@@ -61,8 +79,111 @@ func TestRequestProfile(t *testing.T) {
 					t.Errorf("%s request profile peerID mismatch. expected: %s, got: %s", p1.ID, p2.ID, pid)
 				}
 
+				pro1, err := p2.Repo.Profiles().PeerProfile(p1.ID)
+				if err != nil {
+					t.Errorf("error getting request profile from respond profile store: %s", err.Error())
+					return
+				}
+
+				if pro1 == nil {
+					t.Error("profile shouldn't be nil")
+					return
+				}
+				if len(pro1.PeerIDs) == 0 {
+					t.Error("profile should have peer IDs")
+					return
+				}
+
 			}(p1, p2)
 		}
+	}
+
+	wg.Wait()
+}
+
+func TestRequestProfileOneWayConnection(t *testing.T) {
+	ctx := context.Background()
+	f := p2ptest.NewTestNodeFactory(NewTestableQriNode)
+	testPeers, err := p2ptest.NewTestNetwork(ctx, f, 5)
+	if err != nil {
+		t.Errorf("error creating network: %s", err.Error())
+		return
+	}
+
+	// Convert from test nodes to QriNodes.
+	peers := make([]*QriNode, len(testPeers))
+	for i, node := range testPeers {
+		peers[i] = node.(*QriNode)
+	}
+
+	p1 := peers[0]
+	peers = peers[1:]
+
+	for _, peer := range peers {
+		p1.Addrs().AddAddr(peer.HostNetwork().LocalPeer(), peer.HostNetwork().ListenAddresses()[0], pstore.PermanentAddrTTL)
+	}
+
+	t.Logf("testing profile message with %d peers", len(peers))
+	var wg sync.WaitGroup
+	for _, p2 := range peers {
+		wg.Add(1)
+		go func(p1, p2 *QriNode) {
+			defer wg.Done()
+			_, err := p1.RequestProfile(p2.ID)
+			if err != nil {
+				t.Errorf("%s -> %s error: %s", p1.ID.Pretty(), p2.ID.Pretty(), err.Error())
+			}
+			pro, err := p1.Repo.Profiles().PeerProfile(p2.ID)
+			if err != nil {
+				t.Errorf("error getting profile from profile store: %s", err.Error())
+				return
+			}
+
+			if pro == nil {
+				t.Error("profile shouldn't be nil")
+				return
+			}
+			if len(pro.PeerIDs) == 0 {
+				t.Error("profile should have peer IDs")
+				return
+			}
+
+			peerInfo2 := p1.Host.Peerstore().PeerInfo(p2.ID)
+			if len(peerInfo2.Addrs) == 0 {
+				t.Errorf("%s (request node) should have addrs of %s (response node)", p1.ID.Pretty(), p2.ID.Pretty())
+			}
+			peerInfo1 := p2.Host.Peerstore().PeerInfo(p1.ID)
+			if len(peerInfo1.Addrs) == 0 {
+				t.Errorf("%s (request node) should have addrs of %s (response node)", p2.ID.Pretty(), p1.ID.Pretty())
+			}
+
+			pid := pro.PeerIDs[0]
+			if err != nil {
+				t.Error(err.Error())
+				return
+			}
+
+			if pid != p2.ID {
+				p2pro, _ := p2.Repo.Profile()
+				t.Logf("p2 profile ID: %s peerID: %s, host peerID: %s", peer.ID(p2pro.ID), p2.ID, p2.Host.ID())
+				t.Errorf("%s request profile peerID mismatch. expected: %s, got: %s", p1.ID, p2.ID, pid)
+			}
+
+			pro1, err := p2.Repo.Profiles().PeerProfile(p1.ID)
+			if err != nil {
+				t.Errorf("error getting request profile from response profile store: %s", err.Error())
+				return
+			}
+
+			if pro1 == nil {
+				t.Error("profile shouldn't be nil")
+				return
+			}
+			if len(pro1.PeerIDs) == 0 {
+				t.Error("profile should have peer IDs")
+				return
+			}
+		}(p1, p2)
 	}
 
 	wg.Wait()

--- a/p2p/qri_peers_test.go
+++ b/p2p/qri_peers_test.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 // Test passes when the fifth node connects to the other three nodes by asking
 // it's one connection for the other three peer's profiles
 func TestSharePeers(t *testing.T) {
-	fmt.Println("hallo?")
 	ctx := context.Background()
 	f := p2ptest.NewTestNodeFactory(NewTestableQriNode)
 	testPeers, err := p2ptest.NewTestNetwork(ctx, f, 5)
@@ -33,9 +31,8 @@ func TestSharePeers(t *testing.T) {
 	done := make(chan bool)
 	deadline := time.NewTimer(time.Second * 2)
 	go func() {
-		for msg := range nasma.ReceiveMessages() {
+		for range nasma.ReceiveMessages() {
 			if len(nasma.ConnectedPeers()) == len(group) {
-				fmt.Println(msg.Type, len(nasma.ConnectedPeers()))
 				done <- true
 			}
 		}


### PR DESCRIPTION
Right now, your peer sends it's profile to a peer. The peer sends its own profile back, but doesn't save the incoming profile.

This is causing certain peers to not show up in our peers list, even when we do have an underlying connection.