### PR TITLE
Refactor(AddQriPeer): rename `AddQriPeer` to `UpgradeToQriConnection` and formalize it's role

### DIFF
--- a/actions/dataset_ref_test.go
+++ b/actions/dataset_ref_test.go
@@ -16,11 +16,11 @@ func TestResolveDatasetRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating network: %s", err.Error())
 	}
-	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
 		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
-	// Convert from test nodes to non-test nodes.
+	// Convert from test nodes to qri nodes.
 	peers := make([]*p2p.QriNode, len(testPeers))
 	for i, node := range testPeers {
 		peers[i] = node.(*p2p.QriNode)
@@ -52,13 +52,6 @@ func TestResolveDatasetRef(t *testing.T) {
 		t.Error("expected local to equal false")
 	}
 
-	if local, err = ResolveDatasetRef(peers[1], in); err != nil {
-		t.Error(err.Error())
-	}
-	if local != true {
-		t.Error("expected local to equal true")
-	}
-
 	if local, err = ResolveDatasetRef(peers[0], in); err != nil {
 		t.Error(err.Error())
 	}
@@ -68,4 +61,12 @@ func TestResolveDatasetRef(t *testing.T) {
 	if in.String() != expect {
 		t.Errorf("returned ref mismatch. expected: %s, got: %s", expect, in.String())
 	}
+
+	if local, err = ResolveDatasetRef(peers[1], in); err != nil {
+		t.Error(err.Error())
+	}
+	if local != true {
+		t.Error("expected local to equal true")
+	}
+
 }

--- a/actions/dataset_test.go
+++ b/actions/dataset_test.go
@@ -65,10 +65,10 @@ func TestAddDataset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating network: %s", err.Error())
 	}
-	// Peers exchange Qri profile information.
-	if err := p2ptest.ConnectQriPeers(ctx, testPeers); err != nil {
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
 		t.Fatalf("error connecting peers: %s", err.Error())
 	}
+
 	// Convert from test nodes to non-test nodes.
 	peers := make([]*p2p.QriNode, len(testPeers))
 	for i, node := range testPeers {

--- a/actions/peers_test.go
+++ b/actions/peers_test.go
@@ -18,15 +18,15 @@ func TestListPeers(t *testing.T) {
 
 	ctx := context.Background()
 	factory := p2ptest.NewTestNodeFactory(p2p.NewTestableQriNode)
-	testNodes, err := p2ptest.NewTestNetwork(ctx, factory, 5)
+	testPeers, err := p2ptest.NewTestNetwork(ctx, factory, 5)
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatalf("error creating network: %s", err.Error())
 	}
-	if err := p2ptest.ConnectQriPeers(ctx, testNodes); err != nil {
-		t.Fatal(err.Error())
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
-	peers, err := ListPeers(testNodes[0].(*p2p.QriNode), 3, 2, false)
+	peers, err := ListPeers(testPeers[0].(*p2p.QriNode), 3, 2, false)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -326,7 +326,7 @@ func TestDatasetRequestsListP2p(t *testing.T) {
 		return
 	}
 
-	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
 		t.Errorf("error connecting peers: %s", err.Error())
 	}
 
@@ -424,7 +424,7 @@ func TestDatasetRequestsGetP2p(t *testing.T) {
 		return
 	}
 
-	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
 		t.Errorf("error connecting peers: %s", err.Error())
 	}
 
@@ -657,8 +657,9 @@ func TestDatasetRequestsAddP2P(t *testing.T) {
 	}
 
 	// Peers exchange Qri profile information.
-	if err := p2ptest.ConnectQriPeers(ctx, testPeers); err != nil {
-		t.Errorf("error connecting peers: %s", err.Error())
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Errorf("error upgrading to qri connections: %s", err.Error())
+		return
 	}
 
 	// Convert from test nodes to non-test nodes.

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -26,7 +26,7 @@ func (n *QriNode) Bootstrap(boostrapAddrs []string, boostrapPeers chan pstore.Pe
 		go func(p pstore.PeerInfo) {
 			log.Infof("boostrapping to: %s", p.ID.Pretty())
 			if err := n.host.Connect(context.Background(), p); err == nil {
-				if err = n.UpgradeToQriConnection(p); err != nil {
+				if err = n.UpgradeToQriConnection(p); err != nil && err != ErrQriProtocolNotSupported {
 					log.Errorf("error adding peer: %s", err.Error())
 				} else {
 					boostrapPeers <- p

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -26,7 +26,7 @@ func (n *QriNode) Bootstrap(boostrapAddrs []string, boostrapPeers chan pstore.Pe
 		go func(p pstore.PeerInfo) {
 			log.Infof("boostrapping to: %s", p.ID.Pretty())
 			if err := n.host.Connect(context.Background(), p); err == nil {
-				if err = n.AddQriPeer(p); err != nil {
+				if err = n.UpgradeToQriConnection(p); err != nil {
 					log.Errorf("error adding peer: %s", err.Error())
 				} else {
 					boostrapPeers <- p

--- a/p2p/connected_test.go
+++ b/p2p/connected_test.go
@@ -12,20 +12,17 @@ func TestAnnounceConnected(t *testing.T) {
 	ctx := context.Background()
 	// create a network of connected nodes
 	factory := p2ptest.NewTestNodeFactory(NewTestableQriNode)
-	testNodes, err := p2ptest.NewTestDirNetwork(ctx, factory)
+	testPeers, err := p2ptest.NewTestDirNetwork(ctx, factory)
 	if err != nil {
-		t.Error(err.Error())
-		return
+		t.Fatalf("error creating network: %s", err.Error())
 	}
-
-	if err := p2ptest.ConnectQriPeers(ctx, testNodes); err != nil {
-		t.Error(err.Error())
-		return
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
 	// Convert from test nodes to non-test nodes.
-	nodes := make([]*QriNode, len(testNodes))
-	for i, node := range testNodes {
+	nodes := make([]*QriNode, len(testPeers))
+	for i, node := range testPeers {
 		nodes[i] = node.(*QriNode)
 	}
 
@@ -60,7 +57,7 @@ func TestAnnounceConnected(t *testing.T) {
 	}(node.(*QriNode))
 
 	// connected that node to only one member of the network
-	if err := p2ptest.ConnectQriPeers(ctx, []p2ptest.TestablePeerNode{node, testNodes[0]}); err != nil {
+	if err := p2ptest.ConnectQriNodes(ctx, []p2ptest.TestablePeerNode{node, testPeers[0]}); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/p2p/dataset_test.go
+++ b/p2p/dataset_test.go
@@ -14,12 +14,10 @@ func TestRequestDatasetInfo(t *testing.T) {
 	factory := p2ptest.NewTestNodeFactory(NewTestableQriNode)
 	testPeers, err := p2ptest.NewTestDirNetwork(ctx, factory)
 	if err != nil {
-		t.Errorf("error creating network: %s", err.Error())
-		return
+		t.Fatalf("error creating network: %s", err.Error())
 	}
-
-	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
-		t.Errorf("error connecting peers: %s", err.Error())
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
 	peers := asQriNodes(testPeers)

--- a/p2p/datasets_test.go
+++ b/p2p/datasets_test.go
@@ -13,12 +13,10 @@ func TestRequestDatasetsList(t *testing.T) {
 	factory := p2ptest.NewTestNodeFactory(NewTestableQriNode)
 	testPeers, err := p2ptest.NewTestDirNetwork(ctx, factory)
 	if err != nil {
-		t.Errorf("error creating network: %s", err.Error())
-		return
+		t.Fatalf("error creating network: %s", err.Error())
 	}
-
-	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
-		t.Errorf("error connecting peers: %s", err.Error())
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
 	peers := asQriNodes(testPeers)

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -7,11 +7,7 @@ import (
 
 	discovery "gx/ipfs/QmY51bqSM5XgxQZqsBrQcRkKTnCb8EKpJpR9K6Qax7Njco/go-libp2p/p2p/discovery"
 	pstore "gx/ipfs/QmZR2XWVVBCtbgBWnQhWk2xcQfaR3W8faQPriAiaaj7rsr/go-libp2p-peerstore"
-	peer "gx/ipfs/QmdVrMn1LhB4ybb8hMVaMLXnA8XRSewMnK6YqXKXoTcRvN/go-libp2p-peer"
 )
-
-// qriSupportKey is the key we store the flag for qri support under in Peerstores
-const qriSupportKey = "qri-support"
 
 // StartDiscovery initiates peer discovery, allocating a discovery
 // services if one doesn't exist, then registering to be notified on peer discovery
@@ -40,39 +36,11 @@ func (n *QriNode) StartDiscovery(bootstrapPeers chan pstore.PeerInfo) error {
 // HandlePeerFound deals with the discovery of a peer that may or may not support
 // the qri protocol
 func (n *QriNode) HandlePeerFound(pinfo pstore.PeerInfo) {
-	log.Debugf("In %s node, handling peer found %s", n.ID, pinfo.ID)
-	log.Debug(n.host.Peerstore().PeerInfo(pinfo.ID))
-	log.Debug(n.host.Network().Conns())
-	// first check to see if we've seen this peer before
-	if _, err := n.host.Peerstore().Get(pinfo.ID, qriSupportKey); err == nil {
-		return
+	log.Debugf("found peer %s", pinfo.ID)
+	err := n.UpgradeToQriConnection(pinfo)
+	if err != nil && err != ErrQriProtocolNotSupported {
+		log.Error(err)
 	}
-	n.UpgradeToQriConnection(pinfo)
-}
-
-var errNoProtos = fmt.Errorf("no protocols available")
-
-// SupportsQriProtocol checks to see if this peer supports the qri
-// streaming protocol, returns
-func (n *QriNode) SupportsQriProtocol(peer peer.ID) (bool, error) {
-	protos, err := n.host.Peerstore().GetProtocols(peer)
-
-	// if the list of protocols for this peer is empty, there's a good chance
-	// we've not yet connected to them. Bailing on an empty slice of protos
-	// has the effect of demanding we connect at least once before checking for
-	// qri protocol support
-	if len(protos) == 0 {
-		return false, errNoProtos
-	}
-
-	if err == nil {
-		for _, p := range protos {
-			if p == string(QriProtocolID) {
-				return true, nil
-			}
-		}
-	}
-	return false, err
 }
 
 // DiscoverPeerstoreQriPeers handles the case where a store has seen peers that
@@ -80,7 +48,7 @@ func (n *QriNode) SupportsQriProtocol(peer peer.ID) (bool, error) {
 func (n *QriNode) DiscoverPeerstoreQriPeers(store pstore.Peerstore) {
 	for _, pid := range store.Peers() {
 		if _, err := n.host.Peerstore().Get(pid, qriSupportKey); err == pstore.ErrNotFound {
-			if supports, err := n.SupportsQriProtocol(pid); err == nil && supports {
+			if supports, err := n.supportsQriProtocol(pid); err == nil && supports {
 				// TODO - slow this down plz
 				if err := n.UpgradeToQriConnection(store.PeerInfo(pid)); err != nil {
 					fmt.Println(err.Error())

--- a/p2p/events_test.go
+++ b/p2p/events_test.go
@@ -14,18 +14,16 @@ func TestRequestEventsList(t *testing.T) {
 	f := p2ptest.NewTestNodeFactory(NewTestableQriNode)
 	testPeers, err := p2ptest.NewTestNetwork(ctx, f, 5)
 	if err != nil {
-		t.Errorf("error creating network: %s", err.Error())
-		return
+		t.Fatalf("error creating network: %s", err.Error())
+	}
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
 	peers := asQriNodes(testPeers)
 
 	for _, p := range peers {
 		p.Repo.LogEvent(repo.ETDsCreated, repo.DatasetRef{})
-	}
-
-	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
-		t.Errorf("error connecting peers: %s", err.Error())
 	}
 
 	t.Logf("testing RequestEventsList message with %d peers", len(peers))

--- a/p2p/log_test.go
+++ b/p2p/log_test.go
@@ -15,12 +15,10 @@ func TestRequestDatasetLog(t *testing.T) {
 	factory := p2ptest.NewTestNodeFactory(NewTestableQriNode)
 	testPeers, err := p2ptest.NewTestDirNetwork(ctx, factory)
 	if err != nil {
-		t.Errorf("error creating network: %s", err.Error())
-		return
+		t.Fatalf("error creating network: %s", err.Error())
 	}
-
-	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
-		t.Errorf("error connecting peers: %s", err.Error())
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
 	peers := asQriNodes(testPeers)

--- a/p2p/network_notifee.go
+++ b/p2p/network_notifee.go
@@ -1,0 +1,29 @@
+package p2p
+
+import (
+	net "gx/ipfs/QmPjvxTpVH8qJyQDnxnsxF9kv9jezKD1kozz1hs3fCGsNh/go-libp2p-net"
+	ma "gx/ipfs/QmYmsdtJ3HsodkePE3eU3TsCaP2YvPZJ4LoXnNkDE5Tpt7/go-multiaddr"
+)
+
+// a no-op implimentation of the Notifee interface
+type networkNotifee struct {
+	node *QriNode
+}
+
+// Connected is called when a connection opened
+func (n networkNotifee) Connected(net net.Network, conn net.Conn) {}
+
+// Disconnectec is called when a connection closed
+func (n networkNotifee) Disconnected(net net.Network, conn net.Conn) {}
+
+// OpenedStream is called when a stream opened
+func (n networkNotifee) OpenedStream(net net.Network, s net.Stream) {}
+
+// ClosedStream is called when a stream closed
+func (n networkNotifee) ClosedStream(net net.Network, s net.Stream) {}
+
+// Listen is called when a network starts listening on an addr
+func (n networkNotifee) Listen(net net.Network, addr ma.Multiaddr) {}
+
+// ListenClose is called when a network stops listening on an addr
+func (n networkNotifee) ListenClose(net net.Network, addr ma.Multiaddr) {}

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -355,10 +355,6 @@ func (n *QriNode) handleStream(ws *WrappedStream, replies chan Message) {
 			break
 		}
 
-		conn := ws.stream.Conn()
-		n.host.ConnManager().TagPeer(conn.RemotePeer(), qriConnManagerTag, qriConnManagerValue)
-		n.host.Peerstore().AddAddr(conn.RemotePeer(), conn.RemoteMultiaddr(), pstore.TempAddrTTL)
-
 		if replies != nil {
 			go func() { replies <- msg }()
 		}

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -70,6 +70,9 @@ type QriNode struct {
 	// local http handlers/websockets/stdio, but these streams are meant for
 	// local feedback as opposed to p2p connections
 	LocalStreams ioes.IOStreams
+
+	// networkNotifee satisfies the net.Notifee interface
+	networkNotifee networkNotifee
 }
 
 // Assert that conversions needed by the tests are valid.
@@ -103,6 +106,11 @@ func NewQriNode(r repo.Repo, p2pconf *config.P2P) (node *QriNode, err error) {
 		LocalStreams: ioes.NewDiscardIOStreams(),
 	}
 	node.handlers = MakeHandlers(node)
+
+	// using this work around, rather than implimenting the Notifee
+	// functions themselves, allows us to not pollute the QriNode
+	// namespace with function names that we may want to use in the future
+	node.networkNotifee = networkNotifee{node}
 
 	return node, nil
 }
@@ -162,6 +170,9 @@ func (n *QriNode) GoOnline() (err error) {
 	// the distributed web that this node supports Qri. for more info on
 	// multistreams  check github.com/multformats/go-multistream
 	n.host.SetStreamHandler(QriProtocolID, n.QriStreamHandler)
+
+	// add n.networkNotifee as a Notifee of this network
+	n.host.Network().Notify(n.networkNotifee)
 
 	p, err := n.Repo.Profile()
 	if err != nil {
@@ -320,7 +331,6 @@ func (n *QriNode) SendMessage(msg Message, replies chan Message, pids ...peer.ID
 		// now that we have a confirmed working connection
 		// tag this peer as supporting the qri protocol in the connection manager
 		n.host.ConnManager().TagPeer(peerID, qriSupportKey, qriSupportValue)
-		n.host.Peerstore().AddAddr(peerID, s.Conn().RemoteMultiaddr(), pstore.TempAddrTTL)
 
 		ws := WrapStream(s)
 		go n.handleStream(ws, replies)

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -398,12 +398,6 @@ func (n *QriNode) SimplePeerInfo() pstore.PeerInfo {
 	}
 }
 
-// UpgradeToQriConnection marks this connection as a Qri peer and exchanges
-// profile information with the peer
-func (n *QriNode) UpgradeToQriConnection(peer pstore.PeerInfo) error {
-	return n.AddQriPeer(peer)
-}
-
 // MakeHandlers generates a map of MsgTypes to their corresponding handler functions
 func MakeHandlers(n *QriNode) map[MsgType]HandlerFunc {
 	return map[MsgType]HandlerFunc{

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -319,7 +319,7 @@ func (n *QriNode) SendMessage(msg Message, replies chan Message, pids ...peer.ID
 
 		// now that we have a confirmed working connection
 		// tag this peer as supporting the qri protocol in the connection manager
-		n.host.ConnManager().TagPeer(peerID, qriConnManagerTag, qriConnManagerValue)
+		n.host.ConnManager().TagPeer(peerID, qriSupportKey, qriSupportValue)
 		n.host.Peerstore().AddAddr(peerID, s.Conn().RemoteMultiaddr(), pstore.TempAddrTTL)
 
 		ws := WrapStream(s)

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -17,10 +17,10 @@ const (
 	QriProtocolID = protocol.ID("/qri")
 	// QriServiceTag tags the type & version of the qri service
 	QriServiceTag = "qri/0.5.6"
-	// tag qri service uses in host connection Manager
-	qriConnManagerTag = "qri"
 	// default value to give qri peer connections in connmanager
-	qriConnManagerValue = 6
+	qriSupportValue = 1
+	// qriSupportKey is the key we store the flag for qri support under in Peerstores and in ConnManager()
+	qriSupportKey = "qri-support"
 )
 
 func init() {
@@ -33,3 +33,6 @@ func init() {
 
 // ErrNotConnected is for a missing required network connection
 var ErrNotConnected = fmt.Errorf("no p2p connection")
+
+// ErrQriProtocolNotSupported is returned when a connection can't be upgraded
+var ErrQriProtocolNotSupported = fmt.Errorf("peer doesn't support the qri protocol")

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -111,53 +111,6 @@ func (n *QriNode) PeerInfo(pid peer.ID) pstore.PeerInfo {
 	return n.host.Peerstore().PeerInfo(pid)
 }
 
-// UpgradeToQriConnection negotiates a connection with a peer to get their profile details
-// and peer list.
-func (n *QriNode) UpgradeToQriConnection(pinfo pstore.PeerInfo) error {
-	// bail early if we have seen this peer before
-	if _, err := n.host.Peerstore().Get(pinfo.ID, qriSupportKey); err == nil {
-		return nil
-	}
-	log.Debugf("In UpgradeToQriConnection %s", n.ID)
-	log.Debug(n.host.Peerstore().PeerInfo(pinfo.ID))
-	log.Debug(n.host.Network().Conns())
-	// check if this connection supports the qri protocol
-	support, err := n.SupportsQriProtocol(pinfo.ID)
-	if err != nil {
-		log.Debugf("error checking for qri support: %s", err)
-		return err
-	}
-
-	// mark whether or not this connection supports the qri protocol:
-	if err := n.host.Peerstore().Put(pinfo.ID, qriSupportKey, support); err != nil {
-		log.Debugf("error setting qri support flag: %s", err)
-		return err
-	}
-	// if it does support the qri protocol
-	// - tag the connection as a qri connection in the ConnManager
-	// - request profile
-	// - request profiles
-	if support {
-
-		// tag the connection as more important in the conn manager:
-		n.host.ConnManager().TagPeer(pinfo.ID, qriConnManagerTag, qriConnManagerValue)
-
-		if _, err := n.RequestProfile(pinfo.ID); err != nil {
-			log.Debug(err.Error())
-			return err
-		}
-
-		go func() {
-			ps, err := n.RequestQriPeers(pinfo.ID)
-			if err != nil {
-				log.Debug("error fetching qri peers: %s", err)
-			}
-			n.RequestNewPeers(n.ctx, ps)
-		}()
-	}
-	return nil
-}
-
 // Peers returns a list of currently connected peer IDs
 func (n *QriNode) Peers() []peer.ID {
 	if n.host == nil {
@@ -224,6 +177,8 @@ func (n *QriNode) ConnectToPeer(ctx context.Context, p PeerConnectionParams) (*p
 	}
 
 	if err := n.UpgradeToQriConnection(pinfo); err != nil {
+		// TODO: if the err is ErrQriProtocolNotSupported, let the user know the
+		// connection has been established, but that the Qri Protocol is not supported
 		return nil, err
 	}
 

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -134,9 +134,14 @@ func (n *QriNode) UpgradeToQriConnection(pinfo pstore.PeerInfo) error {
 		return err
 	}
 	// if it does support the qri protocol
+	// - tag the connection as a qri connection in the ConnManager
 	// - request profile
 	// - request profiles
 	if support {
+
+		// tag the connection as more important in the conn manager:
+		n.host.ConnManager().TagPeer(pinfo.ID, qriConnManagerTag, qriConnManagerValue)
+
 		if _, err := n.RequestProfile(pinfo.ID); err != nil {
 			log.Debug(err.Error())
 			return err

--- a/p2p/peers_test.go
+++ b/p2p/peers_test.go
@@ -22,13 +22,10 @@ func TestConnectedQriProfiles(t *testing.T) {
 	f := p2ptest.NewTestNodeFactory(NewTestableQriNode)
 	testPeers, err := p2ptest.NewTestDirNetwork(ctx, f)
 	if err != nil {
-		t.Error(err.Error())
-		return
+		t.Fatalf("error creating network: %s", err.Error())
 	}
-
-	if err := p2ptest.ConnectQriPeers(ctx, testPeers); err != nil {
-		t.Error(err.Error())
-		return
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
 	nodes := asQriNodes(testPeers)

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -12,16 +12,14 @@ func TestPing(t *testing.T) {
 	f := p2ptest.NewTestNodeFactory(NewTestableQriNode)
 	testPeers, err := p2ptest.NewTestNetwork(ctx, f, 3)
 	if err != nil {
-		t.Errorf("error creating network: %s", err.Error())
-		return
+		t.Fatalf("error creating network: %s", err.Error())
+	}
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
 	// Convert from test nodes to non-test nodes.
 	peers := asQriNodes(testPeers)
-
-	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
-		t.Errorf("error connecting peers: %s", err.Error())
-	}
 
 	for i, p1 := range peers {
 		for _, p2 := range peers[i+1:] {

--- a/p2p/profile_test.go
+++ b/p2p/profile_test.go
@@ -17,15 +17,13 @@ func TestRequestProfileConnectNodes(t *testing.T) {
 	f := p2ptest.NewTestNodeFactory(NewTestableQriNode)
 	testPeers, err := p2ptest.NewTestNetwork(ctx, f, 5)
 	if err != nil {
-		t.Errorf("error creating network: %s", err.Error())
-		return
+		t.Fatalf("error creating network: %s", err.Error())
+	}
+	if err := p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
 	peers := asQriNodes(testPeers)
-
-	if err := p2ptest.ConnectNodes(ctx, testPeers); err != nil {
-		t.Errorf("error connecting peers: %s", err.Error())
-	}
 
 	t.Logf("testing profile message with %d peers", len(peers))
 	var wg sync.WaitGroup

--- a/p2p/profile_test.go
+++ b/p2p/profile_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 
 	"github.com/qri-io/qri/p2p/test"
-	// "github.com/qri-io/qri/repo/profile"
 
-	pstore "gx/ipfs/QmZR2XWVVBCtbgBWnQhWk2xcQfaR3W8faQPriAiaaj7rsr/go-libp2p-peerstore"
+	// pstore "gx/ipfs/QmZR2XWVVBCtbgBWnQhWk2xcQfaR3W8faQPriAiaaj7rsr/go-libp2p-peerstore"
 	peer "gx/ipfs/QmdVrMn1LhB4ybb8hMVaMLXnA8XRSewMnK6YqXKXoTcRvN/go-libp2p-peer"
 )
 
@@ -96,76 +95,83 @@ func TestRequestProfileConnectNodes(t *testing.T) {
 	wg.Wait()
 }
 
-func TestRequestProfileOneWayConnection(t *testing.T) {
-	ctx := context.Background()
-	f := p2ptest.NewTestNodeFactory(NewTestableQriNode)
-	testPeers, err := p2ptest.NewTestNetwork(ctx, f, 5)
-	if err != nil {
-		t.Errorf("error creating network: %s", err.Error())
-		return
-	}
+// We have disabled this test because we don't actually live in a world where
+// you can have a one way connection. In fact, we shouldn't be asking for a profile
+// on a connection that hasn't been vetted (aka, UpgradeToQriConnection)
+// There may be a time where we want to resurrect this test, perhaps our idea
+// of a connection has changed, and it's possible to communicate without ensuring that
+// the connection is a qri connection first. Or that we assert something is a qri
+// connection in multiple places.
+// func TestRequestProfileOneWayConnection(t *testing.T) {
+// 	ctx := context.Background()
+// 	f := p2ptest.NewTestNodeFactory(NewTestableQriNode)
+// 	testPeers, err := p2ptest.NewTestNetwork(ctx, f, 5)
+// 	if err != nil {
+// 		t.Errorf("error creating network: %s", err.Error())
+// 		return
+// 	}
 
-	peers := asQriNodes(testPeers)
+// 	peers := asQriNodes(testPeers)
 
-	p1 := peers[0]
-	peers = peers[1:]
+// 	p1 := peers[0]
+// 	peers = peers[1:]
 
-	for _, peer := range peers {
-		p1.Addrs().AddAddr(peer.host.Network().LocalPeer(), peer.host.Network().ListenAddresses()[0], pstore.PermanentAddrTTL)
-	}
+// 	for _, peer := range peers {
+// 		p1.Addrs().AddAddr(peer.host.Network().LocalPeer(), peer.host.Network().ListenAddresses()[0], pstore.PermanentAddrTTL)
+// 	}
 
-	t.Logf("testing profile message with %d peers", len(peers))
-	for _, p2 := range peers {
-		t.Logf("Getting profile from peer %s", p2.ID)
-		_, err := p1.RequestProfile(p2.ID)
-		if err != nil {
-			t.Errorf("%s -> %s error: %s", p1.ID.Pretty(), p2.ID.Pretty(), err.Error())
-		}
-		pro, err := p1.Repo.Profiles().PeerProfile(p2.ID)
-		if err != nil {
-			t.Errorf("error getting profile from profile store: %s", err.Error())
-			continue
-		}
+// 	t.Logf("testing profile message with %d peers", len(peers))
+// 	for _, p2 := range peers {
+// 		t.Logf("Getting profile from peer %s", p2.ID)
+// 		_, err := p1.RequestProfile(p2.ID)
+// 		if err != nil {
+// 			t.Errorf("%s -> %s error: %s", p1.ID.Pretty(), p2.ID.Pretty(), err.Error())
+// 		}
+// 		pro, err := p1.Repo.Profiles().PeerProfile(p2.ID)
+// 		if err != nil {
+// 			t.Errorf("error getting profile from profile store: %s", err.Error())
+// 			continue
+// 		}
 
-		if pro == nil {
-			t.Error("profile shouldn't be nil")
-			continue
-		}
-		if len(pro.PeerIDs) == 0 {
-			t.Error("profile should have peer IDs")
-			continue
-		}
+// 		if pro == nil {
+// 			t.Error("profile shouldn't be nil")
+// 			continue
+// 		}
+// 		if len(pro.PeerIDs) == 0 {
+// 			t.Error("profile should have peer IDs")
+// 			continue
+// 		}
 
-		peerInfo2 := p1.host.Peerstore().PeerInfo(p2.ID)
-		if len(peerInfo2.Addrs) == 0 {
-			t.Errorf("%s (request node) should have addrs of %s (response node)", p1.ID, p2.ID)
-		}
-		peerInfo1 := p2.host.Peerstore().PeerInfo(p1.ID)
-		if len(peerInfo1.Addrs) == 0 {
-			t.Errorf("%s (response node) should have addrs of %s (request node)", p2.ID, p1.ID)
-		}
+// 		peerInfo2 := p1.host.Peerstore().PeerInfo(p2.ID)
+// 		if len(peerInfo2.Addrs) == 0 {
+// 			t.Errorf("%s (request node) should have addrs of %s (response node)", p1.ID, p2.ID)
+// 		}
+// 		peerInfo1 := p2.host.Peerstore().PeerInfo(p1.ID)
+// 		if len(peerInfo1.Addrs) == 0 {
+// 			t.Errorf("%s (response node) should have addrs of %s (request node)", p2.ID, p1.ID)
+// 		}
 
-		pid := pro.PeerIDs[0]
+// 		pid := pro.PeerIDs[0]
 
-		if pid != p2.ID {
-			p2pro, _ := p2.Repo.Profile()
-			t.Logf("p2 profile ID: %s peerID: %s, host peerID: %s", peer.ID(p2pro.ID), p2.ID, p2.host.ID())
-			t.Errorf("%s request profile peerID mismatch. expected: %s, got: %s", p1.ID, p2.ID, pid)
-		}
+// 		if pid != p2.ID {
+// 			p2pro, _ := p2.Repo.Profile()
+// 			t.Logf("p2 profile ID: %s peerID: %s, host peerID: %s", peer.ID(p2pro.ID), p2.ID, p2.host.ID())
+// 			t.Errorf("%s request profile peerID mismatch. expected: %s, got: %s", p1.ID, p2.ID, pid)
+// 		}
 
-		pro1, err := p2.Repo.Profiles().List()
-		if err != nil {
-			t.Errorf("error getting request profile from response profile store: %s", err.Error())
-			continue
-		}
+// 		pro1, err := p2.Repo.Profiles().List()
+// 		if err != nil {
+// 			t.Errorf("error getting request profile from response profile store: %s", err.Error())
+// 			continue
+// 		}
 
-		if pro1 == nil {
-			t.Error("profile shouldn't be nil")
-			continue
-		}
-		if len(pro1) == 0 {
-			t.Error("profile should have peer IDs")
-			continue
-		}
-	}
-}
+// 		if pro1 == nil {
+// 			t.Error("profile shouldn't be nil")
+// 			continue
+// 		}
+// 		if len(pro1) == 0 {
+// 			t.Error("profile should have peer IDs")
+// 			continue
+// 		}
+// 	}
+// }

--- a/p2p/qri_peers_test.go
+++ b/p2p/qri_peers_test.go
@@ -23,13 +23,18 @@ func TestSharePeers(t *testing.T) {
 	single := testPeers[0]
 	group := testPeers[1:]
 
-	if err := p2ptest.ConnectQriPeers(ctx, group); err != nil {
-		t.Errorf("error connecting peers: %s", err.Error())
+	if err := p2ptest.ConnectQriNodes(ctx, group); err != nil {
+		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
 	nasma := single.(*QriNode)
 	done := make(chan bool)
 	deadline := time.NewTimer(time.Second * 2)
+
+	if err := p2ptest.ConnectQriNodes(ctx, []p2ptest.TestablePeerNode{nasma, group[0]}); err != nil {
+		t.Fatalf("error connecting single node to single group node %s", err.Error())
+	}
+
 	go func() {
 		for range nasma.ReceiveMessages() {
 			if len(nasma.ConnectedPeers()) == len(group) {
@@ -37,8 +42,6 @@ func TestSharePeers(t *testing.T) {
 			}
 		}
 	}()
-
-	nasma.AddQriPeer(group[0].SimplePeerInfo())
 
 	select {
 	case <-done:

--- a/p2p/resolve_ref_test.go
+++ b/p2p/resolve_ref_test.go
@@ -16,7 +16,7 @@ func TestResolveDatasetRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating network: %s", err.Error())
 	}
-	if err = p2ptest.ConnectNodes(ctx, testPeers); err != nil {
+	if err = p2ptest.ConnectQriNodes(ctx, testPeers); err != nil {
 		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 

--- a/p2p/test/p2ptest.go
+++ b/p2p/test/p2ptest.go
@@ -163,10 +163,10 @@ func ConnectNodes(ctx context.Context, nodes []TestablePeerNode) error {
 	return nil
 }
 
-// ConnectQriPeers takes a slice of unconnected nodes and returns a slice
+// ConnectQriNodes takes a slice of unconnected nodes and returns a slice
 // of connected nodes that have upgraded qri connections:
 // They support the qri protocol and have exchanged profile
-func ConnectQriPeers(ctx context.Context, nodes []TestablePeerNode) error {
+func ConnectQriNodes(ctx context.Context, nodes []TestablePeerNode) error {
 	var wgConnect sync.WaitGroup
 	connect := func(n TestablePeerNode, pinfo pstore.PeerInfo) error {
 		if err := n.Host().Connect(ctx, pinfo); err != nil {

--- a/p2p/test/p2ptest.go
+++ b/p2p/test/p2ptest.go
@@ -66,6 +66,7 @@ func (f *TestNodeFactory) NextInfo() *cfgtest.PeerInfo {
 }
 
 // NewTestNetwork constructs nodes to test p2p functionality.
+// each of these peers has no datasets and no peers are connected
 func NewTestNetwork(ctx context.Context, f *TestNodeFactory, num int) ([]TestablePeerNode, error) {
 	nodes := make([]TestablePeerNode, num)
 	for i := 0; i < num; i++ {
@@ -84,6 +85,8 @@ func NewTestNetwork(ctx context.Context, f *TestNodeFactory, num int) ([]Testabl
 }
 
 // NewTestDirNetwork constructs nodes from the testdata directory, for p2p testing
+// Peers are pulled from the "testdata" directory, and come pre-populated with datasets
+// no peers are connected.
 func NewTestDirNetwork(ctx context.Context, f *TestNodeFactory) ([]TestablePeerNode, error) {
 	dirs, err := ioutil.ReadDir("testdata")
 	if err != nil {
@@ -157,31 +160,53 @@ func ConnectNodes(ctx context.Context, nodes []TestablePeerNode) error {
 		}
 	}
 	wg.Wait()
-
 	return nil
 }
 
-// ConnectQriPeers connects the nodes as Qri peers using PeerInfo
+// ConnectQriPeers takes a slice of unconnected nodes and returns a slice
+// of connected nodes that have upgraded qri connections:
+// They support the qri protocol and have exchanged profile
 func ConnectQriPeers(ctx context.Context, nodes []TestablePeerNode) error {
-	var wg sync.WaitGroup
-	connect := func(a, b TestablePeerNode) error {
-		bpi := b.SimplePeerInfo()
-		if err := a.UpgradeToQriConnection(bpi); err != nil {
-			return err
+	var wgConnect sync.WaitGroup
+	connect := func(n TestablePeerNode, pinfo pstore.PeerInfo) error {
+		if err := n.Host().Connect(ctx, pinfo); err != nil {
+			return fmt.Errorf("error connecting nodes: %s", err)
 		}
-		wg.Done()
+		wgConnect.Done()
 		return nil
 	}
 
 	for i, s1 := range nodes {
 		for _, s2 := range nodes[i+1:] {
-			wg.Add(1)
-			if err := connect(s1, s2); err != nil {
+			wgConnect.Add(1)
+			if err := connect(s1, s2.SimplePeerInfo()); err != nil {
 				return err
 			}
 		}
 	}
-	wg.Wait()
+	wgConnect.Wait()
+	var wgUpgrade sync.WaitGroup
+	upgradeConnection := func(a, b TestablePeerNode) error {
+		bpi := b.SimplePeerInfo()
+		if err := a.UpgradeToQriConnection(bpi); err != nil {
+			return err
+		}
+		wgUpgrade.Done()
+		return nil
+	}
+
+	for _, s1 := range nodes {
+		for _, s2 := range nodes {
+			if s1.SimplePeerInfo().ID == s2.SimplePeerInfo().ID {
+				continue
+			}
+			wgUpgrade.Add(1)
+			if err := upgradeConnection(s1, s2); err != nil {
+				return err
+			}
+		}
+	}
+	wgUpgrade.Wait()
 
 	return nil
 }

--- a/p2p/test/p2ptest.go
+++ b/p2p/test/p2ptest.go
@@ -185,7 +185,6 @@ func ConnectQriNodes(ctx context.Context, nodes []TestablePeerNode) error {
 		}
 	}
 	wgConnect.Wait()
-
 	// previously, we had UpgradeToQriConnection running in separate threads
 	// much like we did with the basic connection
 	// however, UpgradeToQriConnection asks for and sends profile information
@@ -198,7 +197,7 @@ func ConnectQriNodes(ctx context.Context, nodes []TestablePeerNode) error {
 				continue
 			}
 			if err := s1.UpgradeToQriConnection(pinfo); err != nil {
-				return err
+				return fmt.Errorf("%s error upgrading connection to %s: %s", s1.SimplePeerInfo().ID, pinfo.ID, err)
 			}
 		}
 	}

--- a/p2p/test/p2ptest_test.go
+++ b/p2p/test/p2ptest_test.go
@@ -56,14 +56,14 @@ func TestConnectNodes(t *testing.T) {
 	}
 }
 
-// Ensure that when we use ConnectQriPeers:
+// Ensure that when we use ConnectQriNodes:
 // - we have connections to each peer
 // - we have the addrs of each peer
 // - we have a tag on each peer
 // - we have the protocols each peer supports
 // - we have a record of if the peer supports the qri protocol
 // - we have a profile of that peer
-func TestConnectQriPeers(t *testing.T) {
+func TestConnectQriNodes(t *testing.T) {
 	ctx := context.Background()
 	f := NewTestNodeFactory(NewTestableNode)
 	testNodes, err := NewTestDirNetwork(ctx, f)
@@ -76,7 +76,7 @@ func TestConnectQriPeers(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := ConnectQriPeers(ctx, testNodes); err != nil {
+	if err := ConnectQriNodes(ctx, testNodes); err != nil {
 		t.Error(err)
 	}
 

--- a/p2p/test/p2ptest_test.go
+++ b/p2p/test/p2ptest_test.go
@@ -62,6 +62,7 @@ func TestConnectNodes(t *testing.T) {
 // - we have a tag on each peer
 // - we have the protocols each peer supports
 // - we have a record of if the peer supports the qri protocol
+// - we have tagged the connection in the conn manager
 // - we have a profile of that peer
 func TestConnectQriNodes(t *testing.T) {
 	ctx := context.Background()
@@ -106,12 +107,17 @@ func TestConnectQriNodes(t *testing.T) {
 			}
 			tag := node.Host().ConnManager().GetTagInfo(rpid)
 			if tag == nil {
-				t.Errorf("node %s has not tag info on node %s", pid, rpid)
+				t.Errorf("node %s does has not tag info on node %s", pid, rpid)
+			}
+			if tag != nil {
+				tagVal := tag.Tags[TestQriConnManagerTag]
+				if tagVal != TestQriConnManagerValue {
+					t.Errorf("node %s tag value for %s incorrect. expected: %d, got: %d", pid, rpid, TestQriConnManagerValue, tagVal)
+				}
 			}
 			supports, err := node.Host().Peerstore().Get(rpid, string(TestQriSupportKey))
 			if err != nil {
 				t.Errorf("node %s error getting %s support from peerstore: %s", pid, rpid, err)
-				continue
 			}
 			_, ok := supports.(bool)
 			if !ok {

--- a/p2p/test/p2ptest_test.go
+++ b/p2p/test/p2ptest_test.go
@@ -10,6 +10,7 @@ import (
 // - we have connections to each peer
 // - we have the addrs of each peer
 // - we have a tag on each peer
+// - we have the protocols each peer supports
 func TestConnectNodes(t *testing.T) {
 	ctx := context.Background()
 	f := NewTestNodeFactory(NewTestableNode)
@@ -32,6 +33,13 @@ func TestConnectNodes(t *testing.T) {
 			if pid == rpid {
 				continue
 			}
+			protos, err := node.Host().Peerstore().SupportsProtocols(rpid, string(TestQriProtocolID))
+			if err != nil {
+				t.Errorf("node %s, error getting %s's protocols", pid, rpid)
+			}
+			if len(protos) == 0 {
+				t.Errorf("node %s does not have a record that node %s can communicate over the testQri protocol", pid, rpid)
+			}
 			conns := node.Host().Network().ConnsToPeer(rpid)
 			if len(conns) == 0 {
 				t.Errorf("node %s has no connections to node %s", pid, rpid)
@@ -43,6 +51,71 @@ func TestConnectNodes(t *testing.T) {
 			tag := node.Host().ConnManager().GetTagInfo(rpid)
 			if tag == nil {
 				t.Errorf("node %s has not tag info on node %s", pid, rpid)
+			}
+		}
+	}
+}
+
+// Ensure that when we use ConnectQriPeers:
+// - we have connections to each peer
+// - we have the addrs of each peer
+// - we have a tag on each peer
+// - we have the protocols each peer supports
+// - we have a record of if the peer supports the qri protocol
+// - we have a profile of that peer
+func TestConnectQriPeers(t *testing.T) {
+	ctx := context.Background()
+	f := NewTestNodeFactory(NewTestableNode)
+	testNodes, err := NewTestDirNetwork(ctx, f)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := ConnectNodes(ctx, testNodes); err != nil {
+		t.Error(err)
+	}
+
+	if err := ConnectQriPeers(ctx, testNodes); err != nil {
+		t.Error(err)
+	}
+
+	for _, node := range testNodes {
+		// test that each conn has a connection to at least one peer id
+		pid := node.SimplePeerInfo().ID
+		for _, rnode := range testNodes {
+			rpid := rnode.SimplePeerInfo().ID
+			// dont need to check for connections to self
+			if pid == rpid {
+				continue
+			}
+			protos, err := node.Host().Peerstore().SupportsProtocols(rpid, string(TestQriProtocolID))
+			if err != nil {
+				t.Errorf("node %s, error getting %s's protocols", pid, rpid)
+			}
+			if len(protos) == 0 {
+				t.Errorf("node %s does not have a record that node %s can communicate over the testQri protocol", pid, rpid)
+			}
+			conns := node.Host().Network().ConnsToPeer(rpid)
+			if len(conns) == 0 {
+				t.Errorf("node %s has no connections to node %s", pid, rpid)
+			}
+			addrs := node.Host().Peerstore().Addrs(rpid)
+			if len(addrs) == 0 {
+				t.Errorf("node %s has no addrs for node %s", pid, rpid)
+			}
+			tag := node.Host().ConnManager().GetTagInfo(rpid)
+			if tag == nil {
+				t.Errorf("node %s has not tag info on node %s", pid, rpid)
+			}
+			supports, err := node.Host().Peerstore().Get(rpid, string(TestQriSupportKey))
+			if err != nil {
+				t.Errorf("node %s error getting %s support from peerstore: %s", pid, rpid, err)
+				continue
+			}
+			_, ok := supports.(bool)
+			if !ok {
+				t.Errorf("node %s support flag for %s is not bool", pid, rpid)
 			}
 		}
 	}

--- a/p2p/test/testable_node_test.go
+++ b/p2p/test/testable_node_test.go
@@ -30,6 +30,8 @@ type TestableNode struct {
 // testing protocol
 const TestQriProtocolID = protocol.ID("/qri/_testing")
 const TestQriSupportKey = "qri-support-test"
+const TestQriConnManagerTag = "qri_test"
+const TestQriConnManagerValue = 6
 
 // Host returns the node's underlying host
 func (n *TestableNode) Host() host.Host {
@@ -73,6 +75,12 @@ func (n *TestableNode) UpgradeToQriConnection(pinfo pstore.PeerInfo) error {
 	// if it does support the qri protocol
 	// - request profile
 	// - request profiles
+	// - tag as qri connection
+	if !support {
+		return nil
+	}
+
+	n.Host().ConnManager().TagPeer(pinfo.ID, TestQriConnManagerTag, TestQriConnManagerValue)
 	return nil
 }
 

--- a/p2p/test/testable_node_test.go
+++ b/p2p/test/testable_node_test.go
@@ -33,6 +33,8 @@ const TestQriSupportKey = "qri-support-test"
 const TestQriConnManagerTag = "qri_test"
 const TestQriConnManagerValue = 6
 
+var ErrTestQriProtocolNotSupported = fmt.Errorf("test qri protocol not supported")
+
 // Host returns the node's underlying host
 func (n *TestableNode) Host() host.Host {
 	return n.host
@@ -57,8 +59,7 @@ func (n *TestableNode) UpgradeToQriConnection(pinfo pstore.PeerInfo) error {
 	// check if this connection supports the qri protocol
 	protos, err := n.Host().Peerstore().SupportsProtocols(pinfo.ID, string(TestQriProtocolID))
 	if err != nil {
-		fmt.Printf("error checking for qri support: %s\n", err)
-		return err
+		fmt.Printf("error getting protocols from peerstore: %s", err)
 	}
 
 	support := true
@@ -77,7 +78,7 @@ func (n *TestableNode) UpgradeToQriConnection(pinfo pstore.PeerInfo) error {
 	// - request profiles
 	// - tag as qri connection
 	if !support {
-		return nil
+		return ErrTestQriProtocolNotSupported
 	}
 
 	n.Host().ConnManager().TagPeer(pinfo.ID, TestQriConnManagerTag, TestQriConnManagerValue)

--- a/p2p/test/testable_node_test.go
+++ b/p2p/test/testable_node_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/repo"
 
-	// net "gx/ipfs/QmPjvxTpVH8qJyQDnxnsxF9kv9jezKD1kozz1hs3fCGsNh/go-libp2p-net"
+	net "gx/ipfs/QmPjvxTpVH8qJyQDnxnsxF9kv9jezKD1kozz1hs3fCGsNh/go-libp2p-net"
 	libp2p "gx/ipfs/QmY51bqSM5XgxQZqsBrQcRkKTnCb8EKpJpR9K6Qax7Njco/go-libp2p"
 	// ma "gx/ipfs/QmYmsdtJ3HsodkePE3eU3TsCaP2YvPZJ4LoXnNkDE5Tpt7/go-multiaddr"
 	connmgr "gx/ipfs/QmYAL9JsqVVPFWwM1ZzHNsofmTzRYQHJ2KqQaBmFJjJsNx/go-libp2p-connmgr"
+	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
 	pstore "gx/ipfs/QmZR2XWVVBCtbgBWnQhWk2xcQfaR3W8faQPriAiaaj7rsr/go-libp2p-peerstore"
 	host "gx/ipfs/Qmb8T6YBBsjYsVGfrihQLfCJveczZnneSBqBKkYEBWDjge/go-libp2p-host"
 	peer "gx/ipfs/QmdVrMn1LhB4ybb8hMVaMLXnA8XRSewMnK6YqXKXoTcRvN/go-libp2p-peer"
@@ -25,9 +26,10 @@ type TestableNode struct {
 	Repo repo.Repo
 }
 
-// TestProtocolID is the key used to set the stream handler to our
+// TestQriProtocolID is the key used to set the stream handler to our
 // testing protocol
-var TestProtocolID = "qri"
+const TestQriProtocolID = protocol.ID("/qri/_testing")
+const TestQriSupportKey = "qri-support-test"
 
 // Host returns the node's underlying host
 func (n *TestableNode) Host() host.Host {
@@ -44,8 +46,38 @@ func (n *TestableNode) SimplePeerInfo() pstore.PeerInfo {
 
 // UpgradeToQriConnection upgrades the connection from a basic connection
 // to a Qri connection
-func (n *TestableNode) UpgradeToQriConnection(pstore.PeerInfo) error {
+func (n *TestableNode) UpgradeToQriConnection(pinfo pstore.PeerInfo) error {
+	// bail early if we have seen this peer before
+	if _, err := n.Host().Peerstore().Get(pinfo.ID, TestQriSupportKey); err == nil {
+		return nil
+	}
+
+	// check if this connection supports the qri protocol
+	protos, err := n.Host().Peerstore().SupportsProtocols(pinfo.ID, string(TestQriProtocolID))
+	if err != nil {
+		fmt.Printf("error checking for qri support: %s\n", err)
+		return err
+	}
+
+	support := true
+
+	if len(protos) == 0 {
+		support = false
+	}
+
+	// mark whether or not this connection supports the qri protocol:
+	if err := n.Host().Peerstore().Put(pinfo.ID, string(TestQriSupportKey), support); err != nil {
+		fmt.Printf("error setting qri support flag: %s\n", err)
+		return err
+	}
+	// if it does support the qri protocol
+	// - request profile
+	// - request profiles
 	return nil
+}
+
+func (n *TestableNode) TestStreamHandler(s net.Stream) {
+	fmt.Println("stream handler called")
 }
 
 // GoOnline assumes the TestNode is not online, it will set
@@ -54,7 +86,9 @@ func (n *TestableNode) GoOnline() error {
 
 	// add multistream handler for qri protocol to the host
 	// for more info on multistreams check github.com/multformats/go-multistream
-	// n.host().SetStreamHandler(QriProtocolID, n.QriStreamHandler)
+	// Setting the StreamHandler with the TestQriProtocol will let other peers
+	// know that we can speak the TestQriProtocol
+	n.Host().SetStreamHandler(TestQriProtocolID, n.TestStreamHandler)
 
 	p, err := n.Repo.Profile()
 	if err != nil {


### PR DESCRIPTION
UpgradeToQriConnection expects:
- we have connections to each peer
- we have the addrs of each peer
- we have a tag on each peer
- we have the protocols each peer supports

UpgradeToQriConnection then:
- records if the peer supports the qri protocol
- tags the ConnManager that this is a qri connection, and therefore more important
- requests the profile of that peer
- requests the ids of the peers that that peer knows.
- requests the profiles for those peers

This pr also formalizes the differences between `ConnectNodes` and `ConnectQriNodes` and adjusts tests to use `ConnectQriNodes`.

A basic p2p connection:
- we have the connections listed in the network
- we have the addrs in the peerstore
- we have a basic tag in the ConnManager
- we know what protocols the peer understands

A Qri p2p connection:
- notes if a peer understands the qri protocol (stored in the peerstore)
- has tagged the connection as a qri connection in the ConnManager
- have requested the peers profile
- have requested a list of that peer's peers
- have requested the profiles of those peers

I want to note that although we have formalized a difference between `ConnectNodes`, which should create a basic connection and a qri connection respectfully, since running `n.host.Connect()` triggers a `HandlePeerFound` call, which in turn called `UpgradeToQriConnection`, we do not actually have a way to create a network of peers that all only have a basic connection.


### edit:
So we realized that `HandlePeerFound` is not the location we want to be upgrading to a qri connection. UpgradeToQriConnection requires knowing the protocols of the remote peer. In `HandlePeerFound`, we do not yet know the protocols of the remote peer.

Since we re-tag the connection as being a qri connection when we `SendMessage`, we have a little bit of safety.

We are also having QriNode satisfy the `inet.Notifee` interface. This will give us hooks into the connection process as we move forward with p2p. Right now all the functions are no-op