### PR TITLE
fix(bootstrap peers): fix network not ever contacting bootstrap peers

### DIFF
--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -26,7 +26,7 @@ func (n *QriNode) StartDiscovery(bootstrapPeers chan pstore.PeerInfo) error {
 	// Check our existing peerstore for any potential friends
 	go n.DiscoverPeerstoreQriPeers(n.host.Peerstore())
 	// Boostrap off of default addresses
-	go n.Bootstrap(n.cfg.BootstrapAddrs, bootstrapPeers)
+	go n.Bootstrap(n.cfg.QriBootstrapAddrs, bootstrapPeers)
 	// Bootstrap to IPFS network if this node is using an IPFS fs
 	go n.BootstrapIPFS()
 


### PR DESCRIPTION
well, this one is funny. In a refactor a while ago, I missed switching `conf.BoostrapAddrs` -> `conf.QriBootstrapAddrs`. The result of this oversight is qri connect bootstraps to *no* peers, which means the network seems empty. Sad emoji. Programming is hard.