### PR TITLE
refactor: Distinguish Manual & Scripted Tranforms

### DIFF
--- a/actions/dataset.go
+++ b/actions/dataset.go
@@ -51,6 +51,7 @@ func SaveDataset(node *p2p.QriNode, dsp *dataset.DatasetPod, dryRun, pin bool) (
 		}
 	}
 
+	mutateCheck := mutatedComponentsFunc(dsp)
 	userSet.Assign(ds)
 
 	if ds.Transform != nil {
@@ -66,7 +67,7 @@ func SaveDataset(node *p2p.QriNode, dsp *dataset.DatasetPod, dryRun, pin bool) (
 		script := cafs.NewMemfileReader(ds.Transform.ScriptPath, ds.Transform.Script)
 
 		node.LocalStreams.Print("🤖 executing transform\n")
-		bodyFile, err = ExecTransform(node, ds, script, bodyFile, secrets)
+		bodyFile, err = ExecTransform(node, ds, script, bodyFile, secrets, mutateCheck)
 		if err != nil {
 			return
 		}
@@ -157,7 +158,7 @@ func localUpdate(node *p2p.QriNode, ref *repo.DatasetRef, dryRun, pin bool) (res
 	ds.Transform.ScriptPath = script.FileName()
 
 	node.LocalStreams.Print("🤖 executing transform\n")
-	bodyFile, err = ExecTransform(node, ds, script, bodyFile, secrets)
+	bodyFile, err = ExecTransform(node, ds, script, bodyFile, secrets, nil)
 	if err != nil {
 		log.Error(err)
 		return

--- a/actions/transform.go
+++ b/actions/transform.go
@@ -1,20 +1,48 @@
 package actions
 
 import (
+	"fmt"
+
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/startf"
 )
 
+func mutatedComponentsFunc(dsp *dataset.DatasetPod) func(path ...string) error {
+	components := map[string][]string{}
+	if dsp.Transform != nil {
+		components["transform"] = []string{}
+	}
+	if dsp.Meta != nil {
+		components["meta"] = []string{}
+	}
+	if dsp.Structure != nil {
+		components["structure"] = []string{}
+	}
+	if dsp.Body != nil || dsp.BodyBytes != nil || dsp.BodyPath != "" {
+		components["body"] = []string{}
+	}
+
+	return func(path ...string) error {
+		if len(path) > 0 && components[path[0]] != nil {
+			return fmt.Errorf(`transform script and user-supplied dataset are both trying to set:
+  %s
+
+please adjust either the transform script or remove the supplied '%s'`, path[0], path[0])
+		}
+		return nil
+	}
+}
+
 // ExecTransform executes a designated transformation
-func ExecTransform(node *p2p.QriNode, ds *dataset.Dataset, script, bodyFile cafs.File, secrets map[string]string) (file cafs.File, err error) {
+func ExecTransform(node *p2p.QriNode, ds *dataset.Dataset, script, bodyFile cafs.File, secrets map[string]string, mutateCheck func(...string) error) (file cafs.File, err error) {
 	// filepath := ds.Transform.ScriptPath
 
 	// TODO - consider making this a standard method on dataset.Transform:
 	// script := cafs.NewMemfileReader(ds.Transform.ScriptPath, ds.Transform.Script)
 
-	file, err = startf.ExecFile(ds, script, bodyFile, startf.AddQriNodeOpt(node), func(o *startf.ExecOpts) {
+	file, err = startf.ExecScript(ds, script, bodyFile, startf.AddQriNodeOpt(node), startf.AddMutateFieldCheck(mutateCheck), func(o *startf.ExecOpts) {
 		if secrets != nil {
 			// convert to map[string]interface{}, which the lower-level startf supports
 			// until we're sure map[string]string is going to work in the majority of use cases
@@ -28,29 +56,6 @@ func ExecTransform(node *p2p.QriNode, ds *dataset.Dataset, script, bodyFile cafs
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO - adding here just to get the content-addressed script path for the event.
-	// clean up events to handle this situation
-	// f, err := os.Open(filepath)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// tfPath, err := node.Repo.Store().Put(cafs.NewMemfileReader("transform.sky", f), false)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// ref := repo.DatasetRef{
-	// 	Dataset: &dataset.DatasetPod{
-	// 		Transform: &dataset.TransformPod{
-	// 			Syntax:     "starlark",
-	// 			ScriptPath: tfPath.String(),
-	// 		},
-	// 	},
-	// }
-
-	// if err = node.Repo.LogEvent(repo.ETTransformExecuted, ref); err != nil {
-	// 	return
-	// }
 
 	return
 }

--- a/actions/transform_test.go
+++ b/actions/transform_test.go
@@ -41,7 +41,7 @@ def transform(ds,ctx):
 		},
 	}
 
-	if _, err := ExecTransform(node, ds, script, nil, nil); err != nil {
+	if _, err := ExecTransform(node, ds, script, nil, nil, nil); err != nil {
 		t.Error(err.Error())
 	}
 }

--- a/lib/file.go
+++ b/lib/file.go
@@ -125,7 +125,7 @@ func ReadDatasetFile(path string) (dsp *dataset.DatasetPod, err error) {
 // absDatasetPaths converts any relative filepath references in a DatasetPod to
 // their absolute counterpart
 func absDatasetPaths(path string, dsp *dataset.DatasetPod) {
-	base := filepath.Base(path)
+	base := filepath.Dir(path)
 	if dsp.BodyPath != "" && pathKind(dsp.BodyPath) == "file" && !filepath.IsAbs(dsp.BodyPath) {
 		dsp.BodyPath = filepath.Join(base, dsp.BodyPath)
 	}


### PR DESCRIPTION
When finished, this PR should implement the first step of [RFC0020](https://github.com/qri-io/rfcs/blob/master/text/0020-distingush_manual_vs_scripted_transforms.md)

### TODOS:
* [ ] lib:
  * [ ] an integration test on lib that runs the tutorial from RFC 0020
* [ ] cmd: 
  * [ ] update: add --recall-tf flag
  * [ ] save
    * [ ] add --run-tf flag
    * [ ] add command documentation explaining transforms run only the first time they're provided
* [ ] startf
  * [x] adjust startf/dataset to accept a MutationCheckFunc
  * [ ] lib version needs to to go 0.1.0
  * [ ] startf/dataset infile -> bodyFile
* [ ] actions:
  * [ ] adjust logic of `SaveDataset` and `UpdateDataset` transform exec to match RFC
  * [ ] test to ensure previous dataset is provided to transform
  * [ ] confirm manual transforms run before scripted transforms
  * [x] generate a MutationCheckFunc from the result of user-provided values, pass to transform
  * [ ] test to ensure tf is removed by save that doesn't run
  * [ ] add no-transform error that uses history check
* [ ] base:
  * [ ] add history check to look for transforms