### PR TITLE
fix(fs refstore): don't store DatasetPod in refstore

### DIFF
--- a/repo/fs/refstore.go
+++ b/repo/fs/refstore.go
@@ -29,6 +29,7 @@ type Refstore struct {
 // PutRef adds a reference to the store
 func (n Refstore) PutRef(p repo.DatasetRef) (err error) {
 	var ds *dataset.Dataset
+	p.Dataset = nil
 
 	if p.ProfileID == "" {
 		return repo.ErrPeerIDRequired


### PR DESCRIPTION
this is causing silly stuff to be stored in `ds_refs.json`