### PR TITLE
fix(webapp): restore webapp

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -140,10 +140,10 @@ func (s *Server) HandleIPFSPath(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.fetchIPFSPath(r.URL.Path, w, r)
+	s.fetchCAFSPath(r.URL.Path, w, r)
 }
 
-func (s *Server) fetchIPFSPath(path string, w http.ResponseWriter, r *http.Request) {
+func (s *Server) fetchCAFSPath(path string, w http.ResponseWriter, r *http.Request) {
 	file, err := s.qriNode.Repo.Store().Get(datastore.NewKey(path))
 	if err != nil {
 		apiutil.WriteErrResponse(w, http.StatusInternalServerError, err)

--- a/api/templates.go
+++ b/api/templates.go
@@ -33,6 +33,6 @@ const webapptmpl = `
 </head>
 <body>
   <div id="root"></div>
-  <script type="text/javascript" src="/webapp.js"></script>
+  <script type="text/javascript" src="/webapp/main.js"></script>
 </body>
 </html>`

--- a/api/transports.go
+++ b/api/transports.go
@@ -37,7 +37,7 @@ func StartServer(c *config.API, s *http.Server) error {
 	}
 
 	// Attempt to boot a port 80 https redirect
-	go func() { HTTPSRedirect() }()
+	go HTTPSRedirect(":80")
 
 	s.TLSConfig = &tls.Config{
 		GetCertificate: certManager.GetCertificate,
@@ -54,14 +54,14 @@ func StartServer(c *config.API, s *http.Server) error {
 	return s.ListenAndServeTLS(cert, key)
 }
 
-// HTTPSRedirect listens on port 80, redirecting HTTP requests to https
-func HTTPSRedirect() {
-	ln, err := net.Listen("tcp", ":80")
+// HTTPSRedirect listens pver TCP on addr, redirecting HTTP requests to https
+func HTTPSRedirect(addr string) {
+	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return
 	}
 
-	// log.Infoln("TCP Port 80 is available, redirecting traffic to https")
+	log.Infof("TCP Port %s is available, redirecting traffic to https", addr)
 
 	srv := &http.Server{
 		ReadTimeout:  5 * time.Second,

--- a/api/transports.go
+++ b/api/transports.go
@@ -54,7 +54,7 @@ func StartServer(c *config.API, s *http.Server) error {
 	return s.ListenAndServeTLS(cert, key)
 }
 
-// HTTPSRedirect listens pver TCP on addr, redirecting HTTP requests to https
+// HTTPSRedirect listens over TCP on addr, redirecting HTTP requests to https
 func HTTPSRedirect(addr string) {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/api/transports_test.go
+++ b/api/transports_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHTTPSRedirect(t *testing.T) {
+	HTTPSRedirect("foobar")
+
+	go HTTPSRedirect(":5432")
+
+	cli := http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if req.URL.String() != "https://localhost:5432/foo" {
+				t.Errorf("expected to be redirect to https. got: %s", req.URL.String())
+			}
+			if req.Response.StatusCode != http.StatusMovedPermanently {
+				t.Errorf("expected permanent redirect. got: %d", req.Response.StatusCode)
+			}
+			return nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "http://localhost:5432/foo", nil)
+	cli.Do(req)
+}

--- a/api/webapp.go
+++ b/api/webapp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 )
 
 // ServeWebapp launches a webapp server on s.cfg.Webapp.Port
@@ -20,20 +21,25 @@ func (s *Server) ServeWebapp() {
 	}
 
 	m := http.NewServeMux()
-	m.Handle("/", s.middleware(s.WebappHandler))
-	m.Handle("/webapp.js", s.WebappJSHandler())
+	m.Handle("/", s.middleware(s.WebappTemplateHandler))
+	m.Handle("/webapp/", s.FrontendHandler("/webapp"))
+
 	webappserver := &http.Server{Handler: m}
 	webappserver.Serve(listener)
 	return
 }
 
-// WebappJSHandler attempts to resolve an update
-func (s *Server) WebappJSHandler() http.Handler {
+// FrontendHandler resolves the current webapp hash, (fetching the compiled frontend in the process)
+// and serves it up as a traditional HTTP endpoint, transparently redirecting requests
+// for [prefix]/foo.js to [CAFS Hash]/foo.js
+// prefix is the path prefix that should be stripped from the request URL.Path
+func (s *Server) FrontendHandler(prefix string) http.Handler {
 	var webappPath = s.cfg.Webapp.EntrypointHash
 	go s.resolveWebappPath(&webappPath)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s.fetchIPFSPath(webappPath, w, r)
+		path := fmt.Sprintf("%s%s", webappPath, strings.TrimPrefix(r.URL.Path, prefix))
+		s.fetchCAFSPath(path, w, r)
 	})
 }
 
@@ -61,7 +67,7 @@ func (s *Server) resolveWebappPath(path *string) {
 	*path = p.String()
 }
 
-// WebappHandler renders the home page
-func (s *Server) WebappHandler(w http.ResponseWriter, r *http.Request) {
+// WebappTemplateHandler renders the home page
+func (s *Server) WebappTemplateHandler(w http.ResponseWriter, r *http.Request) {
 	renderTemplate(s.cfg.Webapp, w, "webapp")
 }

--- a/api/webapp.go
+++ b/api/webapp.go
@@ -34,6 +34,13 @@ func (s *Server) ServeWebapp() {
 // for [prefix]/foo.js to [CAFS Hash]/foo.js
 // prefix is the path prefix that should be stripped from the request URL.Path
 func (s *Server) FrontendHandler(prefix string) http.Handler {
+	// TODO - refactor these next two lines. This kicks off a goroutine that checks a IPNS dns entry
+	// for the latest hash of the webapp and overwrites with that hash on completion. Problems:
+	// * it's mutating its input parameter
+	// * it has a race condition with the code below
+	// * there's no error handling,
+	// * and really the data could be owned by Server and initialized by it,
+	//   as there's nothing that necessitates it being within FrontendHandler.
 	var webappPath = s.cfg.Webapp.EntrypointHash
 	go s.resolveWebappPath(&webappPath)
 

--- a/api/webapp_test.go
+++ b/api/webapp_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/qri-io/qri/config"
+)
+
+func TestServeWebapp(t *testing.T) {
+
+	node, teardown := newTestNode(t)
+	defer teardown()
+	cfg := config.DefaultConfigForTesting()
+	cfg.Webapp.Enabled = false
+	New(node, cfg).ServeWebapp()
+
+	cfg.Webapp.EntrypointUpdateAddress = ""
+	cfg.Webapp.Enabled = true
+	s := New(node, cfg)
+	go s.ServeWebapp()
+
+	url := fmt.Sprintf("http://localhost:%d", cfg.Webapp.Port)
+	res, err := http.Get(url)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(data) != webapptmpl {
+		t.Errorf("base url should return webapp template")
+	}
+
+	_, err = http.Get(url + "/webapp/main.js")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// TODO - actually respond with something meaningful
+}


### PR DESCRIPTION
Our webapp has gotten too complicated to reasonably serve as a single file. This PR adjusts the way we serve frontend stack files. We can compile our frontend down to a directory, and serve that CAFS directory behind the `/webapp/` endpoint. webapp code can come from the dweb and always be served consistently behind the `/webapp/` endpoint from api's webapp server. neat!