### PR TITLE
test(save): Test case for saving a dataset with a relative body path.

### DIFF
--- a/cmd/testdata/movies/ds_ten.yaml
+++ b/cmd/testdata/movies/ds_ten.yaml
@@ -1,0 +1,5 @@
+name: ten_movies
+meta:
+  qri: md:0
+  title: example movie data
+bodypath: body_ten.csv


### PR DESCRIPTION
Prior to commit 00a30d3fb6c, trying to save a dataset with a bodypath at a relative path would erroneously use the current directory to try to resolve that path, instead of the directory that the dataset.yaml was in. This change adds a test case for this new, correct behavior. Note that you can restore this old, invalid behavior by commenting out the assignment to dsp.BodyPath in the function absDatasetPaths in /lib/file.go, currently line 130; doing so will also cause this test to fail.

As part of this test case, we're also doing something new: validating that the body of the saved dataset matches the input that the save command was given. This is accomplished by using the ipfs bindings to read the the body directory from our testRepo, exercising our full tech stack. In the future, it might be useful to move this new utility (TestRepoRoot) to a lower package, or rename it to something better, and probably use it in more existing tests in order to validate body contents in more places.