### PR TITLE
refactor(registry): remove `status` and replace it with `registryDataset`

### DIFF
--- a/actions/registry.go
+++ b/actions/registry.go
@@ -214,8 +214,8 @@ func regToRepo(rds *registry.Dataset) *repo.DatasetRef {
 	}
 }
 
-// RegistryDataset gets commit, structure, meta, viz & transform form a given reference
-// from a registry
+// RegistryDataset gets dataset info published to the registry, which is usually subset
+// of the full dataset, and not suitable for hash-referencing.
 func RegistryDataset(node *p2p.QriNode, ds *repo.DatasetRef) error {
 	cli := node.Repo.Registry()
 	if cli == nil {

--- a/actions/registry_test.go
+++ b/actions/registry_test.go
@@ -2,11 +2,23 @@ package actions
 
 import (
 	"testing"
+	"time"
 
+	"github.com/qri-io/dataset/dsfs"
+	"github.com/qri-io/qri/repo"
 	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
 func TestRegistry(t *testing.T) {
+	// we need to artificially specify the timestamp
+	// we use the dsfs.Timestamp func variable to override
+	// the actual time
+	prevTs := dsfs.Timestamp
+	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
+	defer func() {
+		dsfs.Timestamp = prevTs
+	}()
+
 	reg := regmock.NewMemRegistry()
 	regClient, regServer := regmock.NewMockServerRegistry(reg)
 	defer regServer.Close()
@@ -17,8 +29,23 @@ func TestRegistry(t *testing.T) {
 	if err := Publish(node, ref); err != nil {
 		t.Error(err.Error())
 	}
-	if err := Status(node, ref); err != nil {
+
+	cities := repo.DatasetRef{
+		Peername: "me",
+		Name:     "cities",
+	}
+	if err := RegistryDataset(node, &cities); err != nil {
 		t.Error(err.Error())
+	}
+
+	if cities.Path != "/map/QmW3QAZWmLcjS1RyPgYDa59w23k5VeyPHim2b8Zj7z8Zpo" {
+		t.Errorf("error getting dataset from registry, expected path to be '/map/QmW3QAZWmLcjS1RyPgYDa59w23k5VeyPHim2b8Zj7z8Zpo', got %s", cities.Path)
+	}
+	if cities.Dataset == nil {
+		t.Errorf("error getting dataset from registry, dataset is nil")
+	}
+	if cities.Published != true {
+		t.Errorf("error getting dataset from registry, expected published to be 'true'")
 	}
 
 	ref2 := addFlourinatedCompoundsDataset(t, node)

--- a/actions/registry_test.go
+++ b/actions/registry_test.go
@@ -10,9 +10,8 @@ import (
 )
 
 func TestRegistry(t *testing.T) {
-	// we need to artificially specify the timestamp
-	// we use the dsfs.Timestamp func variable to override
-	// the actual time
+	// to keep hashes consistent, artificially specify the timestamp by overriding
+	// the dsfs.Timestamp func
 	prevTs := dsfs.Timestamp
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 	defer func() {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -41,9 +41,8 @@ func newTestRepo(t *testing.T) (r repo.Repo, teardown func()) {
 
 	// use a test registry server (with a pinset) & client & client
 	rc, registryServer := regmock.NewMockServer()
-	// we need to artificially specify the timestamp
-	// we use the dsfs.Timestamp func variable to override
-	// the actual time
+	// to keep hashes consistent, artificially specify the timestamp by overriding
+	// the dsfs.Timestamp func
 	prevTs := dsfs.Timestamp
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
@@ -166,10 +165,8 @@ func TestServerReadOnlyRoutes(t *testing.T) {
 	golog.SetLogLevel("qriapi", "error")
 	defer golog.SetLogLevel("qriapi", "info")
 
-	// in order to have consistent responses
-	// we need to artificially specify the timestamp
-	// we use the dsfs.Timestamp func variable to override
-	// the actual time
+	// to keep hashes consistent, artificially specify the timestamp by overriding
+	// the dsfs.Timestamp func
 	prev := dsfs.Timestamp
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }

--- a/api/registry.go
+++ b/api/registry.go
@@ -7,17 +7,19 @@ import (
 	util "github.com/datatogether/api/apiutil"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/p2p"
+	"github.com/qri-io/qri/repo"
 )
 
 // RegistryHandlers wraps a requests struct to interface with http.HandlerFunc
 type RegistryHandlers struct {
 	lib.RegistryRequests
+	repo repo.Repo
 }
 
 // NewRegistryHandlers allocates a RegistryHandlers pointer
 func NewRegistryHandlers(node *p2p.QriNode) *RegistryHandlers {
 	req := lib.NewRegistryRequests(node, nil)
-	h := RegistryHandlers{*req}
+	h := RegistryHandlers{*req, node.Repo}
 	return &h
 }
 
@@ -27,8 +29,8 @@ func (h *RegistryHandlers) RegistryHandler(w http.ResponseWriter, r *http.Reques
 	case "OPTIONS":
 		util.EmptyOkHandler(w, r)
 	case "GET":
-		// get status of dataset, is it published or not
-		h.statusRegistryHandler(w, r)
+		// get a dataset if it is published, error if not
+		h.registryDatasetHandler(w, r)
 	case "POST", "PUT":
 		// publish a dataset to the registry
 		h.publishRegistryHandler(w, r)
@@ -54,19 +56,18 @@ func (h *RegistryHandlers) RegistryDatasetsHandler(w http.ResponseWriter, r *htt
 	}
 }
 
-func (h *RegistryHandlers) statusRegistryHandler(w http.ResponseWriter, r *http.Request) {
-	ref, err := DatasetRefFromPath(r.URL.Path[len("/registry"):])
-	if err != nil {
-		util.WriteErrResponse(w, http.StatusBadRequest, err)
-		return
+// RegistryDatasetHandler is the endpoint to get a dataset summary
+// from the registry
+func (h *RegistryHandlers) RegistryDatasetHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "OPTIONS":
+		util.EmptyOkHandler(w, r)
+	case "GET":
+		// returns a registry dataset
+		h.registryDatasetHandler(w, r)
+	default:
+		util.NotFoundHandler(w, r)
 	}
-	var res bool
-	if err := h.RegistryRequests.Status(&ref, &res); err != nil {
-		util.WriteErrResponse(w, http.StatusInternalServerError, fmt.Errorf("error getting status from registry: %s", err))
-		return
-	}
-
-	util.WriteResponse(w, fmt.Sprintf("dataset %s is published to the registry", ref))
 }
 
 func (h *RegistryHandlers) publishRegistryHandler(w http.ResponseWriter, r *http.Request) {
@@ -119,4 +120,24 @@ func (h *RegistryHandlers) listRegistryDatasetsHandler(w http.ResponseWriter, r 
 	if err := util.WritePageResponse(w, params.Refs, r, args.Page()); err != nil {
 		log.Infof("error listing registry datasets: %s", err.Error())
 	}
+}
+
+func (h *RegistryHandlers) registryDatasetHandler(w http.ResponseWriter, r *http.Request) {
+	res := &repo.DatasetRef{}
+	ref, err := DatasetRefFromPath(r.URL.Path[len("/registry/"):])
+	if err != nil {
+		util.WriteErrResponse(w, http.StatusBadRequest, err)
+		return
+	}
+	if err = repo.CanonicalizeDatasetRef(h.repo, &ref); err != nil && err != repo.ErrNotFound {
+		util.WriteErrResponse(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	err = h.RegistryRequests.Get(&ref, res)
+	if err != nil {
+		util.WriteErrResponse(w, http.StatusInternalServerError, err)
+		return
+	}
+	util.WriteResponse(w, res)
 }

--- a/api/registry.go
+++ b/api/registry.go
@@ -134,7 +134,7 @@ func (h *RegistryHandlers) registryDatasetHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	err = h.RegistryRequests.Get(&ref, res)
+	err = h.RegistryRequests.GetDataset(&ref, res)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -194,7 +194,7 @@ func (o *RegistryOptions) Status() error {
 			return err
 		}
 
-		err = o.RegistryRequests.Get(&ref, &res)
+		err = o.RegistryRequests.GetDataset(&ref, &res)
 		o.StopSpinner()
 
 		if err != nil {

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -184,21 +184,20 @@ func (o *RegistryOptions) Publish() error {
 
 // Status gets the status of a dataset reference on the registry
 func (o *RegistryOptions) Status() error {
-	var res bool
-
 	for _, arg := range o.Refs {
 		o.StartSpinner()
+
+		res := repo.DatasetRef{}
 
 		ref, err := repo.ParseDatasetRef(arg)
 		if err != nil {
 			return err
 		}
 
-		err = o.RegistryRequests.Status(&ref, &res)
+		err = o.RegistryRequests.Get(&ref, &res)
 		o.StopSpinner()
 
 		if err != nil {
-			printErr(o.Out, err)
 			printInfo(o.Out, "%s is not on this registry", ref.String())
 		}
 		if ref.Dataset != nil {

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -92,10 +92,8 @@ func TestRemoveRun(t *testing.T) {
 	streams, in, out, errs := ioes.NewTestIOStreams()
 	setNoColor(true)
 
-	// in order to have consistent responses
-	// we need to artificially specify the timestamp
-	// we use the dsfs.Timestamp func variable to override
-	// the actual time
+	// to keep hashes consistent, artificially specify the timestamp by overriding
+	// the dsfs.Timestamp func
 	prev := dsfs.Timestamp
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -102,10 +102,8 @@ func TestSaveRun(t *testing.T) {
 	setNoColor(true)
 	setNoPrompt(true)
 
-	// in order to have consistent responses
-	// we need to artificially specify the timestamp
-	// we use the dsfs.Timestamp func variable to override
-	// the actual time
+	// to keep hashes consistent, artificially specify the timestamp by overriding
+	// the dsfs.Timestamp func
 	prev := dsfs.Timestamp
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -93,8 +93,8 @@ func (r *RegistryRequests) List(params *RegistryListParams, done *bool) error {
 	return nil
 }
 
-// Get returns a dataset that has been published to the registry
-func (r *RegistryRequests) Get(ref *repo.DatasetRef, res *repo.DatasetRef) error {
+// GetDataset returns a dataset that has been published to the registry
+func (r *RegistryRequests) GetDataset(ref *repo.DatasetRef, res *repo.DatasetRef) error {
 	if r.cli != nil {
 		return r.cli.Call("DatasetRequests.Get", ref, res)
 	}

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -54,14 +54,6 @@ func (r *RegistryRequests) Unpublish(ref *repo.DatasetRef, done *bool) error {
 	return actions.Unpublish(r.node, *ref)
 }
 
-// Status checks if a dataset has been published to a registry
-func (r *RegistryRequests) Status(ref *repo.DatasetRef, done *bool) error {
-	if r.cli != nil {
-		return r.cli.Call("RegistryRequests.Status", ref, done)
-	}
-	return actions.Status(r.node, *ref)
-}
-
 // Pin asks a registry to host a copy of a dataset
 func (r *RegistryRequests) Pin(ref *repo.DatasetRef, done *bool) (err error) {
 	if r.cli != nil {
@@ -98,5 +90,24 @@ func (r *RegistryRequests) List(params *RegistryListParams, done *bool) error {
 		return err
 	}
 	params.Refs = dsRefs
+	return nil
+}
+
+// Get returns a dataset that has been published to the registry
+func (r *RegistryRequests) Get(ref *repo.DatasetRef, res *repo.DatasetRef) error {
+	if r.cli != nil {
+		return r.cli.Call("DatasetRequests.Get", ref, res)
+	}
+
+	// Handle `qri use` to get the current default dataset
+	if err := DefaultSelectedRef(r.node.Repo, ref); err != nil {
+		return err
+	}
+
+	if err := actions.RegistryDataset(r.node, ref); err != nil {
+		return err
+	}
+
+	*res = *ref
 	return nil
 }

--- a/lib/registry_test.go
+++ b/lib/registry_test.go
@@ -2,11 +2,23 @@ package lib
 
 import (
 	"testing"
+	"time"
 
+	"github.com/qri-io/dataset/dsfs"
+	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/registry/regserver/mock"
 )
 
 func TestRegistryRequests(t *testing.T) {
+	// we need to artificially specify the timestamp
+	// we use the dsfs.Timestamp func variable to override
+	// the actual time
+	prevTs := dsfs.Timestamp
+	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
+	defer func() {
+		dsfs.Timestamp = prevTs
+	}()
+
 	reg := mock.NewMemRegistry()
 	cli, _ := mock.NewMockServerRegistry(reg)
 	node := newTestQriNodeRegClient(t, cli)
@@ -20,6 +32,26 @@ func TestRegistryRequests(t *testing.T) {
 	done := false
 	if err := req.Publish(params, &done); err != nil {
 		t.Fatal(err)
+	}
+
+	// test getting a dataset from the registry
+	citiesRef := repo.DatasetRef{
+		Peername: "me",
+		Name:     "cities",
+	}
+	citiesRes := repo.DatasetRef{}
+	if err := req.Get(&citiesRef, &citiesRes); err != nil {
+		t.Error(err)
+	}
+
+	if citiesRes.Path != "/map/QmW3QAZWmLcjS1RyPgYDa59w23k5VeyPHim2b8Zj7z8Zpo" {
+		t.Errorf("error getting dataset from registry, expected path to be '/map/QmW3QAZWmLcjS1RyPgYDa59w23k5VeyPHim2b8Zj7z8Zpo', got %s", citiesRes.Path)
+	}
+	if citiesRes.Dataset == nil {
+		t.Errorf("error getting dataset from registry, dataset is nil")
+	}
+	if citiesRes.Published != true {
+		t.Errorf("error getting dataset from registry, expected published to be 'true'")
 	}
 
 	params = &PublishParams{Ref: ref2, Pin: true}

--- a/lib/registry_test.go
+++ b/lib/registry_test.go
@@ -10,9 +10,8 @@ import (
 )
 
 func TestRegistryRequests(t *testing.T) {
-	// we need to artificially specify the timestamp
-	// we use the dsfs.Timestamp func variable to override
-	// the actual time
+	// to keep hashes consistent, artificially specify the timestamp by overriding
+	// the dsfs.Timestamp func
 	prevTs := dsfs.Timestamp
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 	defer func() {
@@ -40,7 +39,7 @@ func TestRegistryRequests(t *testing.T) {
 		Name:     "cities",
 	}
 	citiesRes := repo.DatasetRef{}
-	if err := req.Get(&citiesRef, &citiesRes); err != nil {
+	if err := req.GetDataset(&citiesRef, &citiesRes); err != nil {
 		t.Error(err)
 	}
 

--- a/repo/ref.go
+++ b/repo/ref.go
@@ -450,6 +450,10 @@ func CanonicalizeProfile(r Repo, ref *DatasetRef, need *NeedPeernameRenames) err
 	if ref.Peername != "" {
 		id, err := r.Profiles().PeernameID(ref.Peername)
 		if err != nil {
+			// TODO: compare to actual error here, not string
+			if err.Error() == "datastore: key not found" {
+				return ErrNotFound
+			}
 			return fmt.Errorf("error fetching peer from store: %s", err)
 		}
 		if ref.ProfileID == "" {


### PR DESCRIPTION
Status is helpful on the cmd, but over the api and on the frontend, we want the actual dataset to be returned. We can infer from the response whether or not the dataset exists on the registry.

this pr adds:
`registryDatasetHandler`
`RegistryRequests.Get`
`actions.RegistryDataset`

and removes:
`statusRegistryHandler`
`RegistryRequests.Status`
`actions.Status`

and adjusts:
`cmd/registry.go` to use `RegistryRequests.Get`
`/registry/` GET endpoint to use `registryDatasetHandler`