### PR TITLE
feat(online): Set Online flag for peers when using lib.Info. Cleanups.

### DIFF
--- a/actions/peers_test.go
+++ b/actions/peers_test.go
@@ -38,8 +38,14 @@ func TestListPeers(t *testing.T) {
 func TestConnectedQriProfiles(t *testing.T) {
 	node := newTestNode(t)
 
-	_, err := ConnectedQriProfiles(node, 100)
+	peers, err := ConnectedQriProfiles(node)
 	if err != nil {
 		t.Error(err.Error())
 	}
+
+	if len(peers) != 0 {
+		t.Errorf("expected 0 connected peers, got %d", len(peers))
+	}
+
+	// TODO: Test for node with at least 1 connected peer
 }


### PR DESCRIPTION
When getting Info for a peer, set the Online flag appropriately, to match the behavior of lib.List (peers.go). Do this by checking the other connected peers that are known to be online, and also checking if you yourself are online.

Cleanup some of the usage around ConnectedQriProfiles.

Fixes part 2 of #577.