### PR TITLE
refactor(config): Rename Config constructors.

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -123,7 +123,7 @@ func (o *SetupOptions) Run(f Factory) error {
 
 // DoSetup executes the setup-ie bit from the setup command
 func (o *SetupOptions) DoSetup(f Factory) (err error) {
-	cfg := config.DefaultConfigWithoutKeys()
+	cfg := config.DefaultConfig()
 
 	envVars := map[string]*string{
 		"QRI_SETUP_CONFIG_DATA":      &o.ConfigData,
@@ -146,7 +146,7 @@ func (o *SetupOptions) DoSetup(f Factory) (err error) {
 	}
 
 	if cfg.P2P == nil {
-		cfg.P2P = config.DefaultP2PWithoutKeys()
+		cfg.P2P = config.DefaultP2P()
 	}
 	if cfg.P2P.PrivKey == "" {
 		privKey, peerID := o.Generator.GeneratePrivateKeyAndPeerID()
@@ -154,7 +154,7 @@ func (o *SetupOptions) DoSetup(f Factory) (err error) {
 		cfg.P2P.PeerID = peerID
 	}
 	if cfg.Profile == nil {
-		cfg.Profile = config.DefaultProfileWithoutKeys()
+		cfg.Profile = config.DefaultProfile()
 	}
 	if cfg.Profile.PrivKey == "" {
 		cfg.Profile.PrivKey = cfg.P2P.PrivKey

--- a/config/config.go
+++ b/config/config.go
@@ -37,18 +37,26 @@ type Config struct {
 	Render *Render
 }
 
-// DefaultConfigWithoutKeys gives a new default configuration without any crypto keys
-func DefaultConfigWithoutKeys() *Config {
+// NOTE: The configuration returned by DefaultConfig is insufficient, as is, to run a functional
+// qri node. In particular, it lacks cryptographic keys and a peerID, which are necessary to
+// join the p2p network. However, these are very expensive to create, so they shouldn't be added
+// to the DefaultConfig, which only does the bare minimum necessary to construct the object. In
+// real use, the only places a Config object comes from are the cmd/setup command, which builds
+// upon DefaultConfig by adding p2p data, and LoadConfig, which parses a serialized config file
+// from the user's repo.
+
+// DefaultConfig gives a new configuration with simple, default settings
+func DefaultConfig() *Config {
 	return &Config{
 		Revision: CurrentConfigRevision,
-		Profile:  DefaultProfileWithoutKeys(),
+		Profile:  DefaultProfile(),
 		Repo:     DefaultRepo(),
 		Store:    DefaultStore(),
 		Registry: DefaultRegistry(),
 
 		CLI:     DefaultCLI(),
 		API:     DefaultAPI(),
-		P2P:     DefaultP2PWithoutKeys(),
+		P2P:     DefaultP2P(),
 		Webapp:  DefaultWebapp(),
 		RPC:     DefaultRPC(),
 		Logging: DefaultLogging(),

--- a/config/migrate/migrate.go
+++ b/config/migrate/migrate.go
@@ -13,7 +13,7 @@ func RunMigrations(streams ioes.IOStreams, cfg *config.Config) (migrated bool, e
 		if err := ZeroToOne(cfg); err != nil {
 			return false, err
 		}
-		streams.Print("done!")
+		streams.Print("done!\n")
 		return true, nil
 	}
 	return false, nil
@@ -29,7 +29,7 @@ func ZeroToOne(cfg *config.Config) error {
 			"/ip4/35.192.140.245/tcp/4001/ipfs/QmUUVNiTz2K9zQSH9PxerKWXmN1p3DBo3oJXurvYziFzqh": true, // EDGI
 		}
 
-		adds := config.NewP2P().QriBootstrapAddrs
+		adds := config.DefaultP2P().QriBootstrapAddrs
 
 		for i, addr := range cfg.P2P.QriBootstrapAddrs {
 			// remove any old, invalid addresses

--- a/config/p2p.go
+++ b/config/p2p.go
@@ -51,13 +51,8 @@ type P2P struct {
 	AutoNAT bool `json:"autoNAT"`
 }
 
-// DefaultP2PWithoutKeys generates a p2p struct without keys or peerID
-func DefaultP2PWithoutKeys() *P2P {
-	return NewP2P()
-}
-
-// NewP2P generates a p2p struct with only addresses, no keys or peer id
-func NewP2P() *P2P {
+// DefaultP2P generates a p2p struct with only bootstrap addresses set
+func DefaultP2P() *P2P {
 	p2p := &P2P{
 		Enabled:         true,
 		HTTPGatewayAddr: "https://ipfs.io",

--- a/config/profile.go
+++ b/config/profile.go
@@ -49,8 +49,8 @@ type ProfilePod struct {
 	NetworkAddrs []string `json:"networkAddrs,omitempty"`
 }
 
-// DefaultProfileWithoutKeys gives a new default profile configuration without keys or peer.ID.
-func DefaultProfileWithoutKeys() *ProfilePod {
+// DefaultProfile gives a new default profile configuration
+func DefaultProfile() *ProfilePod {
 	now := time.Now()
 	return &ProfilePod{
 		Created: now,

--- a/config/test_config.go
+++ b/config/test_config.go
@@ -4,10 +4,10 @@ import (
 	"github.com/qri-io/qri/config/test"
 )
 
-// DefaultConfigForTesting constructs a config with no keys, only used for testing.
+// DefaultConfigForTesting constructs a config with precomputed keys, only used for testing.
 func DefaultConfigForTesting() *Config {
 	info := test.GetTestPeerInfo(0)
-	cfg := DefaultConfigWithoutKeys()
+	cfg := DefaultConfig()
 	cfg.P2P.PrivKey = info.EncodedPrivKey
 	cfg.P2P.PeerID = info.EncodedPeerID
 	cfg.Profile.PrivKey = info.EncodedPrivKey
@@ -15,19 +15,19 @@ func DefaultConfigForTesting() *Config {
 	return cfg
 }
 
-// DefaultProfileForTesting constructs a profile with no keys, only used for testing.
+// DefaultProfileForTesting constructs a profile with precomputed keys, only used for testing.
 func DefaultProfileForTesting() *ProfilePod {
 	info := test.GetTestPeerInfo(0)
-	pro := DefaultProfileWithoutKeys()
+	pro := DefaultProfile()
 	pro.PrivKey = info.EncodedPrivKey
 	pro.ID = info.EncodedPeerID
 	return pro
 }
 
-// DefaultP2PForTesting constructs a p2p with no keys, only used for testing.
+// DefaultP2PForTesting constructs a p2p with precomputed keys, only used for testing.
 func DefaultP2PForTesting() *P2P {
 	info := test.GetTestPeerInfo(0)
-	p := DefaultP2PWithoutKeys()
+	p := DefaultP2P()
 	p.PrivKey = info.EncodedPrivKey
 	p.PeerID = info.EncodedPeerID
 	return p

--- a/lib/peers_test.go
+++ b/lib/peers_test.go
@@ -246,7 +246,7 @@ func newTestDisconnectedQriNode() (*p2p.QriNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	p2pconf := config.NewP2P()
+	p2pconf := config.DefaultP2P()
 	// This Node has P2P disabled.
 	p2pconf.Enabled = false
 	n, err := p2ptest.NewTestNodeFactory(p2p.NewTestableQriNode).NewWithConf(r, p2pconf)

--- a/p2p/test/p2ptest.go
+++ b/p2p/test/p2ptest.go
@@ -45,7 +45,7 @@ func NewTestNodeFactory(maker NodeMakerFunc) *TestNodeFactory {
 func (f *TestNodeFactory) New(r repo.Repo) (TestablePeerNode, error) {
 	info := cfgtest.GetTestPeerInfo(f.count)
 	f.count++
-	p2pconf := config.NewP2P()
+	p2pconf := config.DefaultP2P()
 	p2pconf.PeerID = info.EncodedPeerID
 	p2pconf.PrivKey = info.EncodedPrivKey
 	return f.maker(r, p2pconf)
@@ -116,7 +116,7 @@ func NewTestDirNetwork(ctx context.Context, f *TestNodeFactory) ([]TestablePeerN
 func NewAvailableTestNode(r repo.Repo, f *TestNodeFactory) (TestablePeerNode, error) {
 	info := f.NextInfo()
 	addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/0")
-	p2pconf := config.NewP2P()
+	p2pconf := config.DefaultP2P()
 	p2pconf.Addrs = []ma.Multiaddr{addr}
 	p2pconf.QriBootstrapAddrs = []string{}
 	node, err := f.NewWithConf(r, p2pconf)


### PR DESCRIPTION
Now that no Config constructors are inefficiently adding p2p keys, rename the Default\*WithoutKeys methods so that they are just Default\*. Add a comment to config/config.go explaining that DefaultConfig does not contain any p2p keys, but that cmd/setup.go adds them.