### PR TITLE
fix(cmd): Both body and setup runnable during "qri connect"

### DIFF
--- a/cmd/body.go
+++ b/cmd/body.go
@@ -62,7 +62,6 @@ type BodyOptions struct {
 
 	UsingRPC        bool
 	DatasetRequests *lib.DatasetRequests
-	Repo            repo.Repo
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -72,11 +71,7 @@ func (o *BodyOptions) Complete(f Factory, args []string) (err error) {
 	}
 	o.UsingRPC = f.RPC() != nil
 	o.DatasetRequests, err = f.DatasetRequests()
-	if err != nil {
-		return
-	}
-	o.Repo, err = f.Repo()
-	return
+	return err
 }
 
 // Run executes the body command

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/config"
 	libtest "github.com/qri-io/qri/lib/test"
-	regmock "github.com/qri-io/registry/regserver/mock"
 	"github.com/qri-io/qri/repo/gen"
+	regmock "github.com/qri-io/registry/regserver/mock"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -93,6 +93,8 @@ func (o *ExportOptions) Complete(f Factory, args []string) (err error) {
 	}
 
 	o.DatasetRequests, err = f.DatasetRequests()
+	// TODO (dlong): All other callers of this method have removed their need of it. Remove
+	// this call and then remove it from the factory interface.
 	o.Repo, err = f.Repo()
 	if err != nil {
 		return

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -22,6 +22,8 @@ type Factory interface {
 	QriRepoPath() string
 	CryptoGenerator() gen.CryptoGenerator
 
+	Init() error
+	// TODO (dlong): This function is deprecated. Don't add new calls. Remove it soon.
 	Repo() (repo.Repo, error)
 	Node() (*p2p.QriNode, error)
 	RPC() *rpc.Client

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -85,6 +85,11 @@ func (t TestFactory) CryptoGenerator() gen.CryptoGenerator {
 	return t.generator
 }
 
+// Init will initialize the internal state
+func (t TestFactory) Init() error {
+	return nil
+}
+
 // Repo returns from internal state
 func (t TestFactory) Repo() (repo.Repo, error) {
 	return t.repo, nil

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -113,7 +113,8 @@ func NewQriOptions(qriPath, ipfsPath string, generator gen.CryptoGenerator, ioSt
 	}
 }
 
-func (o *QriOptions) init() (err error) {
+// Init will initialize the internal state
+func (o *QriOptions) Init() (err error) {
 	initBody := func() {
 		cfgPath := filepath.Join(o.qriRepoPath, "config.yaml")
 
@@ -181,7 +182,7 @@ func (o *QriOptions) init() (err error) {
 
 // Config returns from internal state
 func (o *QriOptions) Config() (*config.Config, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	return o.config, nil
@@ -208,8 +209,9 @@ func (o *QriOptions) RPC() *rpc.Client {
 }
 
 // Repo returns from internal state
+// TODO (dlong): This function is deprecated. Don't add new calls. Remove it soon.
 func (o *QriOptions) Repo() (repo.Repo, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	if o.repo == nil {
@@ -220,7 +222,7 @@ func (o *QriOptions) Repo() (repo.Repo, error) {
 
 // Node returns the internal QriNode
 func (o *QriOptions) Node() (*p2p.QriNode, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	if o.repo == nil {
@@ -231,7 +233,7 @@ func (o *QriOptions) Node() (*p2p.QriNode, error) {
 
 // DatasetRequests generates a lib.DatasetRequests from internal state
 func (o *QriOptions) DatasetRequests() (*lib.DatasetRequests, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	return lib.NewDatasetRequests(o.node, o.rpc), nil
@@ -239,7 +241,7 @@ func (o *QriOptions) DatasetRequests() (*lib.DatasetRequests, error) {
 
 // RegistryRequests generates a lib.RegistryRequests from internal state
 func (o *QriOptions) RegistryRequests() (*lib.RegistryRequests, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	return lib.NewRegistryRequests(o.node, o.rpc), nil
@@ -247,7 +249,7 @@ func (o *QriOptions) RegistryRequests() (*lib.RegistryRequests, error) {
 
 // LogRequests generates a lib.LogRequests from internal state
 func (o *QriOptions) LogRequests() (*lib.LogRequests, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	return lib.NewLogRequests(o.node, o.rpc), nil
@@ -255,7 +257,7 @@ func (o *QriOptions) LogRequests() (*lib.LogRequests, error) {
 
 // PeerRequests generates a lib.PeerRequests from internal state
 func (o *QriOptions) PeerRequests() (*lib.PeerRequests, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	return lib.NewPeerRequests(nil, o.rpc), nil
@@ -263,7 +265,7 @@ func (o *QriOptions) PeerRequests() (*lib.PeerRequests, error) {
 
 // ProfileRequests generates a lib.ProfileRequests from internal state
 func (o *QriOptions) ProfileRequests() (*lib.ProfileRequests, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	return lib.NewProfileRequests(o.node, o.rpc), nil
@@ -271,7 +273,7 @@ func (o *QriOptions) ProfileRequests() (*lib.ProfileRequests, error) {
 
 // SelectionRequests creates a lib.SelectionRequests from internal state
 func (o *QriOptions) SelectionRequests() (*lib.SelectionRequests, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	return lib.NewSelectionRequests(o.repo, o.rpc), nil
@@ -279,7 +281,7 @@ func (o *QriOptions) SelectionRequests() (*lib.SelectionRequests, error) {
 
 // SearchRequests generates a lib.SearchRequests from internal state
 func (o *QriOptions) SearchRequests() (*lib.SearchRequests, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	return lib.NewSearchRequests(o.node, o.rpc), nil
@@ -287,7 +289,7 @@ func (o *QriOptions) SearchRequests() (*lib.SearchRequests, error) {
 
 // RenderRequests generates a lib.RenderRequests from internal state
 func (o *QriOptions) RenderRequests() (*lib.RenderRequests, error) {
-	if err := o.init(); err != nil {
+	if err := o.Init(); err != nil {
 		return nil, err
 	}
 	return lib.NewRenderRequests(o.repo, o.rpc), nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -204,10 +204,7 @@ func (o *SetupOptions) DoSetup(f Factory) (err error) {
 		}
 		break
 	}
-
-	// TODO - this call is to trigger initialization
-	_, err = f.Repo()
-	return err
+	return f.Init()
 }
 
 // QRIRepoInitialized checks to see if a repository has been initialized at $QRI_PATH

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -384,7 +384,7 @@ type LookupResult struct {
 // LookupBody retrieves the dataset body
 func (r *DatasetRequests) LookupBody(p *LookupParams, data *LookupResult) (err error) {
 	if r.cli != nil {
-		return r.cli.Call("DatasetRequests.StructuredData", p, data)
+		return r.cli.Call("DatasetRequests.LookupBody", p, data)
 	}
 
 	if p.Limit < 0 || p.Offset < 0 {


### PR DESCRIPTION
Prior to this change, both `qri body` and `qri setup` would fail with "repo not available (are you running qri in another terminal?)" if run while `qri connect` was running. This is due to the face that the repo and ipfs are locked so that only only process touches that at once. The Repo() method on
cmd/factory.go Factory would therefore fail with this error. However, body doesn't actually need to directly touch the repo, and can be run over RPC like other commands. Setup will fail anyway because the repo already exists.

Only `qri export` is now using the Repo() method, we should stop doing that and then remove Repo() if possible.