### PR TITLE
fix(remove): Remove requires the --revisions to specify what to delete

### DIFF
--- a/actions/dataset.go
+++ b/actions/dataset.go
@@ -360,8 +360,8 @@ func SetPublishStatus(node *p2p.QriNode, ref *repo.DatasetRef, published bool) (
 	return base.SetPublishStatus(node.Repo, ref, published)
 }
 
-// RenameDataset alters a dataset name
-func RenameDataset(node *p2p.QriNode, current, new *repo.DatasetRef) (err error) {
+// ModifyDataset alters a reference by changing what dataset it refers to
+func ModifyDataset(node *p2p.QriNode, current, new *repo.DatasetRef, isRename bool) (err error) {
 	r := node.Repo
 	if err := validate.ValidName(new.Name); err != nil {
 		return err
@@ -372,12 +372,16 @@ func RenameDataset(node *p2p.QriNode, current, new *repo.DatasetRef) (err error)
 	}
 	err = repo.CanonicalizeDatasetRef(r, new)
 	if err == nil {
-		return fmt.Errorf("dataset '%s/%s' already exists", new.Peername, new.Name)
+		if isRename {
+			return fmt.Errorf("dataset '%s/%s' already exists", new.Peername, new.Name)
+		}
 	} else if err != repo.ErrNotFound {
 		log.Debug(err.Error())
 		return fmt.Errorf("error with new reference: %s", err.Error())
 	}
-	new.Path = current.Path
+	if isRename {
+		new.Path = current.Path
+	}
 
 	if err = r.DeleteRef(*current); err != nil {
 		return err

--- a/actions/dataset_test.go
+++ b/actions/dataset_test.go
@@ -291,7 +291,7 @@ func testRenameDataset(t *testing.T, rmf RepoMakerFunc) {
 		Peername: "me",
 	}
 
-	if err := RenameDataset(node, &ref, b); err != nil {
+	if err := ModifyDataset(node, &ref, b, true); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -325,7 +325,7 @@ func testEventsLog(t *testing.T, rmf RepoMakerFunc) {
 		ProfileID: ref.ProfileID,
 	}
 
-	if err := RenameDataset(node, &ref, b); err != nil {
+	if err := ModifyDataset(node, &ref, b, true); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -22,6 +22,7 @@ import (
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
+	"github.com/qri-io/qri/rev"
 )
 
 // DatasetHandlers wraps a requests struct to interface with http.HandlerFunc
@@ -541,8 +542,9 @@ func (h *DatasetHandlers) removeHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	res := false
-	if err := h.Remove(ref, &res); err != nil {
+	numDeleted := 0
+	params := lib.RemoveParams{Ref: ref, Revision: rev.Rev{Field: "ds", Gen: -1}}
+	if err := h.Remove(&params, &numDeleted); err != nil {
 		log.Infof("error deleting dataset: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -294,6 +294,86 @@ func TestRemoveOnlyTwoRevisions(t *testing.T) {
 	}
 }
 
+// Test that adding three revision, then removing all of them leaves nothing.
+func TestRemoveAllRevisionsLongForm(t *testing.T) {
+	if err := confirmQriNotRunning(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	r := NewTestRepoRoot(t, "qri_test_remove_only_one_revision")
+	defer r.Delete()
+
+	cmdR := r.CreateCommandRunner()
+	_, err := executeCommand(cmdR, "qri save --body=testdata/movies/body_ten.csv me/test_movies")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	cmdR = r.CreateCommandRunner()
+	_, err = executeCommand(cmdR, "qri save --body=testdata/movies/body_twenty.csv me/test_movies")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	cmdR = r.CreateCommandRunner()
+	_, err = executeCommand(cmdR, "qri save --body=testdata/movies/body_thirty.csv me/test_movies")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	cmdR = r.CreateCommandRunner()
+	_, err = executeCommand(cmdR, "qri remove me/test_movies --revisions=all")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// Read path for dataset, which shouldn't exist anymore.
+	dsPath := r.GetPathForDataset(0)
+	if dsPath != "" {
+		t.Errorf("expected dataset to be removed entirely, found at \"%s\"", dsPath)
+	}
+}
+
+// Test that adding three revision, then removing all of them leaves nothing, using --all.
+func TestRemoveAllRevisionsShortForm(t *testing.T) {
+	if err := confirmQriNotRunning(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	r := NewTestRepoRoot(t, "qri_test_remove_only_one_revision")
+	defer r.Delete()
+
+	cmdR := r.CreateCommandRunner()
+	_, err := executeCommand(cmdR, "qri save --body=testdata/movies/body_ten.csv me/test_movies")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	cmdR = r.CreateCommandRunner()
+	_, err = executeCommand(cmdR, "qri save --body=testdata/movies/body_twenty.csv me/test_movies")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	cmdR = r.CreateCommandRunner()
+	_, err = executeCommand(cmdR, "qri save --body=testdata/movies/body_thirty.csv me/test_movies")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	cmdR = r.CreateCommandRunner()
+	_, err = executeCommand(cmdR, "qri remove me/test_movies --all")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// Read path for dataset, which shouldn't exist anymore.
+	dsPath := r.GetPathForDataset(0)
+	if dsPath != "" {
+		t.Errorf("expected dataset to be removed entirely, found at \"%s\"", dsPath)
+	}
+}
+
 // TODO: Perhaps this utility should move to a lower package, and be used as a way to validate the
 // bodies of dataset in more of our test case. That would require extracting some parts out, like
 // pathFactory, which would probably necessitate the pathFactory taking the testRepoRoot as a
@@ -384,6 +464,11 @@ func (r *TestRepoRoot) GetPathForDataset(index int) string {
 	err = json.Unmarshal([]byte(bytes), &result)
 	if err != nil {
 		r.t.Fatal(err)
+	}
+
+	// If dataset doesn't exist, return an empty string for the path.
+	if len(result) == 0 {
+		return ""
 	}
 
 	var dsPath string

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/qri-io/dataset/dsfs"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/lib"
+	"github.com/qri-io/qri/rev"
 )
 
 func TestRemoveComplete(t *testing.T) {
@@ -106,15 +107,16 @@ func TestRemoveRun(t *testing.T) {
 
 	cases := []struct {
 		args     []string
+		revision int
 		expected string
 		err      string
 		msg      string
 	}{
-		{[]string{}, "", "", ""},
-		{[]string{"me/bad_dataset"}, "", "repo: not found", "could not find dataset 'peer/bad_dataset'"},
-		{[]string{"me/movies"}, "removed dataset 'peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/Qme8h7HtAPAjjkUJcoSHWt6NXVvQjvUFCtyK7u66qN6gyV'\n", "", ""},
-		{[]string{"me/cities", "me/counter"}, "removed dataset 'peer/cities@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmVQBd1UF2qehbQ4PsMGy7fmcRZ8as3G6zNmnzqcJ2qyTn'\nremoved dataset 'peer/counter@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmUu4aj4aQN5seAJUXxjBLgWuMwtXR5GYumV7McpF6w8a3'\n", "", ""},
-		{[]string{"me/movies"}, "", "repo: not found", "could not find dataset 'peer/movies'"},
+		{[]string{}, -1, "", "", ""},
+		{[]string{"me/bad_dataset"}, -1, "", "repo: not found", "could not find dataset 'peer/bad_dataset'"},
+		{[]string{"me/movies"}, -1, "removed entire dataset 'peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/Qme8h7HtAPAjjkUJcoSHWt6NXVvQjvUFCtyK7u66qN6gyV'\n", "", ""},
+		{[]string{"me/cities", "me/counter"}, -1, "removed entire dataset 'peer/cities@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmVQBd1UF2qehbQ4PsMGy7fmcRZ8as3G6zNmnzqcJ2qyTn'\nremoved entire dataset 'peer/counter@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmUu4aj4aQN5seAJUXxjBLgWuMwtXR5GYumV7McpF6w8a3'\n", "", ""},
+		{[]string{"me/movies"}, -1, "", "repo: not found", "could not find dataset 'peer/movies'"},
 	}
 
 	for i, c := range cases {
@@ -127,6 +129,7 @@ func TestRemoveRun(t *testing.T) {
 		opt := &RemoveOptions{
 			IOStreams:       streams,
 			Args:            c.args,
+			Revision:        rev.Rev{Field: "ds", Gen: c.revision},
 			DatasetRequests: dsr,
 		}
 

--- a/cmd/testdata/movies/body_thirty.csv
+++ b/cmd/testdata/movies/body_thirty.csv
@@ -1,0 +1,29 @@
+movie_title,duration
+Avatar ,178
+Pirates of the Caribbean: At World's End ,169
+Spectre ,148
+The Dark Knight Rises ,164
+Star Wars: Episode VII - The Force Awakens             ,
+John Carter ,132
+Spider-Man 3 ,156
+Tangled ,100
+Avengers: Age of Ultron ,141
+Harry Potter and the Half-Blood Prince ,153
+Batman v Superman: Dawn of Justice ,183
+Superman Returns ,169
+Quantum of Solace ,106
+Pirates of the Caribbean: Dead Man's Chest ,151
+The Lone Ranger ,150
+Man of Steel ,143
+The Chronicles of Narnia: Prince Caspian ,150
+The Avengers ,173
+Dragonfly ,104
+The Black Dahlia ,121
+Flyboys ,140
+The Last Castle ,131
+Supernova ,91
+Winter's Tale ,118
+The Mortal Instruments: City of Bones ,130
+Meet Dave ,90
+Dark Water ,103
+Edtv ,122

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/qri-io/qri/p2p/test"
 	"github.com/qri-io/qri/repo"
 	testrepo "github.com/qri-io/qri/repo/test"
+	"github.com/qri-io/qri/rev"
 	regmock "github.com/qri-io/registry/regserver/mock"
 )
 
@@ -525,8 +526,9 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 	req := NewDatasetRequests(node, nil)
 	for i, c := range cases {
-		got := false
-		err := req.Remove(c.p, &got)
+		numDeleted := 0
+		params := RemoveParams{Ref: c.p, Revision: rev.Rev{Field: "ds", Gen: -1}}
+		err := req.Remove(&params, &numDeleted)
 
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch: expected: %s, got: %s", i, c.err, err)

--- a/lib/params.go
+++ b/lib/params.go
@@ -4,7 +4,9 @@ import (
 	"net/http"
 
 	util "github.com/datatogether/api/apiutil"
+	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
+	"github.com/qri-io/qri/rev"
 )
 
 // DefaultPageSize is the max number of items in a page if no
@@ -71,4 +73,10 @@ func (lp ListParams) Page() util.Page {
 	}
 	number = lp.Offset/size + 1
 	return util.NewPage(number, size)
+}
+
+// RemoveParams defines parameters for remove command
+type RemoveParams struct {
+	Ref      *repo.DatasetRef
+	Revision rev.Rev
 }

--- a/rev/rev.go
+++ b/rev/rev.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Rev names a field of a dataset at a snapshot
@@ -53,7 +51,7 @@ func ParseRev(rev string) (*Rev, error) {
 	if ok {
 		return &Rev{Gen: 1, Field: field}, nil
 	}
-	return nil, errors.New(fmt.Sprintf("unrecognized revision field: %s", rev))
+	return nil, fmt.Errorf("unrecognized revision field: %s", rev)
 }
 
 var fieldMap = map[string]string{

--- a/rev/rev.go
+++ b/rev/rev.go
@@ -8,6 +8,7 @@ package rev
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -20,6 +21,9 @@ type Rev struct {
 	// the nth-generational ancestor of a history
 	Gen int
 }
+
+// AllGenerations represents all the generations of a dataset's history
+const AllGenerations = -1
 
 // ParseRevs turns a comma-separated list of revisions into a slice of revisions
 func ParseRevs(str string) (revs []*Rev, err error) {
@@ -35,14 +39,21 @@ func ParseRevs(str string) (revs []*Rev, err error) {
 
 // ParseRev turns a string into a revision
 func ParseRev(rev string) (*Rev, error) {
-	field, ok := fieldMap[rev]
-	if !ok {
-		return nil, errors.New(fmt.Sprintf("unrecognized revision field: %s", rev))
+	// Check for "all".
+	if rev == "all" {
+		return &Rev{Gen: AllGenerations, Field: "ds"}, nil
 	}
-	return &Rev{
-		Gen:   1,
-		Field: field,
-	}, nil
+	// Check for integer.
+	num, err := strconv.Atoi(rev)
+	if err == nil {
+		return &Rev{Gen: num, Field: "ds"}, nil
+	}
+	// Check for field name.
+	field, ok := fieldMap[rev]
+	if ok {
+		return &Rev{Gen: 1, Field: field}, nil
+	}
+	return nil, errors.New(fmt.Sprintf("unrecognized revision field: %s", rev))
 }
 
 var fieldMap = map[string]string{

--- a/rev/rev.go
+++ b/rev/rev.go
@@ -54,6 +54,11 @@ func ParseRev(rev string) (*Rev, error) {
 	return nil, fmt.Errorf("unrecognized revision field: %s", rev)
 }
 
+// NewAllRevisions returns a Rev struct that represents all revisions.
+func NewAllRevisions() Rev {
+	return Rev{Field: "ds", Gen: AllGenerations}
+}
+
 var fieldMap = map[string]string{
 	"dataset":   "ds",
 	"meta":      "md",

--- a/rev/rev_test.go
+++ b/rev/rev_test.go
@@ -14,6 +14,11 @@ func TestParseRevs(t *testing.T) {
 		{"", []*Rev{}, "unrecognized revision field: "},
 		{"body", []*Rev{&Rev{"bd", 1}}, ""},
 		{"md", []*Rev{&Rev{"md", 1}}, ""},
+		{"ds", []*Rev{&Rev{"ds", 1}}, ""},
+		{"1", []*Rev{&Rev{"ds", 1}}, ""},
+		{"2", []*Rev{&Rev{"ds", 2}}, ""},
+		{"3", []*Rev{&Rev{"ds", 3}}, ""},
+		{"all", []*Rev{&Rev{"ds", AllGenerations}}, ""},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
New flag --revisions is now required by remove. If set to an integer greater than zero, will remove that many revisions, starting from newest. If set to "all", will remove the dataset entirely (the old behavior).