### PR TITLE
fix(list): Listing a non-existant profile should not crash

### DIFF
--- a/actions/list_datasets.go
+++ b/actions/list_datasets.go
@@ -45,8 +45,11 @@ func ListDatasets(node *p2p.QriNode, ds *repo.DatasetRef, limit, offset int, RPC
 				pro = p
 			}
 		}
-		if pro == nil {
+		if err != nil {
 			return nil, fmt.Errorf("couldn't find profile: %s", err.Error())
+		}
+		if pro == nil {
+			return nil, fmt.Errorf("profile not found: \"%s\"", ds.Peername)
 		}
 
 		if len(pro.PeerIDs) == 0 {

--- a/actions/list_datasets_test.go
+++ b/actions/list_datasets_test.go
@@ -19,3 +19,17 @@ func TestListDatasets(t *testing.T) {
 		t.Error("expected one dataset response")
 	}
 }
+
+func TestListDatasetsNotFound(t *testing.T) {
+	node := newTestNode(t)
+	addCitiesDataset(t, node)
+
+	_, err := ListDatasets(node, &repo.DatasetRef{Peername: "not_found"}, 1, 0, false, false)
+	if err == nil {
+		t.Error("expected to get error")
+	}
+	expect := "profile not found: \"not_found\""
+	if expect != err.Error() {
+		t.Errorf("expected error \"%s\", got \"%s\"", expect, err.Error())
+	}
+}


### PR DESCRIPTION
Before, running `qri list not_found` would try to deref a nil error value, leading to a crash. Instead, check if the returned profile pointer is null and print an appropriate error.