### PR TITLE
fix(export): Export can be used while running `qri connect`

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -101,12 +101,12 @@ func (o *ConnectOptions) Complete(f Factory, args []string) (err error) {
 		return fmt.Errorf("no qri repo exists")
 	}
 
-	// TODO - calling f.Node has the side effect of
-	// calling init if we haven't initialized so far. Should this be made
-	// more explicit?
-	o.Node, err = f.Node()
-	if err != nil {
+	if err = f.Init(); err != nil {
 		return err
+	}
+	o.Node, err = f.ConnectionNode()
+	if err != nil {
+		return fmt.Errorf("%s, is `qri connect` already running?", err)
 	}
 	o.Config, err = f.Config()
 	return

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -9,7 +9,6 @@ import (
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/p2p"
-	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/gen"
 )
 
@@ -23,14 +22,13 @@ type Factory interface {
 	CryptoGenerator() gen.CryptoGenerator
 
 	Init() error
-	// TODO (dlong): This function is deprecated. Don't add new calls. Remove it soon.
-	Repo() (repo.Repo, error)
-	Node() (*p2p.QriNode, error)
 	RPC() *rpc.Client
+	ConnectionNode() (*p2p.QriNode, error)
 
 	DatasetRequests() (*lib.DatasetRequests, error)
 	RegistryRequests() (*lib.RegistryRequests, error)
 	LogRequests() (*lib.LogRequests, error)
+	ExportRequests() (*lib.ExportRequests, error)
 	PeerRequests() (*lib.PeerRequests, error)
 	ProfileRequests() (*lib.ProfileRequests, error)
 	SearchRequests() (*lib.SearchRequests, error)

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -90,13 +90,8 @@ func (t TestFactory) Init() error {
 	return nil
 }
 
-// Repo returns from internal state
-func (t TestFactory) Repo() (repo.Repo, error) {
-	return t.repo, nil
-}
-
 // Node returns the internal qri node from state
-func (t TestFactory) Node() (*p2p.QriNode, error) {
+func (t TestFactory) ConnectionNode() (*p2p.QriNode, error) {
 	return t.node, nil
 }
 
@@ -118,6 +113,11 @@ func (t TestFactory) RegistryRequests() (*lib.RegistryRequests, error) {
 // LogRequests generates a lib.LogRequests from internal state
 func (t TestFactory) LogRequests() (*lib.LogRequests, error) {
 	return lib.NewLogRequests(t.node, t.rpc), nil
+}
+
+// ExportRequests generates a lib.ExportRequests from internal state
+func (t TestFactory) ExportRequests() (*lib.ExportRequests, error) {
+	return lib.NewExportRequests(t.node, t.rpc), nil
 }
 
 // PeerRequests generates a lib.PeerRequests from internal state

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -208,25 +208,10 @@ func (o *QriOptions) RPC() *rpc.Client {
 	return o.rpc
 }
 
-// Repo returns from internal state
-// TODO (dlong): This function is deprecated. Don't add new calls. Remove it soon.
-func (o *QriOptions) Repo() (repo.Repo, error) {
-	if err := o.Init(); err != nil {
-		return nil, err
-	}
+// ConnectionNode returns the internal QriNode, if it is available
+func (o *QriOptions) ConnectionNode() (*p2p.QriNode, error) {
 	if o.repo == nil {
-		return nil, fmt.Errorf("repo not available (are you running qri in another terminal?)")
-	}
-	return o.repo, nil
-}
-
-// Node returns the internal QriNode
-func (o *QriOptions) Node() (*p2p.QriNode, error) {
-	if err := o.Init(); err != nil {
-		return nil, err
-	}
-	if o.repo == nil {
-		return nil, fmt.Errorf("repo not available (are you running qri in another terminal?)")
+		return nil, fmt.Errorf("repo not available")
 	}
 	return o.node, nil
 }
@@ -253,6 +238,14 @@ func (o *QriOptions) LogRequests() (*lib.LogRequests, error) {
 		return nil, err
 	}
 	return lib.NewLogRequests(o.node, o.rpc), nil
+}
+
+// ExportRequests generates a lib.ExportRequests from internal state
+func (o *QriOptions) ExportRequests() (*lib.ExportRequests, error) {
+	if err := o.Init(); err != nil {
+		return nil, err
+	}
+	return lib.NewExportRequests(o.node, o.rpc), nil
 }
 
 // PeerRequests generates a lib.PeerRequests from internal state

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -76,11 +76,16 @@ func TestRenderRun(t *testing.T) {
 
 	templateFile := cafs.NewMemfileBytes("template.html", []byte(`<html><h2>{{.Peername}}/{{.Name}}</h2></html>`))
 
-	r, err := f.Repo()
-	if err != nil {
-		t.Errorf("error getting repo from factory: %s", err)
+	if err := f.Init(); err != nil {
+		t.Errorf("error initializing: %s", err)
 		return
 	}
+	node, err := f.ConnectionNode()
+	if err != nil {
+		t.Errorf("error getting node from factory: %s", err)
+		return
+	}
+	r := node.Repo
 
 	key, err := r.Store().Put(templateFile, false)
 	if err != nil {

--- a/lib/export.go
+++ b/lib/export.go
@@ -1,0 +1,176 @@
+package lib
+
+import (
+	"fmt"
+	"net/rpc"
+	"os"
+	"path/filepath"
+
+	"github.com/qri-io/dataset/dsutil"
+	"github.com/qri-io/qri/actions"
+	"github.com/qri-io/qri/p2p"
+)
+
+// ExportRequests encapsulates business logic of export operation
+type ExportRequests struct {
+	node *p2p.QriNode
+	cli  *rpc.Client
+}
+
+// CoreRequestsName implements the Requests interface
+func (r ExportRequests) CoreRequestsName() string { return "export" }
+
+// NewExportRequests creates a ExportRequests pointer from either a repo
+// or an rpc.Client
+func NewExportRequests(node *p2p.QriNode, cli *rpc.Client) *ExportRequests {
+	if node != nil && cli != nil {
+		panic(fmt.Errorf("both node and client supplied to NewExportRequests"))
+	}
+	return &ExportRequests{
+		node: node,
+		cli:  cli,
+	}
+}
+
+// Export exports a dataset in the specified format
+func (r *ExportRequests) Export(p *ExportParams, ok *bool) error {
+	if r.cli != nil {
+		return r.cli.Call("ExportRequests.Export", p, ok)
+	}
+
+	ref := p.Ref
+
+	// Handle `qri use` to get the current default dataset.
+	if err := DefaultSelectedRef(r.node.Repo, &ref); err != nil {
+		return err
+	}
+
+	if err := actions.DatasetHead(r.node, &ref); err != nil {
+		return err
+	}
+
+	ds, err := ref.DecodeDataset()
+	if err != nil {
+		return err
+	}
+
+	profile, err := r.node.Repo.Profile()
+	if err != nil {
+		return err
+	}
+
+	var path string
+	if p.PeerDir {
+		peerName := ref.Peername
+		if peerName == "me" {
+			peerName = profile.Peername
+		}
+		path = filepath.Join(path, peerName)
+	}
+	path = filepath.Join(path, ref.Name)
+
+	// TODO (dlong): When --zip flag is not required, don't always do this.
+	dst, err := os.Create(fmt.Sprintf("%s.zip", path))
+	if err != nil {
+		return err
+	}
+
+	store := r.node.Repo.Store()
+
+	// TODO (dlong): Use --body-format here to convert the body and ds.Structure.Format, before
+	// passing ds to WriteZipArchive.
+	if err = dsutil.WriteZipArchive(store, ds, p.Format, ref.String(), dst); err != nil {
+		return err
+	}
+	*ok = true
+	return dst.Close()
+
+	// TODO (dlong): Document the full functionality of export, and restore this code below. Allow
+	// non-zip formats like dataset.json with inline body, body.json by itself, outputting to a
+	// a directory, along with yaml, and xlsx.
+	/*if path != "" {
+		if err = os.MkdirAll(path, os.ModePerm); err != nil {
+			return err
+		}
+	}
+
+	if !o.NoBody {
+		if bodyFormat == "" {
+			bodyFormat = ds.Structure.Format.String()
+		}
+
+		df, err := dataset.ParseDataFormatString(bodyFormat)
+		if err != nil {
+			return err
+		}
+
+		p := &lib.LookupParams{
+			Format: df,
+			Path:   ds.Path().String(),
+			All:    true,
+		}
+		r := &lib.LookupResult{}
+
+		if err = o.DatasetRequests.LookupBody(p, r); err != nil {
+			return err
+		}
+
+		dataPath := filepath.Join(path, fmt.Sprintf("data.%s", bodyFormat))
+		dst, err := os.Create(dataPath)
+		if err != nil {
+			return err
+		}
+
+		if p.Format == dataset.CBORDataFormat {
+			r.Data = []byte(hex.EncodeToString(r.Data))
+		}
+		if _, err = dst.Write(r.Data); err != nil {
+			return err
+		}
+
+		if err = dst.Close(); err != nil {
+			return err
+		}
+		printSuccess(o.Out, "exported data to: %s", dataPath)
+	}
+
+	dsPath := filepath.Join(path, dsfs.PackageFileDataset.String())
+	var dsBytes []byte
+
+	switch format {
+	case "json":
+		dsBytes, err = json.MarshalIndent(ds, "", "  ")
+		if err != nil {
+			return err
+		}
+	default:
+		dsBytes, err = yaml.Marshal(ds)
+		if err != nil {
+			return err
+		}
+		dsPath = fmt.Sprintf("%s.yaml", strings.TrimSuffix(dsPath, filepath.Ext(dsPath)))
+	}
+	if err = ioutil.WriteFile(dsPath, dsBytes, os.ModePerm); err != nil {
+		return err
+	}
+
+	if ds.Transform != nil && ds.Transform.ScriptPath != "" {
+		f, err := o.Repo.Store().Get(datastore.NewKey(ds.Transform.ScriptPath))
+		if err != nil {
+			return err
+		}
+		scriptData, err := ioutil.ReadAll(f)
+		if err != nil {
+			return err
+		}
+		// TODO - transformations should have default file extensions
+		if err = ioutil.WriteFile(filepath.Join(path, "transform.sky"), scriptData, os.ModePerm); err != nil {
+			return err
+		}
+		printSuccess(o.Out, "exported transform script to: %s", filepath.Join(path, "transform.sky"))
+	}
+
+	printSuccess(o.Out, "exported dataset.json to: %s", dsPath)
+
+	return nil*/
+}

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -37,6 +37,7 @@ func Receivers(node *p2p.QriNode) []Requests {
 		NewDatasetRequests(node, nil),
 		NewRegistryRequests(node, nil),
 		NewLogRequests(node, nil),
+		NewExportRequests(node, nil),
 		NewPeerRequests(node, nil),
 		NewProfileRequests(node, nil),
 		NewSearchRequests(node, nil),

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -57,8 +57,8 @@ func TestReceivers(t *testing.T) {
 
 	node := n.(*p2p.QriNode)
 	reqs := Receivers(node)
-	if len(reqs) != 8 {
-		t.Errorf("unexpected number of receivers returned. expected: %d. got: %d\nhave you added/removed a receiver?", 8, len(reqs))
+	if len(reqs) != 9 {
+		t.Errorf("unexpected number of receivers returned. expected: %d. got: %d\nhave you added/removed a receiver?", 9, len(reqs))
 		return
 	}
 }

--- a/lib/params.go
+++ b/lib/params.go
@@ -80,3 +80,10 @@ type RemoveParams struct {
 	Ref      *repo.DatasetRef
 	Revision rev.Rev
 }
+
+// ExportParams defines parameters for the export method
+type ExportParams struct {
+	Ref     repo.DatasetRef
+	PeerDir bool
+	Format  string
+}


### PR DESCRIPTION
Move the main functionality of export down to lib/. Invoke the RPC call if needed. Remove the Repo method from Factory, and make the Node method more explicit (only `qri connect` needs it). Now all commands can be run while connected.

Fixes https://github.com/qri-io/qri/issues/661.