### PR TITLE
fix(export): Write exported file to pwd where command is run.

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -133,8 +133,15 @@ func (o *ExportOptions) Run() error {
 		return err
 	}
 
+	// TOOD (dlong): Handle -o flag, use it to get target directory.
+	root := "."
+	if err = lib.AbsPath(&root); err != nil {
+		return err
+	}
+
 	p := &lib.ExportParams{
 		Ref:     ref,
+		RootDir: root,
 		PeerDir: false,
 		Format:  format,
 	}

--- a/lib/export.go
+++ b/lib/export.go
@@ -59,7 +59,8 @@ func (r *ExportRequests) Export(p *ExportParams, ok *bool) error {
 		return err
 	}
 
-	var path string
+	// TODO (dlong): The -o option, once it is implemened, can be used to calculate `path`.
+	path := p.RootDir
 	if p.PeerDir {
 		peerName := ref.Peername
 		if peerName == "me" {

--- a/lib/params.go
+++ b/lib/params.go
@@ -84,6 +84,7 @@ type RemoveParams struct {
 // ExportParams defines parameters for the export method
 type ExportParams struct {
 	Ref     repo.DatasetRef
+	RootDir string
 	PeerDir bool
 	Format  string
 }


### PR DESCRIPTION
Prior to this, an exported file would write to a file in the directory of a terminal running `qri connect`, instead of the terminal that ran the export command. Fix this by passing the path to the RPC.

Fixes https://github.com/qri-io/qri/issues/669.