### PR TITLE
feat: Ipfs api

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -45,7 +45,7 @@ new dataset, use --blank.`,
 	}
 
 	cmd.Flags().BoolVarP(&o.Blank, "blank", "", false, "export a blank dataset YAML file, overrides all other flags except output")
-	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "path to write to, default is current directory")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", ".", "path to write to, default is current directory")
 	cmd.Flags().StringVarP(&o.Format, "format", "f", "yaml", "format for all exported files, except for body. yaml is the default format. options: yaml, json")
 	cmd.Flags().StringVarP(&o.BodyFormat, "body-format", "", "", "format for dataset body. default is the original data format. options: json, csv, cbor")
 	cmd.Flags().BoolVarP(&o.NoBody, "no-body", "b", false, "don't include dataset body in export")
@@ -133,15 +133,13 @@ func (o *ExportOptions) Run() error {
 		return err
 	}
 
-	// TOOD (dlong): Handle -o flag, use it to get target directory.
-	root := "."
-	if err = lib.AbsPath(&root); err != nil {
+	if err = lib.AbsPath(&path); err != nil {
 		return err
 	}
 
 	p := &lib.ExportParams{
 		Ref:     ref,
-		RootDir: root,
+		RootDir: path,
 		PeerDir: false,
 		Format:  format,
 	}

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -145,10 +145,16 @@ func (o *QriOptions) Init() (err error) {
 		}
 
 		var fs *ipfs.Filestore
-		fs, err = ipfs.NewFilestore(func(cfg *ipfs.StoreCfg) {
-			cfg.FsRepoPath = o.ipfsFsPath
-			// cfg.Online = online
-		})
+
+		fsOpts := []ipfs.Option{
+			func(cfg *ipfs.StoreCfg) {
+				cfg.FsRepoPath = o.ipfsFsPath
+				// cfg.Online = online
+			},
+			ipfs.OptsFromMap(o.config.Store.Options),
+		}
+
+		fs, err = ipfs.NewFilestore(fsOpts...)
 		if err != nil {
 			return
 		}

--- a/config/store.go
+++ b/config/store.go
@@ -4,13 +4,17 @@ import "github.com/qri-io/jsonschema"
 
 // Store configures a qri content addessed file store (cafs)
 type Store struct {
-	Type string `json:"type"`
+	Type    string                 `json:"type"`
+	Options map[string]interface{} `json:"options,omitempty"`
 }
 
 // DefaultStore returns a new default Store configuration
 func DefaultStore() *Store {
 	return &Store{
 		Type: "ipfs",
+		Options: map[string]interface{}{
+			"api": true,
+		},
 	}
 }
 
@@ -38,7 +42,8 @@ func (cfg Store) Validate() error {
 // Copy returns a deep copy of the Store struct
 func (cfg *Store) Copy() *Store {
 	res := &Store{
-		Type: cfg.Type,
+		Type:    cfg.Type,
+		Options: cfg.Options,
 	}
 
 	return res


### PR DESCRIPTION
depends on qri-io/cafs#21.

This adds a new "Options" object to store configuration, which after recent upgrades to github.com/qri-io/cafs/ipfs, supports configuring qri's IPFS node to enable the IPFS HTTP API and optionally support for pubsub.

To enable both, config.yaml's `store` should now look like this:

```yaml
store:
  type: "ipfs"
  options:
    api: true
    pubsub: true
```

if `store.options.api` is set to `true` it will use the IPFS config to figure out what address to bind the api to (in ipfs that defaults to localhost:5001).

with both api and pubsub activated, it's possible to talk to the underlying pubsub api by supplying an `--api` flag to the go-ipfs binary (version 0.4.18 or higher):
1. run `qri connect` in a terminal 
2. in another terminal: `ipfs --api /ip4/127.0.0.1/tcp/5001/ pubsub sub foo` should hang. 
3. in a third terminal `ipfs --api /ip4/127.0.0.1/tcp/5001/ pubsub pub foo bar` should publish `bar` to the second terminal. fun!

This `--api` flag trick should work for nearly all ipfs commands, which is a _huge_ win for us, and will end me constantly having to stop & start qri to get back to regular IPFS stuff.