### PR TITLE
fix(get): Fix get command using a dotted path

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -71,7 +71,7 @@ type GetOptions struct {
 }
 
 // isDatasetField checks if a string is a dataset field or not
-var isDatasetField = regexp.MustCompile("(?i)^(commit|structure|body|meta|viz|transform)$")
+var isDatasetField = regexp.MustCompile("(?i)^(commit|structure|body|meta|viz|transform)($|\\.)")
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *GetOptions) Complete(f Factory, args []string) (err error) {

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -25,6 +25,7 @@ func TestGetComplete(t *testing.T) {
 		{[]string{}, "", []string{}, ""},
 		{[]string{"one arg"}, "", []string{"one arg"}, ""},
 		{[]string{"commit", "peer/ds"}, "commit", []string{"peer/ds"}, ""},
+		{[]string{"commit.author", "peer/ds"}, "commit.author", []string{"peer/ds"}, ""},
 		{[]string{"peer/ds_two", "peer/ds"}, "", []string{"peer/ds_two", "peer/ds"}, ""},
 		{[]string{"foo", "peer/ds"}, "", []string{"foo", "peer/ds"}, ""},
 		{[]string{"structure"}, "structure", []string{}, ""},


### PR DESCRIPTION
Commit 97410fbecde broke the ability to use `get` command to retrieve a path with multiple fields, for example `qri get commit.author me/ds`. This restores that functionality, and adds a test.