### PR TITLE
fix(save): Improve error message if new ds has no body or structure

### DIFF
--- a/actions/dataset.go
+++ b/actions/dataset.go
@@ -101,6 +101,11 @@ func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string
 		return
 	}
 
+	if prevPath == "" && changes.BodyFile() == nil && changes.Structure == nil {
+		err = fmt.Errorf("creating a new dataset requires a structure or a body")
+		return
+	}
+
 	if changes.BodyFile() != nil && prev.Structure != nil && changes.Structure != nil && prev.Structure.Format != changes.Structure.Format {
 		if convertFormatToPrev {
 			var f qfs.File

--- a/actions/dataset_test.go
+++ b/actions/dataset_test.go
@@ -260,6 +260,24 @@ func TestSaveDataset(t *testing.T) {
 	}
 }
 
+
+func TestSaveDatasetWithoutStructureOrBody(t *testing.T) {
+	n := newTestNode(t)
+
+	ds := &dataset.Dataset{
+		Name:      "no_st_or_body_test",
+		Meta: &dataset.Meta{
+			Title: "test title",
+		},
+	}
+
+	_, err := SaveDataset(n, ds, nil, nil, false, false, false)
+	expect := "creating a new dataset requires a structure or a body"
+	if err == nil || err.Error() != expect {
+		t.Errorf("expected error, but got %s", err.Error())
+	}
+}
+
 type RepoMakerFunc func(t *testing.T) repo.Repo
 type RepoTestFunc func(t *testing.T, rmf RepoMakerFunc)
 


### PR DESCRIPTION
The old error message was "invalid dataset: structure is required", coming from https://github.com/qri-io/dataset/blob/bd4df7ad41d13b78a6ce1ed786e112319dbba210/validate/dataset.go#L33. This one more accurately describes what's going on.