### PR TITLE
docs: Change contributor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Breaking that down:
 - Specific to **datasets** because data deserves purpose-built tools
 - **version control** to keep data in sync, attributing all changes to authors
 - On the **distributed web** to make *all* of the data published on qri simultaneously available, letting peers work on data together.
+
 If you’re unfamiliar with *version control,* particularly the distributed kind, well you're probably viewing this document on [github](https://github.com/qri-io/qri) — which is a version control system intended for code. Its underlying technology – git – popularized some magic sauce that has inspired a generation of programmers and popularized concepts at the heart of the distributed web. Qri is applying that family of concepts to four common data problems:
 
 1. **Discovery** _Can I find data I’m looking for?_

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
     <a href="#packages">
       Packages
     </a>
-
     <span> | </span>
     <a href="https://github.com/qri-io/qri/blob/master/CONTRIBUTOR.md">
       Contribute
@@ -63,7 +62,6 @@ Breaking that down:
 - Specific to **datasets** because data deserves purpose-built tools
 - **version control** to keep data in sync, attributing all changes to authors
 - On the **distributed web** to make *all* of the data published on qri simultaneously available, letting peers work on data together.
-
 If you’re unfamiliar with *version control,* particularly the distributed kind, well you're probably viewing this document on [github](https://github.com/qri-io/qri) — which is a version control system intended for code. Its underlying technology – git – popularized some magic sauce that has inspired a generation of programmers and popularized concepts at the heart of the distributed web. Qri is applying that family of concepts to four common data problems:
 
 1. **Discovery** _Can I find data I’m looking for?_

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
       Packages
     </a>
     <span> | </span>
-    <a href="https://github.com/qri-io/qri/blob/master/.github/CONTRIBUTING.md">
+    <a href="https://github.com/qri-io/qri/blob/master/CONTRIBUTOR.md">
       Contribute
     </a>
     <span> | </span>
@@ -62,7 +62,7 @@ Breaking that down:
 - Specific to **datasets** because data deserves purpose-built tools
 - **version control** to keep data in sync, attributing all changes to authors
 - On the **distributed web** to make *all* of the data published on qri simultaneously available, letting peers work on data together.
- 
+
 If you’re unfamiliar with *version control,* particularly the distributed kind, well you're probably viewing this document on [github](https://github.com/qri-io/qri) — which is a version control system intended for code. Its underlying technology – git – popularized some magic sauce that has inspired a generation of programmers and popularized concepts at the heart of the distributed web. Qri is applying that family of concepts to four common data problems:
 
 1. **Discovery** _Can I find data I’m looking for?_

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     <a href="#packages">
       Packages
     </a>
+
     <span> | </span>
     <a href="https://github.com/qri-io/qri/blob/master/CONTRIBUTOR.md">
       Contribute
@@ -51,7 +52,7 @@
 | "I want to download Qri" | [Download Qri](https://qri.io/download) |
 | "I have a question" | [Create an issue](https://github.com/qri-io/qri/issues) and use the label 'question' |
 | "I found a bug" | [Create an issue](https://github.com/qri-io/qri/issues) and use the label 'bug' |
-| "I want to help build the Qri backend" | [Read the Contributing guides](https://github.com/qri-io/qri/blob/master/.github/CONTRIBUTING.md) |
+| "I want to help build the Qri backend" | [Read the Contributing guides](https://github.com/qri-io/qri/blob/master/CONTRIBUTOR.md) |
 | "I want to build Qri from source" | [Build Qri from source](#build)
 
 __qri is a global dataset version control system (GDVCS) built on the distributed web__


### PR DESCRIPTION
Current contributor link in the heading of README goes to a 404 page, this fixes it