### PR TITLE
feat(lib.Datasets.Save): add force flag to skip empty-commit checking

### DIFF
--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p-crypto"
-	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/dataset/dstest"
 	"github.com/qri-io/qfs"
+	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qfs/httpfs"
 	"github.com/qri-io/qfs/localfs"
 	"github.com/qri-io/qfs/muxfs"
@@ -116,7 +116,7 @@ func addCitiesDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 		t.Fatal(err.Error())
 	}
 
-	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false)
+	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -129,7 +129,7 @@ func addFlourinatedCompoundsDataset(t *testing.T, node *p2p.QriNode) repo.Datase
 		t.Fatal(err.Error())
 	}
 
-	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false)
+	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -145,7 +145,7 @@ func addNowTransformDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	// this was put here to satisfy qri-io/qri/actions.TestUpdateDatasetLocal
 	tc.Input.Peername = "peer"
 
-	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false)
+	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/actions/dataset.go
+++ b/actions/dataset.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SaveDataset initializes a dataset from a dataset pointer and data file
-func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string]string, scriptOut io.Writer, dryRun, pin, convertFormatToPrev bool) (ref repo.DatasetRef, err error) {
+func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string]string, scriptOut io.Writer, dryRun, pin, convertFormatToPrev, force bool) (ref repo.DatasetRef, err error) {
 	var (
 		prevPath string
 		pro      *profile.Profile
@@ -87,7 +87,7 @@ func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string
 	// let's make history, if it exists:
 	changes.PreviousPath = prevPath
 
-	return base.CreateDataset(r, node.LocalStreams, changes, prev, dryRun, pin)
+	return base.CreateDataset(r, node.LocalStreams, changes, prev, dryRun, pin, force)
 }
 
 // UpdateRemoteDataset brings a reference to the latest version, syncing to the

--- a/actions/dataset_test.go
+++ b/actions/dataset_test.go
@@ -52,7 +52,7 @@ func TestUpdateRemoteDataset(t *testing.T) {
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
 
 	// run a local update to advance history
-	now0, err := SaveDataset(peers[0], ds, nil, nil, false, true, false)
+	now0, err := SaveDataset(peers[0], ds, nil, nil, false, true, false, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -120,7 +120,7 @@ func TestSaveDataset(t *testing.T) {
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
 
-	ref, err := SaveDataset(n, ds, nil, nil, true, false, false)
+	ref, err := SaveDataset(n, ds, nil, nil, true, false, false, false)
 	if err != nil {
 		t.Errorf("dry run error: %s", err.Error())
 	}
@@ -143,7 +143,7 @@ func TestSaveDataset(t *testing.T) {
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
 
 	// test save
-	ref, err = SaveDataset(n, ds, nil, nil, false, true, false)
+	ref, err = SaveDataset(n, ds, nil, nil, false, true, false, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -173,7 +173,7 @@ func TestSaveDataset(t *testing.T) {
 	ds.Transform.OpenScriptFile(nil)
 
 	// dryrun should work
-	ref, err = SaveDataset(n, ds, secrets, nil, true, false, false)
+	ref, err = SaveDataset(n, ds, secrets, nil, true, false, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestSaveDataset(t *testing.T) {
 	ds.Transform.OpenScriptFile(nil)
 
 	// test save with transform
-	ref, err = SaveDataset(n, ds, secrets, nil, false, true, false)
+	ref, err = SaveDataset(n, ds, secrets, nil, false, true, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestSaveDataset(t *testing.T) {
 		},
 	}
 
-	ref, err = SaveDataset(n, ds, nil, nil, false, true, false)
+	ref, err = SaveDataset(n, ds, nil, nil, false, true, false, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -247,7 +247,7 @@ func TestSaveDataset(t *testing.T) {
 		t.Error(err)
 	}
 
-	ref, err = SaveDataset(n, ds, secrets, nil, false, true, false)
+	ref, err = SaveDataset(n, ds, secrets, nil, false, true, false, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -256,18 +256,17 @@ func TestSaveDataset(t *testing.T) {
 	}
 }
 
-
 func TestSaveDatasetWithoutStructureOrBody(t *testing.T) {
 	n := newTestNode(t)
 
 	ds := &dataset.Dataset{
-		Name:      "no_st_or_body_test",
+		Name: "no_st_or_body_test",
 		Meta: &dataset.Meta{
 			Title: "test title",
 		},
 	}
 
-	_, err := SaveDataset(n, ds, nil, nil, false, false, false)
+	_, err := SaveDataset(n, ds, nil, nil, false, false, false, false)
 	expect := "creating a new dataset requires a structure or a body"
 	if err == nil || err.Error() != expect {
 		t.Errorf("expected error, but got %s", err.Error())

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -477,6 +477,7 @@ func (h *DatasetHandlers) saveHandler(w http.ResponseWriter, r *http.Request) {
 		Private:             r.FormValue("private") == "true",
 		DryRun:              r.FormValue("dry_run") == "true",
 		ReturnBody:          r.FormValue("return_body") == "true",
+		Force:               r.FormValue("force") == "true",
 		ConvertFormatToPrev: true,
 		ScriptOutput:        scriptOutput,
 	}

--- a/base/base_test.go
+++ b/base/base_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p-crypto"
-	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/dataset/dstest"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qfs"
+	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
 	"github.com/qri-io/registry/regserver/mock"
@@ -62,7 +62,7 @@ func addCitiesDataset(t *testing.T, r repo.Repo) repo.DatasetRef {
 		t.Fatal(err.Error())
 	}
 
-	ref, err := CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true)
+	ref, err := CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -94,7 +94,7 @@ func updateCitiesDataset(t *testing.T, r repo.Repo) repo.DatasetRef {
 		tc.Input.PreviousPath = ""
 	}()
 
-	ref, err = CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true)
+	ref, err = CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -107,7 +107,7 @@ func addFlourinatedCompoundsDataset(t *testing.T, r repo.Repo) repo.DatasetRef {
 		t.Fatal(err.Error())
 	}
 
-	ref, err := CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true)
+	ref, err := CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/base/dataset.go
+++ b/base/dataset.go
@@ -108,7 +108,7 @@ func ListDatasets(r repo.Repo, limit, offset int, RPC, publishedOnly bool) (res 
 // CreateDataset uses dsfs to add a dataset to a repo's store, updating all
 // references within the repo if successful. CreateDataset is a lower-level
 // component of github.com/qri-io/qri/actions.CreateDataset
-func CreateDataset(r repo.Repo, streams ioes.IOStreams, ds, dsPrev *dataset.Dataset, dryRun, pin bool) (ref repo.DatasetRef, err error) {
+func CreateDataset(r repo.Repo, streams ioes.IOStreams, ds, dsPrev *dataset.Dataset, dryRun, pin, force bool) (ref repo.DatasetRef, err error) {
 	var (
 		pro     *profile.Profile
 		path    string
@@ -124,7 +124,7 @@ func CreateDataset(r repo.Repo, streams ioes.IOStreams, ds, dsPrev *dataset.Data
 		return
 	}
 
-	if path, err = dsfs.CreateDataset(r.Store(), ds, dsPrev, r.PrivateKey(), pin); err != nil {
+	if path, err = dsfs.CreateDataset(r.Store(), ds, dsPrev, r.PrivateKey(), pin, force); err != nil {
 		return
 	}
 	if ds.PreviousPath != "" && ds.PreviousPath != "/" {

--- a/base/dataset_test.go
+++ b/base/dataset_test.go
@@ -74,11 +74,11 @@ func TestCreateDataset(t *testing.T) {
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
 
-	if _, err := CreateDataset(r, streams, &dataset.Dataset{}, &dataset.Dataset{}, false, true); err == nil {
+	if _, err := CreateDataset(r, streams, &dataset.Dataset{}, &dataset.Dataset{}, false, true, false); err == nil {
 		t.Error("expected bad dataset to error")
 	}
 
-	ref, err := CreateDataset(r, streams, ds, &dataset.Dataset{}, false, true)
+	ref, err := CreateDataset(r, streams, ds, &dataset.Dataset{}, false, true, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -96,7 +96,7 @@ func TestCreateDataset(t *testing.T) {
 
 	prev := ref.Dataset
 
-	ref, err = CreateDataset(r, streams, ds, prev, false, true)
+	ref, err = CreateDataset(r, streams, ds, prev, false, true, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -106,6 +106,19 @@ func TestCreateDataset(t *testing.T) {
 	}
 	if len(refs) != 1 {
 		t.Errorf("ref length mismatch. expected 1, got: %d", len(refs))
+	}
+
+	ds.PreviousPath = ref.Path
+	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
+	prev = ref.Dataset
+
+	if ref, err = CreateDataset(r, streams, ds, prev, false, true, false); err == nil {
+		t.Error("expected unchanged dataset with no force flag to error")
+	}
+
+	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
+	if ref, err = CreateDataset(r, streams, ds, prev, false, true, true); err != nil {
+		t.Errorf("unexpected force-save error: %s", err)
 	}
 }
 
@@ -328,7 +341,7 @@ func TestDatasetPinning(t *testing.T) {
 		return
 	}
 
-	ref2, err := CreateDataset(r, streams, tc.Input, nil, false, false)
+	ref2, err := CreateDataset(r, streams, tc.Input, nil, false, false, false)
 	if err != nil {
 		t.Error(err.Error())
 		return

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -65,6 +65,7 @@ commit message and title to the save.`,
 	cmd.Flags().StringSliceVar(&o.Secrets, "secrets", nil, "transform secrets as comma separated key,value,key,value,... sequence")
 	cmd.Flags().BoolVarP(&o.Publish, "publish", "p", false, "publish this dataset to the registry")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "simulate saving a dataset")
+	cmd.Flags().BoolVar(&o.Force, "force", false, "force a new commit, even if no changes are detected")
 	cmd.Flags().BoolVarP(&o.KeepFormat, "keep-format", "k", false, "convert incoming data to stored data format")
 
 	return cmd
@@ -86,6 +87,7 @@ type SaveOptions struct {
 	Publish        bool
 	DryRun         bool
 	KeepFormat     bool
+	Force          bool
 	Secrets        []string
 
 	DatasetRequests *lib.DatasetRequests
@@ -145,6 +147,7 @@ func (o *SaveOptions) Run() (err error) {
 		DryRun:              o.DryRun,
 		Recall:              o.Recall,
 		ConvertFormatToPrev: o.KeepFormat,
+		Force:               o.Force,
 	}
 
 	if o.Secrets != nil {

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -204,6 +204,8 @@ type SaveParams struct {
 	ConvertFormatToPrev bool
 	// string of references to recall before saving
 	Recall string
+	// force a new commit, even if no changes are detected
+	Force bool
 	// optional writer to have transform script record standard output to
 	// note: this won't work over RPC, only on local calls
 	ScriptOutput io.Writer
@@ -255,7 +257,8 @@ func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) 
 	if ds.Name == "" {
 		return fmt.Errorf("name is required")
 	}
-	if ds.BodyPath == "" &&
+	if !p.Force &&
+		ds.BodyPath == "" &&
 		ds.Body == nil &&
 		ds.BodyBytes == nil &&
 		ds.Structure == nil &&
@@ -269,7 +272,7 @@ func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) 
 		return
 	}
 
-	ref, err := actions.SaveDataset(r.node, ds, p.Secrets, p.ScriptOutput, p.DryRun, true, p.ConvertFormatToPrev)
+	ref, err := actions.SaveDataset(r.node, ds, p.Secrets, p.ScriptOutput, p.DryRun, true, p.ConvertFormatToPrev, p.Force)
 	if err != nil {
 		log.Debugf("create ds error: %s\n", err.Error())
 		return err

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -140,6 +140,24 @@ func TestDatasetRequestsSave(t *testing.T) {
 	}
 }
 
+func TestDatasetRequestsForceSave(t *testing.T) {
+	node := newTestQriNode(t)
+	ref := addCitiesDataset(t, node)
+	r := NewDatasetRequests(node, nil)
+
+	res := &repo.DatasetRef{}
+	if err := r.Save(&SaveParams{Dataset: &dataset.Dataset{Name: ref.Name, Peername: ref.Peername}}, res); err == nil {
+		t.Error("expected empty save without force flag to error")
+	}
+
+	if err := r.Save(&SaveParams{
+		Dataset: &dataset.Dataset{Name: ref.Name, Peername: ref.Peername},
+		Force:   true,
+	}, res); err != nil {
+		t.Errorf("expected empty save with flag to not error. got: %s", err.Error())
+	}
+}
+
 func TestDatasetRequestsSaveRecall(t *testing.T) {
 	node := newTestQriNode(t)
 	ref := addNowTransformDataset(t, node)

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	crypto "github.com/libp2p/go-libp2p-crypto"
-	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/dataset/dstest"
 	"github.com/qri-io/qfs"
+	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/actions"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/p2p/test"
@@ -79,7 +79,7 @@ func addCitiesDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	ds.Name = tc.Name
 	ds.BodyBytes = tc.Body
 
-	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false)
+	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -95,7 +95,7 @@ func addNowTransformDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	ds.Name = tc.Name
 	ds.Transform.ScriptPath = "testdata/now_tf/transform.star"
 
-	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false)
+	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/p2p/log_diff_test.go
+++ b/p2p/log_diff_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/dataset/dstest"
 	"github.com/qri-io/ioes"
+	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/base"
 	p2ptest "github.com/qri-io/qri/p2p/test"
 )
@@ -31,7 +31,7 @@ func TestRequestLogDiff(t *testing.T) {
 	}
 
 	// add a dataset to peer 4
-	ref, err := base.CreateDataset(peers[4].Repo, streams, tc.Input, nil, false, true)
+	ref, err := base.CreateDataset(peers[4].Repo, streams, tc.Input, nil, false, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestRequestLogDiff(t *testing.T) {
 	update.Name = tc.Name
 
 	// add an update on peer 4
-	ref2, err := base.CreateDataset(peers[4].Repo, streams, update, tc.Input, false, true)
+	ref2, err := base.CreateDataset(peers[4].Repo, streams, update, tc.Input, false, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/log_test.go
+++ b/p2p/log_test.go
@@ -29,7 +29,7 @@ func TestRequestDatasetLog(t *testing.T) {
 	}
 
 	// add a dataset to tim
-	ref, err := base.CreateDataset(peers[4].Repo, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true)
+	ref, err := base.CreateDataset(peers[4].Repo, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/libp2p/go-libp2p-crypto"
-	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dstest"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qfs"
+	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qfs/httpfs"
 	"github.com/qri-io/qfs/localfs"
 	"github.com/qri-io/qfs/muxfs"
@@ -177,7 +177,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (err error) {
 		ds.Commit.Author = &dataset.User{ID: pro.ID.String()}
 	}
 
-	_, err = base.CreateDataset(r, ioes.NewDiscardIOStreams(), ds, nil, false, true)
+	_, err = base.CreateDataset(r, ioes.NewDiscardIOStreams(), ds, nil, false, true, false)
 	return
 }
 


### PR DESCRIPTION
adds a new option to `lib.DatasetRequests().Save()` that forces new commit creation even if `no meaningful changes` are detected.