### PR TITLE
feat(fill_struct): Json and yaml deserialization rewrite

### DIFF
--- a/base/fill_struct.go
+++ b/base/fill_struct.go
@@ -22,6 +22,7 @@ func FillStruct(fields map[string]interface{}, output interface{}) error {
 type KeyValSetter interface {
 	SetKeyVal(string, interface{}) error
 }
+
 // TODO (dlong): Implement this interface for dataset.Meta. It currently has the similar method
 // `Set`, which does more than needed, since it assigns to any field, not just the private map.
 
@@ -76,6 +77,11 @@ func putFieldsToTargetStruct(fields map[string]interface{}, target reflect.Value
 			num, ok := val.(int)
 			if ok {
 				field.SetInt(int64(num))
+				continue
+			}
+			numFloat, ok := val.(float64)
+			if ok {
+				field.SetInt(int64(numFloat))
 				continue
 			}
 			errs = append(errs, fmt.Sprintf("field %s type int, value %s", fieldName, val))

--- a/base/fill_struct.go
+++ b/base/fill_struct.go
@@ -1,0 +1,195 @@
+package base
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// FillStruct fills in the values of an arbitrary structure using an already deserialized
+// map of nested data. Fields names are case-insensitive. Unknown fields are treated as an
+// error, *unless* the output structure implementes the KeyValSetter interface.
+func FillStruct(fields map[string]interface{}, output interface{}) error {
+	target := reflect.ValueOf(output)
+	if target.Kind() == reflect.Ptr {
+		target = target.Elem()
+	}
+	return putFieldsToTargetStruct(fields, target)
+}
+
+// KeyValSetter should be implemented by structs that can store arbitrary fields in a private map.
+type KeyValSetter interface {
+	SetKeyVal(string, interface{}) error
+}
+// TODO (dlong): Implement this interface for dataset.Meta. It currently has the similar method
+// `Set`, which does more than needed, since it assigns to any field, not just the private map.
+
+// timeObj is used for reflect.TypeOf
+var timeObj time.Time
+
+// putFieldsToTargetStruct iterates over the fields in the target struct, and assigns each
+// field the value from the `fields` map. Recursively call this for an sub structures. Field
+// names are treated as case-insensitive. Return any errors found during this process, or nil if
+// there are no errors.
+func putFieldsToTargetStruct(fields map[string]interface{}, target reflect.Value) error {
+	if target.Kind() != reflect.Struct {
+		return fmt.Errorf("can only put fields to a struct")
+	}
+
+	// Collect errors that occur in this single call, at the end of the function, join them
+	// using newlines, if any exist.
+	errs := make([]string, 0)
+
+	// Collect real key names used by the `fields` map.
+	realKeys := make([]string, 0)
+	for k := range fields {
+		realKeys = append(realKeys, k)
+	}
+	// Handle case-insensitivity by building a map from lowercase keys to real keys.
+	caseMap := make(map[string]string)
+	for i := 0; i < len(realKeys); i++ {
+		realKey := realKeys[i]
+		lowerKey := strings.ToLower(realKey)
+		caseMap[lowerKey] = realKey
+	}
+
+	// Keep track of which keys have been used from the `fields` map
+	usedKeys := make(map[string]bool)
+
+	for i := 0; i < target.NumField(); i++ {
+		// Lowercase the key in order to make matching case-insensitive.
+		fieldName := target.Type().Field(i).Name
+		lowerName := strings.ToLower(fieldName)
+
+		val := fields[caseMap[lowerName]]
+		if val == nil {
+			// Nothing to assign to this field, go to next.
+			continue
+		}
+		usedKeys[caseMap[lowerName]] = true
+
+		// Dispatch on kind of field.
+		field := target.Field(i)
+		switch field.Kind() {
+		case reflect.Int:
+			num, ok := val.(int)
+			if ok {
+				field.SetInt(int64(num))
+				continue
+			}
+			errs = append(errs, fmt.Sprintf("field %s type int, value %s", fieldName, val))
+		case reflect.String:
+			text, ok := val.(string)
+			if ok {
+				field.SetString(text)
+				continue
+			}
+			errs = append(errs, fmt.Sprintf("field %s type string, value %s", fieldName, val))
+		case reflect.Struct:
+			// Specially handle time.Time, represented as a string, which needs to be parsed.
+			if field.Type() == reflect.TypeOf(timeObj) {
+				timeText, ok := val.(string)
+				if ok {
+					ts, err := time.Parse(time.RFC3339, timeText)
+					if err == nil {
+						field.Set(reflect.ValueOf(ts))
+						continue
+					}
+					errs = append(errs, err.Error())
+					continue
+				}
+				errs = append(errs, fmt.Sprintf("field %s type time, value %s", fieldName, val))
+				continue
+			}
+			// Other struct types are not handled currently. Should probably do the same thing
+			// as what's done for `pointer` below.
+			errs = append(errs, fmt.Sprintf("unknown struct %s for field %s\n", field.Type(), fieldName))
+		case reflect.Map:
+			m, ok := val.(map[string]interface{})
+			if ok {
+				field.Set(reflect.ValueOf(m))
+				continue
+			}
+			errs = append(errs, fmt.Sprintf("field %s type map, value %s", fieldName, val))
+		case reflect.Ptr:
+			// Allocate a new pointer for the sub-component to be filled in.
+			alloc := reflect.New(field.Type().Elem())
+			field.Set(alloc)
+			inner := alloc.Elem()
+			// For now, can only point to a struct.
+			if inner.Kind() != reflect.Struct {
+				errs = append(errs, fmt.Sprintf("can only assign to *struct @ %s", fieldName))
+				continue
+			}
+			// Struct must be assigned from a map.
+			component, err := toStringMap(val)
+			if err != nil {
+				errs = append(errs, err.Error())
+				continue
+			}
+			// Recursion to handle sub-component.
+			err = putFieldsToTargetStruct(component, inner)
+			if err != nil {
+				errs = append(errs, err.Error())
+			}
+		default:
+			errs = append(errs, fmt.Sprintf("unknown kind %s, field name %s (IMPLEMENT ME)", field.Kind(), fieldName))
+		}
+	}
+
+	// If the target struct is able, assign unknown keys to it.
+	arbitrarySetter := getArbitraryKeyValSetter(target)
+
+	// Iterate over keys in the `fields` data, see if there were any keys that were not stored in
+	// the target struct.
+	for i := 0; i < len(realKeys); i++ {
+		k := realKeys[i]
+		if _, ok := usedKeys[k]; !ok {
+			// If target struct allows storing unknown keys to a map of arbitrary data.
+			if arbitrarySetter != nil {
+				arbitrarySetter.SetKeyVal(k, fields[k])
+				continue
+			}
+			// Otherwise, unknown fields are an error.
+			errs = append(errs, fmt.Sprintf("field \"%s\" not found in target", k))
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s", strings.Join(errs, "\n"))
+}
+
+// toStringMap converts the input to a map[string] if able. This is needed because, while JSON
+// correctly deserializes sub structures to map[string], YAML instead deserializes to
+// map[interface{}]interface{}, so we need to manually convert this case to map[string].
+func toStringMap(val interface{}) (map[string]interface{}, error) {
+	m, ok := val.(map[string]interface{})
+	if ok {
+		return m, nil
+	}
+	imap, ok := val.(map[interface{}]interface{})
+	if ok {
+		convert := make(map[string]interface{})
+		for k, v := range imap {
+			convert[fmt.Sprintf("%v", k)] = v
+		}
+		return convert, nil
+	}
+	return nil, fmt.Errorf("could not convert to map[string]")
+}
+
+// getArbitraryKeyValSetter returns a KeyValSetter if the target implements it.
+func getArbitraryKeyValSetter(target reflect.Value) KeyValSetter {
+	if !target.CanAddr() {
+		return nil
+	}
+	ptr := target.Addr()
+	iface := ptr.Interface()
+	if s, ok := iface.(KeyValSetter); ok {
+		return s
+	}
+	return nil
+}

--- a/base/fill_struct.go
+++ b/base/fill_struct.go
@@ -18,9 +18,9 @@ func FillStruct(fields map[string]interface{}, output interface{}) error {
 	return putFieldsToTargetStruct(fields, target)
 }
 
-// KeyValSetter should be implemented by structs that can store arbitrary fields in a private map.
-type KeyValSetter interface {
-	SetKeyVal(string, interface{}) error
+// ArbitrarySetter should be implemented by structs that can store arbitrary fields in a private map.
+type ArbitrarySetter interface {
+	SetArbitrary(string, interface{}) error
 }
 
 // TODO (dlong): Implement this interface for dataset.Meta. It currently has the similar method
@@ -78,7 +78,7 @@ func putFieldsToTargetStruct(fields map[string]interface{}, target reflect.Value
 	}
 
 	// If the target struct is able, assign unknown keys to it.
-	arbitrarySetter := getArbitraryKeyValSetter(target)
+	arbitrarySetter := getArbitrarySetter(target)
 
 	// Iterate over keys in the `fields` data, see if there were any keys that were not stored in
 	// the target struct.
@@ -87,7 +87,7 @@ func putFieldsToTargetStruct(fields map[string]interface{}, target reflect.Value
 		if _, ok := usedKeys[k]; !ok {
 			// If target struct allows storing unknown keys to a map of arbitrary data.
 			if arbitrarySetter != nil {
-				arbitrarySetter.SetKeyVal(k, fields[k])
+				arbitrarySetter.SetArbitrary(k, fields[k])
 				continue
 			}
 			// Otherwise, unknown fields are an error.
@@ -229,15 +229,15 @@ func toStringMap(val interface{}) (map[string]interface{}, error) {
 	return nil, fmt.Errorf("could not convert to map[string]")
 }
 
-// getArbitraryKeyValSetter returns a KeyValSetter if the target implements it.
-func getArbitraryKeyValSetter(target reflect.Value) KeyValSetter {
+// getArbitrarySetter returns a ArbitrarySetter if the target implements it.
+func getArbitrarySetter(target reflect.Value) ArbitrarySetter {
 	if !target.CanAddr() {
 		return nil
 	}
 	ptr := target.Addr()
 	iface := ptr.Interface()
-	if s, ok := iface.(KeyValSetter); ok {
-		return s
+	if setter, ok := iface.(ArbitrarySetter); ok {
+		return setter
 	}
 	return nil
 }

--- a/base/fill_struct.go
+++ b/base/fill_struct.go
@@ -9,7 +9,7 @@ import (
 
 // FillStruct fills in the values of an arbitrary structure using an already deserialized
 // map of nested data. Fields names are case-insensitive. Unknown fields are treated as an
-// error, *unless* the output structure implementes the KeyValSetter interface.
+// error, *unless* the output structure implementes the ArbitrarySetter interface.
 func FillStruct(fields map[string]interface{}, output interface{}) error {
 	target := reflect.ValueOf(output)
 	if target.Kind() == reflect.Ptr {
@@ -22,9 +22,6 @@ func FillStruct(fields map[string]interface{}, output interface{}) error {
 type ArbitrarySetter interface {
 	SetArbitrary(string, interface{}) error
 }
-
-// TODO (dlong): Implement this interface for dataset.Meta. It currently has the similar method
-// `Set`, which does more than needed, since it assigns to any field, not just the private map.
 
 // timeObj and ifaceObj are used for reflect.TypeOf
 var timeObj time.Time

--- a/base/fill_struct_test.go
+++ b/base/fill_struct_test.go
@@ -1,0 +1,40 @@
+package base
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/qri-io/dataset"
+)
+
+func TestFillStruct(t *testing.T) {
+	jsonData := `{
+  "Name": "test_name",
+  "ProfileID": "test_profile_id",
+  "Qri": "qri:0"
+}`
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var ds dataset.Dataset
+	err = FillStruct(data, &ds)
+	if err != nil {
+		panic(err)
+	}
+
+	if ds.Name != "test_name" {
+		t.Errorf("expected: ds.Name should be \"test_name\", got: %s", ds.Name)
+	}
+	if ds.ProfileID != "test_profile_id" {
+		t.Errorf("expected: ds.ProfileID should be \"test_profile_id\", got: %s", ds.Name)
+	}
+	if ds.Qri != "qri:0" {
+		t.Errorf("expected: ds.Qri should be \"qri:0\", got: %s", ds.Qri)
+	}
+}
+
+// TODO (dlong): More tests

--- a/base/fill_struct_test.go
+++ b/base/fill_struct_test.go
@@ -3,8 +3,10 @@ package base
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/qri-io/dataset"
+	"gopkg.in/yaml.v2"
 )
 
 func TestFillStruct(t *testing.T) {
@@ -37,4 +39,162 @@ func TestFillStruct(t *testing.T) {
 	}
 }
 
-// TODO (dlong): More tests
+func TestFillCommitTimestamp(t *testing.T) {
+	jsonData := `{
+  "Name": "test_commit_timestamp",
+  "Commit": {
+    "Timestamp": "1999-03-31T19:30:00.000Z"
+  }
+}`
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var ds dataset.Dataset
+	err = FillStruct(data, &ds)
+	if err != nil {
+		panic(err)
+	}
+
+	loc := time.FixedZone("UTC", 0)
+	expect := time.Date(1999, 03, 31, 19, 30, 0, 0, loc)
+
+	if ds.Name != "test_commit_timestamp" {
+		t.Errorf("expected: ds.Name should be \"test_name\", got: %s", ds.Name)
+	}
+	if !ds.Commit.Timestamp.Equal(expect) {
+		t.Errorf("expected: timestamp expected %s, got: %s", expect, ds.Commit.Timestamp)
+	}
+}
+
+func TestFillStructInsensitive(t *testing.T) {
+	jsonData := `{
+  "name": "test_name",
+  "pRoFiLeId": "test_profile_id",
+  "QRI": "qri:0"
+}`
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var ds dataset.Dataset
+	err = FillStruct(data, &ds)
+	if err != nil {
+		panic(err)
+	}
+
+	if ds.Name != "test_name" {
+		t.Errorf("expected: ds.Name should be \"test_name\", got: %s", ds.Name)
+	}
+	if ds.ProfileID != "test_profile_id" {
+		t.Errorf("expected: ds.ProfileID should be \"test_profile_id\", got: %s", ds.Name)
+	}
+	if ds.Qri != "qri:0" {
+		t.Errorf("expected: ds.Qri should be \"qri:0\", got: %s", ds.Qri)
+	}
+}
+
+func TestFillStructUnknownFields(t *testing.T) {
+	jsonData := `{
+  "Name": "test_name",
+  "ProfileID": "test_profile_id",
+  "Qri": "qri:0",
+  "Unknown": "value"
+}`
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var ds dataset.Dataset
+	err = FillStruct(data, &ds)
+	if err == nil {
+		t.Errorf("expected: error for unknown field, but no error returned")
+	}
+
+	expect := "field \"Unknown\" not found in target"
+	if err.Error() != expect {
+		t.Errorf("expected: expect: \"%s\", got: \"%s\"", expect, err.Error())
+	}
+}
+
+func TestFillStructYaml(t *testing.T) {
+	yamlData := `name: test_name
+profileID: test_profile_id
+qri: qri:0
+`
+
+	data := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte(yamlData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var ds dataset.Dataset
+	err = FillStruct(data, &ds)
+	if err != nil {
+		panic(err)
+	}
+
+	if ds.Name != "test_name" {
+		t.Errorf("expected: ds.Name should be \"test_name\", got: %s", ds.Name)
+	}
+	if ds.ProfileID != "test_profile_id" {
+		t.Errorf("expected: ds.ProfileID should be \"test_profile_id\", got: %s", ds.Name)
+	}
+	if ds.Qri != "qri:0" {
+		t.Errorf("expected: ds.Qri should be \"qri:0\", got: %s", ds.Qri)
+	}
+}
+
+type Collection struct {
+	More map[string]interface{}
+	Name string
+	Age  int
+}
+
+func (c *Collection) SetKeyVal(key string, val interface{}) error {
+	if c.More == nil {
+		c.More = make(map[string]interface{})
+	}
+	c.More[key] = val
+	return nil
+}
+
+func TestFillCollection(t *testing.T) {
+	jsonData := `{
+  "Name": "Alice",
+  "Age": 42,
+  "Unknown": "value"
+}`
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var c Collection
+	err = FillStruct(data, &c)
+	if err != nil {
+		panic(err)
+	}
+
+	if c.Name != "Alice" {
+		t.Errorf("expected: c.Name should be \"Alice\", got: %s", c.Name)
+	}
+	if c.Age != 42 {
+		t.Errorf("expected: c.Age should be 42, got: %d", c.Age)
+	}
+	if c.More["Unknown"] != "value" {
+		t.Errorf("expected: c.More[\"Unknown\"] should be \"value\", got: %s", c.More["Unknown"])
+	}
+}

--- a/base/fill_struct_test.go
+++ b/base/fill_struct_test.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -159,6 +160,8 @@ type Collection struct {
 	More map[string]interface{}
 	Name string
 	Age  int
+	IsOn bool
+	Xpos float64
 }
 
 func (c *Collection) SetKeyVal(key string, val interface{}) error {
@@ -169,7 +172,7 @@ func (c *Collection) SetKeyVal(key string, val interface{}) error {
 	return nil
 }
 
-func TestFillCollection(t *testing.T) {
+func TestFillKeyValSetter(t *testing.T) {
 	jsonData := `{
   "Name": "Alice",
   "Age": 42,
@@ -196,5 +199,121 @@ func TestFillCollection(t *testing.T) {
 	}
 	if c.More["Unknown"] != "value" {
 		t.Errorf("expected: c.More[\"Unknown\"] should be \"value\", got: %s", c.More["Unknown"])
+	}
+}
+
+func TestFillBoolean(t *testing.T) {
+	jsonData := `{
+  "Name": "Bob",
+  "IsOn": true
+}`
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var c Collection
+	err = FillStruct(data, &c)
+	if err != nil {
+		panic(err)
+	}
+
+	if c.Name != "Bob" {
+		t.Errorf("expected: c.Name should be \"Alice\", got: %s", c.Name)
+	}
+	if c.IsOn != true {
+		t.Errorf("expected: c.IsOn should be true, got: %v", c.IsOn)
+	}
+}
+
+func TestFillFloatingPoint(t *testing.T) {
+	jsonData := `{
+  "Name": "Carol",
+  "Xpos": 6.283
+}`
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var c Collection
+	err = FillStruct(data, &c)
+	if err != nil {
+		panic(err)
+	}
+
+	if c.Name != "Carol" {
+		t.Errorf("expected: c.Name should be \"Alice\", got: %s", c.Name)
+	}
+	if c.Xpos != 6.283 {
+		t.Errorf("expected: c.Xpos should be 6.283, got: %v", c.Xpos)
+	}
+}
+
+func TestFillMetaKeywords(t *testing.T) {
+	jsonData := `{
+  "Keywords": [
+    "Test0",
+    "Test1",
+    "Test2"
+  ]
+}`
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var meta dataset.Meta
+	err = FillStruct(data, &meta)
+	if err != nil {
+		panic(err)
+	}
+
+	expect := []string{"Test0", "Test1", "Test2"}
+	if !reflect.DeepEqual(meta.Keywords, expect) {
+		t.Errorf("expected: c.Keywords should expect: %s, got: %s", expect, meta.Keywords)
+	}
+}
+
+func TestFillMetaCitations(t *testing.T) {
+	jsonData := `{
+  "Citations": [
+    {
+      "Name": "A website",
+      "URL": "http://example.com",
+      "Email": "me@example.com"
+    }
+  ]
+}`
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		panic(err)
+	}
+
+	var meta dataset.Meta
+	err = FillStruct(data, &meta)
+	if err != nil {
+		panic(err)
+	}
+
+	expect := dataset.Meta{
+		Citations: []*dataset.Citation{
+			&dataset.Citation{
+				Name:  "A website",
+				URL:   "http://example.com",
+				Email: "me@example.com",
+			},
+		},
+	}
+	if !reflect.DeepEqual(meta, expect) {
+		t.Errorf("expected: c.Keywords should expect: %s, got: %s", expect, meta.Keywords)
 	}
 }

--- a/base/fill_struct_test.go
+++ b/base/fill_struct_test.go
@@ -164,7 +164,7 @@ type Collection struct {
 	Xpos float64
 }
 
-func (c *Collection) SetKeyVal(key string, val interface{}) error {
+func (c *Collection) SetArbitrary(key string, val interface{}) error {
 	if c.More == nil {
 		c.More = make(map[string]interface{})
 	}
@@ -172,7 +172,7 @@ func (c *Collection) SetKeyVal(key string, val interface{}) error {
 	return nil
 }
 
-func TestFillKeyValSetter(t *testing.T) {
+func TestFillArbitrarySetter(t *testing.T) {
 	jsonData := `{
   "Name": "Alice",
   "Age": 42,
@@ -221,7 +221,7 @@ func TestFillBoolean(t *testing.T) {
 	}
 
 	if c.Name != "Bob" {
-		t.Errorf("expected: c.Name should be \"Alice\", got: %s", c.Name)
+		t.Errorf("expected: c.Name should be \"Bob\", got: %s", c.Name)
 	}
 	if c.IsOn != true {
 		t.Errorf("expected: c.IsOn should be true, got: %v", c.IsOn)
@@ -247,7 +247,7 @@ func TestFillFloatingPoint(t *testing.T) {
 	}
 
 	if c.Name != "Carol" {
-		t.Errorf("expected: c.Name should be \"Alice\", got: %s", c.Name)
+		t.Errorf("expected: c.Name should be \"Carol\", got: %s", c.Name)
 	}
 	if c.Xpos != 6.283 {
 		t.Errorf("expected: c.Xpos should be 6.283, got: %v", c.Xpos)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -107,9 +107,9 @@ func (o *ListOptions) Run() (err error) {
 		// TODO: It would be a bit more efficient to pass dsName to the ListParams
 		// and only retrieve information about that one dataset.
 		p := &lib.ListParams{
-			Peername:    peername,
-			Limit:       o.Limit,
-			Offset:      o.Offset,
+			Peername:        peername,
+			Limit:           o.Limit,
+			Offset:          o.Offset,
 			ShowNumVersions: o.ShowNumVersions,
 		}
 		if err = o.DatasetRequests.List(p, &refs); err != nil {

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -141,7 +141,7 @@ func (o *SaveOptions) Run() (err error) {
 
 	p := &lib.SaveParams{
 		Dataset:             dsp,
-		DatasetPath:         o.FilePath,
+		FilePath:            o.FilePath,
 		Private:             false,
 		Publish:             o.Publish,
 		DryRun:              o.DryRun,

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -155,9 +155,9 @@ func TestSaveRun(t *testing.T) {
 
 		{"no changes detected", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "trying to add again", "hopefully this errors", false, false, "", "error saving: no changes detected", ""},
 
-		{"add viz", "me/movies", "testdata/movies/dataset_with_viz.json", "", "", "", false, false, "dataset saved: peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmPauqpHsrRKmg1TbT6aBi7Axse9uPETDgMGxZShv3c79F\nthis dataset has 1 validation errors\n", "", ""},
+		{"add viz", "me/movies", "testdata/movies/dataset_with_viz.json", "", "", "", false, false, "dataset saved: peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/Qmcmjcw1onuvWCvM2NZzqDztfp3djpCErcD2zSirmAw65p\nthis dataset has 1 validation errors\n", "", ""},
 
-		{"add transform", "me/movies", "testdata/movies/dataset_with_tf.json", "", "", "", false, false, "dataset saved: peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmSHGct4PB15jvW6N5xVdWmJL8MPiK3jDwcTAt9uAzpz5f\nthis dataset has 1 validation errors\n", "", ""},
+		{"add transform", "me/movies", "testdata/movies/dataset_with_tf.json", "", "", "", false, false, "dataset saved: peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmTwkFwddz8pFHj4z7JCxNEydzZbMY8L77hAH3aMokZzy2\nthis dataset has 1 validation errors\n", "", ""},
 	}
 
 	for _, c := range cases {

--- a/cmd/testdata/movies/meta_override.yaml
+++ b/cmd/testdata/movies/meta_override.yaml
@@ -1,0 +1,2 @@
+qri: md:0
+title: different title

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -183,11 +183,11 @@ func (r *DatasetRequests) Get(p *GetParams, res *GetResult) (err error) {
 
 // SaveParams encapsulates arguments to Save
 type SaveParams struct {
-	// dataset to create. If both Dataset and DatasetPath are provided
-	// dataset values will override any values in the document at DatasetPath
+	// dataset to create. If both Dataset and FilePath are provided
+	// dataset values will override any values in the document at FilePath
 	Dataset *dataset.Dataset
-	// absolute path or URL to a dataset file to load dataset from
-	DatasetPath string
+	// absolute path or URL to a dataset file or component to load
+	FilePath string
 	// secrets for transform execution
 	Secrets map[string]string
 	// option to make dataset private. private data is not currently implimented,
@@ -222,8 +222,8 @@ func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) 
 	}
 
 	ds := p.Dataset
-	if ds == nil && p.DatasetPath == "" {
-		return fmt.Errorf("at least one of Dataset, DatasetPath is required")
+	if ds == nil && p.FilePath == "" {
+		return fmt.Errorf("at least one of Dataset, FilePath is required")
 	}
 
 	if p.Recall != "" {
@@ -243,9 +243,9 @@ func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) 
 		ds = recall
 	}
 
-	if p.DatasetPath != "" {
+	if p.FilePath != "" {
 		// TODO (b5): handle this with a fs.Filesystem
-		dsf, err := ReadDatasetFile(p.DatasetPath)
+		dsf, err := ReadDatasetFile(p.FilePath)
 		if err != nil {
 			return err
 		}

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -208,7 +208,7 @@ func TestDatasetRequestsSaveZip(t *testing.T) {
 
 	dsp := &dataset.Dataset{Peername: "me"}
 	res := repo.DatasetRef{}
-	err = req.Save(&SaveParams{Dataset: dsp, DatasetPath: "testdata/import.zip"}, &res)
+	err = req.Save(&SaveParams{Dataset: dsp, FilePath: "testdata/import.zip"}, &res)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/lib/file.go
+++ b/lib/file.go
@@ -127,34 +127,26 @@ func ReadDatasetFile(path string) (ds *dataset.Dataset, err error) {
 	return
 }
 
-func fillDatasetOrComponent(fields map[string]interface{}, path string, ds *dataset.Dataset) error {
-	switch fields["qri"] {
-	case "md:0":
-		md := &dataset.Meta{}
-		err := base.FillStruct(fields, md)
-		if err != nil {
-			return err
+func fillDatasetOrComponent(fields map[string]interface{}, path string, ds *dataset.Dataset) (err error) {
+	var fill interface{}
+	fill = ds
+
+	if kindStr, ok := fields["qri"].(string); ok && len(kindStr) > 3 {
+		switch kindStr[:2] {
+		case "md":
+			ds.Meta = &dataset.Meta{}
+			fill = ds.Meta
+		case "cm":
+			ds.Commit = &dataset.Commit{}
+			fill = ds.Commit
+		case "st":
+			ds.Structure = &dataset.Structure{}
+			fill = ds.Structure
 		}
-		ds.Meta = md
-	case "cm:0":
-		cm := &dataset.Commit{}
-		err := base.FillStruct(fields, cm)
-		if err != nil {
-			return err
-		}
-		ds.Commit = cm
-	case "st:0":
-		st := &dataset.Structure{}
-		err := base.FillStruct(fields, st)
-		if err != nil {
-			return err
-		}
-		ds.Structure = st
-	default:
-		err := base.FillStruct(fields, ds)
-		if err != nil {
-			return err
-		}
+	}
+
+	if err = base.FillStruct(fields, fill); err != nil {
+		return err
 	}
 	absDatasetPaths(path, ds)
 	return nil


### PR DESCRIPTION
Add a custom routine FillStruct for deserialization. This will used for parsing dataset json and yaml files when saving. This solves 4 problems:

* Field names are now case insensitive
* Unknown field names (such as misspellings) are now an error
* That is, unless the target struct is able to store arbitrary fields (Meta)
* Allow for saving individual components, by checking the "qri" field