### PR TITLE
refactor(fill): Move base/FillStruct to base/fill/Struct

### DIFF
--- a/base/fill/struct.go
+++ b/base/fill/struct.go
@@ -1,4 +1,4 @@
-package base
+package fill
 
 import (
 	"fmt"
@@ -7,10 +7,10 @@ import (
 	"time"
 )
 
-// FillStruct fills in the values of an arbitrary structure using an already deserialized
+// Struct fills in the values of an arbitrary structure using an already deserialized
 // map of nested data. Fields names are case-insensitive. Unknown fields are treated as an
 // error, *unless* the output structure implementes the ArbitrarySetter interface.
-func FillStruct(fields map[string]interface{}, output interface{}) error {
+func Struct(fields map[string]interface{}, output interface{}) error {
 	target := reflect.ValueOf(output)
 	if target.Kind() == reflect.Ptr {
 		target = target.Elem()

--- a/base/fill/struct.go
+++ b/base/fill/struct.go
@@ -1,3 +1,9 @@
+// Package fill matches arbitrary values to struct fields using reflection
+// fill is case-insensitive.
+// It's primary use is to support decoding data
+// from a number of serialization formats (JSON,YAML,CBOR) into an intermediate
+// map[string]interface{} value which can then be used to "fill" arbitrary struct
+// values
 package fill
 
 import (
@@ -9,7 +15,7 @@ import (
 
 // Struct fills in the values of an arbitrary structure using an already deserialized
 // map of nested data. Fields names are case-insensitive. Unknown fields are treated as an
-// error, *unless* the output structure implementes the ArbitrarySetter interface.
+// error, *unless* the output structure implements the ArbitrarySetter interface.
 func Struct(fields map[string]interface{}, output interface{}) error {
 	target := reflect.ValueOf(output)
 	if target.Kind() == reflect.Ptr {

--- a/base/fill/struct_test.go
+++ b/base/fill/struct_test.go
@@ -1,4 +1,4 @@
-package base
+package fill
 
 import (
 	"encoding/json"
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestFillStruct(t *testing.T) {
+func TestStruct(t *testing.T) {
 	jsonData := `{
   "Name": "test_name",
   "ProfileID": "test_profile_id",
@@ -24,7 +24,7 @@ func TestFillStruct(t *testing.T) {
 	}
 
 	var ds dataset.Dataset
-	err = FillStruct(data, &ds)
+	err = Struct(data, &ds)
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ func TestFillCommitTimestamp(t *testing.T) {
 	}
 
 	var ds dataset.Dataset
-	err = FillStruct(data, &ds)
+	err = Struct(data, &ds)
 	if err != nil {
 		panic(err)
 	}
@@ -71,7 +71,7 @@ func TestFillCommitTimestamp(t *testing.T) {
 	}
 }
 
-func TestFillStructInsensitive(t *testing.T) {
+func TestStructInsensitive(t *testing.T) {
 	jsonData := `{
   "name": "test_name",
   "pRoFiLeId": "test_profile_id",
@@ -85,7 +85,7 @@ func TestFillStructInsensitive(t *testing.T) {
 	}
 
 	var ds dataset.Dataset
-	err = FillStruct(data, &ds)
+	err = Struct(data, &ds)
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +101,7 @@ func TestFillStructInsensitive(t *testing.T) {
 	}
 }
 
-func TestFillStructUnknownFields(t *testing.T) {
+func TestStructUnknownFields(t *testing.T) {
 	jsonData := `{
   "Name": "test_name",
   "ProfileID": "test_profile_id",
@@ -116,7 +116,7 @@ func TestFillStructUnknownFields(t *testing.T) {
 	}
 
 	var ds dataset.Dataset
-	err = FillStruct(data, &ds)
+	err = Struct(data, &ds)
 	if err == nil {
 		t.Errorf("expected: error for unknown field, but no error returned")
 	}
@@ -127,7 +127,7 @@ func TestFillStructUnknownFields(t *testing.T) {
 	}
 }
 
-func TestFillStructYaml(t *testing.T) {
+func TestStructYaml(t *testing.T) {
 	yamlData := `name: test_name
 profileID: test_profile_id
 qri: qri:0
@@ -140,7 +140,7 @@ qri: qri:0
 	}
 
 	var ds dataset.Dataset
-	err = FillStruct(data, &ds)
+	err = Struct(data, &ds)
 	if err != nil {
 		panic(err)
 	}
@@ -195,7 +195,7 @@ func TestFillArbitrarySetter(t *testing.T) {
 	}
 
 	var c Collection
-	err = FillStruct(data, &c)
+	err = Struct(data, &c)
 	if err != nil {
 		panic(err)
 	}
@@ -224,7 +224,7 @@ func TestFillBoolean(t *testing.T) {
 	}
 
 	var c Collection
-	err = FillStruct(data, &c)
+	err = Struct(data, &c)
 	if err != nil {
 		panic(err)
 	}
@@ -250,7 +250,7 @@ func TestFillFloatingPoint(t *testing.T) {
 	}
 
 	var c Collection
-	err = FillStruct(data, &c)
+	err = Struct(data, &c)
 	if err != nil {
 		panic(err)
 	}
@@ -279,7 +279,7 @@ func TestFillMetaKeywords(t *testing.T) {
 	}
 
 	var meta dataset.Meta
-	err = FillStruct(data, &meta)
+	err = Struct(data, &meta)
 	if err != nil {
 		panic(err)
 	}
@@ -308,7 +308,7 @@ func TestFillMetaCitations(t *testing.T) {
 	}
 
 	var meta dataset.Meta
-	err = FillStruct(data, &meta)
+	err = Struct(data, &meta)
 	if err != nil {
 		panic(err)
 	}
@@ -342,7 +342,7 @@ func TestFillMapStringToString(t *testing.T) {
 	}
 
 	var c Collection
-	err = FillStruct(data, &c)
+	err = Struct(data, &c)
 	if err != nil {
 		panic(err)
 	}
@@ -366,7 +366,7 @@ func TestStringSlice(t *testing.T) {
 	}
 
 	var c Collection
-	err = FillStruct(data, &c)
+	err = Struct(data, &c)
 	if err != nil {
 		panic(err)
 	}
@@ -390,7 +390,7 @@ func TestNilStringSlice(t *testing.T) {
 	}
 
 	var c Collection
-	err = FillStruct(data, &c)
+	err = Struct(data, &c)
 	if err != nil {
 		panic(err)
 	}
@@ -411,7 +411,7 @@ func TestNilMap(t *testing.T) {
 	}
 
 	var c Collection
-	err = FillStruct(data, &c)
+	err = Struct(data, &c)
 	if err != nil {
 		panic(err)
 	}
@@ -432,7 +432,7 @@ func TestNilPointer(t *testing.T) {
 	}
 
 	var c Collection
-	err = FillStruct(data, &c)
+	err = Struct(data, &c)
 	if err != nil {
 		panic(err)
 	}
@@ -456,7 +456,7 @@ func TestFillSubSection(t *testing.T) {
 	}
 
 	var c Collection
-	err = FillStruct(data, &c)
+	err = Struct(data, &c)
 	if err != nil {
 		panic(err)
 	}
@@ -481,7 +481,7 @@ func TestFillPointerToMap(t *testing.T) {
 	}
 
 	var s SubElement
-	err = FillStruct(data, &s)
+	err = Struct(data, &s)
 	if err != nil {
 		panic(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/qri-io/jsonschema"
+	"github.com/qri-io/qri/base/fill"
 )
 
 // CurrentConfigRevision is the latest configuration revision configurations
@@ -87,6 +88,26 @@ func (cfg Config) SummaryString() (summary string) {
 	}
 
 	return summary
+}
+
+// ReadFromFile reads a YAML configuration file from path
+func ReadFromFile(path string) (*Config, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fields := make(map[string]interface{})
+	if err = yaml.Unmarshal(data, &fields); err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{}
+	if err = fill.Struct(fields, cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
 }
 
 // WriteToFile encodes a configration to YAML and writes it to path

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,6 +13,20 @@ import (
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
+func TestReadFromFile(t *testing.T) {
+	_, err := ReadFromFile("testdata/default.yaml")
+	if err != nil {
+		t.Errorf("error reading config: %s", err.Error())
+		return
+	}
+
+	_, err = ReadFromFile("foobar")
+	if err == nil {
+		t.Error("expected read from bad path to error")
+		return
+	}
+}
+
 func TestWriteToFile(t *testing.T) {
 	path := filepath.Join(os.TempDir(), "config.yaml")
 	t.Log(path)

--- a/config/testdata/default.yaml
+++ b/config/testdata/default.yaml
@@ -26,9 +26,7 @@ p2p:
   - /ip4/130.211.198.23/tcp/4001/ipfs/QmNX9nSos8sRFvqGTwdEme6LQ8R1eJ8EuFgW32F9jjp2Pb
   - /ip4/35.193.162.149/tcp/4001/ipfs/QmTZxETL4YCCzB1yFx4GT1te68henVHD1XPQMkHZ1N22mm
   - /ip4/35.226.92.45/tcp/4001/ipfs/QmP6sbnHXANXgQ7JeCCeCKdJrgpvUd8s75YNfzdkHf6Mpi
-  online: true
-  selfreplication: full
-  boostrapaddrs: []
+  bootstrapaddrs: []
   httpgatewayaddr: https://ipfs.io
 webapp:
   enabled: true

--- a/lib/config.go
+++ b/lib/config.go
@@ -3,12 +3,10 @@ package lib
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/ghodss/yaml"
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/ioes"
-	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/config/migrate"
 )
@@ -30,19 +28,8 @@ var SaveConfig = func() error {
 
 // LoadConfig loads the global default configuration
 func LoadConfig(streams ioes.IOStreams, path string) (err error) {
-	var data []byte
-	data, err = ioutil.ReadFile(path)
+	cfg, err := config.ReadFromFile(path)
 	if err != nil {
-		return err
-	}
-
-	fields := make(map[string]interface{})
-	if err = yaml.Unmarshal(data, &fields); err != nil {
-		return err
-	}
-
-	cfg := &config.Config{}
-	if err = base.FillStruct(fields, cfg); err != nil {
 		return err
 	}
 

--- a/lib/file.go
+++ b/lib/file.go
@@ -12,7 +12,7 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsutil"
 	"github.com/qri-io/qfs"
-	"github.com/qri-io/qri/base"
+	"github.com/qri-io/qri/base/fill"
 	"gopkg.in/yaml.v2"
 )
 
@@ -175,24 +175,24 @@ func toMapIface(i map[interface{}]interface{}) map[string]interface{} {
 }
 
 func fillDatasetOrComponent(fields map[string]interface{}, path string, ds *dataset.Dataset) (err error) {
-	var fill interface{}
-	fill = ds
+	var target interface{}
+	target = ds
 
 	if kindStr, ok := fields["qri"].(string); ok && len(kindStr) > 3 {
 		switch kindStr[:2] {
 		case "md":
 			ds.Meta = &dataset.Meta{}
-			fill = ds.Meta
+			target = ds.Meta
 		case "cm":
 			ds.Commit = &dataset.Commit{}
-			fill = ds.Commit
+			target = ds.Commit
 		case "st":
 			ds.Structure = &dataset.Structure{}
-			fill = ds.Structure
+			target = ds.Structure
 		}
 	}
 
-	if err = base.FillStruct(fields, fill); err != nil {
+	if err = fill.Struct(fields, target); err != nil {
 		return err
 	}
 	absDatasetPaths(path, ds)


### PR DESCRIPTION
Now fill.Struct is in base/fill/struct.go. Restore the config.ReadFromFile function, originally deleted by a2efbf30e35. Fix config/testdata/deafult.yaml which had invalid field names that were not being caught by old tests.