### PR TITLE
feat(dag.Info, cmd/save, cmd/get): adjusts qri command line to work with the rendered visualization

### DIFF
--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -116,7 +116,7 @@ func addCitiesDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 		t.Fatal(err.Error())
 	}
 
-	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false)
+	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -129,7 +129,7 @@ func addFlourinatedCompoundsDataset(t *testing.T, node *p2p.QriNode) repo.Datase
 		t.Fatal(err.Error())
 	}
 
-	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false)
+	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -145,7 +145,7 @@ func addNowTransformDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	// this was put here to satisfy qri-io/qri/actions.TestUpdateDatasetLocal
 	tc.Input.Peername = "peer"
 
-	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false)
+	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/actions/dataset.go
+++ b/actions/dataset.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SaveDataset initializes a dataset from a dataset pointer and data file
-func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string]string, scriptOut io.Writer, dryRun, pin, convertFormatToPrev, force bool) (ref repo.DatasetRef, err error) {
+func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string]string, scriptOut io.Writer, dryRun, pin, convertFormatToPrev, force, shouldRender bool) (ref repo.DatasetRef, err error) {
 	var (
 		prevPath string
 		pro      *profile.Profile
@@ -86,7 +86,7 @@ func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string
 	// let's make history, if it exists:
 	changes.PreviousPath = prevPath
 
-	return base.CreateDataset(r, node.LocalStreams, changes, prev, dryRun, pin, force)
+	return base.CreateDataset(r, node.LocalStreams, changes, prev, dryRun, pin, force, shouldRender)
 }
 
 // UpdateRemoteDataset brings a reference to the latest version, syncing to the

--- a/actions/dataset_test.go
+++ b/actions/dataset_test.go
@@ -52,7 +52,7 @@ func TestUpdateRemoteDataset(t *testing.T) {
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
 
 	// run a local update to advance history
-	now0, err := SaveDataset(peers[0], ds, nil, nil, false, true, false, false)
+	now0, err := SaveDataset(peers[0], ds, nil, nil, false, true, false, false, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -120,7 +120,7 @@ func TestSaveDataset(t *testing.T) {
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
 
-	ref, err := SaveDataset(n, ds, nil, nil, true, false, false, false)
+	ref, err := SaveDataset(n, ds, nil, nil, true, false, false, false, true)
 	if err != nil {
 		t.Errorf("dry run error: %s", err.Error())
 	}
@@ -143,7 +143,7 @@ func TestSaveDataset(t *testing.T) {
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
 
 	// test save
-	ref, err = SaveDataset(n, ds, nil, nil, false, true, false, false)
+	ref, err = SaveDataset(n, ds, nil, nil, false, true, false, false, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -173,7 +173,7 @@ func TestSaveDataset(t *testing.T) {
 	ds.Transform.OpenScriptFile(nil)
 
 	// dryrun should work
-	ref, err = SaveDataset(n, ds, secrets, nil, true, false, false, false)
+	ref, err = SaveDataset(n, ds, secrets, nil, true, false, false, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestSaveDataset(t *testing.T) {
 	ds.Transform.OpenScriptFile(nil)
 
 	// test save with transform
-	ref, err = SaveDataset(n, ds, secrets, nil, false, true, false, false)
+	ref, err = SaveDataset(n, ds, secrets, nil, false, true, false, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestSaveDataset(t *testing.T) {
 		},
 	}
 
-	ref, err = SaveDataset(n, ds, nil, nil, false, true, false, false)
+	ref, err = SaveDataset(n, ds, nil, nil, false, true, false, false, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -247,7 +247,7 @@ func TestSaveDataset(t *testing.T) {
 		t.Error(err)
 	}
 
-	ref, err = SaveDataset(n, ds, secrets, nil, false, true, false, false)
+	ref, err = SaveDataset(n, ds, secrets, nil, false, true, false, false, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -266,7 +266,7 @@ func TestSaveDatasetWithoutStructureOrBody(t *testing.T) {
 		},
 	}
 
-	_, err := SaveDataset(n, ds, nil, nil, false, false, false, false)
+	_, err := SaveDataset(n, ds, nil, nil, false, false, false, false, true)
 	expect := "creating a new dataset requires a structure or a body"
 	if err == nil || err.Error() != expect {
 		t.Errorf("expected error, but got %s", err.Error())

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -452,11 +452,13 @@ func (h *DatasetHandlers) saveHandler(w http.ResponseWriter, r *http.Request) {
 	res := &repo.DatasetRef{}
 	scriptOutput := &bytes.Buffer{}
 	p := &lib.SaveParams{
-		Dataset:             ds,
-		Private:             r.FormValue("private") == "true",
-		DryRun:              r.FormValue("dry_run") == "true",
-		ReturnBody:          r.FormValue("return_body") == "true",
-		Force:               r.FormValue("force") == "true",
+		Dataset:      ds,
+		Private:      r.FormValue("private") == "true",
+		DryRun:       r.FormValue("dry_run") == "true",
+		ReturnBody:   r.FormValue("return_body") == "true",
+		Force:        r.FormValue("force") == "true",
+		ShouldRender: !(r.FormValue("no_render") == "true"),
+
 		ConvertFormatToPrev: true,
 		ScriptOutput:        scriptOutput,
 	}

--- a/base/base_test.go
+++ b/base/base_test.go
@@ -62,7 +62,7 @@ func addCitiesDataset(t *testing.T, r repo.Repo) repo.DatasetRef {
 		t.Fatal(err.Error())
 	}
 
-	ref, err := CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false)
+	ref, err := CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -94,7 +94,7 @@ func updateCitiesDataset(t *testing.T, r repo.Repo) repo.DatasetRef {
 		tc.Input.PreviousPath = ""
 	}()
 
-	ref, err = CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false)
+	ref, err = CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -107,7 +107,7 @@ func addFlourinatedCompoundsDataset(t *testing.T, r repo.Repo) repo.DatasetRef {
 		t.Fatal(err.Error())
 	}
 
-	ref, err := CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false)
+	ref, err := CreateDataset(r, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/base/dag.go
+++ b/base/dag.go
@@ -54,7 +54,7 @@ func NewDAGInfo(ctx context.Context, store cafs.Filestore, ng ipld.NodeGetter, p
 			return nil, err
 		}
 		if ds.Viz.RenderedPath != "" {
-			err := info.AddLabelByID("rendered", dsfs.GetHashBase(ds.Viz.RenderedPath, prefix))
+			err := info.AddLabelByID("rd", dsfs.GetHashBase(ds.Viz.RenderedPath, prefix))
 			if err != nil {
 				return nil, err
 			}

--- a/base/dag.go
+++ b/base/dag.go
@@ -50,6 +50,15 @@ func NewDAGInfo(ctx context.Context, store cafs.Filestore, ng ipld.NodeGetter, p
 		if err != nil {
 			return nil, err
 		}
+		if err := dsfs.DerefDatasetViz(store, ds); err != nil {
+			return nil, err
+		}
+		if ds.Viz.RenderedPath != "" {
+			err := info.AddLabelByID("rendered", dsfs.GetHashBase(ds.Viz.RenderedPath, prefix))
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 	if ds.Transform != nil {
 		err := info.AddLabelByID("tf", dsfs.GetHashBase(ds.Transform.Path, prefix))

--- a/base/dataset.go
+++ b/base/dataset.go
@@ -127,7 +127,7 @@ func ListDatasets(r repo.Repo, limit, offset int, RPC, publishedOnly, showVersio
 // CreateDataset uses dsfs to add a dataset to a repo's store, updating all
 // references within the repo if successful. CreateDataset is a lower-level
 // component of github.com/qri-io/qri/actions.CreateDataset
-func CreateDataset(r repo.Repo, streams ioes.IOStreams, ds, dsPrev *dataset.Dataset, dryRun, pin, force bool) (ref repo.DatasetRef, err error) {
+func CreateDataset(r repo.Repo, streams ioes.IOStreams, ds, dsPrev *dataset.Dataset, dryRun, pin, force, shouldRender bool) (ref repo.DatasetRef, err error) {
 	var (
 		pro     *profile.Profile
 		path    string
@@ -143,7 +143,7 @@ func CreateDataset(r repo.Repo, streams ioes.IOStreams, ds, dsPrev *dataset.Data
 		return
 	}
 
-	if path, err = dsfs.CreateDataset(r.Store(), ds, dsPrev, r.PrivateKey(), pin, force); err != nil {
+	if path, err = dsfs.CreateDataset(r.Store(), ds, dsPrev, r.PrivateKey(), pin, force, shouldRender); err != nil {
 		return
 	}
 	if ds.PreviousPath != "" && ds.PreviousPath != "/" {

--- a/base/dataset.go
+++ b/base/dataset.go
@@ -40,6 +40,11 @@ func OpenDataset(fsys qfs.Filesystem, ds *dataset.Dataset) (err error) {
 			return
 		}
 	}
+	if ds.Viz != nil && ds.Viz.RenderedFile() == nil {
+		if err = ds.Viz.OpenRenderedFile(fsys); err != nil {
+			return
+		}
+	}
 	return
 }
 
@@ -57,6 +62,11 @@ func CloseDataset(ds *dataset.Dataset) (err error) {
 	}
 	if ds.Viz != nil && ds.Viz.ScriptFile() != nil {
 		if err = ds.Viz.ScriptFile().Close(); err != nil {
+			return
+		}
+	}
+	if ds.Viz != nil && ds.Viz.RenderedFile() != nil {
+		if err = ds.Viz.RenderedFile().Close(); err != nil {
 			return
 		}
 	}

--- a/base/dataset_test.go
+++ b/base/dataset_test.go
@@ -74,11 +74,11 @@ func TestCreateDataset(t *testing.T) {
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
 
-	if _, err := CreateDataset(r, streams, &dataset.Dataset{}, &dataset.Dataset{}, false, true, false); err == nil {
+	if _, err := CreateDataset(r, streams, &dataset.Dataset{}, &dataset.Dataset{}, false, true, false, true); err == nil {
 		t.Error("expected bad dataset to error")
 	}
 
-	ref, err := CreateDataset(r, streams, ds, &dataset.Dataset{}, false, true, false)
+	ref, err := CreateDataset(r, streams, ds, &dataset.Dataset{}, false, true, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -96,7 +96,7 @@ func TestCreateDataset(t *testing.T) {
 
 	prev := ref.Dataset
 
-	ref, err = CreateDataset(r, streams, ds, prev, false, true, false)
+	ref, err = CreateDataset(r, streams, ds, prev, false, true, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -112,12 +112,12 @@ func TestCreateDataset(t *testing.T) {
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
 	prev = ref.Dataset
 
-	if ref, err = CreateDataset(r, streams, ds, prev, false, true, false); err == nil {
+	if ref, err = CreateDataset(r, streams, ds, prev, false, true, false, true); err == nil {
 		t.Error("expected unchanged dataset with no force flag to error")
 	}
 
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte("[]")))
-	if ref, err = CreateDataset(r, streams, ds, prev, false, true, true); err != nil {
+	if ref, err = CreateDataset(r, streams, ds, prev, false, true, true, true); err != nil {
 		t.Errorf("unexpected force-save error: %s", err)
 	}
 }
@@ -341,7 +341,7 @@ func TestDatasetPinning(t *testing.T) {
 		return
 	}
 
-	ref2, err := CreateDataset(r, streams, tc.Input, nil, false, false, false)
+	ref2, err := CreateDataset(r, streams, tc.Input, nil, false, false, false, true)
 	if err != nil {
 		t.Error(err.Error())
 		return

--- a/cmd/dag.go
+++ b/cmd/dag.go
@@ -286,6 +286,8 @@ func fullFieldToAbbr(field string) string {
 		return "vz"
 	case "transform":
 		return "tf"
+	case "rendered":
+		return "rd"
 	default:
 		return field
 	}
@@ -305,6 +307,8 @@ func abbrFieldToFull(abbr string) string {
 		return "viz"
 	case "tf":
 		return "transform"
+	case "rd":
+		return "rendered"
 	default:
 		return abbr
 	}

--- a/cmd/dag_test.go
+++ b/cmd/dag_test.go
@@ -19,6 +19,7 @@ func TestFullFieldToAbbr(t *testing.T) {
 		{"meta", "md"},
 		{"viz", "vz"},
 		{"transform", "tf"},
+		{"rendered", "rd"},
 		{"foo", "foo"},
 	}
 
@@ -30,7 +31,7 @@ func TestFullFieldToAbbr(t *testing.T) {
 	}
 }
 
-func TestAbbrFieldToField(t *testing.T) {
+func TestAbbrFieldToFull(t *testing.T) {
 	cases := []struct {
 		field, exp string
 	}{
@@ -40,6 +41,7 @@ func TestAbbrFieldToField(t *testing.T) {
 		{"md", "meta"},
 		{"vz", "viz"},
 		{"tf", "transform"},
+		{"rd", "rendered"},
 		{"foo", "foo"},
 	}
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -73,7 +73,7 @@ type GetOptions struct {
 }
 
 // isDatasetField checks if a string is a dataset field or not
-var isDatasetField = regexp.MustCompile("(?i)^(commit|cm|structure|st|body|bd|meta|md|viz|vz|transform|tf)($|\\.)")
+var isDatasetField = regexp.MustCompile("(?i)^(commit|cm|structure|st|body|bd|meta|md|viz|vz|transform|tf|rendered|rd)($|\\.)")
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *GetOptions) Complete(f Factory, args []string) (err error) {

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -68,6 +68,7 @@ commit message and title to the save.`,
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "simulate saving a dataset")
 	cmd.Flags().BoolVar(&o.Force, "force", false, "force a new commit, even if no changes are detected")
 	cmd.Flags().BoolVarP(&o.KeepFormat, "keep-format", "k", false, "convert incoming data to stored data format")
+	cmd.Flags().BoolVarP(&o.NoRender, "no-render", "n", false, "don't store a rendered version of the the vizualization ")
 
 	return cmd
 }
@@ -89,6 +90,7 @@ type SaveOptions struct {
 	DryRun         bool
 	KeepFormat     bool
 	Force          bool
+	NoRender       bool
 	Secrets        []string
 
 	DatasetRequests *lib.DatasetRequests
@@ -150,6 +152,7 @@ func (o *SaveOptions) Run() (err error) {
 		ConvertFormatToPrev: o.KeepFormat,
 		Force:               o.Force,
 		ReturnBody:          o.DryRun,
+		ShouldRender:        !o.NoRender,
 	}
 
 	if o.Secrets != nil {

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -155,9 +155,9 @@ func TestSaveRun(t *testing.T) {
 
 		{"no changes detected", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "trying to add again", "hopefully this errors", false, false, "", "error saving: no changes detected", ""},
 
-		{"add viz", "me/movies", "testdata/movies/dataset_with_viz.json", "", "", "", false, false, "dataset saved: peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/Qmcmjcw1onuvWCvM2NZzqDztfp3djpCErcD2zSirmAw65p\nthis dataset has 1 validation errors\n", "", ""},
+		{"add viz", "me/movies", "testdata/movies/dataset_with_viz.json", "", "", "", false, false, "dataset saved: peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmcEF5R1ga5ny1AKxUurnYgbvV4Ai4Me9DdQPSrPuTSro2\nthis dataset has 1 validation errors\n", "", ""},
 
-		{"add transform", "me/movies", "testdata/movies/dataset_with_tf.json", "", "", "", false, false, "dataset saved: peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmTMqfrua11V8AK3vMB9QeZcZtX5ZB1RNqAdapBWjn2615\nthis dataset has 1 validation errors\n", "", ""},
+		{"add transform", "me/movies", "testdata/movies/dataset_with_tf.json", "", "", "", false, false, "dataset saved: peer/movies@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt/map/QmVzGDaYZbXPoNKm8G9gCDdUS6GSDaPwqaiNo23eJjT6T7\nthis dataset has 1 validation errors\n", "", ""},
 	}
 
 	for _, c := range cases {
@@ -198,6 +198,7 @@ func TestSaveRun(t *testing.T) {
 
 		if c.expect != errs.String() {
 			t.Errorf("case '%s', err output mismatch. Expected: '%s', Got: '%s'", c.description, c.expect, errs.String())
+
 			continue
 		}
 	}

--- a/cmd/testdata/movies/dataset_with_viz.json
+++ b/cmd/testdata/movies/dataset_with_viz.json
@@ -28,6 +28,7 @@
     }
   },
   "viz": {
+    "format": "html",
     "scriptPath": "viz.html"
   }
 }

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -155,6 +155,10 @@ func (r *DatasetRequests) Get(p *GetParams, res *GetResult) (err error) {
 		// `qri get viz.script` loads the visualization script, as a special case
 		res.Bytes, err = ioutil.ReadAll(ds.Viz.ScriptFile())
 		return err
+	} else if p.Selector == "rendered" && ds.Viz != nil && ds.Viz.RenderedFile() != nil {
+		// `qri get rendered` loads the rendered visualization script, as a special case
+		res.Bytes, err = ioutil.ReadAll(ds.Viz.RenderedFile())
+		return err
 	} else {
 		var value interface{}
 		if p.Selector == "" {

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -209,6 +209,8 @@ type SaveParams struct {
 	Recall string
 	// force a new commit, even if no changes are detected
 	Force bool
+	// save a rendered version of the template along with the dataset
+	ShouldRender bool
 	// optional writer to have transform script record standard output to
 	// note: this won't work over RPC, only on local calls
 	ScriptOutput io.Writer
@@ -275,7 +277,7 @@ func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) 
 		return
 	}
 
-	ref, err := actions.SaveDataset(r.node, ds, p.Secrets, p.ScriptOutput, p.DryRun, true, p.ConvertFormatToPrev, p.Force)
+	ref, err := actions.SaveDataset(r.node, ds, p.Secrets, p.ScriptOutput, p.DryRun, true, p.ConvertFormatToPrev, p.Force, p.ShouldRender)
 	if err != nil {
 		log.Debugf("create ds error: %s\n", err.Error())
 		return err

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -79,7 +79,7 @@ func addCitiesDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	ds.Name = tc.Name
 	ds.BodyBytes = tc.Body
 
-	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false, false)
+	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -95,7 +95,7 @@ func addNowTransformDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	ds.Name = tc.Name
 	ds.Transform.ScriptPath = "testdata/now_tf/transform.star"
 
-	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false, false)
+	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/p2p/log_diff_test.go
+++ b/p2p/log_diff_test.go
@@ -31,7 +31,7 @@ func TestRequestLogDiff(t *testing.T) {
 	}
 
 	// add a dataset to peer 4
-	ref, err := base.CreateDataset(peers[4].Repo, streams, tc.Input, nil, false, true, false)
+	ref, err := base.CreateDataset(peers[4].Repo, streams, tc.Input, nil, false, true, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestRequestLogDiff(t *testing.T) {
 	update.Name = tc.Name
 
 	// add an update on peer 4
-	ref2, err := base.CreateDataset(peers[4].Repo, streams, update, tc.Input, false, true, false)
+	ref2, err := base.CreateDataset(peers[4].Repo, streams, update, tc.Input, false, true, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/log_test.go
+++ b/p2p/log_test.go
@@ -29,7 +29,7 @@ func TestRequestDatasetLog(t *testing.T) {
 	}
 
 	// add a dataset to tim
-	ref, err := base.CreateDataset(peers[4].Repo, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false)
+	ref, err := base.CreateDataset(peers[4].Repo, ioes.NewDiscardIOStreams(), tc.Input, nil, false, true, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -177,7 +177,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (err error) {
 		ds.Commit.Author = &dataset.User{ID: pro.ID.String()}
 	}
 
-	_, err = base.CreateDataset(r, ioes.NewDiscardIOStreams(), ds, nil, false, true, false)
+	_, err = base.CreateDataset(r, ioes.NewDiscardIOStreams(), ds, nil, false, true, false, true)
 	return
 }
 

--- a/rev/rev.go
+++ b/rev/rev.go
@@ -66,6 +66,7 @@ var fieldMap = map[string]string{
 	"transform": "tf",
 	"structure": "st",
 	"body":      "bd",
+	"rendered":  "rd",
 
 	"ds": "ds",
 	"md": "md",
@@ -73,4 +74,5 @@ var fieldMap = map[string]string{
 	"tf": "tf",
 	"st": "st",
 	"bd": "bd",
+	"rd": "rd",
 }

--- a/rev/rev_test.go
+++ b/rev/rev_test.go
@@ -15,6 +15,7 @@ func TestParseRevs(t *testing.T) {
 		{"body", []*Rev{&Rev{"bd", 1}}, ""},
 		{"md", []*Rev{&Rev{"md", 1}}, ""},
 		{"ds", []*Rev{&Rev{"ds", 1}}, ""},
+		{"rd", []*Rev{&Rev{"rd", 1}}, ""},
 		{"1", []*Rev{&Rev{"ds", 1}}, ""},
 		{"2", []*Rev{&Rev{"ds", 2}}, ""},
 		{"3", []*Rev{&Rev{"ds", 3}}, ""},


### PR DESCRIPTION
1) Adds 'rd' as a label to dag.Info
2) Adds 'rendered' and 'rd' as options to `qri dag info [label]`
3) Adds 'rendered' as an option to `qri get`
4) Adds `no-render` flag to `qri save`, to not save a rendered visualization with the dataset
5) Adds `shouldRender` flag to `lib.Save`, `actions.SaveDataset`, and `base.CreateDataset`
6) Updates tests!

need to close qri-io/dataset#181