### PR TITLE
replace lib.AbsPath -> qfs.AbsPath, add lib.File tests

### DIFF
--- a/cmd/save.go
+++ b/cmd/save.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/ioes"
+	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
@@ -106,12 +107,12 @@ func (o *SaveOptions) Complete(f Factory, args []string) (err error) {
 	// `qri connect` in a different terminal, and that instance is in a different directory;
 	// that instance won't correctly find the body file we want to load if it's not absolute.
 	for i := range o.FilePaths {
-		if err := lib.AbsPath(&o.FilePaths[i]); err != nil {
+		if err := qfs.AbsPath(&o.FilePaths[i]); err != nil {
 			return err
 		}
 	}
 
-	if err := lib.AbsPath(&o.BodyPath); err != nil {
+	if err := qfs.AbsPath(&o.BodyPath); err != nil {
 		return fmt.Errorf("body file: %s", err)
 	}
 

--- a/lib/export.go
+++ b/lib/export.go
@@ -15,6 +15,7 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
 	"github.com/qri-io/dataset/dsutil"
+	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
@@ -54,7 +55,7 @@ type ExportParams struct {
 func (r *ExportRequests) Export(p *ExportParams, fileWritten *string) (err error) {
 	if p.TargetDir == "" {
 		p.TargetDir = "."
-		if err = AbsPath(&p.TargetDir); err != nil {
+		if err = qfs.AbsPath(&p.TargetDir); err != nil {
 			return err
 		}
 	}

--- a/lib/file_test.go
+++ b/lib/file_test.go
@@ -1,54 +1,12 @@
 package lib
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/qri-io/dataset"
 )
 
-func TestAbsPath(t *testing.T) {
-	tmp, err := filepath.Abs(os.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pathAbs, err := filepath.Abs("relative/path/data.yaml")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	httpAbs, err := filepath.Abs("http_got/relative/dataset.yaml")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cases := []struct {
-		in, out, err string
-	}{
-		{"", "", ""},
-		{"http://example.com/zipfile.zip", "http://example.com/zipfile.zip", ""},
-		{"https://example.com/zipfile.zip", "https://example.com/zipfile.zip", ""},
-		{"relative/path/data.yaml", pathAbs, ""},
-		{"http_got/relative/dataset.yaml", httpAbs, ""},
-		{"/ipfs", "/ipfs", ""},
-		{tmp, tmp, ""},
-	}
-
-	for i, c := range cases {
-		got := c.in
-		err := AbsPath(&got)
-		if !(err == nil && c.err == "" || (err != nil && c.err == err.Error())) {
-			t.Errorf("case %d error mismatch. expected: %s, got: %s", i, c.err, err)
-		}
-		if got != c.out {
-			t.Errorf("case %d error mismatch. expected: %s, got: %s", i, c.out, got)
-		}
-	}
-}
-
-func TestReadDatasetFile(t *testing.T) {
+func TestReadDatasetFiles(t *testing.T) {
 	cases := []struct {
 		description string
 		path        string

--- a/lib/file_test.go
+++ b/lib/file_test.go
@@ -9,11 +9,13 @@ import (
 func TestReadDatasetFiles(t *testing.T) {
 	cases := []struct {
 		description string
-		path        string
+		paths       []string
 		ds          *dataset.Dataset
 	}{
 		{".star file to transform script",
-			"testdata/tf/transform.star",
+			[]string{
+				"testdata/tf/transform.star",
+			},
 			&dataset.Dataset{
 				Transform: &dataset.Transform{
 					ScriptPath: "testdata/tf/transform.star",
@@ -22,7 +24,9 @@ func TestReadDatasetFiles(t *testing.T) {
 		},
 
 		{".html file to viz script",
-			"testdata/viz/visualization.html",
+			[]string{
+				"testdata/viz/visualization.html",
+			},
 			&dataset.Dataset{
 				Viz: &dataset.Viz{
 					Format:     "html",
@@ -30,10 +34,93 @@ func TestReadDatasetFiles(t *testing.T) {
 				},
 			},
 		},
+
+		{"structure.json, meta.json component files",
+			[]string{
+				"testdata/component_files/structure.json",
+				"testdata/component_files/meta.json",
+			},
+			&dataset.Dataset{
+				Meta: &dataset.Meta{
+					Qri:   "md",
+					Title: "build a dataset with component files",
+				},
+				Structure: &dataset.Structure{
+					Qri:    "st",
+					Format: "json",
+					Schema: map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "array",
+							"items": []interface{}{
+								map[string]interface{}{"type": "string", "name": "field_1"},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{"structure.yaml, meta.yaml component files",
+			[]string{
+				"testdata/component_files/structure.yaml",
+				"testdata/component_files/meta.yaml",
+			},
+			&dataset.Dataset{
+				Meta: &dataset.Meta{
+					Qri:   "md",
+					Title: "build a dataset with component files",
+				},
+				Structure: &dataset.Structure{
+					Qri:    "st",
+					Format: "json",
+					Schema: map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "array",
+							"items": []interface{}{
+								map[string]interface{}{"type": "string", "name": "field_1"},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{"structure.json, meta.yaml, commit.yaml component files",
+			[]string{
+				"testdata/component_files/commit.yaml",
+				"testdata/component_files/structure.json",
+				"testdata/component_files/meta.yaml",
+			},
+			&dataset.Dataset{
+				Commit: &dataset.Commit{
+					Qri:   "cm",
+					Title: "this is a commit",
+				},
+				Meta: &dataset.Meta{
+					Qri:   "md",
+					Title: "build a dataset with component files",
+				},
+				Structure: &dataset.Structure{
+					Qri:    "st",
+					Format: "json",
+					Schema: map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "array",
+							"items": []interface{}{
+								map[string]interface{}{"type": "string", "name": "field_1"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, c := range cases {
-		got, err := ReadDatasetFiles(c.path)
+		got, err := ReadDatasetFiles(c.paths...)
 		if err != nil {
 			t.Errorf("case %d %s unexpected error: %s", i, c.description, err.Error())
 			continue

--- a/lib/testdata/component_files/commit.yaml
+++ b/lib/testdata/component_files/commit.yaml
@@ -1,0 +1,2 @@
+qri: cm
+title: this is a commit

--- a/lib/testdata/component_files/meta.json
+++ b/lib/testdata/component_files/meta.json
@@ -1,0 +1,4 @@
+{
+    "qri": "md",
+    "title": "build a dataset with component files"
+}

--- a/lib/testdata/component_files/meta.yaml
+++ b/lib/testdata/component_files/meta.yaml
@@ -1,0 +1,2 @@
+qri: md
+title: "build a dataset with component files"

--- a/lib/testdata/component_files/structure.json
+++ b/lib/testdata/component_files/structure.json
@@ -1,0 +1,13 @@
+{
+    "qri": "st",
+    "format": "json",
+    "schema": {
+        "type": "array",
+        "items": {
+            "type": "array",
+            "items": [
+                {"type" : "string", "name" : "field_1"}
+            ]
+        }
+    }
+}

--- a/lib/testdata/component_files/structure.yaml
+++ b/lib/testdata/component_files/structure.yaml
@@ -1,0 +1,9 @@
+qri: st
+format: json
+schema:
+  type: array
+  items:
+    type: array
+    items:
+    - type: string
+      name: field_1


### PR DESCRIPTION
AbsPath is a filesystem concern, and belongs in the qfs package. This moves it (and properly documents the lib API break, a habit we need to improve on a bit)

Plus small bump to test coverage for lib.ReadDatasetFiles