### PR TITLE
fix(render): supply default 'html' format if none exists

### DIFF
--- a/base/render.go
+++ b/base/render.go
@@ -67,6 +67,10 @@ func init() {
 // MaybeAddDefaultViz sets a dataset viz component and template if none exists
 func MaybeAddDefaultViz(ds *dataset.Dataset) {
 	if ds.Viz != nil {
+		// ensure viz defaults to HTML if unspecified
+		if ds.Viz.Format == "" {
+			ds.Viz.Format = "html"
+		}
 		return
 	}
 	ds.Viz = &dataset.Viz{Format: "html"}


### PR DESCRIPTION
I was running into issues adding templates to existing datasets that for some reason didn't have `format: "html"`. This tiny hack fixes that for now