### PR TITLE
refactor(p2p): Give node a CoreAPI accessor to simplify dependencies

### DIFF
--- a/actions/dag.go
+++ b/actions/dag.go
@@ -6,8 +6,6 @@ import (
 	"github.com/qri-io/qri/p2p"
 
 	ipld "gx/ipfs/QmR7TcHkR9nxkUorfi8XMTAMLUK7GiP64TWWBzY3aacc1o/go-ipld-format"
-	"gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core/coreapi"
-	coreiface "gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core/coreapi/interface"
 )
 
 // NewManifest generates a manifest for a given node
@@ -41,23 +39,10 @@ func NewDAGInfo(node *p2p.QriNode, path, label string) (*dag.Info, error) {
 }
 
 // newNodeGetter generates an ipld.NodeGetter from a QriNode
-func newNodeGetter(node *p2p.QriNode) (ng ipld.NodeGetter, err error) {
-	ipfsn, err := node.IPFSNode()
+func newNodeGetter(node *p2p.QriNode) (ipld.NodeGetter, error) {
+	capi, err := node.IPFSCoreAPI()
 	if err != nil {
 		return nil, err
 	}
-
-	ng = &dag.NodeGetter{Dag: coreapi.NewCoreAPI(ipfsn).Dag()}
-	return
-}
-
-// newIPFSCoreAPI generates a coreiface.CoreAPI from a QriNode
-// from go-ipfs: "coreapi provides direct access to the core commands in IPFS"
-func newIPFSCoreAPI(node *p2p.QriNode) (capi coreiface.CoreAPI, err error) {
-	ipfsn, err := node.IPFSNode()
-	if err != nil {
-		return nil, err
-	}
-
-	return coreapi.NewCoreAPI(ipfsn), nil
+	return dag.NewNodeGetter(capi), nil
 }

--- a/actions/dataset.go
+++ b/actions/dataset.go
@@ -159,7 +159,7 @@ func AddDataset(node *p2p.QriNode, ref *repo.DatasetRef) (err error) {
 				return
 			}
 
-			capi, err := newIPFSCoreAPI(node)
+			capi, err := node.IPFSCoreAPI()
 			if res.Error != nil {
 				res.Error = err
 				return

--- a/api/webapp.go
+++ b/api/webapp.go
@@ -56,13 +56,13 @@ func (s *Server) resolveWebappPath(path *string) {
 		return
 	}
 
-	node, err := s.qriNode.IPFSNode()
+	namesys, err := s.qriNode.GetIPFSNamesys()
 	if err != nil {
 		log.Debugf("no IPFS node present to resolve webapp address: %s", err.Error())
 		return
 	}
 
-	p, err := node.Namesys.Resolve(context.Background(), s.cfg.Webapp.EntrypointUpdateAddress)
+	p, err := namesys.Resolve(context.Background(), s.cfg.Webapp.EntrypointUpdateAddress)
 	if err != nil {
 		log.Infof("error resolving IPNS Name: %s", err.Error())
 		return

--- a/lib/remote.go
+++ b/lib/remote.go
@@ -16,9 +16,6 @@ import (
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
-
-	ipld "gx/ipfs/QmR7TcHkR9nxkUorfi8XMTAMLUK7GiP64TWWBzY3aacc1o/go-ipld-format"
-	"gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core/coreapi"
 )
 
 const allowedDagInfoSize uint64 = 10 * 1024 * 1024
@@ -116,10 +113,11 @@ func (r *RemoteRequests) PushToRemote(p *PushParams, out *bool) error {
 	// Run dsync to transfer all of the blocks of the dataset.
 	fmt.Printf("Running dsync...\n")
 
-	ng, err := newNodeGetter(r.node)
+	capi, err := r.node.IPFSCoreAPI()
 	if err != nil {
 		return err
 	}
+	ng := dag.NewNodeGetter(capi)
 
 	remote := &dsync.HTTPRemote{
 		URL: fmt.Sprintf("%s/dsync", location),
@@ -169,17 +167,6 @@ func (r *RemoteRequests) PushToRemote(p *PushParams, out *bool) error {
 
 	*out = true
 	return nil
-}
-
-// newNodeGetter generates an ipld.NodeGetter from a QriNode
-func newNodeGetter(node *p2p.QriNode) (ng ipld.NodeGetter, err error) {
-	ipfsn, err := node.IPFSNode()
-	if err != nil {
-		return nil, err
-	}
-
-	ng = &dag.NodeGetter{Dag: coreapi.NewCoreAPI(ipfsn).Dag()}
-	return
 }
 
 // Receive is used to save a dataset when running as a remote. API only, not RPC or command-line.

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -40,7 +40,7 @@ func (n *QriNode) Bootstrap(boostrapAddrs []string, boostrapPeers chan pstore.Pe
 
 // BootstrapIPFS connects this node to standard ipfs nodes for file exchange
 func (n *QriNode) BootstrapIPFS() {
-	if node, err := n.IPFSNode(); err == nil {
+	if node, err := n.ipfsNode(); err == nil {
 		if err := node.Bootstrap(ipfscore.DefaultBootstrapConfig); err != nil {
 			log.Errorf("IPFS bootsrap error: %s", err.Error())
 		}

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -262,7 +262,7 @@ func (n *QriNode) GetIPFSNamesys() (namesys.NameSystem, error) {
 	return ipfsn.Namesys, nil
 }
 
-// IPFSCoreAPI returns a pointer to the core IPFS API
+// IPFSCoreAPI returns a IPFS API interface instance
 func (n *QriNode) IPFSCoreAPI() (coreiface.CoreAPI, error) {
 	ipfsfs, ok := n.Repo.Store().(*ipfs_filestore.Filestore)
 	if !ok {

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -21,6 +21,9 @@ import (
 	libp2p "gx/ipfs/QmUDTcnDp2WssbmiDLC6aYurUeyt7QeRakHUQMxA2mZ5iB/go-libp2p"
 	discovery "gx/ipfs/QmUDTcnDp2WssbmiDLC6aYurUeyt7QeRakHUQMxA2mZ5iB/go-libp2p/p2p/discovery"
 	core "gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core"
+	"gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core/coreapi"
+	coreiface "gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core/coreapi/interface"
+	namesys "gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/namesys"
 	circuit "gx/ipfs/QmVYDvJjiKb9iFEyHxx4i1TJSRBLkQhGb5Fc8XpmDuNCEA/go-libp2p-circuit"
 	net "gx/ipfs/QmXuRkCR7BNQa9uqfpTiFWsTQLzmTWYg91Ja1w95gnqb6u/go-libp2p-net"
 	host "gx/ipfs/QmdJfsSbKSZnMkfZ1kpopiyB9i3Hd6cp8VKWZmtWPa7Moc/go-libp2p-host"
@@ -242,12 +245,31 @@ func (n *QriNode) echoMessages() {
 	}
 }
 
-// IPFSNode returns the underlying IPFS node if this Qri Node is running on IPFS
-func (n *QriNode) IPFSNode() (*core.IpfsNode, error) {
+// ipfsNode returns the internal IPFS node
+func (n *QriNode) ipfsNode() (*core.IpfsNode, error) {
 	if ipfsfs, ok := n.Repo.Store().(*ipfs_filestore.Filestore); ok {
 		return ipfsfs.Node(), nil
 	}
 	return nil, fmt.Errorf("not using IPFS")
+}
+
+// GetIPFSNamesys returns a namesystem from IPFS
+func (n *QriNode) GetIPFSNamesys() (namesys.NameSystem, error) {
+	ipfsn, err := n.ipfsNode()
+	if err != nil {
+		return nil, err
+	}
+	return ipfsn.Namesys, nil
+}
+
+// IPFSCoreAPI returns a pointer to the core IPFS API
+func (n *QriNode) IPFSCoreAPI() (coreiface.CoreAPI, error) {
+	ipfsfs, ok := n.Repo.Store().(*ipfs_filestore.Filestore)
+	if !ok {
+		return nil, fmt.Errorf("not using IPFS")
+	}
+	inode := ipfsfs.Node()
+	return coreapi.NewCoreAPI(inode), nil
 }
 
 // ListenAddresses gives the listening addresses of this node on the p2p network as

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -253,7 +253,7 @@ func (n *QriNode) getPeerInfo(pid peer.ID) (pstore.PeerInfo, error) {
 	}
 
 	// attempt to use ipfs routing table to discover peer
-	ipfsnode, err := n.IPFSNode()
+	ipfsnode, err := n.ipfsNode()
 	if err != nil {
 		log.Debug(err.Error())
 		return pstore.PeerInfo{}, err


### PR DESCRIPTION
Instead of passing around IPFSNode pointers everywhere, add an accessor that directly returns a CoreAPI pointer, and an IPFSNamesys pointer. Simplifies a bunch of call sites. Fixes #720.