### PR TITLE
fix(ref): CanonicalizeProfile just handles renames all the time

### DIFF
--- a/actions/list_datasets.go
+++ b/actions/list_datasets.go
@@ -23,7 +23,7 @@ func ListDatasets(node *p2p.QriNode, ds *repo.DatasetRef, limit, offset int, RPC
 		ds.ProfileID = pro.ID
 	}
 
-	if err := repo.CanonicalizeProfile(r, ds, nil); err != nil {
+	if err := repo.CanonicalizeProfile(r, ds); err != nil {
 		return nil, fmt.Errorf("error canonicalizing peer: %s", err.Error())
 	}
 

--- a/base/dataset.go
+++ b/base/dataset.go
@@ -95,10 +95,9 @@ func ListDatasets(r repo.Repo, limit, offset int, RPC, publishedOnly, showVersio
 		res = pub[:i]
 	}
 
-	renames := repo.NewNeedPeernameRenames()
 	for i, ref := range res {
 		// May need to change peername.
-		if err := repo.CanonicalizeProfile(r, &res[i], &renames); err != nil {
+		if err := repo.CanonicalizeProfile(r, &res[i]); err != nil {
 			return nil, fmt.Errorf("error canonicalizing dataset peername: %s", err.Error())
 		}
 
@@ -120,7 +119,6 @@ func ListDatasets(r repo.Repo, limit, offset int, RPC, publishedOnly, showVersio
 		}
 	}
 
-	// TODO (dustmop): If renames.Renames is non-empty, apply it to r
 	return
 }
 

--- a/lib/profile.go
+++ b/lib/profile.go
@@ -77,7 +77,7 @@ func (r *ProfileRequests) getProfile(idStr, peername string) (pro *profile.Profi
 		ref := &repo.DatasetRef{
 			Peername: peername,
 		}
-		if err = repo.CanonicalizeProfile(r.node.Repo, ref, nil); err != nil {
+		if err = repo.CanonicalizeProfile(r.node.Repo, ref); err != nil {
 			log.Error("error canonicalizing profile", err.Error())
 			return nil, err
 		}

--- a/repo/ref.go
+++ b/repo/ref.go
@@ -332,18 +332,6 @@ func isBase58Multihash(hash string) bool {
 	return true
 }
 
-// NeedPeernameRenames represents which peernames need to be renamed, and to what.
-type NeedPeernameRenames struct {
-	Renames map[string]string
-}
-
-// NewNeedPeernameRenames returns a new NeedPeerNameRenames struct.
-func NewNeedPeernameRenames() NeedPeernameRenames {
-	return NeedPeernameRenames{
-		Renames: make(map[string]string),
-	}
-}
-
 // CanonicalizeDatasetRef uses the user's repo to turn any local aliases into full dataset
 // references using known canonical peernames and paths. If the provided reference is not
 // in the local repo, still do the work of handling aliases, but return a repo.ErrNotFound
@@ -361,7 +349,7 @@ func CanonicalizeDatasetRef(r Repo, ref *DatasetRef) error {
 		return ErrEmptyRef
 	}
 
-	if err := CanonicalizeProfile(r, ref, nil); err != nil {
+	if err := CanonicalizeProfile(r, ref); err != nil {
 		return err
 	}
 
@@ -395,7 +383,7 @@ func CanonicalizeDatasetRef(r Repo, ref *DatasetRef) error {
 
 // CanonicalizeProfile populates dataset DatasetRef ProfileID and Peername properties,
 // changing aliases to known names, and adding ProfileID from a peerstore
-func CanonicalizeProfile(r Repo, ref *DatasetRef, need *NeedPeernameRenames) error {
+func CanonicalizeProfile(r Repo, ref *DatasetRef) error {
 	if ref.Peername == "" && ref.ProfileID == "" {
 		return nil
 	}
@@ -417,13 +405,10 @@ func CanonicalizeProfile(r Repo, ref *DatasetRef, need *NeedPeernameRenames) err
 				return fmt.Errorf("Peername and ProfileID combination not valid: Peername = %s, ProfileID = %s, but was given ProfileID = %s", p.Peername, p.ID, ref.ProfileID)
 			}
 			if ref.ProfileID == p.ID && ref.Peername != p.Peername {
-				// Rename may have happended, record it if requested by caller.
-				if need != nil {
-					need.Renames[ref.Peername] = p.Peername
-					ref.Peername = p.Peername
-					return nil
-				}
-				return fmt.Errorf("Peername and ProfileID combination not valid: ProfileID = %s, Peername = %s, but was given Peername = %s", p.ID, p.Peername, ref.Peername)
+				// The peer renamed itself at some point, but the profileID matches. Use the
+				// new peername.
+				ref.Peername = p.Peername
+				return nil
 			}
 			if ref.Peername == p.Peername && ref.ProfileID == p.ID {
 				return nil


### PR DESCRIPTION
Handle peername changes all the time, by matching profileID, instead of only doing so if a third parameter was being supplied to CanonicalizeProfile.