### PR TITLE
refactor(lib.ConfigMethods): removes `lib.ConfigMethods` interface

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -143,7 +143,7 @@ func (s Server) ServeRPC() {
 
 	for _, rcvr := range lib.Receivers(s.Instance) {
 		if err := rpc.Register(rcvr); err != nil {
-			log.Infof("error registering RPC receiver %s: %s", rcvr.CoreRequestsName(), err.Error())
+			log.Errorf("cannot start RPC: error registering RPC receiver %s: %s", rcvr.CoreRequestsName(), err.Error())
 			return
 		}
 	}

--- a/api/profile.go
+++ b/api/profile.go
@@ -20,7 +20,7 @@ type ProfileHandlers struct {
 // NewProfileHandlers allocates a ProfileHandlers pointer
 func NewProfileHandlers(inst *lib.Instance, readOnly bool) *ProfileHandlers {
 	h := ProfileHandlers{
-		ProfileMethods: lib.NewProfileMethods(inst),
+		ProfileMethods: *lib.NewProfileMethods(inst),
 		ReadOnly:       readOnly,
 	}
 	return &h

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -124,8 +124,8 @@ type ConfigOptions struct {
 	Output          string
 
 	inst           *lib.Instance
-	ConfigMethods  lib.ConfigMethods
-	ProfileMethods lib.ProfileMethods
+	ConfigMethods  *lib.ConfigMethods
+	ProfileMethods *lib.ProfileMethods
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -225,7 +225,7 @@ func (o *ConfigOptions) Set(args []string) (err error) {
 	return nil
 }
 
-func setPhotoPath(m lib.ProfileMethods, proppath, filepath string) error {
+func setPhotoPath(m *lib.ProfileMethods, proppath, filepath string) error {
 	f, err := loadFileIfPath(filepath)
 	if err != nil {
 		return err

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -26,14 +26,14 @@ type Factory interface {
 	RPC() *rpc.Client
 	ConnectionNode() (*p2p.QriNode, error)
 
-	ConfigMethods() (lib.ConfigMethods, error)
+	ConfigMethods() (*lib.ConfigMethods, error)
 	DatasetRequests() (*lib.DatasetRequests, error)
 	RemoteRequests() (*lib.RemoteRequests, error)
 	RegistryRequests() (*lib.RegistryRequests, error)
 	LogRequests() (*lib.LogRequests, error)
 	ExportRequests() (*lib.ExportRequests, error)
 	PeerRequests() (*lib.PeerRequests, error)
-	ProfileMethods() (lib.ProfileMethods, error)
+	ProfileMethods() (*lib.ProfileMethods, error)
 	SearchRequests() (*lib.SearchRequests, error)
 	RenderRequests() (*lib.RenderRequests, error)
 	SelectionRequests() (*lib.SelectionRequests, error)

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -106,7 +106,7 @@ func (t TestFactory) RPC() *rpc.Client {
 }
 
 // ConfigMethods generates a lib.ConfigMethods from internal state
-func (t TestFactory) ConfigMethods() (lib.ConfigMethods, error) {
+func (t TestFactory) ConfigMethods() (*lib.ConfigMethods, error) {
 	return lib.NewConfigMethods(t.inst), nil
 }
 
@@ -141,7 +141,7 @@ func (t TestFactory) PeerRequests() (*lib.PeerRequests, error) {
 }
 
 // ProfileMethods generates a lib.ProfileMethods from internal state
-func (t TestFactory) ProfileMethods() (lib.ProfileMethods, error) {
+func (t TestFactory) ProfileMethods() (*lib.ProfileMethods, error) {
 	return lib.NewProfileMethods(t.inst), nil
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -84,7 +84,9 @@ func (o *GetOptions) Complete(f Factory, args []string) (err error) {
 		}
 	}
 	o.Refs = args
-	o.DatasetRequests, err = f.DatasetRequests()
+	if o.DatasetRequests, err = f.DatasetRequests(); err != nil {
+		return
+	}
 
 	if o.Selector == "body" {
 		// if we have a limit, but not offset, assume an offset of 0

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -65,7 +65,9 @@ type PublishOptions struct {
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *PublishOptions) Complete(f Factory, args []string) (err error) {
 	o.Refs = args
-	o.DatasetRequests, err = f.DatasetRequests()
+	if o.DatasetRequests, err = f.DatasetRequests(); err != nil {
+		return err
+	}
 	o.RemoteRequests, err = f.RemoteRequests()
 	return
 }

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -214,7 +214,7 @@ func (o *QriOptions) PeerRequests() (*lib.PeerRequests, error) {
 }
 
 // ProfileMethods generates a lib.ProfileMethods from internal state
-func (o *QriOptions) ProfileMethods() (m lib.ProfileMethods, err error) {
+func (o *QriOptions) ProfileMethods() (m *lib.ProfileMethods, err error) {
 	if err = o.Init(); err != nil {
 		return
 	}
@@ -247,7 +247,7 @@ func (o *QriOptions) RenderRequests() (*lib.RenderRequests, error) {
 }
 
 // ConfigMethods generates a lib.ConfigMethods from internal state
-func (o *QriOptions) ConfigMethods() (m lib.ConfigMethods, err error) {
+func (o *QriOptions) ConfigMethods() (m *lib.ConfigMethods, err error) {
 	if err = o.Init(); err != nil {
 		return
 	}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -64,8 +64,7 @@ type RemoveOptions struct {
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *RemoveOptions) Complete(f Factory, args []string) (err error) {
 	o.Args = args
-	o.DatasetRequests, err = f.DatasetRequests()
-	if err != nil {
+	if o.DatasetRequests, err = f.DatasetRequests(); err != nil {
 		return err
 	}
 	if o.All {

--- a/lib/config.go
+++ b/lib/config.go
@@ -15,8 +15,8 @@ type ConfigMethods struct {
 
 
 // NewConfigMethods creates a configuration handle from an instance
-func NewConfigMethods(inst *Instance) ConfigMethods {
-	return ConfigMethods{inst: inst}
+func NewConfigMethods(inst *Instance) *ConfigMethods {
+	return &ConfigMethods{inst: inst}
 }
 
 // CoreRequestsName specifies this is a configuration handle
@@ -33,7 +33,7 @@ type GetConfigParams struct {
 
 // GetConfig returns the Config, or one of the specified fields of the Config,
 // as a slice of bytes the bytes can be formatted as json, concise json, or yaml
-func (m ConfigMethods) GetConfig(p *GetConfigParams, res *[]byte) (err error) {
+func (m *ConfigMethods) GetConfig(p *GetConfigParams, res *[]byte) (err error) {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ConfigMethods.GetConfig", p, res)
 	}
@@ -76,7 +76,7 @@ func (m ConfigMethods) GetConfig(p *GetConfigParams, res *[]byte) (err error) {
 }
 
 // SetConfig validates, updates and saves the config
-func (m ConfigMethods) SetConfig(update *config.Config, set *bool) (err error) {
+func (m *ConfigMethods) SetConfig(update *config.Config, set *bool) (err error) {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ConfigMethods.SetConfig", update, set)
 	}

--- a/lib/config.go
+++ b/lib/config.go
@@ -9,29 +9,18 @@ import (
 )
 
 // ConfigMethods encapsulates changes to a qri configuration
-type ConfigMethods interface {
-	// CoreRequestsName specifies participation in the methods interface
-	// TODO (b5): update func name when change happens
-	CoreRequestsName() string
-	// GetConfig returns the Config, or one of the specified fields of the Config,
-	// as a slice of bytes the bytes can be formatted as json, concise json, or yaml
-	GetConfig(p *GetConfigParams, res *[]byte) (err error)
-	// SetConfig validates, updates and saves the config
-	SetConfig(update *config.Config, set *bool) (err error)
-}
-
-// NewConfigMethods creates a configuration handle from an instance
-func NewConfigMethods(inst *Instance) ConfigMethods {
-	return configMethods{inst: inst}
-}
-
-// configMethods is the private implementation of ConfigMethods
-type configMethods struct {
+type ConfigMethods struct {
 	inst *Instance
 }
 
+
+// NewConfigMethods creates a configuration handle from an instance
+func NewConfigMethods(inst *Instance) ConfigMethods {
+	return ConfigMethods{inst: inst}
+}
+
 // CoreRequestsName specifies this is a configuration handle
-func (m configMethods) CoreRequestsName() string { return "config" }
+func (m ConfigMethods) CoreRequestsName() string { return "config" }
 
 // GetConfigParams are the params needed to format/specify the fields in bytes
 // returned from the GetConfig function
@@ -44,7 +33,7 @@ type GetConfigParams struct {
 
 // GetConfig returns the Config, or one of the specified fields of the Config,
 // as a slice of bytes the bytes can be formatted as json, concise json, or yaml
-func (m configMethods) GetConfig(p *GetConfigParams, res *[]byte) (err error) {
+func (m ConfigMethods) GetConfig(p *GetConfigParams, res *[]byte) (err error) {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ConfigMethods.GetConfig", p, res)
 	}
@@ -87,7 +76,7 @@ func (m configMethods) GetConfig(p *GetConfigParams, res *[]byte) (err error) {
 }
 
 // SetConfig validates, updates and saves the config
-func (m configMethods) SetConfig(update *config.Config, set *bool) (err error) {
+func (m ConfigMethods) SetConfig(update *config.Config, set *bool) (err error) {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ConfigMethods.SetConfig", update, set)
 	}

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -278,9 +278,11 @@ func NewInstance(opts ...Option) (qri *Instance, err error) {
 	// check if we're operating over RPC
 	if cfg.RPC.Enabled {
 		addr := fmt.Sprintf(":%d", cfg.RPC.Port)
-		if conn, err := net.Dial("tcp", addr); err != nil {
-			err = nil
-		} else {
+		log.Infof("Dialing rpc address %s", addr)
+		conn, err := net.Dial("tcp", addr)
+		if err == nil {
+			// we have a connection
+			log.Infof("Connected over rpc")
 			inst.rpc = rpc.NewClient(conn)
 			return qri, err
 		}

--- a/lib/profile.go
+++ b/lib/profile.go
@@ -25,12 +25,12 @@ func (ProfileMethods) CoreRequestsName() string { return "profile" }
 
 // NewProfileMethods creates a ProfileMethods pointer from either a repo
 // or an rpc.Client
-func NewProfileMethods(inst *Instance) ProfileMethods {
-	return ProfileMethods{inst: inst}
+func NewProfileMethods(inst *Instance) *ProfileMethods {
+	return &ProfileMethods{inst: inst}
 }
 
 // GetProfile get's this node's peer profile
-func (m ProfileMethods) GetProfile(in *bool, res *config.ProfilePod) (err error) {
+func (m *ProfileMethods) GetProfile(in *bool, res *config.ProfilePod) (err error) {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ProfileMethods.GetProfile", in, res)
 	}
@@ -65,7 +65,7 @@ func (m ProfileMethods) GetProfile(in *bool, res *config.ProfilePod) (err error)
 	return nil
 }
 
-func (m ProfileMethods) getProfile(r repo.Repo, idStr, peername string) (pro *profile.Profile, err error) {
+func (m *ProfileMethods) getProfile(r repo.Repo, idStr, peername string) (pro *profile.Profile, err error) {
 	var id profile.ID
 	if idStr == "" {
 		ref := &repo.DatasetRef{
@@ -94,7 +94,7 @@ func (m ProfileMethods) getProfile(r repo.Repo, idStr, peername string) (pro *pr
 }
 
 // SaveProfile stores changes to this peer's editable profile
-func (m ProfileMethods) SaveProfile(p *config.ProfilePod, res *config.ProfilePod) error {
+func (m *ProfileMethods) SaveProfile(p *config.ProfilePod, res *config.ProfilePod) error {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ProfileMethods.SaveProfile", p, res)
 	}
@@ -161,7 +161,7 @@ func (m ProfileMethods) SaveProfile(p *config.ProfilePod, res *config.ProfilePod
 }
 
 // ProfilePhoto fetches the byte slice of a given user's profile photo
-func (m ProfileMethods) ProfilePhoto(req *config.ProfilePod, res *[]byte) (err error) {
+func (m *ProfileMethods) ProfilePhoto(req *config.ProfilePod, res *[]byte) (err error) {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ProfileMethods.ProfilePhoto", req, res)
 	}
@@ -194,7 +194,7 @@ type FileParams struct {
 }
 
 // SetProfilePhoto changes this peer's profile image
-func (m ProfileMethods) SetProfilePhoto(p *FileParams, res *config.ProfilePod) error {
+func (m *ProfileMethods) SetProfilePhoto(p *FileParams, res *config.ProfilePod) error {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ProfileMethods.SetProfilePhoto", p, res)
 	}
@@ -260,7 +260,7 @@ func (m ProfileMethods) SetProfilePhoto(p *FileParams, res *config.ProfilePod) e
 }
 
 // PosterPhoto fetches the byte slice of a given user's poster photo
-func (m ProfileMethods) PosterPhoto(req *config.ProfilePod, res *[]byte) (err error) {
+func (m *ProfileMethods) PosterPhoto(req *config.ProfilePod, res *[]byte) (err error) {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ProfileMethods.PostPhoto", req, res)
 	}
@@ -285,7 +285,7 @@ func (m ProfileMethods) PosterPhoto(req *config.ProfilePod, res *[]byte) (err er
 }
 
 // SetPosterPhoto changes this peer's poster image
-func (m ProfileMethods) SetPosterPhoto(p *FileParams, res *config.ProfilePod) error {
+func (m *ProfileMethods) SetPosterPhoto(p *FileParams, res *config.ProfilePod) error {
 	if m.inst.rpc != nil {
 		return m.inst.rpc.Call("ProfileMethods.SetPosterPhoto", p, res)
 	}


### PR DESCRIPTION
We've talked a bit about this internally, but we have a new guideline for when something should be an interface: if we can think of more then one implementation... it should be an interface!

Otherwise, let's just make it a concrete struct! 

Our first move over to this philosophy is the `lib.ConfigMethods`. Because we need to serve Qri over RPC, we need to follow some rules about the signatures of the methods we are registering. One of the stipulations for registering a method over rpc, is the struct on which the method operates must be exported. Because we implemented a private `configMethods` struct, that satisfies the `ConfigMethods` interface, we would need to jump through a few hoops to get the `configMethods` struct to be seen as exported when we try registering its methods over RPC. Instead, let's just remove the `ConfigMethods` interface in favor of exporting a `ConfigMethods` struct.

Other things this PR addresses:
- we aren't catching the error from getting a`DatasetRequest` in `cmd/Get`, this causes a panic. So let's catch the error
- refactoring `lib.NewInstance` that makes the RPC dialing/connecting process more clear. Basically, the first time we run `Init`, dialing to RPC should fail. If it doesn't fail, then we already have RPC connection running, so we should connect to that RPC connection and return. Otherwise, we have to do a full set up of a qri instance.