### PR TITLE
feat(base/fill): Overhaul error handling

### DIFF
--- a/base/fill/error_collector.go
+++ b/base/fill/error_collector.go
@@ -1,0 +1,57 @@
+package fill
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrorCollector collects errors, merging them into one, while noting the path where they happen
+type ErrorCollector struct {
+	errs   []error
+	fields []string
+}
+
+// NewErrorCollector creates a new ErrorCollector
+func NewErrorCollector() *ErrorCollector {
+	return &ErrorCollector{
+		errs:   make([]error, 0),
+		fields: make([]string, 0),
+	}
+}
+
+// Add adds a non-nil error to the ErrorCollector, noting the path where the error happened
+func (c *ErrorCollector) Add(err error) bool {
+	if err == nil {
+		return false
+	}
+	if len(c.fields) > 0 {
+		c.errs = append(c.errs, fmt.Errorf("at %s: %s", strings.Join(c.fields, "."), err.Error()))
+		return true
+	}
+	c.errs = append(c.errs, err)
+	return true
+}
+
+// AsSingleError returns the collected errors as a single error, or nil if there are none
+func (c *ErrorCollector) AsSingleError() error {
+	if len(c.errs) == 0 {
+		return nil
+	} else if len(c.errs) == 1 {
+		return c.errs[0]
+	}
+	collect := make([]string, 0)
+	for _, err := range c.errs {
+		collect = append(collect, err.Error())
+	}
+	return fmt.Errorf("%s", strings.Join(collect, "\n"))
+}
+
+// PushField adds a field to the current path
+func (c *ErrorCollector) PushField(fieldName string) {
+	c.fields = append(c.fields, fieldName)
+}
+
+// PopField removes the most recent field from the current path
+func (c *ErrorCollector) PopField() {
+	c.fields = c.fields[:len(c.fields)-1]
+}

--- a/base/fill/path_value_test.go
+++ b/base/fill/path_value_test.go
@@ -51,6 +51,35 @@ func TestFillPathValue(t *testing.T) {
 	}
 
 	c = Collection{}
+	err = SetPathValue("ison", "false", &c)
+	if err != nil {
+		panic(err)
+	}
+	if c.IsOn {
+		t.Errorf("expected: s.IsOn should be false")
+	}
+
+	c = Collection{}
+	err = SetPathValue("ison", 123, &c)
+	expect := "at ison: need bool, got int: 123"
+	if err == nil {
+		t.Fatalf("expected: error \"%s\", got no error", expect)
+	}
+	if err.Error() != expect {
+		t.Errorf("expected: error should be \"%s\", got \"%s\"", expect, err.Error())
+	}
+
+	c = Collection{}
+	err = SetPathValue("ison", "abc", &c)
+	expect = "at ison: need bool, got string: \"abc\""
+	if err == nil {
+		t.Fatalf("expected: error \"%s\", got no error", expect)
+	}
+	if err.Error() != expect {
+		t.Errorf("expected: error should be \"%s\", got \"%s\"", expect, err.Error())
+	}
+
+	c = Collection{}
 	err = SetPathValue("ptr", 123, &c)
 	if err != nil {
 		panic(err)
@@ -61,7 +90,30 @@ func TestFillPathValue(t *testing.T) {
 
 	c = Collection{}
 	err = SetPathValue("not_found", "missing", &c)
-	expect := "path: \"not_found\" not found"
+	expect = "path: \"not_found\" not found"
+	if err == nil {
+		t.Fatalf("expected: error \"%s\", got no error", expect)
+	}
+	if err.Error() != expect {
+		t.Errorf("expected: error should be \"%s\", got \"%s\"", expect, err.Error())
+	}
+
+	// TODO: path like `list.0` where the index == len(list), should extend the list by 1
+
+	c = Collection{}
+	err = SetPathValue("list.2", "abc", &c)
+	expect = "at list.2: index outside of range: 2, len is 0"
+	if err == nil {
+		t.Fatalf("expected: error \"%s\", got no error", expect)
+	}
+	if err.Error() != expect {
+		t.Errorf("expected: error should be \"%s\", got \"%s\"", expect, err.Error())
+	}
+
+	c = Collection{}
+	c.List = make([]string, 4)
+	err = SetPathValue("list.2", 123, &c)
+	expect = "at list.2: need string, got int: 123"
 	if err == nil {
 		t.Fatalf("expected: error \"%s\", got no error", expect)
 	}
@@ -119,4 +171,77 @@ func TestFillPathValue(t *testing.T) {
 	if (*s.Things)["frog"] != "ribbit" {
 		t.Errorf("expected: c.Things[\"frog\"] should be \"ribbit\"")
 	}
+
+	// Error
+	c = Collection{}
+	err = SetPathValue("sub.num", "abc", &c)
+	expect = "at sub.num: need int, got string: \"abc\""
+	if err == nil {
+		t.Fatalf("expected: error \"%s\", got no error", expect)
+	}
+	if err.Error() != expect {
+		t.Errorf("expected: error should be \"%s\", got \"%s\"", expect, err.Error())
+	}
+}
+
+func TestGetPathValue(t *testing.T) {
+	c := Collection{
+		Name: "Alice",
+		Dict: map[string]string{
+			"extra": "misc",
+		},
+		List: []string{"cat", "dog", "eel"},
+	}
+
+	val, err := GetPathValue("name", &c)
+	if err != nil {
+		panic(err)
+	}
+	if val != "Alice" {
+		t.Errorf("expected: val should be \"Alice\"")
+	}
+
+	val, err = GetPathValue("dict.extra", &c)
+	if err != nil {
+		panic(err)
+	}
+	if val != "misc" {
+		t.Errorf("expected: val should be \"misc\"")
+	}
+
+	val, err = GetPathValue("not_found", &c)
+	expect := "path: \"not_found\" not found"
+	if err == nil {
+		t.Fatalf("expected: error \"%s\", got no error", expect)
+	}
+	if err.Error() != expect {
+		t.Errorf("expected: error should be \"%s\", got \"%s\"", expect, err.Error())
+	}
+
+	val, err = GetPathValue("dict.missing_key", &c)
+	expect = "invalid path: \"dict.missing_key\""
+	if err == nil {
+		t.Fatalf("expected: error \"%s\", got no error", expect)
+	}
+	if err.Error() != expect {
+		t.Errorf("expected: error should be \"%s\", got \"%s\"", expect, err.Error())
+	}
+
+	val, err = GetPathValue("list.1", &c)
+	if err != nil {
+		panic(err)
+	}
+	if val != "dog" {
+		t.Errorf("expected: val should be \"dog\"")
+	}
+
+	val, err = GetPathValue("list.invalid", &c)
+	expect = "need int, got string: \"invalid\""
+	if err == nil {
+		t.Fatalf("expected: error \"%s\", got no error", expect)
+	}
+	if err.Error() != expect {
+		t.Errorf("expected: error should be \"%s\", got \"%s\"", expect, err.Error())
+	}
+
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -97,7 +97,7 @@ func TestConfigGet(t *testing.T) {
 	}{
 		{"foo", nil, "path: \"foo\" not found"},
 		{"p2p.enabled", true, ""},
-		{"p2p.QriBootstrapAddrs.foo", nil, "strconv.ParseInt: parsing \"foo\": invalid syntax"},
+		{"p2p.QriBootstrapAddrs.foo", nil, "need int, got string: \"foo\""},
 		{"p2p.QriBootstrapAddrs.0", cfg.P2P.QriBootstrapAddrs[0], ""},
 		{"logging.levels.qriapi", cfg.Logging.Levels["qriapi"], ""},
 		{"logging.levels.foo", nil, "invalid path: \"logging.levels.foo\""},
@@ -126,7 +126,7 @@ func TestConfigSet(t *testing.T) {
 		{"foo", nil, "path: \"foo\" not found"},
 		{"p2p.enabled", false, ""},
 		{"p2p.qribootstrapaddrs.0", "wahoo", ""},
-		{"p2p.qribootstrapaddrs.0", false, "invalid type for path \"p2p.qribootstrapaddrs.0\": expected string, got bool"},
+		{"p2p.qribootstrapaddrs.0", false, "at p2p.qribootstrapaddrs.0: need string, got bool: false"},
 		{"logging.levels.qriapi", "debug", ""},
 	}
 


### PR DESCRIPTION
Primary change: the path that an error occurs at is now prepended to the error message. Now they look like "at Meta.Title: need string, got int". Introduce FieldError, for when a field cannot be converted from its given type to the target type. Introduce ErrorCollector, which collects errors and merges them.
Raise test coverage by a significant amount.