### PR TITLE
chore(makefile): add missing text package dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GOFILES = $(shell find . -name '*.go' -not -path './vendor/*')
 define GOPACKAGES 
+golang.org/x/text \
 github.com/briandowns/spinner \
 github.com/datatogether/api/apiutil \
 github.com/fatih/color \


### PR DESCRIPTION
I have no idea why, but CI is now failing without this dependency, I'm guessing some upstream package changed their deps. go modules would be nice