### PR TITLE
fix(canonicalize): Correct peername when profileID matches

### DIFF
--- a/repo/ref.go
+++ b/repo/ref.go
@@ -371,13 +371,14 @@ func CanonicalizeDatasetRef(r Repo, ref *DatasetRef) error {
 	if ref.Name == "" {
 		ref.Name = got.Name
 	}
-	if ref.Peername == "" {
+	if ref.Peername == "" || ref.Peername != got.Peername {
 		ref.Peername = got.Peername
 	}
 	ref.Published = got.Published
-	if ref.Path != got.Path || ref.ProfileID != got.ProfileID || ref.Name != got.Name || ref.Peername != got.Peername {
+	if ref.Path != got.Path || ref.ProfileID != got.ProfileID || ref.Name != got.Name {
 		return fmt.Errorf("Given datasetRef %s does not match datasetRef on file: %s", ref.String(), got.String())
 	}
+
 	return nil
 }
 

--- a/repo/ref_test.go
+++ b/repo/ref_test.go
@@ -404,6 +404,7 @@ func TestCanonicalizeDatasetRef(t *testing.T) {
 		{"lucille/ball", "lucille/ball@2g/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", ""},
 		{"me/ball@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "lucille/ball@2g/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", ""},
 		{"@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "lucille/ball@2g/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", ""},
+		{"renamed/ball@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "lucille/ball@2g/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", ""},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
When CanonicalizeDatasetRef sees a ref with a matching profileID, but a different peername, use that new peername. The profileID is considered reliable, while the peername can change due to a peer rename. It should not be an error to see a different peername.