### PR TITLE
test(transform): Detect when transforms don't produce any changes

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -625,6 +625,38 @@ func TestSaveConflictingComponents(t *testing.T) {
 	}
 }
 
+// Test that running a transform without any changes will not make a new commit
+func TestSaveTransformWithoutChanges(t *testing.T) {
+	if err := confirmQriNotRunning(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	// To keep hashes consistent, artificially specify the timestamp by overriding
+	// the dsfs.Timestamp func
+	prev := dsfs.Timestamp
+	defer func() { dsfs.Timestamp = prev }()
+	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
+
+	r := NewTestRepoRoot(t, "qri_test_transform_same")
+	defer r.Delete()
+
+	cmdR := r.CreateCommandRunner()
+	_, err := executeCommand(cmdR, "qri save --file=testdata/movies/tf_123.star me/test_ds")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	cmdR = r.CreateCommandRunner()
+	_, err = executeCommand(cmdR, "qri save --file=testdata/movies/tf_123.star me/test_ds")
+	expect := `error saving: no changes detected`
+	if err == nil {
+		t.Errorf("expected error: did not get one")
+	}
+	if err.Error() != expect {
+		t.Errorf("expected error: \"%s\", got: \"%s\"", expect, err.Error())
+	}
+}
+
 // TODO: Perhaps this utility should move to a lower package, and be used as a way to validate the
 // bodies of dataset in more of our test case. That would require extracting some parts out, like
 // pathFactory, which would probably necessitate the pathFactory taking the testRepoRoot as a

--- a/cmd/testdata/movies/tf_123.star
+++ b/cmd/testdata/movies/tf_123.star
@@ -1,0 +1,3 @@
+# transform that sets a simple body
+def transform(ds, ctx):
+  ds.set_body([1,2,3])


### PR DESCRIPTION
Depends upon https://github.com/qri-io/dsdiff/pull/16 and https://github.com/qri-io/qri/pull/754. Currently `save`ing with a transform that produces no changes is broken, it always creates a commit because the differ see a new transform.ScriptPath. This fixes that.