### PR TITLE
fix(transform): Pass prev dataset to ExecScript

### DIFF
--- a/actions/dataset.go
+++ b/actions/dataset.go
@@ -46,7 +46,7 @@ func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string
 		mutateCheck := mutatedComponentsFunc(changes)
 
 		changes.Transform.Secrets = secrets
-		if err = ExecTransform(node, changes, scriptOut, mutateCheck); err != nil {
+		if err = ExecTransform(node, changes, prev, scriptOut, mutateCheck); err != nil {
 			return
 		}
 		// changes.Transform.SetScriptFile(mutable.Transform.ScriptFile())

--- a/actions/transform.go
+++ b/actions/transform.go
@@ -39,7 +39,7 @@ please adjust either the transform script or remove the supplied '%s'`, path[0],
 }
 
 // ExecTransform executes a designated transformation
-func ExecTransform(node *p2p.QriNode, ds *dataset.Dataset, scriptOut io.Writer, mutateCheck func(...string) error) error {
+func ExecTransform(node *p2p.QriNode, ds, prev *dataset.Dataset, scriptOut io.Writer, mutateCheck func(...string) error) error {
 	if ds.Transform == nil {
 		return fmt.Errorf("no transform provided")
 	}
@@ -64,7 +64,7 @@ func ExecTransform(node *p2p.QriNode, ds *dataset.Dataset, scriptOut io.Writer, 
 		setSecrets,
 	}
 
-	if err := startf.ExecScript(ds, configs...); err != nil {
+	if err := startf.ExecScript(ds, prev, configs...); err != nil {
 		return err
 	}
 

--- a/actions/transform_test.go
+++ b/actions/transform_test.go
@@ -27,11 +27,13 @@ func TestExecTransform(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	ds := &dataset.Dataset{
+	prev := &dataset.Dataset{
 		Structure: &dataset.Structure{
 			Format: "json",
 			Schema: dataset.BaseSchemaArray,
 		},
+	}
+	next := &dataset.Dataset{
 		Transform: &dataset.Transform{
 			Syntax:  "starlark",
 			Config:  map[string]interface{}{"foo": "config"},
@@ -45,9 +47,9 @@ def transform(ds,ctx):
 	ctx.get_secret("bar")
 	ds.set_body([1,2,3])
 	`)
-	ds.Transform.SetScriptFile(qfs.NewMemfileBytes("transform.star", data))
+	next.Transform.SetScriptFile(qfs.NewMemfileBytes("transform.star", data))
 
-	if err := ExecTransform(node, ds, nil, nil); err != nil {
+	if err := ExecTransform(node, next, prev, nil, nil); err != nil {
 		t.Error(err.Error())
 	}
 }

--- a/cmd/testdata/movies/body_two.json
+++ b/cmd/testdata/movies/body_two.json
@@ -1,0 +1,4 @@
+[
+    ["Avatar", 178],
+    ["Pirates of the Caribbean: At World's End", 169]
+]

--- a/cmd/testdata/movies/tf_add_one.star
+++ b/cmd/testdata/movies/tf_add_one.star
@@ -1,0 +1,6 @@
+def transform(ds, ctx):
+  body = ds.get_body()
+  for row in body:
+    row[1] = row[1] + 1
+  ds.set_body(body)
+

--- a/lib/config.go
+++ b/lib/config.go
@@ -13,7 +13,6 @@ type ConfigMethods struct {
 	inst *Instance
 }
 
-
 // NewConfigMethods creates a configuration handle from an instance
 func NewConfigMethods(inst *Instance) *ConfigMethods {
 	return &ConfigMethods{inst: inst}


### PR DESCRIPTION
Pass prev dataset as well as next dataset, in order to support new get_body functionality added by https://github.com/qri-io/startf/pull/41.