### PR TITLE
fix(config): Check err when parsing config to avoid segfault

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -181,6 +181,9 @@ func OptLoadConfigFile(path string) Option {
 		}
 
 		o.Cfg, err = config.ReadFromFile(path)
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
If loading the config has an error (for example: it contains an unknown field), the OptLoadConfigFile function needs to return an error, otherwise later Options will have a nil pointer for the config, causing them to segfault.