### PR TITLE
feat(pager): to make it easier to read, long output on the cli is sent to a pager

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/repo"
@@ -66,7 +68,8 @@ func (o *AddOptions) Run(args []string) error {
 			return err
 		}
 
-		printDatasetRefInfo(o.Out, 1, res)
+		refStr := refStringer(res)
+		fmt.Fprintf(o.Out, "\n%s", refStr.String())
 		printInfo(o.Out, "Successfully added dataset %s", ref)
 	}
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
-	"fmt"
 
 	"github.com/fatih/color"
 	"github.com/qri-io/deepdiff"
@@ -137,9 +137,6 @@ func (o *DiffOptions) Run() (err error) {
 			}
 		}
 	}
-
-	fmt.Fprintf(o.Out, stats+"\n")
-	fmt.Fprint(o.Out, text)
-
-	return nil
+	buf := bytes.NewBuffer([]byte(stats + "\n" + text))
+	return printToPager(o.Out, buf)
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -138,5 +138,6 @@ func (o *DiffOptions) Run() (err error) {
 		}
 	}
 	buf := bytes.NewBuffer([]byte(stats + "\n" + text))
-	return printToPager(o.Out, buf)
+	printToPager(o.Out, buf)
+	return
 }

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -92,10 +92,10 @@ func TestDiffRun(t *testing.T) {
 		},
 	}
 
-	for i, c := range cases {
+	for _, c := range cases {
 		dsr, err := f.DatasetRequests()
 		if err != nil {
-			t.Errorf("case %d, error creating dataset request: %s", i, err)
+			t.Errorf("case %s, error creating dataset request: %s", c.description, err)
 			continue
 		}
 
@@ -105,25 +105,25 @@ func TestDiffRun(t *testing.T) {
 
 		err = opt.Run()
 		if (err == nil && c.err != "") || (err != nil && c.err != err.Error()) {
-			t.Errorf("case %d, mismatched error. Expected: '%s', Got: '%v'", i, c.err, err)
+			t.Errorf("case %s, mismatched error. Expected: '%s', Got: '%v'", c.description, c.err, err)
 			ioReset(in, out, errs)
 			continue
 		}
 
 		if libErr, ok := err.(lib.Error); ok {
 			if libErr.Message() != c.errMsg {
-				t.Errorf("case %d, mismatched user-friendly message. Expected: '%s', Got: '%s'", i, c.errMsg, libErr.Message())
+				t.Errorf("case %s, mismatched user-friendly message. Expected: '%s', Got: '%s'", c.description, c.errMsg, libErr.Message())
 				ioReset(in, out, errs)
 				continue
 			}
 		} else if c.errMsg != "" {
-			t.Errorf("case %d, mismatched user-friendly message. Expected: '%s', Got: ''", i, c.errMsg)
+			t.Errorf("case %s, mismatched user-friendly message. Expected: '%s', Got: ''", c.description, c.errMsg)
 			ioReset(in, out, errs)
 			continue
 		}
 
 		if c.stdout != out.String() {
-			t.Errorf("case %d, output mismatch. Expected: '%s', Got: '%s'", i, c.stdout, out.String())
+			t.Errorf("case %s, output mismatch. Expected: '%s', Got: '%s'", c.description, c.stdout, out.String())
 			ioReset(in, out, errs)
 			continue
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
 
@@ -140,11 +141,7 @@ func (o *GetOptions) Run() (err error) {
 		return err
 	}
 
-	_, err = o.Out.Write(res.Bytes)
-	if err != nil {
-		return err
-	}
-	// commands should always be newline-terminiated, which isn't included in res.Bytes
-	_, err = o.Out.Write([]byte{'\n'})
-	return err
+	buf := bytes.NewBuffer(res.Bytes)
+	buf.Write([]byte{'\n'})
+	return printToPager(o.Out, buf)
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -143,5 +143,6 @@ func (o *GetOptions) Run() (err error) {
 
 	buf := bytes.NewBuffer(res.Bytes)
 	buf.Write([]byte{'\n'})
-	return printToPager(o.Out, buf)
+	printToPager(o.Out, buf)
+	return
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -87,7 +88,6 @@ func (o *ListOptions) Complete(f Factory, args []string) (err error) {
 
 // Run executes the list command
 func (o *ListOptions) Run() (err error) {
-
 	// convert Page and PageSize to Limit and Offset
 	page := util.NewPage(o.Page, o.PageSize)
 
@@ -122,7 +122,7 @@ func (o *ListOptions) Run() (err error) {
 	case "":
 		items := make([]fmt.Stringer, len(refs))
 		for i, r := range refs {
-			items[i] = ref(r)
+			items[i] = refStringer(r)
 		}
 		printItems(o.Out, items)
 	case dataset.JSONDataFormat.String():
@@ -130,7 +130,8 @@ func (o *ListOptions) Run() (err error) {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(o.Out, "%s\n", string(data))
+		buf := bytes.NewBuffer(data)
+		printToPager(o.Out, buf)
 	default:
 		return fmt.Errorf("unrecognized format: %s", o.Format)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -120,9 +120,11 @@ func (o *ListOptions) Run() (err error) {
 
 	switch o.Format {
 	case "":
-		for i, ref := range refs {
-			printDatasetRefInfo(o.Out, i+1, ref)
+		items := make([]fmt.Stringer, len(refs))
+		for i, r := range refs {
+			items[i] = ref(r)
 		}
+		printItems(o.Out, items)
 	case dataset.JSONDataFormat.String():
 		data, err := json.MarshalIndent(refs, "", "  ")
 		if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -124,14 +124,14 @@ func (o *ListOptions) Run() (err error) {
 		for i, r := range refs {
 			items[i] = refStringer(r)
 		}
-		printItems(o.Out, items)
+		return printItems(o.Out, items)
 	case dataset.JSONDataFormat.String():
 		data, err := json.MarshalIndent(refs, "", "  ")
 		if err != nil {
 			return err
 		}
 		buf := bytes.NewBuffer(data)
-		printToPager(o.Out, buf)
+		return printToPager(o.Out, buf)
 	default:
 		return fmt.Errorf("unrecognized format: %s", o.Format)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -124,14 +124,16 @@ func (o *ListOptions) Run() (err error) {
 		for i, r := range refs {
 			items[i] = refStringer(r)
 		}
-		return printItems(o.Out, items)
+		printItems(o.Out, items)
+		return nil
 	case dataset.JSONDataFormat.String():
 		data, err := json.MarshalIndent(refs, "", "  ")
 		if err != nil {
 			return err
 		}
 		buf := bytes.NewBuffer(data)
-		return printToPager(o.Out, buf)
+		printToPager(o.Out, buf)
+		return nil
 	default:
 		return fmt.Errorf("unrecognized format: %s", o.Format)
 	}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -104,19 +104,4 @@ func (o *LogOptions) Run() error {
 	}
 
 	return printItems(o.Out, items)
-
-	// outformat := cmd.Flag("format").Value.String()
-	// switch outformat {
-	// case "":
-	//  for _, ref := range refs {
-	//    printInfo("%s\t\t\t: %s", ref.Name, ref.Path)
-	//  }
-	// case dataset.JSONDataFormat.String():
-	//  data, err := json.MarshalIndent(refs, "", "  ")
-	//  ExitIfErr(o.ErrOut, err)
-	//  fmt.Printf("%s\n", string(data))
-	// default:
-	//  ErrExit(o.ErrOut, fmt.Errorf("unrecognized format: %s", outformat))
-	// }
-	// return nil
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -103,5 +103,6 @@ func (o *LogOptions) Run() error {
 		items[i] = logStringer(r)
 	}
 
-	return printItems(o.Out, items)
+	printItems(o.Out, items)
+	return nil
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	util "github.com/datatogether/api/apiutil"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/lib"
@@ -96,9 +98,12 @@ func (o *LogOptions) Run() error {
 		return err
 	}
 
-	for _, ref := range refs {
-		printSuccess(o.Out, "%s - %s\n\t%s\n", ref.Dataset.Commit.Timestamp.Format("Jan _2 15:04:05"), ref.Path, ref.Dataset.Commit.Title)
+	items := make([]fmt.Stringer, len(refs))
+	for i, r := range refs {
+		items[i] = logStringer(r)
 	}
+
+	return printItems(o.Out, items)
 
 	// outformat := cmd.Flag("format").Value.String()
 	// switch outformat {
@@ -113,5 +118,5 @@ func (o *LogOptions) Run() error {
 	// default:
 	//  ErrExit(o.ErrOut, fmt.Errorf("unrecognized format: %s", outformat))
 	// }
-	return nil
+	// return nil
 }

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -262,7 +262,8 @@ func (o *PeersOptions) Connect() (err error) {
 	}
 
 	printSuccess(o.Out, "successfully connected to %s:\n", res.Peername)
-	printPeerInfo(o.Out, 0, res)
+	peer := peerStringer(*res)
+	fmt.Fprint(o.Out, peer.String())
 	return nil
 }
 

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -250,7 +250,8 @@ func (o *PeersOptions) List() (err error) {
 		}
 	}
 
-	return printItems(o.Out, items)
+	printItems(o.Out, items)
+	return
 }
 
 // Connect attempts to connect to a peer

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -146,6 +146,48 @@ func printDatasetRefInfo(w io.Writer, i int, ref repo.DatasetRef) {
 	fmt.Fprintf(w, "\n")
 }
 
+type ref repo.DatasetRef
+
+func (r ref) String() string {
+	w := &bytes.Buffer{}
+	white := color.New(color.FgWhite).SprintFunc()
+	// cyan := color.New(color.FgCyan).SprintFunc()
+	blue := color.New(color.FgBlue).SprintFunc()
+	ds := r.Dataset
+	dsr := repo.DatasetRef(r)
+
+	fmt.Fprintf(w, "%s\n", white(dsr.AliasString()))
+	if ds != nil && ds.Meta != nil && ds.Meta.Title != "" {
+		fmt.Fprintf(w, "%s\n", blue(ds.Meta.Title))
+	}
+	if r.Path != "" {
+		fmt.Fprintf(w, "%s\n", r.Path)
+	}
+	if ds != nil && ds.Structure != nil {
+		fmt.Fprintf(w, "%s", printByteInfo(ds.Structure.Length))
+		if ds.Structure.Entries == 1 {
+			fmt.Fprintf(w, ", %d entry", ds.Structure.Entries)
+		} else {
+			fmt.Fprintf(w, ", %d entries", ds.Structure.Entries)
+		}
+		if ds.Structure.ErrCount == 1 {
+			fmt.Fprintf(w, ", %d error", ds.Structure.ErrCount)
+		} else {
+			fmt.Fprintf(w, ", %d errors", ds.Structure.ErrCount)
+		}
+		if ds.NumVersions == 0 {
+			// nothing
+		} else if ds.NumVersions == 1 {
+			fmt.Fprintf(w, ", %d version", ds.NumVersions)
+		} else {
+			fmt.Fprintf(w, ", %d versions", ds.NumVersions)
+		}
+	}
+
+	fmt.Fprintf(w, "\n")
+	return w.String()
+}
+
 func printSearchResult(w io.Writer, i int, result lib.SearchResult) {
 	white := color.New(color.FgWhite).SprintFunc()
 	green := color.New(color.FgGreen).SprintFunc()

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/fatih/color"
@@ -81,7 +82,14 @@ func printToPager(w io.Writer, buf *bytes.Buffer) (err error) {
 			}
 		}
 	}
-	pager := exec.Command("/bin/sh", "-c", envPager+" -R")
+	pager := &exec.Cmd{}
+	os := runtime.GOOS
+	if os == "linux" {
+		pager = exec.Command("/bin/sh", "-c", envPager, "-R")
+	} else {
+		pager = exec.Command("/bin/sh", "-c", envPager+" -R")
+	}
+
 	pager.Stdin = buf
 	pager.Stdout = w
 	err = pager.Run()

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -81,7 +81,7 @@ func printToPager(w io.Writer, buf *bytes.Buffer) (err error) {
 			}
 		}
 	}
-	pager := exec.Command("/bin/sh", "-c", envPager, "-R")
+	pager := exec.Command("/bin/sh", "-c", envPager+" -R")
 	pager.Stdin = buf
 	pager.Stdout = w
 	err = pager.Run()

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -81,7 +81,7 @@ func printToPager(w io.Writer, buf *bytes.Buffer) (err error) {
 			}
 		}
 	}
-	pager := exec.Command(envPager, "-R")
+	pager := exec.Command("/bin/sh", "-c", envPager, "-R")
 	pager.Stdin = buf
 	pager.Stdout = w
 	err = pager.Run()
@@ -239,7 +239,7 @@ func doesCommandExist(cmdName string) bool {
 	if cmdName == "" {
 		return false
 	}
-	cmd := exec.Command("command", "-v", cmdName)
+	cmd := exec.Command("/bin/sh", "-c", "command -v "+cmdName)
 	if err := cmd.Run(); err != nil {
 		return false
 	}

--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -27,3 +27,12 @@ func TestPrintByteInfo(t *testing.T) {
 		}
 	}
 }
+
+func TestDoesCommandExist(t *testing.T) {
+	if doesCommandExist("ls") == false {
+		t.Error("ls command does not exist!")
+	}
+	if doesCommandExist("ls111") == true {
+		t.Error("ls111 command should not exist!")
+	}
+}

--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"runtime"
 	"testing"
 )
 
@@ -29,10 +30,12 @@ func TestPrintByteInfo(t *testing.T) {
 }
 
 func TestDoesCommandExist(t *testing.T) {
-	if doesCommandExist("ls") == false {
-		t.Error("ls command does not exist!")
-	}
-	if doesCommandExist("ls111") == true {
-		t.Error("ls111 command should not exist!")
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		if doesCommandExist("ls") == false {
+			t.Error("ls command does not exist!")
+		}
+		if doesCommandExist("ls111") == true {
+			t.Error("ls111 command should not exist!")
+		}
 	}
 }

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/repo"
@@ -190,12 +192,13 @@ func (o *RegistryOptions) Status() error {
 
 		err = o.RegistryRequests.GetDataset(&ref, &res)
 		o.StopSpinner()
-
 		if err != nil {
 			printInfo(o.Out, "%s is not on this registry", ref.String())
 		}
+		fmt.Printf("\n%+v\n", ref)
 		if ref.Dataset != nil {
-			printDatasetRefInfo(o.Out, -1, ref)
+			refStr := refStringer(ref)
+			fmt.Fprint(o.Out, refStr.String())
 		}
 	}
 

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -195,7 +195,7 @@ func (o *RegistryOptions) Status() error {
 		if err != nil {
 			printInfo(o.Out, "%s is not on this registry", ref.String())
 		}
-		fmt.Printf("\n%+v\n", ref)
+
 		if ref.Dataset != nil {
 			refStr := refStringer(ref)
 			fmt.Fprint(o.Out, refStr.String())

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -112,7 +112,8 @@ func (o *SearchOptions) Run() (err error) {
 			items[i] = refStringer(*ref)
 		}
 		o.StopSpinner()
-		return printItems(o.Out, items)
+		printItems(o.Out, items)
+		return nil
 
 	case dataset.JSONDataFormat.String():
 		data, err := json.MarshalIndent(results, "", "  ")

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -161,14 +161,17 @@ func TestSearchRun(t *testing.T) {
 }
 
 var textSearchResponse = `showing 3 results for 'test'
-1. ramfox/test
+1   ramfox/test
 
-2. b5/test
-   18 KBs, 7 entries, 0 errors
 
-3. EDGI/fib_6
-   Fibonacci(6)
-   7 bytes, 6 entries, 0 errors
+2   b5/test
+    /ipfs/QmPi5wrPsY4xPwy2oRr7NRZyfFxTeupfmnrVDubzoABLNP
+    18 KBs, 7 entries, 0 errors
+
+3   EDGI/fib_6
+    Fibonacci(6)
+    /ipfs/QmS6jJSEJYxZvCeo8cZqzVa7Ybu9yNQeFYfNZAHxM4eyDK
+    7 bytes, 6 entries, 0 errors
 
 `
 
@@ -258,5 +261,4 @@ var jsonSearchResponse = `[
       }
     }
   }
-]
-`
+]`

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -163,7 +163,6 @@ func TestSearchRun(t *testing.T) {
 var textSearchResponse = `showing 3 results for 'test'
 1   ramfox/test
 
-
 2   b5/test
     /ipfs/QmPi5wrPsY4xPwy2oRr7NRZyfFxTeupfmnrVDubzoABLNP
     18 KBs, 7 entries, 0 errors

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/repo"
+)
+
+type peerStringer config.ProfilePod
+
+func (p peerStringer) String() string {
+	w := &bytes.Buffer{}
+	name := color.New(color.FgGreen, color.Bold).SprintFunc()
+	online := color.New(color.FgYellow).SprintFunc()
+	if p.Online {
+		fmt.Fprintf(w, "%s | %s\n", name(p.Peername), online("online"))
+	} else {
+		fmt.Fprintf(w, "%s\n", name(p.Peername))
+	}
+	fmt.Fprintf(w, "profile ID: %s\n", p.ID)
+	if len(p.NetworkAddrs) > 0 {
+		fmt.Fprintf(w, "address:    %s\n", p.NetworkAddrs[0])
+	}
+	fmt.Fprintln(w, "")
+	return w.String()
+}
+
+type stringer string
+
+func (s stringer) String() string {
+	return string(s) + "\n"
+}
+
+type refStringer repo.DatasetRef
+
+func (r refStringer) String() string {
+	w := &bytes.Buffer{}
+	title := color.New(color.FgGreen, color.Bold).SprintFunc()
+	path := color.New(color.Faint).SprintFunc()
+	ds := r.Dataset
+	dsr := repo.DatasetRef(r)
+
+	fmt.Fprintf(w, "%s\n", title(dsr.AliasString()))
+	if ds != nil && ds.Meta != nil && ds.Meta.Title != "" {
+		fmt.Fprintf(w, "%s\n", ds.Meta.Title)
+	}
+	if r.Path != "" {
+		fmt.Fprintf(w, "%s\n", path(r.Path))
+	}
+	if ds != nil && ds.Structure != nil {
+		fmt.Fprintf(w, "%s", printByteInfo(ds.Structure.Length))
+		if ds.Structure.Entries == 1 {
+			fmt.Fprintf(w, ", %d entry", ds.Structure.Entries)
+		} else {
+			fmt.Fprintf(w, ", %d entries", ds.Structure.Entries)
+		}
+		if ds.Structure.ErrCount == 1 {
+			fmt.Fprintf(w, ", %d error", ds.Structure.ErrCount)
+		} else {
+			fmt.Fprintf(w, ", %d errors", ds.Structure.ErrCount)
+		}
+		if ds.NumVersions == 0 {
+			// nothing
+		} else if ds.NumVersions == 1 {
+			fmt.Fprintf(w, ", %d version", ds.NumVersions)
+		} else {
+			fmt.Fprintf(w, ", %d versions", ds.NumVersions)
+		}
+	}
+
+	fmt.Fprintf(w, "\n\n")
+	return w.String()
+}
+
+type logStringer repo.DatasetRef
+
+func (r logStringer) String() string {
+	w := &bytes.Buffer{}
+	// title := color.New(color.Bold).Sprintfunc()
+	path := color.New(color.FgGreen).SprintFunc()
+	dsr := repo.DatasetRef(r)
+
+	fmt.Fprintf(w, "%s%s\n", path("path:   "), path(dsr.Path))
+	fmt.Fprintf(w, "Author: %s\n", dsr.Peername)
+	fmt.Fprintf(w, "Date:   %s\n", dsr.Dataset.Commit.Timestamp.Format("Jan _2 15:04:05"))
+	fmt.Fprintf(w, "\n\t%s\n", dsr.Dataset.Commit.Title)
+	if dsr.Dataset.Commit.Message != "" {
+		fmt.Fprintf(w, "\t%s\n", dsr.Dataset.Commit.Message)
+	}
+
+	fmt.Fprintf(w, "\n")
+	return w.String()
+}

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -11,6 +11,7 @@ import (
 
 type peerStringer config.ProfilePod
 
+// String assumes that Peername and ID are present
 func (p peerStringer) String() string {
 	w := &bytes.Buffer{}
 	name := color.New(color.FgGreen, color.Bold).SprintFunc()
@@ -20,9 +21,18 @@ func (p peerStringer) String() string {
 	} else {
 		fmt.Fprintf(w, "%s\n", name(p.Peername))
 	}
-	fmt.Fprintf(w, "profile ID: %s\n", p.ID)
-	if len(p.NetworkAddrs) > 0 {
-		fmt.Fprintf(w, "address:    %s\n", p.NetworkAddrs[0])
+	fmt.Fprintf(w, "Profile ID: %s\n", p.ID)
+	plural := "es"
+	spacer := "              "
+	if len(p.NetworkAddrs) <= 1 {
+		plural = ""
+	}
+	for i, addr := range p.NetworkAddrs {
+		if i == 0 {
+			fmt.Fprintf(w, "Address%s:    %s\n", plural, addr)
+			continue
+		}
+		fmt.Fprintf(w, "%s%s\n", spacer, addr)
 	}
 	fmt.Fprintln(w, "")
 	return w.String()
@@ -36,6 +46,7 @@ func (s stringer) String() string {
 
 type refStringer repo.DatasetRef
 
+// String assumes Peername and Name are present
 func (r refStringer) String() string {
 	w := &bytes.Buffer{}
 	title := color.New(color.FgGreen, color.Bold).SprintFunc()
@@ -43,15 +54,15 @@ func (r refStringer) String() string {
 	ds := r.Dataset
 	dsr := repo.DatasetRef(r)
 
-	fmt.Fprintf(w, "%s\n", title(dsr.AliasString()))
+	fmt.Fprintf(w, "%s", title(dsr.AliasString()))
 	if ds != nil && ds.Meta != nil && ds.Meta.Title != "" {
-		fmt.Fprintf(w, "%s\n", ds.Meta.Title)
+		fmt.Fprintf(w, "\n%s", ds.Meta.Title)
 	}
 	if r.Path != "" {
-		fmt.Fprintf(w, "%s\n", path(r.Path))
+		fmt.Fprintf(w, "\n%s", path(r.Path))
 	}
 	if ds != nil && ds.Structure != nil {
-		fmt.Fprintf(w, "%s", printByteInfo(ds.Structure.Length))
+		fmt.Fprintf(w, "\n%s", printByteInfo(ds.Structure.Length))
 		if ds.Structure.Entries == 1 {
 			fmt.Fprintf(w, ", %d entry", ds.Structure.Entries)
 		} else {
@@ -77,18 +88,19 @@ func (r refStringer) String() string {
 
 type logStringer repo.DatasetRef
 
+// String assumes Path, Peername, Timestamp and Title are present
 func (r logStringer) String() string {
 	w := &bytes.Buffer{}
 	// title := color.New(color.Bold).Sprintfunc()
 	path := color.New(color.FgGreen).SprintFunc()
 	dsr := repo.DatasetRef(r)
 
-	fmt.Fprintf(w, "%s%s\n", path("path:   "), path(dsr.Path))
+	fmt.Fprintf(w, "%s\n", path("path:   "+dsr.Path))
 	fmt.Fprintf(w, "Author: %s\n", dsr.Peername)
 	fmt.Fprintf(w, "Date:   %s\n", dsr.Dataset.Commit.Timestamp.Format("Jan _2 15:04:05"))
-	fmt.Fprintf(w, "\n\t%s\n", dsr.Dataset.Commit.Title)
+	fmt.Fprintf(w, "\n    %s\n", dsr.Dataset.Commit.Title)
 	if dsr.Dataset.Commit.Message != "" {
-		fmt.Fprintf(w, "\t%s\n", dsr.Dataset.Commit.Message)
+		fmt.Fprintf(w, "    %s\n", dsr.Dataset.Commit.Message)
 	}
 
 	fmt.Fprintf(w, "\n")

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/cron"
 	"github.com/qri-io/qri/repo"
 )
 
@@ -89,11 +90,11 @@ func (r refStringer) String() string {
 type logStringer repo.DatasetRef
 
 // String assumes Path, Peername, Timestamp and Title are present
-func (r logStringer) String() string {
+func (l logStringer) String() string {
 	w := &bytes.Buffer{}
 	// title := color.New(color.Bold).Sprintfunc()
 	path := color.New(color.FgGreen).SprintFunc()
-	dsr := repo.DatasetRef(r)
+	dsr := repo.DatasetRef(l)
 
 	fmt.Fprintf(w, "%s\n", path("path:   "+dsr.Path))
 	fmt.Fprintf(w, "Author: %s\n", dsr.Peername)
@@ -104,5 +105,16 @@ func (r logStringer) String() string {
 	}
 
 	fmt.Fprintf(w, "\n")
+	return w.String()
+}
+
+type jobStringer cron.Job
+
+// String assumes Name, Type, Periodicity, and LastRunStart are present
+func (j jobStringer) String() string {
+	w := &bytes.Buffer{}
+	name := color.New(color.Bold).SprintFunc()
+	time := j.Periodicity.After(j.LastRunStart)
+	fmt.Fprintf(w, "%s\n%s | %s\n\n", name(j.Name), j.Type, time)
 	return w.String()
 }

--- a/cmd/stringers_test.go
+++ b/cmd/stringers_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/repo"
+)
+
+func TestPeerStringer(t *testing.T) {
+	setNoColor(false)
+	cases := []struct {
+		description string
+		peer        *config.ProfilePod
+		expect      string
+	}{
+		// Online & multiple NetworkAddrs
+		{"Peer Stringer - Online & multiple addresses",
+			&config.ProfilePod{
+				Peername:     "cassie",
+				Online:       true,
+				ID:           "Qm...yay",
+				NetworkAddrs: []string{"address_1", "address_2", "address_3"},
+			}, "\u001b[32;1mcassie\u001b[0m | \u001b[33monline\u001b[0m\nProfile ID: Qm...yay\nAddresses:    address_1\n              address_2\n              address_3\n\n"},
+		// online & no NetworkAddrs
+		{"Peer Stringer - Online & no addresses",
+			&config.ProfilePod{
+				Peername: "justin",
+				Online:   true,
+				ID:       "Qm...woo",
+			}, "\u001b[32;1mjustin\u001b[0m | \u001b[33monline\u001b[0m\nProfile ID: Qm...woo\n\n"},
+		// Not online & one NetworkAddrs
+		{"Peer Stringer - Not Online & one address",
+			&config.ProfilePod{
+				Peername:     "brandon",
+				Online:       true,
+				ID:           "Qm...hi",
+				NetworkAddrs: []string{"address_1"},
+			}, "\u001b[32;1mbrandon\u001b[0m | \u001b[33monline\u001b[0m\nProfile ID: Qm...hi\nAddress:    address_1\n\n"},
+		// Not Online
+		{"Peer Stringer - Not Online",
+			&config.ProfilePod{
+				Peername: "ricky",
+				Online:   false,
+				ID:       "Qm...wee",
+			}, "\u001b[32;1mricky\u001b[0m\nProfile ID: Qm...wee\n\n"},
+	}
+	for _, c := range cases {
+		peerStr := peerStringer(*c.peer).String()
+
+		if c.expect != peerStr {
+			t.Errorf("case '%s', expected: '%s', got'%s'", c.description, c.expect, peerStr)
+		}
+	}
+
+}
+
+func TestRefStringer(t *testing.T) {
+	setNoColor(false)
+	cases := []struct {
+		description string
+		ref         *repo.DatasetRef
+		expect      string
+	}{
+		{"RefStringer - all fields, singular",
+			&repo.DatasetRef{
+				Name:     "ds_name",
+				Peername: "peer",
+				Path:     "/network/hash",
+				Dataset: &dataset.Dataset{
+					Structure: &dataset.Structure{
+						Length:   1,
+						Entries:  1,
+						ErrCount: 1,
+					},
+					NumVersions: 1,
+					Meta: &dataset.Meta{
+						Title: "Dataset Title",
+					},
+				},
+			}, "\u001b[32;1mpeer/ds_name\u001b[0m\nDataset Title\n\u001b[2m/network/hash\u001b[0m\n1 byte, 1 entry, 1 error, 1 version\n\n",
+		},
+		{"RefStringer - all fields, plural",
+			&repo.DatasetRef{
+				Name:     "ds_name",
+				Peername: "peer",
+				Path:     "/network/hash",
+				Dataset: &dataset.Dataset{
+					Structure: &dataset.Structure{
+						Length:   10,
+						Entries:  10,
+						ErrCount: 10,
+					},
+					NumVersions: 10,
+					Meta: &dataset.Meta{
+						Title: "Dataset Title",
+					},
+				},
+			}, "\u001b[32;1mpeer/ds_name\u001b[0m\nDataset Title\n\u001b[2m/network/hash\u001b[0m\n10 bytes, 10 entries, 10 errors, 10 versions\n\n",
+		},
+		{"RefStringer - only peername & name",
+			&repo.DatasetRef{
+				Peername: "peer",
+				Name:     "ds_name",
+			}, "\u001b[32;1mpeer/ds_name\u001b[0m\n\n",
+		},
+	}
+	for _, c := range cases {
+		refStr := refStringer(*c.ref).String()
+		if c.expect != refStr {
+			t.Errorf("case '%s', expected: '%s', got'%s'", c.description, c.expect, refStr)
+		}
+	}
+}
+
+func TestLogStringer(t *testing.T) {
+	setNoColor(false)
+	time := time.Unix(0, 0)
+	cases := []struct {
+		description string
+		log         *repo.DatasetRef
+		expect      string
+	}{
+		{"LogStringer - all fields",
+			&repo.DatasetRef{
+				Peername: "peer",
+				Path:     "/network/hash",
+				Dataset: &dataset.Dataset{
+					Commit: &dataset.Commit{
+						Timestamp: time,
+						Title:     "commit title",
+						Message:   "commit message",
+					},
+				},
+			}, "\u001b[32mpath:   /network/hash\u001b[0m\nAuthor: peer\nDate:   Dec 31 19:00:00\n\n    commit title\n    commit message\n\n",
+		},
+		{"LogStringer - no message",
+			&repo.DatasetRef{
+				Peername: "peer",
+				Path:     "/network/hash",
+				Dataset: &dataset.Dataset{
+					Commit: &dataset.Commit{
+						Timestamp: time,
+						Title:     "commit title",
+					},
+				},
+			}, "\u001b[32mpath:   /network/hash\u001b[0m\nAuthor: peer\nDate:   Dec 31 19:00:00\n\n    commit title\n\n",
+		},
+	}
+	for _, c := range cases {
+		logStr := logStringer(*c.log).String()
+		if c.expect != logStr {
+			t.Errorf("case '%s', expected: '%s', got'%s'", c.description, c.expect, logStr)
+		}
+	}
+}

--- a/cmd/stringers_test.go
+++ b/cmd/stringers_test.go
@@ -117,7 +117,7 @@ func TestRefStringer(t *testing.T) {
 
 func TestLogStringer(t *testing.T) {
 	setNoColor(false)
-	time := time.Unix(0, 0)
+	time := time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC)
 	cases := []struct {
 		description string
 		log         *repo.DatasetRef
@@ -134,7 +134,7 @@ func TestLogStringer(t *testing.T) {
 						Message:   "commit message",
 					},
 				},
-			}, "\u001b[32mpath:   /network/hash\u001b[0m\nAuthor: peer\nDate:   Dec 31 19:00:00\n\n    commit title\n    commit message\n\n",
+			}, "\u001b[32mpath:   /network/hash\u001b[0m\nAuthor: peer\nDate:   Jan  1 01:01:01\n\n    commit title\n    commit message\n\n",
 		},
 		{"LogStringer - no message",
 			&repo.DatasetRef{
@@ -146,7 +146,7 @@ func TestLogStringer(t *testing.T) {
 						Title:     "commit title",
 					},
 				},
-			}, "\u001b[32mpath:   /network/hash\u001b[0m\nAuthor: peer\nDate:   Dec 31 19:00:00\n\n    commit title\n\n",
+			}, "\u001b[32mpath:   /network/hash\u001b[0m\nAuthor: peer\nDate:   Jan  1 01:01:01\n\n    commit title\n\n",
 		},
 	}
 	for _, c := range cases {

--- a/cmd/stringers_test.go
+++ b/cmd/stringers_test.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	"github.com/qri-io/dataset"
+	"github.com/qri-io/iso8601"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/repo"
 )
 
@@ -153,6 +155,36 @@ func TestLogStringer(t *testing.T) {
 		logStr := logStringer(*c.log).String()
 		if c.expect != logStr {
 			t.Errorf("case '%s', expected: '%s', got'%s'", c.description, c.expect, logStr)
+		}
+	}
+}
+
+func TestJobStringer(t *testing.T) {
+	setNoColor(false)
+	time := time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC)
+	p, err := iso8601.ParseRepeatingInterval("R/P1D")
+	if err != nil {
+		t.Error(err)
+	}
+
+	cases := []struct {
+		description string
+		job         *lib.Job
+		expect      string
+	}{
+		{"JobStringer - all fields",
+			&lib.Job{
+				Name:         "Job",
+				Type:         "dataset",
+				Periodicity:  p,
+				LastRunStart: time,
+			}, "\u001b[1mJob\u001b[0m\ndataset | 2001-01-02 01:01:01.000000001 +0000 UTC\n\n",
+		},
+	}
+	for _, c := range cases {
+		jobStr := jobStringer(*c.job).String()
+		if c.expect != jobStr {
+			t.Errorf("case '%s', expected: '%s', got'%s'", c.description, c.expect, jobStr)
 		}
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -340,11 +340,11 @@ func (o *UpdateOptions) List() (err error) {
 		return
 	}
 
-	for i, job := range res {
-		num := p.Offset + i + 1
-		printInfo(o.Out, "%d. %s\n  %s | %s\n", num, job.Name, job.Type, job.NextExec())
+	items := make([]fmt.Stringer, len(res))
+	for i, r := range res {
+		items[i] = jobStringer(*r)
 	}
-
+	printItems(o.Out, items)
 	return
 }
 
@@ -366,12 +366,12 @@ func (o *UpdateOptions) Logs(args []string) (err error) {
 		return
 	}
 
-	for i, job := range res {
-		num := p.Offset + i + 1
-		printInfo(o.Out, "%d. %s\n  %s | %s\n", num, job.Name, job.Type, job.NextExec())
+	items := make([]fmt.Stringer, len(res))
+	for i, r := range res {
+		items[i] = jobStringer(*r)
 	}
-
-	return nil
+	printItems(o.Out, items)
+	return
 }
 
 // LogFile prints a log output file

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -105,8 +105,8 @@ func NewTestRepo(rc *regclient.Client) (mr *repo.MemRepo, err error) {
 	return
 }
 
-// NewTestRepoWithHistory generates a repository with a dataset that has a history, usable for testing purposes
-func NewTestRepoWithHistory(rc *regclient.Client) (mr *repo.MemRepo, refs []repo.DatasetRef, err error) {
+// NewTestRepoForLog generates a repository with a dataset that has a history, usable for testing purposes
+func NewTestRepoForLog(rc *regclient.Client) (mr *repo.MemRepo, refs []repo.DatasetRef, err error) {
 	datasets := []string{"movies", "cities", "counter", "craigslist", "sitemap"}
 
 	mr, err = NewEmptyTestRepo(rc)

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -105,8 +105,8 @@ func NewTestRepo(rc *regclient.Client) (mr *repo.MemRepo, err error) {
 	return
 }
 
-// NewTestRepoForLog generates a repository with a dataset that has a history, usable for testing purposes
-func NewTestRepoForLog(rc *regclient.Client) (mr *repo.MemRepo, refs []repo.DatasetRef, err error) {
+// NewTestRepoWithHistory generates a repository with a dataset that has a history, usable for testing purposes
+func NewTestRepoWithHistory(rc *regclient.Client) (mr *repo.MemRepo, refs []repo.DatasetRef, err error) {
 	datasets := []string{"movies", "cities", "counter", "craigslist", "sitemap"}
 
 	mr, err = NewEmptyTestRepo(rc)


### PR DESCRIPTION
While embarking on the previous `page` and `pageSize` journey, we found a fun env variable: `PAGER`, by checking if `PAGER` is set, or by defaulting to `more`, we can send users to a pager for large outputs, typically lists. (If `PAGER` isn't set, and if `more` or `less` isn't valid on the user's system, we default to outputting the text to the terminal)

This refactor also unifies our output, especially for lists. It uses the`fmt.Stringer` interface to leverage one function, `printItems`, that formats lists/numbering items.

Each kind of struct that we wish to output (so far, `config.ProfilePod` and `repo.DatasetRef`) is aliased (to `peerStringer`, `refStringer`, and `logStringer`), and given a new `String` method that formats each struct the way we want for that particular usage. So we can have one `repo.DatasetRef`, but it can be cast as a `refStringer` or `logStringer`, depending on what the user is asking to view.

All the `stringers` live in the `cmd/Stringer.go` files. Each `String` method is tested.

These are the commands that use stringer:
- add
- diff
- get
- list
- log
- peers
- registry
- search

These are the commands that use `printItems` (which prints a slice of stringers to a pager):
- diff
- get
- list
- log
- peers
- search

Just have a few finicky test errors to work out (ci is throwing different errors then I get on my machine), and this is good to go!!