### PR TITLE
refactor(api/body): add limit and offset params to api /body endpoint

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -563,15 +563,57 @@ func loadFileIfPath(path string) (file *os.File, err error) {
 	return os.Open(path)
 }
 
-// default number of entries to limit to when reading
-// TODO - should move this into lib
-const defaultDataLimit = 100
-
 // DataResponse is the struct used to respond to api requests made to the /data endpoint
 // It is necessary because we need to include the 'path' field in the response
 type DataResponse struct {
 	Path string          `json:"path"`
 	Data json.RawMessage `json:"data"`
+}
+
+func makeGetBodyParams(r *http.Request, readOnly bool, path string) (*lib.GetParams, error) {
+	listParams := lib.ListParamsFromRequest(r)
+	download := r.FormValue("download") == "true"
+	format := "json"
+	if download {
+		format = r.FormValue("format")
+	}
+	// if download is not set, and format is set, make sure the user knows that
+	// setting format won't do anything
+	if !download && r.FormValue("format") != "" && r.FormValue("format") != "json" {
+		return nil, fmt.Errorf("the format must be json if used without the download parameter")
+	}
+
+	p := &lib.GetParams{
+		Path:     path,
+		Format:   format,
+		Selector: "body",
+		Limit:    listParams.Limit,
+		Offset:   listParams.Offset,
+		All:      r.FormValue("all") == "true" && !readOnly,
+	}
+
+	if !readOnly {
+		offset, offsetErr := util.ReqParamInt("offset", r)
+		limit, limitErr := util.ReqParamInt("limit", r)
+
+		if offsetErr == nil || limitErr == nil {
+			if limitErr != nil {
+				limit = util.DEFAULT_PAGE_SIZE
+			}
+			if offsetErr != nil {
+				offset = 0
+			}
+			p.Limit = limit
+			p.Offset = offset
+			if limit == -1 && offset == 0 {
+				p.All = true
+			}
+		}
+		// if we request all explicitly, or if offset is zero and limit is -1
+		// return all rows
+		p.All = r.FormValue("all") == "true" || (p.Offset == 0 && p.Limit == -1)
+	}
+	return p, nil
 }
 
 func (h DatasetHandlers) bodyHandler(w http.ResponseWriter, r *http.Request) {
@@ -581,33 +623,16 @@ func (h DatasetHandlers) bodyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	listParams := lib.ListParamsFromRequest(r)
-
 	err = repo.CanonicalizeDatasetRef(h.repo, &d)
 	if err != nil && err != repo.ErrNotFound {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
 	}
 
-	download := r.FormValue("download") == "true"
-	format := "json"
-	if download {
-		format = r.FormValue("format")
-	}
-	// if download is not set, and format is set, make sure the user knows that
-	// setting format won't do anything
-	if !download && r.FormValue("format") != "" && r.FormValue("format") != "json" {
-		util.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("the format must be json if used without the download parameter"))
+	p, err := makeGetBodyParams(r, h.ReadOnly, d.String())
+	if err != nil {
+		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
-	}
-
-	p := &lib.GetParams{
-		Path:     d.String(),
-		Format:   format,
-		Selector: "body",
-		Limit:    listParams.Limit,
-		Offset:   listParams.Offset,
-		All:      r.FormValue("all") == "true" && listParams.Limit == defaultDataLimit && listParams.Offset == 0,
 	}
 
 	result := &lib.GetResult{}
@@ -615,6 +640,7 @@ func (h DatasetHandlers) bodyHandler(w http.ResponseWriter, r *http.Request) {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
 	}
+	download := r.FormValue("download") == "true"
 	if download {
 		filename, err := lib.GenerateFilename(result.Dataset, p.Format)
 		if err != nil {

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -570,7 +570,8 @@ type DataResponse struct {
 	Data json.RawMessage `json:"data"`
 }
 
-func makeGetBodyParams(r *http.Request, readOnly bool, path string) (*lib.GetParams, error) {
+// getParamsFromRequest creates getParams from a request. It's currently only used for paginating dataset bodies
+func getParamsFromRequest(r *http.Request, readOnly bool, path string) (*lib.GetParams, error) {
 	listParams := lib.ListParamsFromRequest(r)
 	download := r.FormValue("download") == "true"
 	format := "json"
@@ -629,7 +630,7 @@ func (h DatasetHandlers) bodyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := makeGetBodyParams(r, h.ReadOnly, d.String())
+	p, err := getParamsFromRequest(r, h.ReadOnly, d.String())
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return

--- a/api/datasets_test.go
+++ b/api/datasets_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+func TestMakeGetBodyParams(t *testing.T) {
+	cases := []struct {
+		description                   string
+		download                      bool
+		format                        string
+		page, pageSize, offset, limit int
+		expOffset, expLimit           int
+		all, readOnly                 bool
+		expAll                        bool
+		expectedErr                   string
+	}{
+		{"download not set, format set",
+			false,
+			"foo",
+			-10, -10, -10, -10,
+			-10, -10,
+			false,
+			false,
+			false,
+			"the format must be json if used without the download parameter",
+		},
+		{
+			"page and pageSize",
+			false,
+			"",
+			1, 25, -10, -10,
+			0, 25,
+			false,
+			false,
+			false,
+			"",
+		},
+		{
+			"page and pageSize, and offset overrides",
+			false,
+			"",
+			1, 40, 0, -10,
+			0, 100,
+			false,
+			false,
+			false,
+			"",
+		},
+		{
+			"page and pageSize, and limit overrides",
+			false,
+			"",
+			1, 40, -10, 20,
+			0, 20,
+			false,
+			false,
+			false,
+			"",
+		},
+		{
+			"request all",
+			false,
+			"",
+			-10, -10, -10, -10,
+			0, 100,
+			true,
+			false,
+			true,
+			"",
+		},
+		{
+			"request all via offset and limit",
+			false,
+			"",
+			-10, -10, 0, -1,
+			0, -1,
+			false,
+			false,
+			true,
+			"",
+		},
+		{
+			"readOnly should ignore limit and offset",
+			false,
+			"",
+			3, 30, 0, 10,
+			60, 30,
+			false,
+			true,
+			false,
+			"",
+		},
+		{
+			"readOnly should override all",
+			false,
+			"",
+			3, 30, -10, -10,
+			60, 30,
+			true,
+			true,
+			false,
+			"",
+		},
+	}
+
+	for _, c := range cases {
+		// create new request
+		// get the query from the request
+		//
+		r, err := http.NewRequest("GET", "/body", nil)
+		if err != nil {
+			t.Fatalf("case '%s', error creating request: %s", c.description, err)
+			return
+		}
+		q := r.URL.Query()
+		q.Set("download", strconv.FormatBool(c.download))
+		if c.format != "" {
+			q.Set("format", c.format)
+		}
+		if c.page > -10 {
+			q.Set("page", strconv.Itoa(c.page))
+		}
+		if c.pageSize > -10 {
+			q.Set("pageSize", strconv.Itoa(c.pageSize))
+		}
+		if c.offset > -10 {
+			q.Set("offset", strconv.Itoa(c.offset))
+		}
+		if c.limit > -10 {
+			q.Set("limit", strconv.Itoa(c.limit))
+		}
+		q.Set("all", strconv.FormatBool(c.all))
+		r.URL.RawQuery = q.Encode()
+
+		p, err := makeGetBodyParams(r, c.readOnly, "/body/path")
+		if err != nil || c.expectedErr != "" {
+			if err != nil && err.Error() != c.expectedErr || (err == nil && c.expectedErr == "") {
+				t.Errorf("case '%s' error mismatch. Expected: '%s', Got: '%s'", c.description, c.expectedErr, err)
+			}
+			continue
+		}
+		if p.Offset != c.expOffset {
+			t.Errorf("case '%s', offset mismatch. Expected: %d, Got: %d", c.description, c.expOffset, p.Offset)
+		}
+		if p.Limit != c.expLimit {
+			t.Errorf("case '%s', limit mismatch. Expected: %d, Got: %d", c.description, c.expLimit, p.Limit)
+		}
+		if p.All != c.expAll {
+			t.Errorf("case '%s', all mismatch. Expected: %t, Got: %t", c.description, c.expAll, p.All)
+		}
+	}
+}

--- a/api/datasets_test.go
+++ b/api/datasets_test.go
@@ -6,110 +6,20 @@ import (
 	"testing"
 )
 
-func TestMakeGetBodyParams(t *testing.T) {
-	cases := []struct {
-		description                   string
-		download                      bool
-		format                        string
-		page, pageSize, offset, limit int
-		expOffset, expLimit           int
-		all, readOnly                 bool
-		expAll                        bool
-		expectedErr                   string
+func TestGetParamsFromRequest(t *testing.T) {
+	casesErr := []struct {
+		description string
+		download    bool
+		format      string
+		expectedErr string
 	}{
 		{"download not set, format set",
 			false,
 			"foo",
-			-10, -10, -10, -10,
-			-10, -10,
-			false,
-			false,
-			false,
 			"the format must be json if used without the download parameter",
 		},
-		{
-			"page and pageSize",
-			false,
-			"",
-			1, 25, -10, -10,
-			0, 25,
-			false,
-			false,
-			false,
-			"",
-		},
-		{
-			"page and pageSize, and offset overrides",
-			false,
-			"",
-			1, 40, 0, -10,
-			0, 100,
-			false,
-			false,
-			false,
-			"",
-		},
-		{
-			"page and pageSize, and limit overrides",
-			false,
-			"",
-			1, 40, -10, 20,
-			0, 20,
-			false,
-			false,
-			false,
-			"",
-		},
-		{
-			"request all",
-			false,
-			"",
-			-10, -10, -10, -10,
-			0, 100,
-			true,
-			false,
-			true,
-			"",
-		},
-		{
-			"request all via offset and limit",
-			false,
-			"",
-			-10, -10, 0, -1,
-			0, -1,
-			false,
-			false,
-			true,
-			"",
-		},
-		{
-			"readOnly should ignore limit and offset",
-			false,
-			"",
-			3, 30, 0, 10,
-			60, 30,
-			false,
-			true,
-			false,
-			"",
-		},
-		{
-			"readOnly should override all",
-			false,
-			"",
-			3, 30, -10, -10,
-			60, 30,
-			true,
-			true,
-			false,
-			"",
-		},
 	}
-
-	for _, c := range cases {
-		// create new request
-		// get the query from the request
-		//
+	for _, c := range casesErr {
 		r, err := http.NewRequest("GET", "/body", nil)
 		if err != nil {
 			t.Fatalf("case '%s', error creating request: %s", c.description, err)
@@ -117,9 +27,86 @@ func TestMakeGetBodyParams(t *testing.T) {
 		}
 		q := r.URL.Query()
 		q.Set("download", strconv.FormatBool(c.download))
-		if c.format != "" {
-			q.Set("format", c.format)
+		q.Set("format", c.format)
+		r.URL.RawQuery = q.Encode()
+		_, err = getParamsFromRequest(r, false, "/body/path")
+		if err == nil || err.Error() != c.expectedErr {
+			t.Errorf("case '%s' error mismatch. Expected: '%s', Got: '%s'", c.description, c.expectedErr, err)
 		}
+	}
+
+	cases := []struct {
+		description                   string
+		page, pageSize, offset, limit int
+		expOffset, expLimit           int
+		all, readOnly                 bool
+		expAll                        bool
+	}{
+		{
+			"page and pageSize",
+			1, 25, -10, -10,
+			0, 25,
+			false,
+			false,
+			false,
+		},
+		{
+			"page and pageSize, and offset overrides",
+			1, 40, 0, -10,
+			0, 100,
+			false,
+			false,
+			false,
+		},
+		{
+			"page and pageSize, and limit overrides",
+			1, 40, -10, 20,
+			0, 20,
+			false,
+			false,
+			false,
+		},
+		{
+			"request all",
+			-10, -10, -10, -10,
+			0, 100,
+			true,
+			false,
+			true,
+		},
+		{
+			"request all via offset and limit",
+			-10, -10, 0, -1,
+			0, -1,
+			false,
+			false,
+			true,
+		},
+		{
+			"readOnly should ignore limit and offset",
+			3, 30, 0, 10,
+			60, 30,
+			false,
+			true,
+			false,
+		},
+		{
+			"readOnly should override all",
+			3, 30, -10, -10,
+			60, 30,
+			true,
+			true,
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		r, err := http.NewRequest("GET", "/body", nil)
+		if err != nil {
+			t.Fatalf("case '%s', error creating request: %s", c.description, err)
+			return
+		}
+		q := r.URL.Query()
 		if c.page > -10 {
 			q.Set("page", strconv.Itoa(c.page))
 		}
@@ -135,11 +122,9 @@ func TestMakeGetBodyParams(t *testing.T) {
 		q.Set("all", strconv.FormatBool(c.all))
 		r.URL.RawQuery = q.Encode()
 
-		p, err := makeGetBodyParams(r, c.readOnly, "/body/path")
-		if err != nil || c.expectedErr != "" {
-			if err != nil && err.Error() != c.expectedErr || (err == nil && c.expectedErr == "") {
-				t.Errorf("case '%s' error mismatch. Expected: '%s', Got: '%s'", c.description, c.expectedErr, err)
-			}
+		p, err := getParamsFromRequest(r, c.readOnly, "/body/path")
+		if err != nil {
+			t.Errorf("case '%s' unexpected error: '%s'", c.description, err)
 			continue
 		}
 		if p.Offset != c.expOffset {

--- a/update/cron/job.go
+++ b/update/cron/job.go
@@ -258,12 +258,12 @@ func (o *DatasetOptions) MarshalFlatbuffer(builder *flatbuffers.Builder) flatbuf
 		offsets := make([]flatbuffers.UOffsetT, nConfigs)
 		i := 0
 		for key, val := range o.Config {
-			kOff := builder.CreateString(key)
-			vOff := builder.CreateString(val)
+			keyOff := builder.CreateString(key)
+			valOff := builder.CreateString(val)
 
 			cronfb.StringMapValStart(builder)
-			cronfb.StringMapValAddKey(builder, kOff)
-			cronfb.StringMapValAddVal(builder, vOff)
+			cronfb.StringMapValAddKey(builder, keyOff)
+			cronfb.StringMapValAddVal(builder, valOff)
 			offsets[i] = cronfb.StringMapValEnd(builder)
 			i++
 		}
@@ -281,12 +281,12 @@ func (o *DatasetOptions) MarshalFlatbuffer(builder *flatbuffers.Builder) flatbuf
 		offsets := make([]flatbuffers.UOffsetT, nSecrets)
 		i := 0
 		for key, val := range o.Secrets {
-			kOff := builder.CreateString(key)
-			vOff := builder.CreateString(val)
+			keyOff := builder.CreateString(key)
+			valOff := builder.CreateString(val)
 
 			cronfb.StringMapValStart(builder)
-			cronfb.StringMapValAddKey(builder, kOff)
-			cronfb.StringMapValAddVal(builder, vOff)
+			cronfb.StringMapValAddKey(builder, keyOff)
+			cronfb.StringMapValAddVal(builder, valOff)
 			offsets[i] = cronfb.StringMapValEnd(builder)
 			i++
 		}


### PR DESCRIPTION
closes #766

This refactor also separates out the part of the bodyHandler that just converts the request params to GetParams, and puts it into a `makeBodyGetParams` func (plz feedback on name). This allows us to test the bodyHandler easier. Added `TestMakeGetBodyParams` which does just that.


This also fixes a linting bug in update/cron/job