### PR TITLE
Organize repo

### DIFF
--- a/api/update_test.go
+++ b/api/update_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/qri-io/qri/config"
@@ -8,11 +10,17 @@ import (
 )
 
 func TestUpdateHandlers(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "update_handlers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	cfg := config.DefaultConfigForTesting()
 	cfg.Store.Type = "map"
 	cfg.Repo.Type = "mem"
 
-	inst, err := lib.NewInstance(
+	inst, err := lib.NewInstance(tmpDir,
 		lib.OptConfig(cfg),
 	)
 	if err != nil {

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/rpc"
-	"path/filepath"
 	"sync"
 
 	"github.com/qri-io/ioes"
@@ -108,16 +107,13 @@ func NewQriOptions(ctx context.Context, qriPath, ipfsPath string, generator gen.
 // Init will initialize the internal state
 func (o *QriOptions) Init() (err error) {
 	initBody := func() {
-		cfgPath := filepath.Join(o.qriRepoPath, "config.yaml")
 		opts := []lib.Option{
-			lib.OptLoadConfigFile(cfgPath),
 			lib.OptIOStreams(o.IOStreams), // transfer iostreams to instance
 			lib.OptCtx(o.ctx),             // transfer request context to instance
-			lib.OptSetQriRepoPath(o.qriRepoPath),
 			lib.OptSetIPFSPath(o.ipfsFsPath),
 			lib.OptCheckConfigMigrations(""),
 		}
-		o.inst, err = lib.NewInstance(opts...)
+		o.inst, err = lib.NewInstance(o.qriRepoPath, opts...)
 	}
 	o.initialized.Do(initBody)
 	return

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -58,10 +60,15 @@ func TestUpdateComplete(t *testing.T) {
 }
 
 func TestUpdateMethods(t *testing.T) {
-	// t.Skip("can't run this because some other test is spinning up an RPC server & not closing it")
 	if err := confirmUpdateServiceNotRunning(); err != nil {
 		t.Skip(err.Error())
 	}
+
+	tmpDir, err := ioutil.TempDir("", "update_methods")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
 
 	streams, in, out, errs := ioes.NewTestIOStreams()
 	setNoColor(true)
@@ -71,7 +78,7 @@ func TestUpdateMethods(t *testing.T) {
 	cfg.Repo = &config.Repo{Type: "mem", Middleware: []string{}}
 	cfg.Store = &config.Store{Type: "map"}
 
-	inst, err := lib.NewInstance(lib.OptConfig(cfg), lib.OptIOStreams(streams))
+	inst, err := lib.NewInstance(tmpDir, lib.OptConfig(cfg), lib.OptIOStreams(streams))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -106,15 +106,6 @@ func OptCtx(ctx context.Context) Option {
 	}
 }
 
-// // OptSetQriRepoPath configures the directory to read Qri from, defaulting to
-// // "$HOME/.qri", unless the environment variable QRI_PATH is set
-// func OptSetQriRepoPath(path string) Option {
-// 	return func(o *InstanceOptions) (err error) {
-// 		o.RepoPath, err = repo.Path(path)
-// 		return
-// 	}
-// }
-
 // OptConfig supplies a configuration directly
 func OptConfig(cfg *config.Config) Option {
 	return func(o *InstanceOptions) error {

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -147,30 +147,6 @@ func OptSetIPFSPath(path string) Option {
 	}
 }
 
-// OptLoadConfigFile loads a configuration from a given path, if no path string
-// is provided, default to looking for a file called config.yaml in the default
-// qri path
-// func OptLoadConfigFile(path string) Option {
-// 	return func(o *InstanceOptions) (err error) {
-// 		if path == "" {
-// 			if path, err = defaultQriPath(); err != nil {
-// 				return
-// 			}
-// 			path = filepath.Join(path, "config.yaml")
-// 		}
-
-// 		if _, e := os.Stat(path); os.IsNotExist(e) {
-// 			return fmt.Errorf("no qri repo found, please run `qri setup`")
-// 		}
-
-// 		o.Cfg, err = config.ReadFromFile(path)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	}
-// }
-
 // OptIOStreams sets the input IOStreams
 func OptIOStreams(streams ioes.IOStreams) Option {
 	return func(o *InstanceOptions) error {
@@ -405,11 +381,16 @@ func newCron(cfg *config.Config, repoPath string) (cron.Scheduler, error) {
 		return cli, nil
 	}
 
+	path, err := update.Path(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
 	var jobStore, logStore cron.JobStore
 	switch updateCfg.Type {
 	case "fs":
-		jobStore = cron.NewFlatbufferJobStore(repoPath + "/cron_jobs.qfb")
-		logStore = cron.NewFlatbufferJobStore(repoPath + "/cron_logs.qfb")
+		jobStore = cron.NewFlatbufferJobStore(filepath.Join(path, "jobs.qfb"))
+		logStore = cron.NewFlatbufferJobStore(filepath.Join(path, "logs.qfb"))
 	case "mem":
 		jobStore = &cron.MemJobStore{}
 		logStore = &cron.MemJobStore{}

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -54,7 +54,7 @@ func TestNewInstance(t *testing.T) {
 	cfg.Store.Type = "map"
 	cfg.Repo.Type = "mem"
 
-	got, err := NewInstance(OptConfig(cfg))
+	got, err := NewInstance(os.TempDir(), OptConfig(cfg))
 	if err != nil {
 		t.Error(err)
 		return
@@ -71,7 +71,7 @@ func TestNewInstance(t *testing.T) {
 
 func TestNewDefaultInstance(t *testing.T) {
 	prevQriEnvLocation, prevIPFSEnvLocation := os.Getenv("QRI_PATH"), os.Getenv("IPFS_PATH")
-	prevDefaultQriLocation, prevDefaultIPFSLocation := defaultQriLocation, defaultIPFSLocation
+	prevDefaultQriLocation, prevDefaultIPFSLocation := repo.DefaultQriLocation, defaultIPFSLocation
 
 	os.Setenv("QRI_PATH", "")
 	os.Setenv("IPFS_PATH", "")
@@ -80,10 +80,10 @@ func TestNewDefaultInstance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defaultQriLocation, defaultIPFSLocation = tempDir, tempDir
+	repo.DefaultQriLocation, defaultIPFSLocation = tempDir, tempDir
 
 	defer func() {
-		defaultQriLocation, defaultIPFSLocation = prevDefaultQriLocation, prevDefaultIPFSLocation
+		repo.DefaultQriLocation, defaultIPFSLocation = prevDefaultQriLocation, prevDefaultIPFSLocation
 		os.Setenv("QRI_PATH", prevQriEnvLocation)
 		os.Setenv("IPFS_PATH", prevIPFSEnvLocation)
 		os.RemoveAll(tempDir)
@@ -94,9 +94,9 @@ func TestNewDefaultInstance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config.DefaultConfigForTesting().WriteToFile(filepath.Join(defaultQriLocation, "config.yaml"))
+	config.DefaultConfigForTesting().WriteToFile(filepath.Join(repo.DefaultQriLocation, "config.yaml"))
 
-	_, err = NewInstance()
+	_, err = NewInstance("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/update.go
+++ b/lib/update.go
@@ -4,11 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"time"
 
-	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/actions"
 	"github.com/qri-io/qri/base"
@@ -21,12 +18,7 @@ import (
 // NewUpdateMethods creates a configuration handle from an instance
 func NewUpdateMethods(inst *Instance) *UpdateMethods {
 	m := &UpdateMethods{
-		inst:        inst,
-		scriptsPath: filepath.Join(inst.RepoPath(), "update_scripts"),
-	}
-
-	if err := os.MkdirAll(m.scriptsPath, os.ModePerm); err != nil {
-		log.Errorf("creating update scripts directory: %s", err.Error())
+		inst: inst,
 	}
 
 	return m
@@ -34,8 +26,7 @@ func NewUpdateMethods(inst *Instance) *UpdateMethods {
 
 // UpdateMethods enapsulates logic for scheduled updates
 type UpdateMethods struct {
-	inst        *Instance
-	scriptsPath string
+	inst *Instance
 }
 
 // CoreRequestsName specifies this is a Methods object
@@ -259,10 +250,7 @@ func (m *UpdateMethods) ServiceStart(p *UpdateServiceStartParams, started *bool)
 	}
 
 	if !p.Daemonize {
-		// TODO (b5): for now this ensures that `qri update service start`
-		// actually prints something. `qri update service start` should print
-		// some basic details AND obey the config.log.levels.cron value
-		golog.SetLogLevel("cron", "debug")
+		log.Info("starting update service")
 	}
 
 	*started = true
@@ -272,7 +260,7 @@ func (m *UpdateMethods) ServiceStart(p *UpdateServiceStartParams, started *bool)
 // ServiceStop halts the scheduler
 func (m *UpdateMethods) ServiceStop(in, out *bool) error {
 	*out = true
-	return update.StopDaemon()
+	return update.StopDaemon(m.inst.RepoPath())
 }
 
 // ServiceRestart uses shell commands to restart the scheduler service

--- a/lib/update.go
+++ b/lib/update.go
@@ -22,7 +22,7 @@ import (
 func NewUpdateMethods(inst *Instance) *UpdateMethods {
 	m := &UpdateMethods{
 		inst:        inst,
-		scriptsPath: filepath.Join(inst.QriPath(), "update_scripts"),
+		scriptsPath: filepath.Join(inst.RepoPath(), "update_scripts"),
 	}
 
 	if err := os.MkdirAll(m.scriptsPath, os.ModePerm); err != nil {
@@ -252,7 +252,7 @@ type UpdateServiceStartParams struct {
 func (m *UpdateMethods) ServiceStart(p *UpdateServiceStartParams, started *bool) error {
 	// TODO (b5) - these work when the API is running
 	if p.RepoPath == "" && m.inst != nil {
-		p.RepoPath = m.inst.QriPath()
+		p.RepoPath = m.inst.RepoPath()
 	}
 	if p.UpdateCfg == nil && m.inst != nil {
 		p.UpdateCfg = m.inst.Config().Update

--- a/lib/update_test.go
+++ b/lib/update_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -9,17 +10,23 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/config"
-	"github.com/qri-io/qri/update/cron"
 	"github.com/qri-io/qri/repo"
+	"github.com/qri-io/qri/update/cron"
 )
 
 func TestUpdateMethods(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "update_methods")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	cfg := config.DefaultConfigForTesting()
 	cfg.Update = &config.Update{Type: "mem"}
 	cfg.Repo = &config.Repo{Type: "mem", Middleware: []string{}}
 	cfg.Store = &config.Store{Type: "map"}
 
-	inst, err := NewInstance(OptConfig(cfg), OptIOStreams(ioes.NewDiscardIOStreams()))
+	inst, err := NewInstance(tmpDir, OptConfig(cfg), OptIOStreams(ioes.NewDiscardIOStreams()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -5,8 +5,11 @@ package repo
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
-	"github.com/libp2p/go-libp2p-crypto"
+	crypto "github.com/libp2p/go-libp2p-crypto"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/repo/profile"
@@ -14,6 +17,10 @@ import (
 )
 
 var (
+	// DefaultQriLocation is where qri data defaults to storing. The keyword $HOME
+	// (and only $HOME) will be replaced with the current user home directory
+	DefaultQriLocation = "$HOME/.qri"
+
 	// ErrNotFound is the err implementers should return when stuff isn't found
 	ErrNotFound = fmt.Errorf("repo: not found")
 	// ErrPeerIDRequired is for when a peerID is missing-but-expected
@@ -95,4 +102,24 @@ type SearchParams struct {
 // Searchable is an opt-in interface for supporting repository search
 type Searchable interface {
 	Search(p SearchParams) ([]DatasetRef, error)
+}
+
+// Path returns the location of a qri repo root, the specified directory must
+// be both readable and writable
+func Path(override string) (path string, err error) {
+	if override != "" {
+		path = override
+	} else {
+		path = os.Getenv("QRI_PATH")
+	}
+
+	if path == "" {
+		var dir string
+		if dir, err = homedir.Dir(); err != nil {
+			return "", err
+		}
+		path = strings.Replace(DefaultQriLocation, "$HOME", dir, 1)
+	}
+
+	return
 }

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -3,6 +3,8 @@ package repo
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	crypto "github.com/libp2p/go-libp2p-crypto"
@@ -35,6 +37,42 @@ func init() {
 	testPeerProfile.PrivKey = privKey
 }
 
-func TestRepoPath(t *testing.T) {
-	t.Skip("TODO (b5)")
+func TestPath(t *testing.T) {
+	prevQriEnvLocation := os.Getenv("QRI_PATH")
+	os.Setenv("QRI_PATH", "")
+	defer func() {
+		os.Setenv("QRI_PATH", prevQriEnvLocation)
+	}()
+
+	got, err := Path("")
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(got, ".qri") {
+		t.Errorf("expected default path to contain '.qri', got: '%s'", got)
+	}
+
+	if got, err = Path("foo"); err != nil {
+		t.Error(err)
+	}
+	if got != "foo" {
+		t.Errorf("override path mismatch. expected: '%s', got: '%s'", "foo", got)
+	}
+
+	envPath := "/this/is/the/qri/repo/path"
+	os.Setenv("QRI_PATH", envPath)
+	if got, err = Path(""); err != nil {
+		t.Error(err)
+	}
+
+	if got != envPath {
+		t.Errorf("env path mismatch. expected '%s', got '%s'", envPath, got)
+	}
+
+	if got, err = Path("foo"); err != nil {
+		t.Error(err)
+	}
+	if got != "foo" {
+		t.Errorf("override path mismatch. expected: '%s', got: '%s'", "foo", got)
+	}
 }

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -3,8 +3,9 @@ package repo
 import (
 	"encoding/base64"
 	"fmt"
+	"testing"
 
-	"github.com/libp2p/go-libp2p-crypto"
+	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/qri/repo/profile"
 )
 
@@ -32,4 +33,8 @@ func init() {
 		panic(fmt.Errorf("error unmarshaling private key: %s", err.Error()))
 	}
 	testPeerProfile.PrivKey = privKey
+}
+
+func TestRepoPath(t *testing.T) {
+	t.Skip("TODO (b5)")
 }

--- a/update/cron/cron.go
+++ b/update/cron/cron.go
@@ -139,7 +139,7 @@ func (c *Cron) Start(ctx context.Context) error {
 		}
 
 		if len(run) > 0 {
-			log.Debugf("found %d job(s) to run", len(run))
+			log.Infof("running %d job(s)", len(run))
 			runner := c.factory(ctx)
 			for _, job := range run {
 				// TODO (b5) - if we want things like per-job timeout, we should create

--- a/update/cron/file_job_store.go
+++ b/update/cron/file_job_store.go
@@ -148,7 +148,7 @@ func (s *FlatbufferJobStore) DeleteJob(ctx context.Context, name string) error {
 	return s.saveJobs(js)
 }
 
-const logsDirName = "logs"
+const logsDirName = "logfiles"
 
 // CreateLogFile creates a log file in the specified logs directory
 func (s *FlatbufferJobStore) CreateLogFile(j *Job) (f io.WriteCloser, path string, err error) {

--- a/update/daemon.go
+++ b/update/daemon.go
@@ -13,12 +13,12 @@ func daemonHelp() error {
 }
 
 // daemonInstall is a stub for platforms that cannot yet install daemons
-func daemonInstall() error {
+func daemonInstall(repoPath string) error {
 	return fmt.Errorf("cannot install daemon on platform: %s", runtime.GOOS)
 }
 
 // daemonUninstall is a stub for platforms that cannot yet uninstall daemons
-func daemonUninstall() error {
+func daemonUninstall(repoPath string) error {
 	return fmt.Errorf("cannot uninstall daemon on platform: %s", runtime.GOOS)
 }
 


### PR DESCRIPTION
This PR closes #765 by requiring a `repoPath` param to `lib.NewInstance`.

I've also reorganized the structure of the `update` service in a qri repo. all update stuff except `/bin` is moved into an `update` subdir. files are relabelled.


before:
```
.qri
├── bin
│   └── qri
├── config.yaml
├── cron_jobs.qfb
├── cron_logs.qfb
├── ds_refs.json
├── events.json
├── index.bleve
│   ├── index_meta.json
│   └── store
│       └── ...
├── logs
│   ├── 1557256003-test_count.log
│   ├── 1557773521-country_codes.log
│   ├── 1557773581-test.sh.log
│   ├── ...
│   ├── stderr.log
│   └── stdout.log
├── peers.json
├── peers.json.lock
├── root
└── selected_refs.json
```

after:
```
.qri
├── config.yaml
├── ds_refs.json
├── events.json
├── index.bleve
│   ├── index_meta.json
│   └── store
│       └── ...
├── peers.json
├── peers.json.lock
├── selected_refs.json
└── update
    ├── bin
    │   └── qri
    ├── jobs.qfb
    ├── logfiles
    │   ├── 1557256003-test_count.log
    │   ├── 1557423597-country_codes.log
    │   ├── 1557760599-airport_codes.log
    │   └── ...
    ├── logs.qfb
    ├── root
    ├── service.log
    └── stderr.log
```