### PR TITLE
refactor lib.NewInstance to require context and a repo path. make cmd the owner of default repo path.

### DIFF
--- a/api/update_test.go
+++ b/api/update_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -20,7 +21,7 @@ func TestUpdateHandlers(t *testing.T) {
 	cfg.Store.Type = "map"
 	cfg.Repo.Type = "mem"
 
-	inst, err := lib.NewInstance(tmpDir,
+	inst, err := lib.NewInstance(context.Background(), tmpDir,
 		lib.OptConfig(cfg),
 	)
 	if err != nil {

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -35,6 +35,8 @@ https://github.com/qri-io/qri/issues`,
 	cmd.SetUsageTemplate(rootUsageTemplate)
 	cmd.PersistentFlags().BoolVarP(&opt.NoPrompt, "no-prompt", "", false, "disable all interactive prompts")
 	cmd.PersistentFlags().BoolVarP(&opt.NoColor, "no-color", "", false, "disable colorized output")
+	cmd.PersistentFlags().StringVar(&opt.RepoPath, "repo", qriPath, "provide a path to load qri from")
+	cmd.PersistentFlags().StringVar(&opt.IpfsPath, "ipfs-path", ipfsPath, "override IPFS path location")
 
 	cmd.AddCommand(
 		NewAddCommand(opt, ioStreams),
@@ -76,10 +78,10 @@ type QriOptions struct {
 	// this stored context object down through function calls
 	ctx context.Context
 
-	// QriRepoPath is the path to the QRI repository
-	qriRepoPath string
-	// IpfsFsPath is the path to the IPFS repo
-	ipfsFsPath string
+	// path to the QRI repository directory
+	RepoPath string
+	// custom path to IPFS repo
+	IpfsPath string
 	// generator is source of generating cryptographic info
 	generator gen.CryptoGenerator
 	// NoPrompt Disables all promt messages
@@ -96,11 +98,11 @@ type QriOptions struct {
 // NewQriOptions creates an options object
 func NewQriOptions(ctx context.Context, qriPath, ipfsPath string, generator gen.CryptoGenerator, ioStreams ioes.IOStreams) *QriOptions {
 	return &QriOptions{
-		IOStreams:   ioStreams,
-		ctx:         ctx,
-		qriRepoPath: qriPath,
-		ipfsFsPath:  ipfsPath,
-		generator:   generator,
+		IOStreams: ioStreams,
+		ctx:       ctx,
+		RepoPath:  qriPath,
+		IpfsPath:  ipfsPath,
+		generator: generator,
 	}
 }
 
@@ -109,10 +111,10 @@ func (o *QriOptions) Init() (err error) {
 	initBody := func() {
 		opts := []lib.Option{
 			lib.OptIOStreams(o.IOStreams), // transfer iostreams to instance
-			lib.OptSetIPFSPath(o.ipfsFsPath),
+			lib.OptSetIPFSPath(o.IpfsPath),
 			lib.OptCheckConfigMigrations(""),
 		}
-		o.inst, err = lib.NewInstance(o.ctx, o.qriRepoPath, opts...)
+		o.inst, err = lib.NewInstance(o.ctx, o.RepoPath, opts...)
 	}
 	o.initialized.Do(initBody)
 	return
@@ -136,12 +138,12 @@ func (o *QriOptions) Config() (*config.Config, error) {
 
 // IpfsFsPath returns from internal state
 func (o *QriOptions) IpfsFsPath() string {
-	return o.ipfsFsPath
+	return o.IpfsPath
 }
 
 // QriRepoPath returns from internal state
 func (o *QriOptions) QriRepoPath() string {
-	return o.qriRepoPath
+	return o.RepoPath
 }
 
 // CryptoGenerator returns a resource for generating cryptographic info

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -109,11 +109,10 @@ func (o *QriOptions) Init() (err error) {
 	initBody := func() {
 		opts := []lib.Option{
 			lib.OptIOStreams(o.IOStreams), // transfer iostreams to instance
-			lib.OptCtx(o.ctx),             // transfer request context to instance
 			lib.OptSetIPFSPath(o.ipfsFsPath),
 			lib.OptCheckConfigMigrations(""),
 		}
-		o.inst, err = lib.NewInstance(o.qriRepoPath, opts...)
+		o.inst, err = lib.NewInstance(o.ctx, o.qriRepoPath, opts...)
 	}
 	o.initialized.Do(initBody)
 	return

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -78,7 +79,7 @@ func TestUpdateMethods(t *testing.T) {
 	cfg.Repo = &config.Repo{Type: "mem", Middleware: []string{}}
 	cfg.Store = &config.Store{Type: "map"}
 
-	inst, err := lib.NewInstance(tmpDir, lib.OptConfig(cfg), lib.OptIOStreams(streams))
+	inst, err := lib.NewInstance(context.Background(), tmpDir, lib.OptConfig(cfg), lib.OptIOStreams(streams))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -8,22 +8,6 @@ import (
 	"github.com/qri-io/qri/config"
 )
 
-// func TestLoadConfig(t *testing.T) {
-// 	path, err := ioutil.TempDir("", "config_tests")
-// 	if err != nil {
-// 		t.Fatal(err.Error())
-// 	}
-// 	defer os.RemoveAll(path)
-// 	cfgPath := path + "/config.yaml"
-
-// 	if err := config.DefaultConfigForTesting().WriteToFile(cfgPath); err != nil {
-// 		t.Fatal(err.Error())
-// 	}
-// 	if err := LoadConfig(ioes.NewDiscardIOStreams(), cfgPath); err != nil {
-// 		t.Error(err.Error())
-// 	}
-// }
-
 func TestGetConfig(t *testing.T) {
 	cfg := config.DefaultConfigForTesting()
 	// TODO (b5) - hack until we can get better test-instance allocation

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -54,7 +55,7 @@ func TestNewInstance(t *testing.T) {
 	cfg.Store.Type = "map"
 	cfg.Repo.Type = "mem"
 
-	got, err := NewInstance(os.TempDir(), OptConfig(cfg))
+	got, err := NewInstance(context.Background(), os.TempDir(), OptConfig(cfg))
 	if err != nil {
 		t.Error(err)
 		return
@@ -68,7 +69,7 @@ func TestNewInstance(t *testing.T) {
 		t.Error(err)
 	}
 
-	if _, err = NewInstance(""); err == nil {
+	if _, err = NewInstance(context.Background(), ""); err == nil {
 		t.Error("expected NewInstance to error when provided no repo path")
 	}
 }
@@ -100,7 +101,7 @@ func TestNewDefaultInstance(t *testing.T) {
 	cfg.Store.Path = tempDir
 	cfg.WriteToFile(filepath.Join(tempDir, "config.yaml"))
 
-	_, err = NewInstance(tempDir)
+	_, err = NewInstance(context.Background(), tempDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/update_test.go
+++ b/lib/update_test.go
@@ -26,7 +26,7 @@ func TestUpdateMethods(t *testing.T) {
 	cfg.Repo = &config.Repo{Type: "mem", Middleware: []string{}}
 	cfg.Store = &config.Store{Type: "map"}
 
-	inst, err := NewInstance(tmpDir, OptConfig(cfg), OptIOStreams(ioes.NewDiscardIOStreams()))
+	inst, err := NewInstance(context.Background(), tmpDir, OptConfig(cfg), OptIOStreams(ioes.NewDiscardIOStreams()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -5,11 +5,8 @@ package repo
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	crypto "github.com/libp2p/go-libp2p-crypto"
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/repo/profile"
@@ -102,24 +99,4 @@ type SearchParams struct {
 // Searchable is an opt-in interface for supporting repository search
 type Searchable interface {
 	Search(p SearchParams) ([]DatasetRef, error)
-}
-
-// Path returns the location of a qri repo root, the specified directory must
-// be both readable and writable
-func Path(override string) (path string, err error) {
-	if override != "" {
-		path = override
-	} else {
-		path = os.Getenv("QRI_PATH")
-	}
-
-	if path == "" {
-		var dir string
-		if dir, err = homedir.Dir(); err != nil {
-			return "", err
-		}
-		path = strings.Replace(DefaultQriLocation, "$HOME", dir, 1)
-	}
-
-	return
 }

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -3,9 +3,6 @@ package repo
 import (
 	"encoding/base64"
 	"fmt"
-	"os"
-	"strings"
-	"testing"
 
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/qri/repo/profile"
@@ -35,44 +32,4 @@ func init() {
 		panic(fmt.Errorf("error unmarshaling private key: %s", err.Error()))
 	}
 	testPeerProfile.PrivKey = privKey
-}
-
-func TestPath(t *testing.T) {
-	prevQriEnvLocation := os.Getenv("QRI_PATH")
-	os.Setenv("QRI_PATH", "")
-	defer func() {
-		os.Setenv("QRI_PATH", prevQriEnvLocation)
-	}()
-
-	got, err := Path("")
-	if err != nil {
-		t.Error(err)
-	}
-	if !strings.Contains(got, ".qri") {
-		t.Errorf("expected default path to contain '.qri', got: '%s'", got)
-	}
-
-	if got, err = Path("foo"); err != nil {
-		t.Error(err)
-	}
-	if got != "foo" {
-		t.Errorf("override path mismatch. expected: '%s', got: '%s'", "foo", got)
-	}
-
-	envPath := "/this/is/the/qri/repo/path"
-	os.Setenv("QRI_PATH", envPath)
-	if got, err = Path(""); err != nil {
-		t.Error(err)
-	}
-
-	if got != envPath {
-		t.Errorf("env path mismatch. expected '%s', got '%s'", envPath, got)
-	}
-
-	if got, err = Path("foo"); err != nil {
-		t.Error(err)
-	}
-	if got != "foo" {
-		t.Errorf("override path mismatch. expected: '%s', got: '%s'", "foo", got)
-	}
 }


### PR DESCRIPTION
@dustmop put forth the view that default path negotiation should be the concern of cmd. Sound right to me, which implies that lib.NewInstance should require a path, and cmd should do the work of deciding between flags, $QRI_PATH, and the default repo location, passing that off to lib. Thankfully we already to do this with our cmd.PathFactory interface, and have a hot-swappable version for testing. This commit removes the recently-introduced repo.Path method, and does some minor cleanup.

While we're playing with the signature of NewInstance, it makes sense to also require a context.
library consumers should always be providing a context to the instance constructor, even if just
context.Background(). Adding this requirement signals to the user that they should first understand how context works before using lib, and that library authors will need to respect the passed in context throughout packages below lib.

If you don't have a context but need one, feel free to just use `context.Background`:
```go
inst, err := lib.NewInstance(context.Background(), "/path/to/repo")
```