### PR TITLE
experimental support for multi-repo updates with --use-repo

### DIFF
--- a/actions/dataset_test.go
+++ b/actions/dataset_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/p2p"
-	"github.com/qri-io/qri/p2p/test"
+	p2ptest "github.com/qri-io/qri/p2p/test"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
 	"github.com/qri-io/registry/regserver/mock"
@@ -159,7 +159,6 @@ func TestSaveDataset(t *testing.T) {
 			Title:   "add transform script",
 			Message: "adding an append-only transform script",
 		},
-		Structure: &dataset.Structure{Format: "json", Schema: map[string]interface{}{"type": "array"}},
 		Transform: &dataset.Transform{
 			Syntax: "starlark",
 			Config: map[string]interface{}{
@@ -186,7 +185,6 @@ func TestSaveDataset(t *testing.T) {
 			Title:   "add transform script",
 			Message: "adding an append-only transform script",
 		},
-		Structure: &dataset.Structure{Format: "json", Schema: map[string]interface{}{"type": "array"}},
 		Transform: &dataset.Transform{
 			Syntax: "starlark",
 			Config: map[string]interface{}{

--- a/actions/testdata/now_tf/input.dataset.json
+++ b/actions/testdata/now_tf/input.dataset.json
@@ -9,15 +9,5 @@
     "qri": "md:0",
     "title": "example transform"
   },
-  "transform": {},
-  "structure": {
-    "qri": "st:0",
-    "format": "json",
-    "schema": {
-      "type": "array",
-      "items": {
-        "type": "integer"
-      }
-    }
-  }
+  "transform": {}
 }

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/qri-io/qri/config"
-	"github.com/qri-io/qri/update/cron"
 	"github.com/qri-io/qri/repo"
+	"github.com/qri-io/qri/update/cron"
 )
 
 type peerStringer config.ProfilePod
@@ -115,6 +115,10 @@ func (j jobStringer) String() string {
 	w := &bytes.Buffer{}
 	name := color.New(color.Bold).SprintFunc()
 	time := j.Periodicity.After(j.LastRunStart)
-	fmt.Fprintf(w, "%s\n%s | %s\n\n", name(j.Name), j.Type, time)
+	fmt.Fprintf(w, "%s\n%s | %s\n", name(j.Name), j.Type, time)
+	if j.RepoPath != "" {
+		fmt.Fprintf(w, "\nrepo: %s\n", j.RepoPath)
+	}
+	fmt.Fprintf(w, "\n")
 	return w.String()
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -77,6 +77,7 @@ responsible for executing your scheduled updates is currently active.
 	scheduleCmd.Flags().StringVarP(&o.BodyPath, "body", "", "", "path to file or url of data to add as dataset contents")
 	scheduleCmd.Flags().BoolVar(&o.Force, "force", false, "force a new commit, even if no changes are detected")
 	scheduleCmd.Flags().BoolVarP(&o.KeepFormat, "keep-format", "k", false, "convert incoming data to stored data format")
+	scheduleCmd.Flags().StringVar(&o.RepoPath, "use-repo", "", "experiment. run update on behalf of another repo")
 
 	unscheduleCmd := &cobra.Command{
 		Use:   "unschedule",
@@ -277,6 +278,10 @@ type UpdateOptions struct {
 	Page      int
 	PageSize  int
 
+	// specifies custom repo location when scheduling a job,
+	// should only be set if --repo persistent flag is set
+	RepoPath string
+
 	inst          *lib.Instance
 	updateMethods *lib.UpdateMethods
 }
@@ -299,6 +304,7 @@ func (o *UpdateOptions) Schedule(args []string) (err error) {
 	p := &lib.ScheduleParams{
 		Name:       args[0],
 		SaveParams: o.saveParams(),
+		RepoPath:   o.RepoPath,
 	}
 	if len(args) > 1 {
 		p.Periodicity = args[1]

--- a/lib/diff_test.go
+++ b/lib/diff_test.go
@@ -100,7 +100,7 @@ func TestDatasetRequestsDiff(t *testing.T) {
 		{"diff local csv & json file",
 			"testdata/now_tf/input.dataset.json", "testdata/jobs_by_automation/body.csv",
 			"",
-			&DiffStat{Left: 17, Right: 156, LeftWeight: 250, RightWeight: 3897, Inserts: 156, Updates: 0, Deletes: 156, Moves: 0},
+			&DiffStat{Left: 10, Right: 156, LeftWeight: 162, RightWeight: 3897, Inserts: 156, Updates: 0, Deletes: 156, Moves: 0},
 			2,
 		},
 	}

--- a/lib/testdata/now_tf/input.dataset.json
+++ b/lib/testdata/now_tf/input.dataset.json
@@ -9,15 +9,5 @@
     "qri": "md:0",
     "title": "example transform"
   },
-  "transform": {},
-  "structure": {
-    "qri": "st:0",
-    "format": "json",
-    "schema": {
-      "type": "array",
-      "items": {
-        "type": "integer"
-      }
-    }
-  }
+  "transform": {}
 }

--- a/update/cron/cron.fbs
+++ b/update/cron/cron.fbs
@@ -48,6 +48,8 @@ table Job {
 	logFilePath:string;
 
 	options:Options;
+
+	repoPath:string; // path to repository to execute job as
 }
 
 // flatbuffers don't (currently) support using a vector as a root type
@@ -60,7 +62,9 @@ table Jobs {
 }
 
 // setting file_identifier adds a "magic number" to bytes 4-7 to use as a
-// sanity check for a "Qri FlatBuffer File"
+// sanity check for a "Qri FlatBuffer File". As our use of flatbuffers grows
+// this file identifier should remain as the top level identifier for all
+// qri flatbuffer schemas
 file_identifier "QFBF";
 
 // for our use this is mainly an annotation. this file extension for a 

--- a/update/cron/cron_fbs/Job.go
+++ b/update/cron/cron_fbs/Job.go
@@ -115,8 +115,16 @@ func (rcv *Job) Options(obj *flatbuffers.Table) bool {
 	return false
 }
 
+func (rcv *Job) RepoPath() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
 func JobStart(builder *flatbuffers.Builder) {
-	builder.StartObject(10)
+	builder.StartObject(11)
 }
 func JobAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(name), 0)
@@ -147,6 +155,9 @@ func JobAddOptionsType(builder *flatbuffers.Builder, optionsType byte) {
 }
 func JobAddOptions(builder *flatbuffers.Builder, options flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(options), 0)
+}
+func JobAddRepoPath(builder *flatbuffers.Builder, repoPath flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(10, flatbuffers.UOffsetT(repoPath), 0)
 }
 func JobEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/update/cron/job.go
+++ b/update/cron/job.go
@@ -51,6 +51,8 @@ type Job struct {
 	LastError    string    `json:"lastError"`
 	LogFilePath  string    `json:"logFilePath"`
 
+	RepoPath string `json:"repoPath"`
+
 	Options Options `json:"options"`
 }
 
@@ -95,6 +97,7 @@ func (job *Job) Copy() *Job {
 		LastRunStop:  job.LastRunStop,
 		LastError:    job.LastError,
 		LogFilePath:  job.LogFilePath,
+		RepoPath:     job.RepoPath,
 	}
 
 	if job.Options != nil {
@@ -121,6 +124,7 @@ func (job *Job) MarshalFlatbuffer(builder *flatbuffers.Builder) flatbuffers.UOff
 	lastRunStop := builder.CreateString(job.LastRunStop.Format(time.RFC3339))
 	lastError := builder.CreateString(job.LastError)
 	logPath := builder.CreateString(job.LogFilePath)
+	repoPath := builder.CreateString(job.RepoPath)
 	p := builder.CreateString(job.Periodicity.String())
 
 	var opts flatbuffers.UOffsetT
@@ -138,6 +142,7 @@ func (job *Job) MarshalFlatbuffer(builder *flatbuffers.Builder) flatbuffers.UOff
 	cronfb.JobAddLastRunStop(builder, lastRunStop)
 	cronfb.JobAddLastError(builder, lastError)
 	cronfb.JobAddLogFilePath(builder, logPath)
+	cronfb.JobAddRepoPath(builder, repoPath)
 	cronfb.JobAddOptionsType(builder, job.fbOptionsType())
 	if opts != 0 {
 		cronfb.JobAddOptions(builder, opts)
@@ -181,6 +186,7 @@ func (job *Job) UnmarshalFlatbuffer(j *cronfb.Job) error {
 		LastRunStop:  lastRunStop,
 		LastError:    string(j.LastError()),
 		LogFilePath:  string(j.LogFilePath()),
+		RepoPath:     string(j.RepoPath()),
 	}
 
 	unionTable := new(flatbuffers.Table)

--- a/update/cron/job_test.go
+++ b/update/cron/job_test.go
@@ -27,6 +27,10 @@ func CompareJobs(a, b *Job) error {
 		return fmt.Errorf("Type mistmatch. %s != %s", a.Type, b.Type)
 	}
 
+	if a.RepoPath != b.RepoPath {
+		return fmt.Errorf("RepoPath mistmatch. %s != %s", a.RepoPath, b.RepoPath)
+	}
+
 	if err := CompareOptions(a.Options, b.Options); err != nil {
 		return fmt.Errorf("Options: %s", err)
 	}

--- a/update/update.go
+++ b/update/update.go
@@ -118,6 +118,10 @@ func JobToCmd(streams ioes.IOStreams, job *cron.Job) *exec.Cmd {
 func datasetSaveCmd(streams ioes.IOStreams, job *cron.Job) *exec.Cmd {
 	args := []string{"save", job.Name}
 
+	if job.RepoPath != "" {
+		args = append(args, fmt.Sprintf(`--repo=%s`, job.RepoPath))
+	}
+
 	if o, ok := job.Options.(*cron.DatasetOptions); ok {
 		if o.Title != "" {
 			args = append(args, fmt.Sprintf(`--title=%s`, o.Title))


### PR DESCRIPTION
This is a somewhat advanced use-case, but one that I'd like to address for my own qri needs (I maintain a number of qri repos on my machine). running:
```
qri update schedule --use-repo /path/to/other/repo user/dataset R/PT1W
```
will store a "repoPath" value along with the job, run qri update with that repo, which will cause updates to be written and stored in that repo, while running against the same daemonized update process. Basically: 1 update process, lots of repos.

I'm calling this an experiment b/c it most definitely relies on not moving your repo directories once updates are scheduled, and I haven't written a test or throught carefully about what error to show if that repo dir moves. Other than that, I've got it working locally & it's delightful.

I'm also keeping it off the API for now. I think this is one feature that should be kept for the command-line literate audience, at least for now.

Also, introduce a number of fixes caused by a downstream change. Turns out some of our tests were relying on a broken behaviour: both the manual transform and `ds.set_body` had a chance to affect dataset.structure. This is now an error, and is fixed in tests.