### PR TITLE
fix(config): fix api.Copy not copying all fields

### DIFF
--- a/config/api.go
+++ b/config/api.go
@@ -107,13 +107,15 @@ func DefaultAPI() *API {
 // Copy returns a deep copy of an API struct
 func (a *API) Copy() *API {
 	res := &API{
-		Enabled:         a.Enabled,
-		Port:            a.Port,
-		ReadOnly:        a.ReadOnly,
-		URLRoot:         a.URLRoot,
-		TLS:             a.TLS,
-		DisconnectAfter: a.DisconnectAfter,
-		ProxyForceHTTPS: a.ProxyForceHTTPS,
+		Enabled:            a.Enabled,
+		Port:               a.Port,
+		ReadOnly:           a.ReadOnly,
+		RemoteMode:         a.RemoteMode,
+		URLRoot:            a.URLRoot,
+		TLS:                a.TLS,
+		DisconnectAfter:    a.DisconnectAfter,
+		ProxyForceHTTPS:    a.ProxyForceHTTPS,
+		ServeRemoteTraffic: a.ServeRemoteTraffic,
 	}
 	if a.AllowedOrigins != nil {
 		res.AllowedOrigins = make([]string, len(a.AllowedOrigins))

--- a/config/api_test.go
+++ b/config/api_test.go
@@ -14,20 +14,31 @@ func TestAPIValidate(t *testing.T) {
 
 func TestAPICopy(t *testing.T) {
 	cases := []struct {
-		api *API
+		description string
+		api         *API
 	}{
-		{DefaultAPI()},
+		{"default", DefaultAPI()},
+		{"ensure boolean values copy", &API{
+			Enabled:            true,
+			ReadOnly:           true,
+			RemoteMode:         true,
+			TLS:                true,
+			ProxyForceHTTPS:    true,
+			ServeRemoteTraffic: true,
+		}},
 	}
 	for i, c := range cases {
 		cpy := c.api.Copy()
 		if !reflect.DeepEqual(cpy, c.api) {
-			t.Errorf("API Copy test case %v, api structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.api)
+			t.Errorf("API Copy test case %d '%s', api structs are not equal: \ncopy: %v, \noriginal: %v", i, c.description, cpy, c.api)
 			continue
 		}
-		cpy.AllowedOrigins[0] = ""
-		if reflect.DeepEqual(cpy, c.api) {
-			t.Errorf("API Copy test case %v, editing one api struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.api)
-			continue
+		if cpy.AllowedOrigins != nil {
+			cpy.AllowedOrigins[0] = ""
+			if reflect.DeepEqual(cpy, c.api) {
+				t.Errorf("API Copy test case %d '%s', editing one api struct should not affect the other: \ncopy: %v, \noriginal: %v", i, c.description, cpy, c.api)
+				continue
+			}
 		}
 	}
 }


### PR DESCRIPTION
we missed a few fields in `config.API.Copy()` that's causing `qri connect --setup` to not allow serving remote traffic, because `cmd`'s `Connect` uses a copy of the api config ☹️ 