### PR TITLE
fix(cmd): listing page 2 starts numbering at the offset

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -124,7 +124,7 @@ func (o *ListOptions) Run() (err error) {
 		for i, r := range refs {
 			items[i] = refStringer(r)
 		}
-		printItems(o.Out, items)
+		printItems(o.Out, items, page.Offset())
 		return nil
 	case dataset.JSONDataFormat.String():
 		data, err := json.MarshalIndent(refs, "", "  ")

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -103,6 +103,6 @@ func (o *LogOptions) Run() error {
 		items[i] = logStringer(r)
 	}
 
-	printItems(o.Out, items)
+	printItems(o.Out, items, page.Offset())
 	return nil
 }

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -250,7 +250,7 @@ func (o *PeersOptions) List() (err error) {
 		}
 	}
 
-	printItems(o.Out, items)
+	printItems(o.Out, items, page.Offset())
 	return
 }
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -56,11 +56,13 @@ func printErr(w io.Writer, err error, params ...interface{}) {
 	fmt.Fprintln(w, color.New(color.FgRed).Sprintf(err.Error(), params...))
 }
 
-func printItems(w io.Writer, items []fmt.Stringer) (err error) {
+// print a slice of stringer items to io.Writer as an indented & numbered list
+// offset specifies the number of items that have been skipped, index is 1-based
+func printItems(w io.Writer, items []fmt.Stringer, offset int) (err error) {
 	buf := &bytes.Buffer{}
 	prefix := []byte("    ")
 	for i, item := range items {
-		buf.WriteString(fmtItem(i+1, item.String(), prefix))
+		buf.WriteString(fmtItem(i+1+offset, item.String(), prefix))
 	}
 	return printToPager(w, buf)
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -112,7 +112,7 @@ func (o *SearchOptions) Run() (err error) {
 			items[i] = refStringer(*ref)
 		}
 		o.StopSpinner()
-		printItems(o.Out, items)
+		printItems(o.Out, items, page.Offset())
 		return nil
 
 	case dataset.JSONDataFormat.String():

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -354,7 +354,7 @@ func (o *UpdateOptions) List() (err error) {
 	for i, r := range res {
 		items[i] = jobStringer(*r)
 	}
-	printItems(o.Out, items)
+	printItems(o.Out, items, page.Offset())
 	return
 }
 
@@ -380,7 +380,7 @@ func (o *UpdateOptions) Logs(args []string) (err error) {
 	for i, r := range res {
 		items[i] = jobStringer(*r)
 	}
-	printItems(o.Out, items)
+	printItems(o.Out, items, page.Offset())
 	return
 }
 


### PR DESCRIPTION
this now starts counting at 25:
```
$ qri list --page 2
```