### PR TITLE
Cleanup update output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOFILES = $(shell find . -name '*.go' -not -path './vendor/*')
 define GOPACKAGES 
 github.com/360EntSecGroup-Skylar/excelize \
 github.com/briandowns/spinner \
-github.com/qri-io/apiutil \
+github.com/dustin/go-humanize \
 github.com/fatih/color \
 github.com/olekukonko/tablewriter \
 github.com/qri-io/apiutil \

--- a/cmd/dag.go
+++ b/cmd/dag.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dustin/go-humanize"
 	"github.com/ghodss/yaml"
 	"github.com/qri-io/dag"
 	"github.com/qri-io/ioes"
@@ -240,7 +241,7 @@ func (o *DAGOptions) Info() (err error) {
 			}
 			out += fmt.Sprintf("\nDAG for: %s\n", refstr)
 			if totalSize != 0 {
-				out += fmt.Sprintf("Total Size: %s\n", printByteInfo(int(totalSize)))
+				out += fmt.Sprintf("Total Size: %s\n", humanize.Bytes(totalSize))
 			}
 			if info.Manifest != nil {
 				out += fmt.Sprintf("Block Count: %d\n", len(info.Manifest.Nodes))
@@ -255,7 +256,7 @@ func (o *DAGOptions) Info() (err error) {
 				for i := 0; i <= spacesLen; i++ {
 					out += fmt.Sprintf(" ")
 				}
-				out += fmt.Sprintf("%s\n", printByteInfo(int(info.Sizes[index])))
+				out += fmt.Sprintf("%s\n", humanize.Bytes(info.Sizes[index]))
 			}
 			buffer = []byte(out)
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -14,18 +14,6 @@ import (
 	"github.com/qri-io/qri/lib"
 )
 
-const (
-	bite = 1 << (10 * iota)
-	kilobyte
-	megabyte
-	gigabyte
-	terabyte
-	petabyte
-	exabyte
-	zettabyte
-	yottabyte
-)
-
 var noPrompt = false
 
 func setNoColor(noColor bool) {
@@ -121,51 +109,6 @@ func fmtItem(i int, item string, prefix []byte) string {
 		bol = c == '\n'
 	}
 	return string(res)
-}
-
-func printByteInfo(n int) string {
-	// Use 64-bit ints to support platforms on which int is not large enough to represent
-	// the constants below (exabyte, petabyte, etc). For example: Raspberry Pi running arm6.
-	l := int64(n)
-	length := struct {
-		name  string
-		value int64
-	}{"", 0}
-
-	switch {
-	// yottabyte and zettabyte overflow int
-	// case l > yottabyte:
-	//  length.name = "YB"
-	//  length.value = l / yottabyte
-	// case l > zettabyte:
-	//  length.name = "ZB"
-	//  length.value = l / zettabyte
-	case l >= exabyte:
-		length.name = "EB"
-		length.value = l / exabyte
-	case l >= petabyte:
-		length.name = "PB"
-		length.value = l / petabyte
-	case l >= terabyte:
-		length.name = "TB"
-		length.value = l / terabyte
-	case l >= gigabyte:
-		length.name = "GB"
-		length.value = l / gigabyte
-	case l >= megabyte:
-		length.name = "MB"
-		length.value = l / megabyte
-	case l >= kilobyte:
-		length.name = "KB"
-		length.value = l / kilobyte
-	default:
-		length.name = "byte"
-		length.value = l
-	}
-	if length.value != 1 {
-		length.name += "s"
-	}
-	return fmt.Sprintf("%v %s", length.value, length.name)
 }
 
 func prompt(w io.Writer, r io.Reader, msg string) string {

--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -5,30 +5,6 @@ import (
 	"testing"
 )
 
-func TestPrintByteInfo(t *testing.T) {
-	cases := []struct {
-		bytes  int
-		expect string
-	}{
-		{1, "1 byte"},
-		{2, "2 bytes"},
-		{kilobyte * 4, "4 KBs"},
-		{megabyte * 3, "3 MBs"},
-		{gigabyte + 1000, "1 GB"},
-		{terabyte * 2, "2 TBs"},
-		{petabyte * 100, "100 PBs"},
-		{exabyte, "1 EB"},
-	}
-
-	for i, c := range cases {
-		got := printByteInfo(c.bytes)
-		if got != c.expect {
-			t.Errorf("case %d expect != got: %s != %s", i, c.expect, got)
-			continue
-		}
-	}
-}
-
 func TestDoesCommandExist(t *testing.T) {
 	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
 		if doesCommandExist("ls") == false {

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -165,12 +165,12 @@ var textSearchResponse = `showing 3 results for 'test'
 
 2   b5/test
     /ipfs/QmPi5wrPsY4xPwy2oRr7NRZyfFxTeupfmnrVDubzoABLNP
-    18 KBs, 7 entries, 0 errors
+    19 kB, 7 entries, 0 errors
 
 3   EDGI/fib_6
     Fibonacci(6)
     /ipfs/QmS6jJSEJYxZvCeo8cZqzVa7Ybu9yNQeFYfNZAHxM4eyDK
-    7 bytes, 6 entries, 0 errors
+    7 B, 6 entries, 0 errors
 
 `
 

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/repo"
@@ -63,7 +64,7 @@ func (r refStringer) String() string {
 		fmt.Fprintf(w, "\n%s", path(r.Path))
 	}
 	if ds != nil && ds.Structure != nil {
-		fmt.Fprintf(w, "\n%s", printByteInfo(ds.Structure.Length))
+		fmt.Fprintf(w, "\n%s", humanize.Bytes(uint64(ds.Structure.Length)))
 		if ds.Structure.Entries == 1 {
 			fmt.Fprintf(w, ", %d entry", ds.Structure.Entries)
 		} else {

--- a/cmd/stringers_test.go
+++ b/cmd/stringers_test.go
@@ -82,7 +82,7 @@ func TestRefStringer(t *testing.T) {
 						Title: "Dataset Title",
 					},
 				},
-			}, "\u001b[32;1mpeer/ds_name\u001b[0m\nDataset Title\n\u001b[2m/network/hash\u001b[0m\n1 byte, 1 entry, 1 error, 1 version\n\n",
+			}, "\u001b[32;1mpeer/ds_name\u001b[0m\nDataset Title\n\u001b[2m/network/hash\u001b[0m\n1 B, 1 entry, 1 error, 1 version\n\n",
 		},
 		{"RefStringer - all fields, plural",
 			&repo.DatasetRef{
@@ -100,7 +100,7 @@ func TestRefStringer(t *testing.T) {
 						Title: "Dataset Title",
 					},
 				},
-			}, "\u001b[32;1mpeer/ds_name\u001b[0m\nDataset Title\n\u001b[2m/network/hash\u001b[0m\n10 bytes, 10 entries, 10 errors, 10 versions\n\n",
+			}, "\u001b[32;1mpeer/ds_name\u001b[0m\nDataset Title\n\u001b[2m/network/hash\u001b[0m\n10 B, 10 entries, 10 errors, 10 versions\n\n",
 		},
 		{"RefStringer - only peername & name",
 			&repo.DatasetRef{

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -378,7 +378,7 @@ func (o *UpdateOptions) Logs(args []string) (err error) {
 
 	items := make([]fmt.Stringer, len(res))
 	for i, r := range res {
-		items[i] = jobStringer(*r)
+		items[i] = finishedJobStringer(*r)
 	}
 	printItems(o.Out, items, page.Offset())
 	return


### PR DESCRIPTION
should address the "usability tested" checklist item in #763

Best to test this one by pulling the branch & building, then playing with update commands. Ideally the output makes things understandable. The less mental gymnastics, the better.

I've switched our human-formatting stuff to a package because we went from needing just one kind of "human" output (file sizes), to a few (relative dates, etc). `github.com/dustin/go-humanize` seems to fit the bill nicely.