### PR TITLE
fix: update cleanup with better CLI output

### DIFF
--- a/api/webapp.go
+++ b/api/webapp.go
@@ -29,7 +29,7 @@ func (s Server) ServeWebapp(ctx context.Context) {
 
 	go func() {
 		<-ctx.Done()
-		log.Info("clsing webapp server")
+		log.Info("closing webapp server")
 		webappserver.Close()
 	}()
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/qri-io/qri/repo/gen"
 	regmock "github.com/qri-io/registry/regserver/mock"
 	"github.com/spf13/cobra"
-
 	golog "github.com/ipfs/go-log"
 )
 

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
@@ -116,8 +117,9 @@ type jobStringer cron.Job
 func (j jobStringer) String() string {
 	w := &bytes.Buffer{}
 	name := color.New(color.Bold).SprintFunc()
-	time := j.Periodicity.After(j.LastRunStart)
-	fmt.Fprintf(w, "%s\n%s | %s\n", name(j.Name), j.Type, time)
+	t := j.Periodicity.After(j.LastRunStart)
+	relTime := humanize.RelTime(time.Now().In(time.UTC), t, "", "")
+	fmt.Fprintf(w, "%s\nin %sat %s | %s\n", name(j.Name), relTime, t.In(time.Now().Location()).Format(time.Kitchen), j.Type)
 	if j.RepoPath != "" {
 		fmt.Fprintf(w, "\nrepo: %s\n", j.RepoPath)
 	}

--- a/cmd/stringers_test.go
+++ b/cmd/stringers_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -160,6 +161,10 @@ func TestLogStringer(t *testing.T) {
 }
 
 func TestJobStringer(t *testing.T) {
+	// NB: JobStringer is tough to write tests for at the moment
+	// thanks to printing in local timezones
+	// TODO (b5) - look into setting local timezone for this test
+
 	setNoColor(false)
 	time := time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC)
 	p, err := iso8601.ParseRepeatingInterval("R/P1D")
@@ -170,7 +175,7 @@ func TestJobStringer(t *testing.T) {
 	cases := []struct {
 		description string
 		job         *lib.Job
-		expect      string
+		contains      string
 	}{
 		{"JobStringer - all fields",
 			&lib.Job{
@@ -178,13 +183,13 @@ func TestJobStringer(t *testing.T) {
 				Type:         "dataset",
 				Periodicity:  p,
 				LastRunStart: time,
-			}, "\u001b[1mJob\u001b[0m\ndataset | 2001-01-02 01:01:01.000000001 +0000 UTC\n\n",
+			}, "\u001b[1mJob\u001b[0m\n",
 		},
 	}
 	for _, c := range cases {
 		jobStr := jobStringer(*c.job).String()
-		if c.expect != jobStr {
-			t.Errorf("case '%s', expected: '%s', got'%s'", c.description, c.expect, jobStr)
+		if !strings.Contains(jobStr, c.contains) {
+			t.Errorf("case '%s', expected '%s' to contain string: '%s'", c.description, jobStr, c.contains)
 		}
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -351,8 +351,13 @@ func (o *UpdateOptions) List() (err error) {
 	}
 
 	items := make([]fmt.Stringer, len(res))
-	for i, r := range res {
-		items[i] = jobStringer(*r)
+	// iterate in reverse to show upcoming items first
+	// TODO (b5) - this will have wierd interaction with pagination,
+	// should use a more proper fix
+	j := 0
+	for i := len(res) - 1; i >= 0; i-- {
+		items[j] = jobStringer(*res[i])
+		j++
 	}
 	printItems(o.Out, items, page.Offset())
 	return

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -107,10 +107,10 @@ with the most immediate update.
 		Example: `  list the upcoming updates:
   $ qri update list
   1. b5/my_dataset
-  dataset | 2019-05-08 16:19:23 -0400 EDT
+  in 4 hours 4:19PM | dataset
 
   2. b5/my_next_dataset
-  dataset | 2019-05-09 16:19:23 -0400 EDT
+  in 2 days 5:22PM | dataset
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -138,10 +138,10 @@ update.
 		Example: `  list the log of previous updates:
   $ qri update logs
   1. 1557173933-my_dataset
-  dataset | 2019-05-06 16:19:23 -0400 EDT
+  1 day ago | no changes to save
 
   2. 1557173585-my_dataset
-  dataset | 2019-05-06 16:13:35 -0400 EDT
+  1 day ago | no changes to save
   ...
 
   get the output of one specific update:

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -106,7 +106,9 @@ func TestUpdateMethods(t *testing.T) {
 	if err := o.List(); err != nil {
 		t.Error(err)
 	}
-	listStdOutContains := "shell | 0001-01-01 00:00:01 +0000 UTC"
+	
+	// TODO (b5) - wee note on TestJobStringer, we should be testing times by setting local timezones
+	listStdOutContains := "| shell"
 	if !strings.Contains(out.String(), listStdOutContains) {
 		t.Errorf("list response mismatch. stdOut doesn't contain:\n%s\ngot:\n%s", listStdOutContains, out.String())
 	}

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -227,6 +227,25 @@ type SaveParams struct {
 	ScriptOutput io.Writer
 }
 
+// AbsolutizePaths converts any relative path references to their absolute
+// variations, safe to call on a nil instance
+func (p *SaveParams) AbsolutizePaths() error {
+	if p == nil {
+		return nil
+	}
+
+	for i := range p.FilePaths {
+		if err := qfs.AbsPath(&p.FilePaths[i]); err != nil {
+			return err
+		}
+	}
+
+	if err := qfs.AbsPath(&p.BodyPath); err != nil {
+		return fmt.Errorf("body file: %s", err)
+	}
+	return nil
+}
+
 // Save adds a history entry, updating a dataset
 // TODO - need to make sure users aren't forking by referencing commits other than tip
 func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) {

--- a/lib/update.go
+++ b/lib/update.go
@@ -90,7 +90,6 @@ func (m *UpdateMethods) Schedule(in *ScheduleParams, out *cron.Job) (err error) 
 
 	err = m.inst.cron.Schedule(ctx, job)
 	*out = *job
-	log.Errorf("%#v", job)
 	return err
 }
 


### PR DESCRIPTION
fix some UX issues around update, make `qri update run` actually work. These changes can/should be better tested, but like, deadlines.