### PR TITLE
feat(cron): add incrementing job number, refactor job names

### DIFF
--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -113,11 +113,11 @@ func (l logStringer) String() string {
 
 type jobStringer cron.Job
 
-// String assumes Name, Type, Periodicity, and LastRunStart are present
+// String assumes Name, Type, Periodicity, and PrevRunStart are present
 func (j jobStringer) String() string {
 	w := &bytes.Buffer{}
 	name := color.New(color.Bold).SprintFunc()
-	t := j.Periodicity.After(j.LastRunStart)
+	t := j.Periodicity.After(j.PrevRunStart)
 	relTime := humanize.RelTime(time.Now().In(time.UTC), t, "", "")
 	fmt.Fprintf(w, "%s\nin %sat %s | %s\n", name(j.Name), relTime, t.In(time.Now().Location()).Format(time.Kitchen), j.Type)
 	if j.RepoPath != "" {
@@ -129,15 +129,15 @@ func (j jobStringer) String() string {
 
 type finishedJobStringer cron.Job
 
-// String assumes Name, Type, LastRunStart and ExitStatus are present
+// String assumes Name, Type, PrevRunStart and ExitStatus are present
 func (j finishedJobStringer) String() string {
 	w := &bytes.Buffer{}
 	name := color.New(color.Bold, color.FgGreen).SprintFunc()
 	msg := ""
-	if j.LastError != "" {
-		msg = oneLiner(j.LastError, 40)
+	if j.RunError != "" {
+		msg = oneLiner(j.RunError, 40)
 		name = color.New(color.Bold, color.FgRed).SprintFunc()
-		if j.LastError == "no changes to save" {
+		if j.RunError == "no changes to save" {
 			name = color.New(color.Bold, color.Faint).SprintFunc()
 		}
 	} else {
@@ -148,7 +148,7 @@ func (j finishedJobStringer) String() string {
 		}
 	}
 
-	fmt.Fprintf(w, "%s\n%s | %s\n", name(j.Name), humanize.Time(j.LastRunStart), msg)
+	fmt.Fprintf(w, "%s\n%s | %s\n", name(j.Name), humanize.Time(j.PrevRunStart), msg)
 	if j.RepoPath != "" {
 		fmt.Fprintf(w, "\nrepo: %s\n", j.RepoPath)
 	}

--- a/cmd/stringers_test.go
+++ b/cmd/stringers_test.go
@@ -182,7 +182,7 @@ func TestJobStringer(t *testing.T) {
 				Name:         "Job",
 				Type:         "dataset",
 				Periodicity:  p,
-				LastRunStart: time,
+				PrevRunStart: time,
 			}, "\u001b[1mJob\u001b[0m\n",
 		},
 	}

--- a/lib/update_test.go
+++ b/lib/update_test.go
@@ -15,11 +15,14 @@ import (
 )
 
 func TestUpdateMethods(t *testing.T) {
+	prevDci := cron.DefaultCheckInterval
 	tmpDir, err := ioutil.TempDir("", "update_methods")
 	if err != nil {
 		t.Fatal(err)
+		cron.DefaultCheckInterval = prevDci
 	}
 	defer os.RemoveAll(tmpDir)
+	cron.DefaultCheckInterval = time.Millisecond * 500
 
 	cfg := config.DefaultConfigForTesting()
 	cfg.Update = &config.Update{Type: "mem"}
@@ -37,7 +40,7 @@ func TestUpdateMethods(t *testing.T) {
 		// this'll create type ShellScript with the .sh extension
 		Name: "testdata/hello.sh",
 		// run one time after one second
-		Periodicity: "R1/PT1S",
+		Periodicity: "R1/PT10S",
 	}
 	shellRes := &Job{}
 	if err := m.Schedule(shellJob, shellRes); err != nil {
@@ -71,7 +74,7 @@ func TestUpdateMethods(t *testing.T) {
 
 	// run the service for one second to generate updates
 	// sorry tests, y'all gotta run a little slower :/
-	ctx, done := context.WithDeadline(context.Background(), time.Now().Add(time.Second))
+	ctx, done := context.WithDeadline(context.Background(), time.Now().Add(time.Second * 2))
 	defer done()
 	if err := inst.cron.(*cron.Cron).Start(ctx); err != nil {
 		t.Fatal(err)

--- a/update/cron/cron.fbs
+++ b/update/cron/cron.fbs
@@ -37,14 +37,16 @@ table ShellScriptOptions {
 }
 
 table Job {
-  name:string;
+	name:string;
 	alias:string;
 	type:JobType;
 	periodicity:string;
+	prevRunStart:string;
 
-	lastRunStart:string;
-	lastRunStop:string;
-	lastError:string;
+	runNumber:long; // int64 value
+	runStart:string;
+	runStop:string;
+	runError:string;
 	logFilePath:string;
 
 	options:Options;

--- a/update/cron/cron.go
+++ b/update/cron/cron.go
@@ -152,9 +152,6 @@ func (c *Cron) Start(ctx context.Context) error {
 		}
 	}
 
-	// initial call to check
-	// go check(ctx)
-
 	t := time.NewTicker(c.interval)
 	for {
 		select {
@@ -213,7 +210,7 @@ func (c *Cron) Schedule(ctx context.Context, job *Job) error {
 		return err
 	}
 
-	// TODO (b5) - check for proir job & inhert the previous run number
+	// TODO (b5) - check for prior job & inherit the previous run number
 
 	return c.schedule.PutJob(ctx, job)
 }

--- a/update/cron/cron_fbs/Job.go
+++ b/update/cron/cron_fbs/Job.go
@@ -62,7 +62,7 @@ func (rcv *Job) Periodicity() []byte {
 	return nil
 }
 
-func (rcv *Job) LastRunStart() []byte {
+func (rcv *Job) PrevRunStart() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -70,15 +70,19 @@ func (rcv *Job) LastRunStart() []byte {
 	return nil
 }
 
-func (rcv *Job) LastRunStop() []byte {
+func (rcv *Job) RunNumber() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.GetInt64(o + rcv._tab.Pos)
 	}
-	return nil
+	return 0
 }
 
-func (rcv *Job) LastError() []byte {
+func (rcv *Job) MutateRunNumber(n int64) bool {
+	return rcv._tab.MutateInt64Slot(14, n)
+}
+
+func (rcv *Job) RunStart() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -86,7 +90,7 @@ func (rcv *Job) LastError() []byte {
 	return nil
 }
 
-func (rcv *Job) LogFilePath() []byte {
+func (rcv *Job) RunStop() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -94,8 +98,24 @@ func (rcv *Job) LogFilePath() []byte {
 	return nil
 }
 
-func (rcv *Job) OptionsType() byte {
+func (rcv *Job) RunError() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func (rcv *Job) LogFilePath() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func (rcv *Job) OptionsType() byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
 	if o != 0 {
 		return rcv._tab.GetByte(o + rcv._tab.Pos)
 	}
@@ -103,11 +123,11 @@ func (rcv *Job) OptionsType() byte {
 }
 
 func (rcv *Job) MutateOptionsType(n byte) bool {
-	return rcv._tab.MutateByteSlot(20, n)
+	return rcv._tab.MutateByteSlot(24, n)
 }
 
 func (rcv *Job) Options(obj *flatbuffers.Table) bool {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(26))
 	if o != 0 {
 		rcv._tab.Union(obj, o)
 		return true
@@ -116,7 +136,7 @@ func (rcv *Job) Options(obj *flatbuffers.Table) bool {
 }
 
 func (rcv *Job) RepoPath() []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
 	}
@@ -124,7 +144,7 @@ func (rcv *Job) RepoPath() []byte {
 }
 
 func JobStart(builder *flatbuffers.Builder) {
-	builder.StartObject(11)
+	builder.StartObject(13)
 }
 func JobAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(name), 0)
@@ -138,26 +158,32 @@ func JobAddType(builder *flatbuffers.Builder, type_ int8) {
 func JobAddPeriodicity(builder *flatbuffers.Builder, periodicity flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(periodicity), 0)
 }
-func JobAddLastRunStart(builder *flatbuffers.Builder, lastRunStart flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(lastRunStart), 0)
+func JobAddPrevRunStart(builder *flatbuffers.Builder, prevRunStart flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(prevRunStart), 0)
 }
-func JobAddLastRunStop(builder *flatbuffers.Builder, lastRunStop flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(5, flatbuffers.UOffsetT(lastRunStop), 0)
+func JobAddRunNumber(builder *flatbuffers.Builder, runNumber int64) {
+	builder.PrependInt64Slot(5, runNumber, 0)
 }
-func JobAddLastError(builder *flatbuffers.Builder, lastError flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(6, flatbuffers.UOffsetT(lastError), 0)
+func JobAddRunStart(builder *flatbuffers.Builder, runStart flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(6, flatbuffers.UOffsetT(runStart), 0)
+}
+func JobAddRunStop(builder *flatbuffers.Builder, runStop flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(7, flatbuffers.UOffsetT(runStop), 0)
+}
+func JobAddRunError(builder *flatbuffers.Builder, runError flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(8, flatbuffers.UOffsetT(runError), 0)
 }
 func JobAddLogFilePath(builder *flatbuffers.Builder, logFilePath flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(7, flatbuffers.UOffsetT(logFilePath), 0)
+	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(logFilePath), 0)
 }
 func JobAddOptionsType(builder *flatbuffers.Builder, optionsType byte) {
-	builder.PrependByteSlot(8, optionsType, 0)
+	builder.PrependByteSlot(10, optionsType, 0)
 }
 func JobAddOptions(builder *flatbuffers.Builder, options flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(options), 0)
+	builder.PrependUOffsetTSlot(11, flatbuffers.UOffsetT(options), 0)
 }
 func JobAddRepoPath(builder *flatbuffers.Builder, repoPath flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(10, flatbuffers.UOffsetT(repoPath), 0)
+	builder.PrependUOffsetTSlot(12, flatbuffers.UOffsetT(repoPath), 0)
 }
 func JobEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/update/cron/http_test.go
+++ b/update/cron/http_test.go
@@ -42,10 +42,10 @@ func TestCronHTTP(t *testing.T) {
 	}
 
 	dsJob := &Job{
-		Name:         "b5/libp2p_node_count",
-		Type:         JTDataset,
-		Periodicity:  mustRepeatingInterval("R/P1W"),
-		LastRunStart: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+		Name:        "b5/libp2p_node_count",
+		Type:        JTDataset,
+		Periodicity: mustRepeatingInterval("R/P1W"),
+		RunStart:    time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 
 	if err = cli.Schedule(cliCtx, dsJob); err != nil {

--- a/update/cron/job_store_test.go
+++ b/update/cron/job_store_test.go
@@ -48,10 +48,10 @@ func RunJobStoreTests(t *testing.T, newStore func() JobStore) {
 		}
 
 		jobTwo := &Job{
-			Name:         "job two",
-			Periodicity:  mustRepeatingInterval("R/P3M"),
-			Type:         JTShellScript,
-			LastRunStart: time.Date(2001, 1, 1, 1, 1, 1, 1, time.UTC),
+			Name:        "job two",
+			Periodicity: mustRepeatingInterval("R/P3M"),
+			Type:        JTShellScript,
+			RunStart:    time.Date(2001, 1, 1, 1, 1, 1, 1, time.UTC),
 		}
 		if err = store.PutJob(ctx, jobTwo); err != nil {
 			t.Errorf("putting job one: %s", err)
@@ -85,10 +85,10 @@ func RunJobStoreTests(t *testing.T, newStore func() JobStore) {
 		}
 
 		updatedJobOne := &Job{
-			Name:         jobOne.Name,
-			Periodicity:  jobOne.Periodicity,
-			Type:         jobOne.Type,
-			LastRunStart: time.Date(2002, 1, 1, 1, 1, 1, 1, time.UTC),
+			Name:        jobOne.Name,
+			Periodicity: jobOne.Periodicity,
+			Type:        jobOne.Type,
+			RunStart:    time.Date(2002, 1, 1, 1, 1, 1, 1, time.UTC),
 		}
 		if err = store.PutJob(ctx, updatedJobOne); err != nil {
 			t.Errorf("putting job one: %s", err)

--- a/update/cron/jobs.go
+++ b/update/cron/jobs.go
@@ -11,10 +11,10 @@ type jobs []*Job
 
 func (js jobs) Len() int { return len(js) }
 func (js jobs) Less(i, j int) bool {
-	if js[i].LastRunStart.Equal(js[j].LastRunStart) {
+	if js[i].RunStart.Equal(js[j].RunStart) {
 		return js[i].Name < js[j].Name
 	}
-	return js[i].LastRunStart.After(js[j].LastRunStart)
+	return js[i].RunStart.After(js[j].RunStart)
 }
 func (js jobs) Swap(i, j int) { js[i], js[j] = js[j], js[i] }
 

--- a/update/update.go
+++ b/update/update.go
@@ -218,8 +218,7 @@ func DatasetToJob(ds *dataset.Dataset, periodicity string, opts *cron.DatasetOpt
 		Name:         fmt.Sprintf("%s/%s", ds.Peername, ds.Name),
 		Periodicity:  p,
 		Type:         cron.JTDataset,
-		LastRunStart: ds.Commit.Timestamp,
-		LastRunStop:  ds.Commit.Timestamp,
+		PrevRunStart: ds.Commit.Timestamp,
 	}
 	if opts != nil {
 		job.Options = opts


### PR DESCRIPTION
builds on #787, let's review & merge that one first.

After playing with cron for a bit myself, the UX of 'qri update log' needs a little work. I've added a RunNumber field to job that increments with each execution, which will allow us to bring cron into line with it's CI/github issue-inspired workflow. I do keep a rough tally of CI run numbers in my head (generally rounded to the second-largest 10's column), and look forward to having this hueristic in Qri update jobs.

I've also taken this last chance before we ship a release to refactor the field names of our job flatbuffer. This is a very permanent API, so the more right we can get things before release, the better. In this case I changed fields like "lastRunStart" to just "runStart", which more accurately depicts what state the field is tracking. The job itself is either unexecuted (and has no RunStart), executing (has a RunStart but no RunStop) or completed (has a RunStart and RunStop).

Finally, I've disambiguated the use of 'LastRunStart', which had different meanings depending on weather the job had executed or not. Now Job has an field called PrevRunStart that keeps, well, the timestamp of the last time a job was started.

BREAKING CHANGE:
Field names of cron.Job have been refactored, which will break repo/update/logs.qfb and repo/update/jobs.qfb files. Delete them to fix.. This will only affect users who have been building from source between releases.