### PR TITLE
docs(viz): add outline comment for HTML viz templating

### DIFF
--- a/base/render.go
+++ b/base/render.go
@@ -78,7 +78,44 @@ func MaybeAddDefaultViz(ds *dataset.Dataset) {
 }
 
 // Render executes a template for a dataset, returning a slice of HTML
+// Render uses go's html/template package to generate html documents from an
+// input dataset. It's API has been adjusted to use lowerCamelCase instead of
+// UpperCamelCase naming conventions
 func Render(r repo.Repo, ref repo.DatasetRef, tmplData []byte) ([]byte, error) {
+	/*
+		outline: html viz
+			HTML template gives users a number of helper template functions, along
+			with a  dataset document at ds. Exposing the dataset  document as "ds"
+			matches our conventions for referring to a dataset elsewhere, and allows
+			access to all defined parts of a dataset.
+			HTML visualization is built atop the
+			[go template syntax](https://golang.org/pkg/text/template/#hdr-Functions)
+			You can use these curly-brace templates anywhere in an HTML template, and
+			qri will replace them with values from your dataset
+			functions:
+				{{ ds }}
+					the dataset being visualized, ds can have a number of components like
+					commit, meta, transform, body, all of which have helpful fields for
+					visualization. Details of the dataset document are outlined in the
+					dataset document definition
+				{{ allBodyEntries }}
+					load the full dataset body
+				{{ bodyEntries offset limit }}
+					get body entries within an offset/limit range. passing offset: 0,
+					limit: -1 returns the entire body
+				{{ filesize }}
+					convert byte count to kb/mb/etc string
+				{{ title }}
+					give the title of a dataset
+				{{ block "stylesheet" . }}
+					minimal inline stylesheet used by the standard viz
+				{{ block "header" . }}
+					"title" info about a dataset
+				{{ block "summary" . }}
+					html block of basic dataset info
+				{{ block "citation" . }}
+					html citation block, uses styles defined in stylesheet
+	*/
 	const tmplName = "template"
 
 	store := r.Store()


### PR DESCRIPTION
this includes a copy-paste from the lower-level qri-io/dataset/dsviz outline comment. I couldn't find a nice place to put it, so I've added the comment inline, in `qri-io/qri/base.Render`