### PR TITLE
fix(setup): load plugins before attempting to setup IPFS

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ github.com/coreos/go-semver v0.2.1-0.20180108230905-e214231b295a h1:U0BbGfKnviqV
 github.com/coreos/go-semver v0.2.1-0.20180108230905-e214231b295a/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/couchbase/ghistogram v0.0.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.0.0-20170304045823-fc637b3f82ec/go.mod h1:mGI1GcdgmlL3Imff7Z+OjkkQ8qSKr443BuZ+qFgWbPQ=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
@@ -622,6 +623,7 @@ github.com/rcrowley/go-metrics v0.0.0-20141108142129-dee209f2455f/go.mod h1:bCqn
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0 h1:G9tHG9lebljV9mfp9SNPDL36nCDxmo3zTlAf1YgvzmI=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -282,7 +282,7 @@ var (
 	pluginLoadError error
 )
 
-func loadPluginsOnce(path string) error {
+func loadIPFSPluginsOnce(path string) error {
 	body := func() {
 		pluginLoadError = ipfs.LoadPlugins(path)
 	}
@@ -304,7 +304,7 @@ func newStore(ctx context.Context, cfg *config.Config) (store cafs.Filestore, er
 			path = filepath.Join(home, ".ipfs")
 		}
 
-		if err := loadPluginsOnce(path); err != nil {
+		if err := loadIPFSPluginsOnce(path); err != nil {
 			return nil, err
 		}
 

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -49,7 +49,8 @@ func init() {
 	testPeerProfile.PrivKey = privKey
 
 	// call LoadPlugins once with the empty string b/c we only rely on standard
-	if err := loadPluginsOnce(""); err != nil {
+	// plugin set
+	if err := loadIPFSPluginsOnce(""); err != nil {
 		panic(err)
 	}
 }

--- a/lib/setup.go
+++ b/lib/setup.go
@@ -26,6 +26,17 @@ func Setup(p SetupParams) error {
 	}
 
 	if p.SetupIPFS {
+		// need to load plugins before attempting to configure IPFS, flatfs is
+		// specified as part of the default IPFS configuration, but all flatfs
+		// code is loaded as a plugin.  ¯\_(ツ)_/¯
+		//
+		// This works without anything present in the /.ipfs/plugins/ directory b/c
+		// the default plugin set is complied into go-ipfs (and subsequently, the
+		// qri binary) by default
+		if err := loadIPFSPluginsOnce(p.IPFSFsPath); err != nil {
+			return err
+		}
+
 		if err := actions.InitIPFS(p.IPFSFsPath, p.SetupIPFSConfigData, p.Generator); err != nil {
 			return err
 		}


### PR DESCRIPTION
need to load plugins before attempting to configure IPFS, flatfs is
specified as part of the default IPFS configuration, but all flatfs
code is loaded as a plugin.  ¯\_(ツ)_/¯

This works without anything present in the /.ipfs/plugins/ directory b/c the default plugin set is complied into go-ipfs (and subsequently, the qri binary) by default

Our tests missed this because the test suite needs to load all plugins to run
tests in the first place. This is going to be particularly tough to test.
We'll need to either:
* figure out a way to cleanly unload all plugins in IPFS
* use an "external" test of some sort

We should do some research into plugin unloading, we could also consider using a higher level package to test the "final" setup behaviour, which may not call plugin loading at initialization time.