### PR TITLE
feat(startf): pass present dataset to download special function

### DIFF
--- a/startf/testdata/fetch.star
+++ b/startf/testdata/fetch.star
@@ -1,7 +1,7 @@
 load("http.star", "http")
 load("qri.star", "qri")
 
-def download(ctx):
+def download(ds, ctx):
   res = http.get(test_server_url)
   return res.json()['foo']
 


### PR DESCRIPTION
I've encountered one-too-many situations where I need access to the present dataset version in the download step to make a proper decision about what network requests are needed, so I'd like make this change now. Normally I'd write a proper RFC for this, but we're extremely crunched for time at the moment trying to produce teaching materials for others. adding a ds argument to download opens up a number of useful techniques and removes at least two steps from the learning curve of the tutorial I'm presently working on.  This change modifies our starlark `download` special function signature from this:
```python
def download(ctx):
```

to this:
```python
def download(ds, ctx):
```

Where the new ds arg is the current dataset version.

By adding ds to the download step, doing append-only fetching is possible, which cuts down on convoluted logic of overfetching-then-matching in the transform step. On top of this, it's possible to drop the transform step entirely by calling ds.set_body in the download step, pushing the entire conversation about context into a more advanced lesson.

Our primary concern for providing a ds argument in the download step has always been security. In a future world where datasets come with an access control layer, we don't want anyone to be able to write a script that publishes private data to a remote location over HTTP in the download step. Our recent work on storing separate read & write dataset pointers and advances in our understanding of what we can and can't do with starlark have me far less worried about this situation. We have all the tools necessary today to pick up when a user is attempting to access dataset data in the download step, and can interrupt that read attempt based on whatever criteria we see fit.

BREAKING CHANGE:
starlark transform download function has changed from 'download(ctx)` to 'download(ds,ctx)`, wehre the ds argument is the dataset being transformed