### PR TITLE
fix(webapp): must resolve path before passing path to frontend webapp handler

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -38,17 +38,7 @@ peers & swapping data.`,
 		},
 	}
 
-	cmd.Flags().IntVarP(&o.DisconnectAfter, "disconnect-after", "", 0, "duration to keep connected in seconds, 0 means run indefinitely")
-
-	cmd.Flags().BoolVarP(&o.DisableAPI, "disable-api", "", false, "disables api, overrides the api-port flag")
-	cmd.Flags().BoolVarP(&o.DisableRPC, "disable-rpc", "", false, "disables rpc, overrides the rpc-port flag")
-	cmd.Flags().BoolVarP(&o.DisableWebapp, "disable-webapp", "", false, "disables webapp, overrides the webapp-port flag")
-	cmd.Flags().BoolVarP(&o.DisableP2P, "disable-p2p", "", false, "disables p2p, overrides the webapp-port flag")
-
 	cmd.Flags().BoolVarP(&o.Setup, "setup", "", false, "run setup if necessary, reading options from environment variables")
-	cmd.Flags().BoolVarP(&o.ReadOnly, "read-only", "", false, "run qri in read-only mode, limits the api endpoints")
-	cmd.Flags().BoolVarP(&o.RemoteMode, "remote-mode", "", false, "run qri in remote mode")
-	cmd.Flags().Int64VarP(&o.RemoteAcceptSizeMax, "remote-accept-size-max", "", -1, "when running as a remote, max size of dataset to accept, -1 for any size")
 	cmd.Flags().StringVarP(&o.Registry, "registry", "", "", "specify registry to setup with. only works when --setup is true")
 
 	return cmd
@@ -57,21 +47,9 @@ peers & swapping data.`,
 // ConnectOptions encapsulates state for the connect command
 type ConnectOptions struct {
 	ioes.IOStreams
-
-	DisconnectAfter int
-
-	DisableAPI    bool
-	DisableRPC    bool
-	DisableWebapp bool
-	DisableP2P    bool
-
-	Registry            string
-	Setup               bool
-	ReadOnly            bool
-	RemoteMode          bool
-	RemoteAcceptSizeMax int64
-
-	inst *lib.Instance
+	inst     *lib.Instance
+	Registry string
+	Setup    bool
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -108,49 +86,8 @@ func (o *ConnectOptions) Complete(f Factory, args []string) (err error) {
 	return
 }
 
-// ConfigFlagIsSet returns true if any connact flags that are also available as config value are set
-// TODO (b5) - need a proper test for this
-func (o *ConnectOptions) ConfigFlagIsSet() bool {
-	return o.DisconnectAfter != 0 || o.RemoteAcceptSizeMax != 0 || o.ReadOnly || o.RemoteMode || o.DisableP2P || o.DisableAPI || o.DisableRPC || o.DisableWebapp
-}
-
 // Run executes the connect command with currently configured state
 func (o *ConnectOptions) Run() (err error) {
-	flagSet := o.ConfigFlagIsSet()
-
-	if flagSet {
-		cfg := o.inst.Config().Copy()
-
-		if o.DisconnectAfter != 0 {
-			cfg.API.DisconnectAfter = o.DisconnectAfter
-		}
-		if o.ReadOnly {
-			cfg.API.ReadOnly = true
-		}
-		if o.RemoteMode {
-			cfg.API.RemoteMode = true
-		}
-		if o.DisableP2P {
-			cfg.P2P.Enabled = false
-		}
-		if o.DisableAPI {
-			cfg.API.Enabled = false
-		}
-		if o.DisableRPC {
-			cfg.RPC.Enabled = false
-		}
-		if o.DisableWebapp {
-			cfg.Webapp.Enabled = false
-		}
-
-		cfg.API.RemoteAcceptSizeMax = o.RemoteAcceptSizeMax
-
-		// TODO (b5) - this is actually modifying config details & saving them
-		// flags should be ephemeral configuration changes
-		if err := o.inst.ChangeConfig(cfg); err != nil {
-			log.Error(err)
-		}
-	}
 
 	s := api.New(o.inst)
 	err = s.Serve(o.inst.Context())

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/qri-io/ioes"
 	libtest "github.com/qri-io/qri/lib/test"
@@ -31,9 +32,9 @@ func TestConnect(t *testing.T) {
 	}
 	defer os.RemoveAll(path)
 
-	cmd := "qri connect --setup --registry=" + registryServer.URL + " --disconnect-after=1"
+	cmd := "qri connect --setup --registry=" + registryServer.URL
 	streams, _, _, _ := ioes.NewTestIOStreams()
-	ctx, done := context.WithCancel(context.Background())
+	ctx, done := context.WithTimeout(context.Background(), time.Second)
 	defer done()
 
 	root := NewQriCommand(ctx, NewDirPathFactory(path), libtest.NewTestCrypto(), streams)

--- a/config/config.go
+++ b/config/config.go
@@ -243,7 +243,9 @@ func (cfg *Config) Copy() *Config {
 	res := &Config{
 		Revision: cfg.Revision,
 	}
-
+	if cfg.path != "" {
+		res.path = cfg.path
+	}
 	if cfg.Profile != nil {
 		res.Profile = cfg.Profile.Copy()
 	}


### PR DESCRIPTION
two funky things were happening when trying set up the `FrontendHandler`

1) `s.resolveWebappPath` was running in a go routine. The `webappEntrypointHash` that was being passed to the `/webapp` handler was therefore old! When the frontend webapp went to make certain requests, such as lazy loading parts of the app, it was being redirected to an incorrect endpoint.

2) the new webapp path was not being saved to the config! This means everytime we `qri connect`, the webapp was being 'updated'

This refactor removes the go routine and saves the new webapp path correctly!

It also adds some logging to the FrontendHandler, noting when we are fetching off the distributed web.

This pr also removes all the ephemeral `qri connect` flags