### PR TITLE
fix(webapp loading):  update, fetch, and pin webapp on `qri connect` 

### DIFF
--- a/api/webapp.go
+++ b/api/webapp.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/qri-io/qfs/cafs"
 )
 
 // ServeWebapp launches a webapp server on s.cfg.Webapp.Port
@@ -59,15 +61,57 @@ func (s Server) FrontendHandler(prefix string) http.Handler {
 	// TODO -
 	// * there's no error handling,
 	// * and really the data could be owned by Server and initialized by it,
-	//   as there's nothing that necessitates updating the webapp within FrontendHandler.
-	if err := s.resolveWebappPath(); err != nil {
-		log.Errorf("error resolving webapp path: %s", err)
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := fmt.Sprintf("%s%s", s.Config().Webapp.EntrypointHash, strings.TrimPrefix(r.URL.Path, prefix))
+	//  as there's nothing that necessitates updating the webapp within FrontendHandler.
+	updating := true
+	updates := make(chan bool)
+	go func() {
+		if err := s.resolveWebappPath(); err != nil {
+			log.Errorf("error resolving webapp path: %s", err)
+		}
+		path := s.Config().Webapp.EntrypointHash
+
+		// TODO (ramfox): frontend handler should accept a context
 		log.Info("fetching webapp off the distributed web...")
+		fetcher, ok := s.Repo().Store().(cafs.Fetcher)
+		if !ok {
+			log.Error("this store cannot fetch from remote sources")
+			updates <- false
+			return
+		}
+		_, err := fetcher.Fetch(cafs.SourceAny, path+"/main.js")
+		if err != nil {
+			log.Errorf("error fetching file: %s", err.Error())
+			updates <- false
+		}
+		log.Info("pinning webapp to your repository...")
+		pinner, ok := s.Repo().Store().(cafs.Pinner)
+		if !ok {
+			log.Error("unable to pin webapp to your repository")
+			updates <- false
+			return
+		}
+		if err := pinner.Pin(path, true); err != nil {
+			log.Errorf("error pinning webapp: %s", err.Error())
+			updates <- false
+			return
+		}
+		log.Info("done pinning webapp!")
+		updates <- false
+	}()
+
+	go func() {
+		updating = <-updates
+	}()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if updating == true {
+			// if the app is still pinning
+			// return a temporary script that tells the user what's going on
+			w.Write([]byte(loadingScript))
+			return
+		}
+		path := fmt.Sprintf("%s%s", s.Config().Webapp.EntrypointHash, strings.TrimPrefix(r.URL.Path, prefix))
 		s.fetchCAFSPath(path, w, r)
-		log.Info("done fetching webapp!")
 	})
 }
 
@@ -105,3 +149,66 @@ func (s Server) resolveWebappPath() error {
 func (s Server) WebappTemplateHandler(w http.ResponseWriter, r *http.Request) {
 	renderTemplate(s.Config().Webapp, w, "webapp")
 }
+
+const loadingScript = `
+var css = document.createElement("style");
+css.type = 'text/css';
+
+var styles = "@keyframes spinnerAnim { 0% { transform: scaleY(0.4); } 20% { transform: scaleY(1.0); } 40% { transform: scaleY(0.4); } 100% { transform: scaleY(0.4);}}"
+styles += " .spinner-spinner { width: 60px; height: 40px; text-align: center; font-size: 10px; display: inline-block;}"
+styles += " .spinner-block { height: 100%; width: 6px; margin-right: 2px; border-radius: 6px; display: inline-block; animation-name: spinnerAnim; animation-duration: 1.2s; animation-iteration-count: infinite; background: #303030;}"
+styles += " .spinner-rect1 { animation-delay: 0s;}"
+styles += " .spinner-rect2 { animation-delay: -1.1s;}"
+styles += " .spinner-rect3 { animation-delay: -1s;}"
+styles += " .spinner-rect4 { animation-delay: -1s;}"
+styles += " .spinner-rect5 { animation-delay: -0.9s;}"
+styles += " .wrapper {	background: #FFF;	position: absolute;	width: 100%;	height: 100%;	top: 0	left: 0;}"
+styles += " .title {	font-size: 18px;	line-height: 30px;	font-family: 'Rubik', 'Avenir Next', Arial, sans-serif;}"
+styles += " p { font-size: 14px; line-height: 18px; font-family: 'Rubik', 'Avenir Next', Arial, sans-serif; font-weight: 300;}"
+styles += " .center {	width: 500px;	height: 300px;	margin: 10em auto;	top: 0;	left: 0;	bottom: 0;	right: 0;	text-align: center;}"
+
+if (css.styleSheet) css.styleSheet.cssText = styles;
+else css.appendChild(document.createTextNode(styles));
+
+var head = document.getElementsByTagName('head')[0].appendChild(css);
+
+var spinner = document.createElement("div");
+spinner.classList.add("spinner-spinner");
+
+var rect1 = document.createElement("div");
+var rect2 = document.createElement("div");
+var rect3 = document.createElement("div");
+var rect4 = document.createElement("div");
+var rect5 = document.createElement("div");
+
+rect1.classList.add("spinner-block", "spinner-rect1", "spinner-dark");
+rect2.classList.add("spinner-block", "spinner-rect2", "spinner-dark");
+rect3.classList.add("spinner-block", "spinner-rect3", "spinner-dark");
+rect4.classList.add("spinner-block", "spinner-rect4", "spinner-dark");
+rect5.classList.add("spinner-block", "spinner-rect5", "spinner-dark");
+
+spinner.appendChild(rect1);
+spinner.appendChild(rect2);
+spinner.appendChild(rect3);
+spinner.appendChild(rect4);
+spinner.appendChild(rect5);
+
+var center = document.createElement("div");
+center.classList.add("center")
+var title = document.createElement("div")
+title.classList.add("title")
+title.innerHTML = "downloading the Qri webapp from the distributed web!";
+var p = document.createElement("p");
+p.innerHTML = "if you are not automatically redirected in a few seconds please refresh"
+center.appendChild(title)
+center.appendChild(p)
+center.appendChild(spinner)
+
+var root = document.getElementById("root");
+root.classList.add("wrapper")
+root.appendChild(center);
+
+setTimeout(function(){
+   window.location.reload(1);
+}, 1000);
+`


### PR DESCRIPTION
 When a user runs `qri connect`, we should 1) checking to see if the current webapp is out of data, 2) trying to fetch and pin a new webapp 3) have the frontend handler send back a temporary script if the webapp has not finished updating 4) send the correct script once it has updated.

This commit creates a go routine that checks is the webapp has updated, and tries to fetch and pin that updated website. This go routine communicates on a channel, to update a `updating` bool. The handler uses this `updating` var to determine if it should send back the temporary script, or the actual webapp.
