### PR TITLE
feat(replace-save,removed-status): report removed components in qri status, replace-save support

### DIFF
--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -116,7 +116,7 @@ func addCitiesDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 		t.Fatal(err.Error())
 	}
 
-	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false, true)
+	ref, err := SaveDataset(node, tc.Input, nil, nil, SaveDatasetSwitches{ Pin: true, ShouldRender: true })
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -129,7 +129,7 @@ func addFlourinatedCompoundsDataset(t *testing.T, node *p2p.QriNode) repo.Datase
 		t.Fatal(err.Error())
 	}
 
-	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false, true)
+	ref, err := SaveDataset(node, tc.Input, nil, nil, SaveDatasetSwitches{ Pin: true, ShouldRender: true })
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -145,7 +145,7 @@ func addNowTransformDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	// this was put here to satisfy qri-io/qri/actions.TestUpdateDatasetLocal
 	tc.Input.Peername = "peer"
 
-	ref, err := SaveDataset(node, tc.Input, nil, nil, false, true, false, false, true)
+	ref, err := SaveDataset(node, tc.Input, nil, nil, SaveDatasetSwitches{ Pin: true, ShouldRender: true })
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/actions/dataset.go
+++ b/actions/dataset.go
@@ -16,16 +16,15 @@ import (
 	"github.com/qri-io/qri/repo/profile"
 )
 
-// SaveDatasetSwitches provides togglable flags to SaveDataset that control 
+// SaveDatasetSwitches provides toggleable flags to SaveDataset that control
 // save behaviour
-// dryRun, pin, convertFormatToPrev, force, shouldRender bool
 type SaveDatasetSwitches struct {
-	Replace bool // 
-	DryRun bool
-	Pin bool
+	Replace             bool //
+	DryRun              bool
+	Pin                 bool
 	ConvertFormatToPrev bool
-	Force bool
-	ShouldRender bool
+	Force               bool
+	ShouldRender        bool
 }
 
 // SaveDataset initializes a dataset from a dataset pointer and data file
@@ -35,7 +34,6 @@ func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string
 		pro      *profile.Profile
 		r        = node.Repo
 	)
-
 
 	prev, mutable, prevPath, err := base.PrepareDatasetSave(r, changes.Peername, changes.Name)
 	if err != nil {
@@ -91,7 +89,7 @@ func SaveDataset(node *p2p.QriNode, changes *dataset.Dataset, secrets map[string
 	}
 
 	if !sw.Replace {
-		// apply the changes to the previous dataset.
+		// Treat the changes as a set of patches applied to the previous dataset
 		mutable.Assign(changes)
 		changes = mutable
 	}

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -86,9 +86,8 @@ type SaveOptions struct {
 
 	Title   string
 	Message string
-
-	Passive        bool
-	Rescursive     bool
+	
+	Replace        bool
 	ShowValidation bool
 	Publish        bool
 	DryRun         bool

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -71,7 +71,7 @@ func (o *StatusOptions) Run() (err error) {
 			clean = false
 		case fsi.STUnmodified:
 			// noop
-		default:
+		case fsi.STAdd, fsi.STChange:
 			printErr(o.Out, fmt.Errorf("  %s: %s (source: %s)", si.Type, si.Component, filepath.Base(si.SourceFile)))
 			clean = false
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/qri-io/ioes"
+	"github.com/qri-io/qri/fsi"
 	"github.com/qri-io/qri/lib"
 	"github.com/spf13/cobra"
 )
@@ -64,8 +65,14 @@ func (o *StatusOptions) Run() (err error) {
 	clean := true
 	valid := true
 	for _, si := range res {
-		if si.Type != "unmodified" {
-			printErr(o.Out, fmt.Errorf("%s: %s (source: %s)", si.Type, si.Path, filepath.Base(si.SourceFile)))
+		switch si.Type {
+		case fsi.STRemoved:
+			printErr(o.Out, fmt.Errorf("  %s:  %s", si.Type, si.Path))
+			clean = false
+		case fsi.STUnmodified:
+			// noop
+		default:
+			printErr(o.Out, fmt.Errorf("  %s: %s (source: %s)", si.Type, si.Path, filepath.Base(si.SourceFile)))
 			clean = false
 		}
 		// TODO(dlong): Validate each file / component, set `valid` to false if any problems exist
@@ -74,7 +81,7 @@ func (o *StatusOptions) Run() (err error) {
 	if clean {
 		printSuccess(o.Out, "working directory clean")
 	} else if valid {
-		printSuccess(o.Out, "run `qri save` to commit this dataset")
+		printSuccess(o.Out, "\nrun `qri save` to commit this dataset")
 	}
 	return nil
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -67,12 +67,12 @@ func (o *StatusOptions) Run() (err error) {
 	for _, si := range res {
 		switch si.Type {
 		case fsi.STRemoved:
-			printErr(o.Out, fmt.Errorf("  %s:  %s", si.Type, si.Path))
+			printErr(o.Out, fmt.Errorf("  %s:  %s", si.Type, si.Component))
 			clean = false
 		case fsi.STUnmodified:
 			// noop
 		default:
-			printErr(o.Out, fmt.Errorf("  %s: %s (source: %s)", si.Type, si.Path, filepath.Base(si.SourceFile)))
+			printErr(o.Out, fmt.Errorf("  %s: %s (source: %s)", si.Type, si.Component, filepath.Base(si.SourceFile)))
 			clean = false
 		}
 		// TODO(dlong): Validate each file / component, set `valid` to false if any problems exist

--- a/fsi/status.go
+++ b/fsi/status.go
@@ -12,6 +12,25 @@ import (
 	// "github.com/qri-io/dataset/validate"
 )
 
+var (
+	// STUnmodified is "no status"
+	STUnmodified = "unmodified"
+	// STAdd is an added component
+	STAdd = "add"
+	// STChange is a modified component
+	STChange = "modified"
+	// STRemoved is a removed component
+	STRemoved = "removed"
+)
+
+// StatusItem is a component that has status representation on the filesystem
+type StatusItem struct {
+	SourceFile string `json:"sourceFile"`
+	Component  string `json:"component"`
+	Type       string `json:"type"`
+	Message    string `json:"message"`
+}
+
 // statusItems is a slice of component Status, used for sorting
 type statusItems []StatusItem
 
@@ -33,25 +52,6 @@ func (si statusItems) Len() int      { return len(si) }
 func (si statusItems) Swap(i, j int) { si[i], si[j] = si[j], si[i] }
 func (si statusItems) Less(i, j int) bool {
 	return componentOrder[si[i].Component] < componentOrder[si[j].Component]
-}
-
-var (
-	// STUnmodified is "no status"
-	STUnmodified = "unmodified"
-	// STAdd is an added component
-	STAdd = "add"
-	// STChange is a modified component
-	STChange = "modified"
-	// STRemoved is a removed component, currently not really supported?
-	STRemoved = "removed"
-)
-
-// StatusItem is a component that has status representation on the filesystem
-type StatusItem struct {
-	SourceFile string `json:"sourceFile"`
-	Component  string `json:"component"`
-	Type       string `json:"type"`
-	Message    string `json:"message"`
 }
 
 // AliasStatus returns the status for a given dataset alias

--- a/fsi/status.go
+++ b/fsi/status.go
@@ -90,7 +90,7 @@ func (fsi *FSI) Status(dir string) (changes []StatusItem, err error) {
 	for cmpName := range storedComponents {
 		// when reporting deletes, ignore "bound" components that must/must-not
 		// exist based on external conditions
-		if cmpName != componentNameStructure && cmpName != componentNameCommit {
+		if cmpName != componentNameDataset && cmpName != componentNameStructure && cmpName != componentNameCommit {
 			if _, ok := mapping[cmpName]; !ok {
 				change := StatusItem{
 					Path: cmpName,

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,9 @@ go 1.12
 
 require (
 	github.com/beme/abide v0.0.0-20181227202223-4c487ef9d895
-	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/gofrs/flock v0.7.1 // indirect
 	github.com/google/flatbuffers v1.11.0
 	github.com/google/go-cmp v0.2.0
 	github.com/ipfs/go-cid v0.0.2
@@ -34,7 +32,7 @@ require (
 	github.com/qri-io/apiutil v0.1.0
 	github.com/qri-io/bleve v0.5.1-0.20190530204435-e47ddda1936d
 	github.com/qri-io/dag v0.1.0
-	github.com/qri-io/dataset v0.1.3-0.20190617151150-bd20b1913ba5
+	github.com/qri-io/dataset v0.1.3-0.20190710190340-f9ddda73d9dd
 	github.com/qri-io/deepdiff v0.1.0
 	github.com/qri-io/doggos v0.1.0
 	github.com/qri-io/ioes v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
+github.com/datatogether/config v0.0.0-20171026195136-ce668ee661fa h1:VfsRLZbkN+N8gSR398MrVtOXNqopCChMkl4oy1+WKng=
+github.com/datatogether/config v0.0.0-20171026195136-ce668ee661fa/go.mod h1:SmY5zu6SfTn9Hsww24MncC6DNVWYQ66D91yOnX/dWjU=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -79,6 +81,8 @@ github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018/go.mod h1:rQY
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgraph-io/badger v2.0.0-rc.2+incompatible h1:7KPp6xv5+wymkVUbkAnZZXvmDrJlf09m/7u1HG5lAYA=
 github.com/dgraph-io/badger v2.0.0-rc.2+incompatible/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f h1:dDxpBYafY/GYpcl+LS4Bn3ziLPuEdGRkRjYAbSlWxSA=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -156,6 +160,10 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=
+github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gxed/go-shellwords v1.0.3/go.mod h1:N7paucT91ByIjmVJHhvoarjoQnmsi3Jd3vH7VqgtMxQ=
@@ -309,6 +317,8 @@ github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/copier v0.0.0-20180308034124-7e38e58719c3 h1:sHsPfNMAG70QAvKbddQ0uScZCHQoZsT5NykGRCeeeIs=
 github.com/jinzhu/copier v0.0.0-20180308034124-7e38e58719c3/go.mod h1:yL958EeXv8Ylng6IfnvG4oflryUi3vgA3xPs9hmII1s=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -327,6 +337,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/libp2p/go-addr-util v0.0.1 h1:TpTQm9cXVRVSKsYbgQ7GKc3KbbHVTnbostgGaDEP+88=
 github.com/libp2p/go-addr-util v0.0.1/go.mod h1:4ac6O7n9rIAKB1dnd+s8IbbMXkt+oBpzX4/+RACcnlQ=
 github.com/libp2p/go-buffer-pool v0.0.1/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=
@@ -565,6 +577,7 @@ github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsq
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/paulmach/orb v0.1.3 h1:Wa1nzU269Zv7V9paVEY1COWW8FCqv4PC/KJRbJSimpM=
 github.com/paulmach/orb v0.1.3/go.mod h1:VFlX/8C+IQ1p6FTRRKzKoOPJnvEtA5G0Veuqwbu//Vk=
+github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -605,6 +618,8 @@ github.com/qri-io/dataset v0.1.2 h1:9s9k+I8yE8FXlXhobMEoiBtMA7IKJFfjACGowKrmFWI=
 github.com/qri-io/dataset v0.1.2/go.mod h1:iLbXBiN11Mf1gr8R+40arhqtbZOEMbhjDtGXPi2JLRQ=
 github.com/qri-io/dataset v0.1.3-0.20190617151150-bd20b1913ba5 h1:JtZAKkeHpSkJBnGMDPG0nbIm6cSC5+MgtQYSkcfj+gE=
 github.com/qri-io/dataset v0.1.3-0.20190617151150-bd20b1913ba5/go.mod h1:iLbXBiN11Mf1gr8R+40arhqtbZOEMbhjDtGXPi2JLRQ=
+github.com/qri-io/dataset v0.1.3-0.20190710190340-f9ddda73d9dd h1:fNFTWGZ/cAXw+bWkmjff2XgDvnUcXt+DuUd+dwX6dwA=
+github.com/qri-io/dataset v0.1.3-0.20190710190340-f9ddda73d9dd/go.mod h1:J/ptld3evb1QyYdU95+H+Ft6XitjYzNPnyW83GJoox0=
 github.com/qri-io/deepdiff v0.1.0 h1:1VXd/ePPrSrq4GRINC4YxmoPHuuLufg2ujMKvvEWsDc=
 github.com/qri-io/deepdiff v0.1.0/go.mod h1:/O1HQVAlm3yhgQvNwyzsKaECfM2vVSx6KxttgXQQGFw=
 github.com/qri-io/doggos v0.1.0 h1:B7Hn9ssRGDAonMhJ4UwDtPDmG9GtvLR8f7VFec7Rs7M=
@@ -620,6 +635,7 @@ github.com/qri-io/jsonschema v0.1.1 h1:t//Doa/gvMqJ0bDhG7PGIKfaWGGxRVaffp+bcvBGG
 github.com/qri-io/jsonschema v0.1.1/go.mod h1:QpzJ6gBQ0GYgGmh7mDQ1YsvvhSgE4rYj0k8t5MBOmUY=
 github.com/qri-io/qfs v0.1.0 h1:XgDhon13qLlwJHI2m0FAc2EhZEcrqMPwizvgfQXHzB8=
 github.com/qri-io/qfs v0.1.0/go.mod h1:vZ5gVAYKaW8bDLh8U8DEr3s/1JyNzQJg1Rg9HYS+VZo=
+github.com/qri-io/qri v0.8.2/go.mod h1:0YvePPjMcND3HMbYRutDEnw87015DxMZiEhPB6iC9B4=
 github.com/qri-io/registry v0.1.0 h1:e4BBcVCfim++7Y0HI9DTKWzeSjNiBqXrKzs62M/GAHw=
 github.com/qri-io/registry v0.1.0/go.mod h1:sSsNnCZPmyG3IGOisEzTeIEwzCXunLpFsnKS16DKw/c=
 github.com/qri-io/starlib v0.4.0 h1:jsq4lZuqTVY+rqGuV5T3YZd5BbgqmRMi00QY+crXn8U=
@@ -780,6 +796,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190522135303-fa69b94a3b58/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -196,6 +196,7 @@ type SaveParams struct {
 	// dataset supplies params directly, all other param fields override values
 	// supplied by dataset
 	Dataset *dataset.Dataset
+
 	// dataset reference string, the name to save to
 	Ref string
 	// commit title, defaults to a generated string based on diff
@@ -208,6 +209,9 @@ type SaveParams struct {
 	FilePaths []string
 	// secrets for transform execution
 	Secrets map[string]string
+	// Replace writes the entire given dataset as a new snapshot instead of 
+	// applying save params as agumentations to the existing history
+	Replace bool
 	// option to make dataset private. private data is not currently implimented,
 	// see https://github.com/qri-io/qri/issues/291 for updates
 	Private bool
@@ -328,7 +332,15 @@ func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) 
 		return
 	}
 
-	ref, err = actions.SaveDataset(r.node, ds, p.Secrets, p.ScriptOutput, p.DryRun, true, p.ConvertFormatToPrev, p.Force, p.ShouldRender)
+	switches := actions.SaveDatasetSwitches{
+		Replace: p.Replace,
+		DryRun: p.DryRun,
+		Pin: true, 
+		ConvertFormatToPrev: p.ConvertFormatToPrev, 
+		Force: p.Force, 
+		ShouldRender: p.ShouldRender,
+	}
+	ref, err = actions.SaveDataset(r.node, ds, p.Secrets, p.ScriptOutput, switches)
 	if err != nil {
 		log.Debugf("create ds error: %s\n", err.Error())
 		return err

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -209,8 +209,8 @@ type SaveParams struct {
 	FilePaths []string
 	// secrets for transform execution
 	Secrets map[string]string
-	// Replace writes the entire given dataset as a new snapshot instead of 
-	// applying save params as agumentations to the existing history
+	// Replace writes the entire given dataset as a new snapshot instead of
+	// applying save params as augmentations to the existing history
 	Replace bool
 	// option to make dataset private. private data is not currently implimented,
 	// see https://github.com/qri-io/qri/issues/291 for updates
@@ -333,12 +333,12 @@ func (r *DatasetRequests) Save(p *SaveParams, res *repo.DatasetRef) (err error) 
 	}
 
 	switches := actions.SaveDatasetSwitches{
-		Replace: p.Replace,
-		DryRun: p.DryRun,
-		Pin: true, 
-		ConvertFormatToPrev: p.ConvertFormatToPrev, 
-		Force: p.Force, 
-		ShouldRender: p.ShouldRender,
+		Replace:             p.Replace,
+		DryRun:              p.DryRun,
+		Pin:                 true,
+		ConvertFormatToPrev: p.ConvertFormatToPrev,
+		Force:               p.Force,
+		ShouldRender:        p.ShouldRender,
 	}
 	ref, err = actions.SaveDataset(r.node, ds, p.Secrets, p.ScriptOutput, switches)
 	if err != nil {

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -162,7 +162,8 @@ func addCitiesDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	ds.Name = tc.Name
 	ds.BodyBytes = tc.Body
 
-	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false, false, true)
+	// dryRun, pin, convertFormatToPrev, force, shouldRender bool
+	ref, err := actions.SaveDataset(node, ds, nil, nil, actions.SaveDatasetSwitches{ Pin: true, ShouldRender: true })
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -178,7 +179,7 @@ func addNowTransformDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	ds.Name = tc.Name
 	ds.Transform.ScriptPath = "testdata/now_tf/transform.star"
 
-	ref, err := actions.SaveDataset(node, ds, nil, nil, false, true, false, false, true)
+	ref, err := actions.SaveDataset(node, ds, nil, nil, actions.SaveDatasetSwitches{ Pin: true, ShouldRender: true })
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -162,8 +162,7 @@ func addCitiesDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	ds.Name = tc.Name
 	ds.BodyBytes = tc.Body
 
-	// dryRun, pin, convertFormatToPrev, force, shouldRender bool
-	ref, err := actions.SaveDataset(node, ds, nil, nil, actions.SaveDatasetSwitches{ Pin: true, ShouldRender: true })
+	ref, err := actions.SaveDataset(node, ds, nil, nil, actions.SaveDatasetSwitches{Pin: true, ShouldRender: true})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -179,7 +178,7 @@ func addNowTransformDataset(t *testing.T, node *p2p.QriNode) repo.DatasetRef {
 	ds.Name = tc.Name
 	ds.Transform.ScriptPath = "testdata/now_tf/transform.star"
 
-	ref, err := actions.SaveDataset(node, ds, nil, nil, actions.SaveDatasetSwitches{ Pin: true, ShouldRender: true })
+	ref, err := actions.SaveDataset(node, ds, nil, nil, actions.SaveDatasetSwitches{Pin: true, ShouldRender: true})
 	if err != nil {
 		t.Fatal(err.Error())
 	}


### PR DESCRIPTION
First, we now check status mapping in _both_ directions, which means we can report removed components as well as added ones. There are some idiosyncrasies here that I think we need to introduce terminology to describe. Yay Spec(ish) time!

### 'Bound' Components
There are components of a dataset who's existence or lack thereof is "bound" to some other factor. Our document model enforces these restrictions to keep datasets working properly. Immediate examples: 

* the `structure` component is bound to the existence of a body. If a body exists, structure MUST exist. if a body doesn't exist, structure MAY exist.
* `commit` is bound to a dataset version existing. if a dataset version exists, it MUST have a commit component.
* the `dataset` itself is bound to any component existing it's not possible to not have a "dataset" component. Getting a little existential, there is no dataset component if no dataset components exist.

This matters when reporting the status of a dataset, because the user has no control over these components, and so we need to treat the edge cases properly. For example, if a user deletes their "structure.json" file, but still has a structure, we shouldn't report it as "removed", because it can't be. We need to either report the fact that structure will be inferred on save, or we should consider this an "implementation detail" and report nothing at all. Personally I'm a fan of the former.

There is a connection between _bound components_ and  _derived values_. To distinguish the two:
* if a bound component doesn't exist, but must, we will _infer_ one for the user based.
* all derived values will ALWAYS be derived, and cannot be wrong

Inference is different from derivation because it can be "wrong" (where "wrong" is _not what the user intended_). We can infer the wrong schema. We can't derive the wrong checksum.

I should point out that "bound" is a descriptive term. We don't need to explicitly write this stuff in code the way we do with, say, derived values.

### Replace Save
`actions.SaveDataset` has been refactored to accept a struct of switches. That struct has a new switch `Replace` that instructs qri to only use input data when creating a dataset commit. This has the effect of "replacing" the dataset instead of applying the input dataset as modifications to the prior version.

We need this for FSI, which operates on a file-system-reflects-current-state paradigm.