### PR TITLE
test(cmd): route output to buffer for cleaner test output

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -209,12 +209,12 @@ func TestCommandsIntegration(t *testing.T) {
 	defer done()
 
 	root := NewQriCommand(ctx, NewDirPathFactory(path), libtest.NewTestCrypto(), streams)
+	root.SetOutput(ioutil.Discard)
 
 	for i, command := range commands {
 		func() {
 			defer func() {
 				if e := recover(); e != nil {
-					fmt.Println(e)
 					t.Errorf("case %d unexpected panic executing command\n%s\n%s", i, command, e)
 					return
 				}
@@ -222,7 +222,6 @@ func TestCommandsIntegration(t *testing.T) {
 
 			er := executeCommand(root, command)
 			if er != nil {
-				fmt.Println(er)
 				t.Errorf("case %d unexpected error executing command\n%s\n%s", i, command, er.Error())
 				return
 			}
@@ -925,7 +924,9 @@ func (r *TestRepoRoot) CreateCommandRunner(ctx context.Context) *cobra.Command {
 	r.streams = ioes.NewIOStreams(in, out, out)
 	setNoColor(true)
 
-	return NewQriCommand(ctx, r.pathFactory, r.testCrypto, r.streams)
+	cmd := NewQriCommand(ctx, r.pathFactory, r.testCrypto, r.streams)
+	cmd.SetOutput(out)
+	return cmd
 }
 
 func (r *TestRepoRoot) GetOutput() string {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -108,7 +108,7 @@ func (o *ExportOptions) Run() error {
 		return err
 	}
 
-	fmt.Printf("dataset exported to \"%s\"\n", fileWritten)
+	fmt.Fprintf(o.Out, "dataset exported to \"%s\"\n", fileWritten)
 
 	return nil
 }


### PR DESCRIPTION
closes #842

stdout printing from tests is irritating. this sends it to output buffer. Also fixes the output of the export command