### PR TITLE
fix(validate): Validate works with FSI. Various FSI cleanups.

### DIFF
--- a/cmd/fsi_test.go
+++ b/cmd/fsi_test.go
@@ -70,7 +70,7 @@ func TestInitStatusSave(t *testing.T) {
 	}
 
 	output := r.GetOutput()
-	expect := `for dataset [test_peer/brand_new]
+	expect := `for linked dataset [test_peer/brand_new]
 
   add: meta (source: meta.json)
   add: schema (source: schema.json)
@@ -99,11 +99,11 @@ run ` + "`qri save`" + ` to commit this dataset
 	}
 
 	output = r.GetOutput()
-	expect = `for dataset [test_peer/brand_new]
+	expect = `for linked dataset [test_peer/brand_new]
 
 working directory clean
 `
-	if diff := cmpTextLines(output, expect); diff != "" {
+	if diff := cmpTextLines(expect, output); diff != "" {
 		t.Errorf("qri status (-want +got):\n%s", diff)
 	}
 }
@@ -168,7 +168,7 @@ func TestCheckoutSimpleStatus(t *testing.T) {
 	}
 
 	output := r.GetOutput()
-	expect := `for dataset [test_peer/two_movies]
+	expect := `for linked dataset [test_peer/two_movies]
 
 working directory clean
 `
@@ -187,7 +187,7 @@ working directory clean
 	}
 
 	output = r.GetOutput()
-	expect = `for dataset [test_peer/two_movies]
+	expect = `for linked dataset [test_peer/two_movies]
 
   modified: body (source: body.json)
 
@@ -210,7 +210,7 @@ run ` + "`qri save`" + ` to commit this dataset
 	}
 
 	output = r.GetOutput()
-	expect = `for dataset [test_peer/two_movies]
+	expect = `for linked dataset [test_peer/two_movies]
 
   add: meta (source: meta.json)
   modified: body (source: body.json)
@@ -281,11 +281,11 @@ func TestCheckoutWithStructure(t *testing.T) {
 	}
 
 	output := r.GetOutput()
-	expect := `for dataset [test_peer/ten_movies]
+	expect := `for linked dataset [test_peer/ten_movies]
 
 working directory clean
 `
-	if diff := cmpTextLines(output, expect); diff != "" {
+	if diff := cmpTextLines(expect, output); diff != "" {
 		t.Errorf("qri status (-want +got):\n%s", diff)
 	}
 
@@ -300,13 +300,13 @@ working directory clean
 	}
 
 	output = r.GetOutput()
-	expect = `for dataset [test_peer/ten_movies]
+	expect = `for linked dataset [test_peer/ten_movies]
 
   modified: body (source: body.csv)
 
 run ` + "`qri save`" + ` to commit this dataset
 `
-	if diff := cmpTextLines(output, expect); diff != "" {
+	if diff := cmpTextLines(expect, output); diff != "" {
 		t.Errorf("qri status (-want +got):\n%s", diff)
 	}
 
@@ -323,14 +323,14 @@ run ` + "`qri save`" + ` to commit this dataset
 	}
 
 	output = r.GetOutput()
-	expect = `for dataset [test_peer/ten_movies]
+	expect = `for linked dataset [test_peer/ten_movies]
 
   modified: meta (source: meta.json)
   modified: body (source: body.csv)
 
 run ` + "`qri save`" + ` to commit this dataset
 `
-	if diff := cmpTextLines(output, expect); diff != "" {
+	if diff := cmpTextLines(expect, output); diff != "" {
 		t.Errorf("qri status (-want +got):\n%s", diff)
 	}
 
@@ -347,14 +347,14 @@ run ` + "`qri save`" + ` to commit this dataset
 	}
 
 	output = r.GetOutput()
-	expect = `for dataset [test_peer/ten_movies]
+	expect = `for linked dataset [test_peer/ten_movies]
 
   removed:  meta
   modified: body (source: body.csv)
 
 run ` + "`qri save`" + ` to commit this dataset
 `
-	if diff := cmpTextLines(output, expect); diff != "" {
+	if diff := cmpTextLines(expect, output); diff != "" {
 		t.Errorf("qri status (-want +got):\n%s", diff)
 	}
 }
@@ -418,11 +418,11 @@ func TestCheckoutAndModifySchema(t *testing.T) {
 	}
 
 	output := r.GetOutput()
-	expect := `for dataset [test_peer/more_movies]
+	expect := `for linked dataset [test_peer/more_movies]
 
 working directory clean
 `
-	if diff := cmpTextLines(output, expect); diff != "" {
+	if diff := cmpTextLines(expect, output); diff != "" {
 		t.Errorf("qri status (-want +got):\n%s", diff)
 	}
 
@@ -440,14 +440,14 @@ working directory clean
 
 	output = r.GetOutput()
 	// TODO(dlong): structure/dataset.json should not be marked as `modified`
-	expect = `for dataset [test_peer/more_movies]
+	expect = `for linked dataset [test_peer/more_movies]
 
   modified: structure (source: dataset.json)
   modified: schema (source: schema.json)
 
 run ` + "`qri save`" + ` to commit this dataset
 `
-	if diff := cmpTextLines(output, expect); diff != "" {
+	if diff := cmpTextLines(expect, output); diff != "" {
 		t.Errorf("qri status (-want +got):\n%s", diff)
 	}
 }
@@ -509,9 +509,9 @@ func TestStatusParseError(t *testing.T) {
 	}
 
 	output := r.GetOutput()
-	expect := `for dataset [test_peer/bad_movies]
+	expect := `for linked dataset [test_peer/bad_movies]
 
-  parse_error: meta (source: meta.json)
+  parse error: meta (source: meta.json)
 
 fix these problems before saving this dataset
 `
@@ -577,9 +577,9 @@ func TestStatusParseErrorForSchema(t *testing.T) {
 	}
 
 	output := r.GetOutput()
-	expect := `for dataset [test_peer/ten_movies]
+	expect := `for linked dataset [test_peer/ten_movies]
 
-  parse_error: schema (source: schema.json)
+  parse error: schema (source: schema.json)
 
 fix these problems before saving this dataset
 `

--- a/cmd/ref_select.go
+++ b/cmd/ref_select.go
@@ -25,12 +25,18 @@ type RefSelect struct {
 // In contrast, when a user is running a command within a working directory that is linked to a
 // dataset, the text sent to standard output shall begin with:
 //
-// for dataset [peername/dataset_name]
+// for linked dataset [peername/dataset_name]
 //
-// That is, "using" is to `use`, as "for" is to `qri-ref`. In all other caes (an explicit dataset
-// ref provided on the command line) neither of these phrases should be displayed. This way, the
-// user can tell at a glance what dataset is being used, and the reason for why is was selected.
-// The `kind` field on RefSelect controls what of these kinds of references is being used.
+// That is, "using" is to `use`, as "for linked" is to `qri-ref`. In all other cases (an
+// explicit dataset ref provided on the command line) neither of these phrases should be
+// displayed. This way, the user can tell at a glance what dataset is being used, and the reason
+// for why is was selected. The `kind` field on RefSelect controls which of these kinds of
+// references is being used.
+
+// NewEmptyRefSelect returns an empty reference selection
+func NewEmptyRefSelect() *RefSelect {
+	return &RefSelect{refs: []string{}}
+}
 
 // NewExplicitRefSelect returns a single explicitly provided reference
 func NewExplicitRefSelect(ref string) *RefSelect {
@@ -49,7 +55,7 @@ func NewLinkedDirectoryRefSelect(ref, dir string) *RefSelect {
 	if pos != -1 {
 		ref = ref[:pos]
 	}
-	return &RefSelect{kind: "for", refs: []string{ref}, dir: dir}
+	return &RefSelect{kind: "for linked", refs: []string{ref}, dir: dir}
 }
 
 // NewUsingRefSelect returns a single reference implied by the use command

--- a/cmd/ref_select_test.go
+++ b/cmd/ref_select_test.go
@@ -4,11 +4,114 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"testing"
 )
 
-func TestRefSelect(t *testing.T) {
+func TestBasicRefSelect(t *testing.T) {
+	refs := NewEmptyRefSelect()
+	if refs.Ref() != "" {
+		t.Errorf("expected ref \"\", got %s", refs.Ref())
+	}
+	if strings.Join(refs.RefList(), ",") != "" {
+		t.Errorf("expected ref list \"\", got %s", refs.RefList())
+	}
+	if refs.String() != "" {
+		t.Errorf("expected ref string \"\", got %s", refs.String())
+	}
+	if refs.Dir() != "" {
+		t.Errorf("expected ref dir \"\", got %s", refs.Dir())
+	}
+	if !refs.IsExplicit() {
+		t.Errorf("expected ref isExplict true, got %t", refs.IsExplicit())
+	}
+	if refs.IsLinked() {
+		t.Errorf("expected ref isLinked false, got %t", refs.IsLinked())
+	}
+
+	refs = NewExplicitRefSelect("peername/test_ds")
+	if refs.Ref() != "peername/test_ds" {
+		t.Errorf("expected ref \"peername/test_ds\", got %s", refs.Ref())
+	}
+	if strings.Join(refs.RefList(), ",") != "peername/test_ds" {
+		t.Errorf("expected ref list \"peername/test_ds\", got %s", refs.RefList())
+	}
+	if refs.String() != "" {
+		t.Errorf("expected ref string \"\", got %s", refs.String())
+	}
+	if refs.Dir() != "" {
+		t.Errorf("expected ref dir \"\", got %s", refs.Dir())
+	}
+	if !refs.IsExplicit() {
+		t.Errorf("expected ref isExplict true, got %t", refs.IsExplicit())
+	}
+	if refs.IsLinked() {
+		t.Errorf("expected ref isLinked false, got %t", refs.IsLinked())
+	}
+
+	refs = NewListOfRefSelects([]string{"peername/test_ds", "peername/another_ds"})
+	if refs.Ref() != "peername/test_ds" {
+		t.Errorf("expected ref \"peername/test_ds\", got %s", refs.Ref())
+	}
+	if strings.Join(refs.RefList(), ",") != "peername/test_ds,peername/another_ds" {
+		t.Errorf("expected ref list \"peername/test_ds,peername/another_ds\", got %s", refs.RefList())
+	}
+	if refs.String() != "" {
+		t.Errorf("expected ref string \"\", got %s", refs.String())
+	}
+	if refs.Dir() != "" {
+		t.Errorf("expected ref dir \"\", got %s", refs.Dir())
+	}
+	if !refs.IsExplicit() {
+		t.Errorf("expected ref isExplict true, got %t", refs.IsExplicit())
+	}
+	if refs.IsLinked() {
+		t.Errorf("expected ref isLinked false, got %t", refs.IsLinked())
+	}
+
+	refs = NewLinkedDirectoryRefSelect("peername/test_ds", "path/to/test_ds")
+	if refs.Ref() != "peername/test_ds" {
+		t.Errorf("expected ref \"peername/test_ds\", got %s", refs.Ref())
+	}
+	if strings.Join(refs.RefList(), ",") != "peername/test_ds" {
+		t.Errorf("expected ref list \"peername/test_ds\", got %s", refs.RefList())
+	}
+	if refs.String() != "for linked dataset [peername/test_ds]" {
+		t.Errorf("expected ref string \"for linked dataset [peername/test_ds]\", got %s", refs.String())
+	}
+	if refs.Dir() != "path/to/test_ds" {
+		t.Errorf("expected ref dir \"path/to/test_ds\", got %s", refs.Dir())
+	}
+	if refs.IsExplicit() {
+		t.Errorf("expected ref isExplict false, got %t", refs.IsExplicit())
+	}
+	if !refs.IsLinked() {
+		t.Errorf("expected ref isLinked true, got %t", refs.IsLinked())
+	}
+
+	refs = NewUsingRefSelect("peername/test_ds")
+	if refs.Ref() != "peername/test_ds" {
+		t.Errorf("expected ref \"peername/test_ds\", got %s", refs.Ref())
+	}
+	if strings.Join(refs.RefList(), ",") != "peername/test_ds" {
+		t.Errorf("expected ref list \"peername/test_ds\", got %s", refs.RefList())
+	}
+	if refs.String() != "using dataset [peername/test_ds]" {
+		t.Errorf("expected ref string \"using dataset [peername/test_ds]\", got %s", refs.String())
+	}
+	if refs.Dir() != "" {
+		t.Errorf("expected ref dir \"\", got %s", refs.Dir())
+	}
+	if refs.IsExplicit() {
+		t.Errorf("expected ref isExplict false, got %t", refs.IsExplicit())
+	}
+	if refs.IsLinked() {
+		t.Errorf("expected ref isLinked false, got %t", refs.IsLinked())
+	}
+}
+
+func TestGetCurrentRefSelect(t *testing.T) {
 	f, err := NewTestFactory(nil)
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/fsi/status.go
+++ b/fsi/status.go
@@ -26,7 +26,7 @@ var (
 	// STRemoved is a removed component
 	STRemoved = "removed"
 	// STParseError is a component that didn't parse
-	STParseError = "parse_error"
+	STParseError = "parse error"
 )
 
 // StatusItem is a component that has status representation on the filesystem

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -802,12 +802,12 @@ Pirates of the Caribbean: At World's End ,foo
 		numErrors int
 		err       string
 	}{
-		{ValidateDatasetParams{Ref: repo.DatasetRef{}}, 0, "bad arguments provided"},
-		{ValidateDatasetParams{Ref: repo.DatasetRef{Peername: "me"}}, 0, "cannot find dataset: peer@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt"},
-		{ValidateDatasetParams{Ref: repo.DatasetRef{Peername: "me", Name: "movies"}}, 4, ""},
-		{ValidateDatasetParams{Ref: repo.DatasetRef{Peername: "me", Name: "movies"}, Data: dataf, DataFilename: "data.csv"}, 1, ""},
-		{ValidateDatasetParams{Ref: repo.DatasetRef{Peername: "me", Name: "movies"}, Schema: schemaf}, 4, ""},
-		{ValidateDatasetParams{Schema: schemaf2, DataFilename: "data.csv", Data: dataf2}, 1, ""},
+		{ValidateDatasetParams{Ref: ""}, 0, "bad arguments provided"},
+		{ValidateDatasetParams{Ref: "me"}, 0, "cannot find dataset: peer@QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt"},
+		{ValidateDatasetParams{Ref: "me/movies"}, 4, ""},
+		{ValidateDatasetParams{Ref: "me/movies", Body: dataf, BodyFilename: "data.csv"}, 1, ""},
+		{ValidateDatasetParams{Ref: "me/movies", Schema: schemaf}, 4, ""},
+		{ValidateDatasetParams{Schema: schemaf2, BodyFilename: "data.csv", Body: dataf2}, 1, ""},
 	}
 
 	mr, err := testrepo.NewTestRepo(nil)


### PR DESCRIPTION
Validate can be run in an FSI directory, using the schema and body in the working directory. Change how linked dataset UI is printed. Turn the underscore in parse_error into a space.