### PR TITLE
fix(api): report publish status when fetching a single dataset

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -282,12 +282,15 @@ func (h *DatasetHandlers) getHandler(w http.ResponseWriter, r *http.Request) {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
 	}
+
+	// TODO (b5) - remove this. res.Ref should be used instead
 	ref := repo.DatasetRef{
 		Peername:  res.Dataset.Peername,
 		ProfileID: profile.ID(res.Dataset.ProfileID),
 		Name:      res.Dataset.Name,
 		Path:      res.Dataset.Path,
 		FSIPath:   res.Ref.FSIPath,
+		Published: res.Ref.Published,
 		Dataset:   res.Dataset,
 	}
 	util.WriteResponse(w, ref)

--- a/api/remote.go
+++ b/api/remote.go
@@ -80,7 +80,7 @@ func (h *RemoteClientHandlers) PublishHandler(w http.ResponseWriter, r *http.Req
 		Ref:        ref.String(),
 		RemoteName: r.FormValue("remote"),
 	}
-	var res bool
+	var res repo.DatasetRef
 
 	switch r.Method {
 	case "POST":

--- a/api/root.go
+++ b/api/root.go
@@ -70,12 +70,14 @@ func (mh *RootHandler) Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO (b5) - why is this necessary?
 	ref = repo.DatasetRef{
 		Peername:  res.Dataset.Peername,
 		ProfileID: profile.ID(res.Dataset.ProfileID),
 		Name:      res.Dataset.Name,
 		Path:      res.Dataset.Path,
 		FSIPath:   res.Ref.FSIPath,
+		Published: res.Ref.Published,
 		Dataset:   res.Dataset,
 	}
 

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -74,34 +74,22 @@ func (o *PublishOptions) Complete(f Factory, args []string) (err error) {
 
 // Run executes the publish command
 func (o *PublishOptions) Run() error {
+	var res repo.DatasetRef
 	for _, ref := range o.Refs {
-		// mark dataset as listed on p2p
-		// TODO (b5) - make this a flag on lib.PushToRemote
-		setPub := lib.SetPublishStatusParams{
-			Ref:           ref,
-			PublishStatus: !o.Unpublish,
-		}
-
-		var publishedRef repo.DatasetRef
-		if err := o.DatasetRequests.SetPublishStatus(&setPub, &publishedRef); err != nil {
-			return err
-		}
-
 		p := lib.PublicationParams{
 			Ref:        ref,
 			RemoteName: o.RemoteName,
 		}
-		var res bool
 		if o.Unpublish {
 			if err := o.RemoteMethods.Unpublish(&p, &res); err != nil {
 				return err
 			}
-			printInfo(o.Out, "unpublished dataset %s", publishedRef)
+			printInfo(o.Out, "unpublished dataset %s", res)
 		} else {
 			if err := o.RemoteMethods.Publish(&p, &res); err != nil {
 				return err
 			}
-			printInfo(o.Out, "published dataset %s", publishedRef)
+			printInfo(o.Out, "published dataset %s", res)
 		}
 	}
 	return nil

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -466,30 +466,6 @@ func (r *DatasetRequests) SetPublishStatus(p *SetPublishStatusParams, publishedR
 	}
 
 	*publishedRef = ref
-
-	// if p.UpdateRegistry && r.node.Repo.Registry() != nil {
-	// 	var done bool
-	// 	rr := NewRegistryRequests(r.node, nil)
-
-	// 	if ref.Published {
-	// 		if err = rr.Publish(&ref, &done); err != nil {
-	// 			return
-	// 		}
-
-	// 		if p.UpdateRegistryPin {
-	// 			return rr.Pin(&ref, &done)
-	// 		}
-	// 	} else {
-	// 		if err = rr.Unpublish(&ref, &done); err != nil {
-	// 			return
-	// 		}
-
-	// 		if p.UpdateRegistryPin {
-	// 			return rr.Unpin(&ref, &done)
-	// 		}
-	// 	}
-	// }
-
 	return
 }
 

--- a/remote/client.go
+++ b/remote/client.go
@@ -230,6 +230,9 @@ func removeDatasetHTTP(ctx context.Context, params map[string]string, remoteAddr
 	}
 
 	if res.StatusCode != http.StatusOK {
+		if data, err := ioutil.ReadAll(res.Body); err == nil {
+			log.Error("HTTP server remove error response: ", string(data))
+		}
 		return fmt.Errorf("failed to remove dataset from remote")
 	}
 


### PR DESCRIPTION
builds on #882. I'll rebase once it's merged. API isn't properly returning publication status when getting single datasets, which is now important for publish status tracking.