### PR TITLE
fix(config): enable setting config over RPC

### DIFF
--- a/config/registry.go
+++ b/config/registry.go
@@ -12,7 +12,7 @@ type Registry struct {
 // DefaultRegistry generates a new default registry instance
 func DefaultRegistry() *Registry {
 	r := &Registry{
-		Location: "https://registry.qri.io",
+		Location: "https://registry.qri.cloud",
 	}
 	return r
 }

--- a/config/repo.go
+++ b/config/repo.go
@@ -28,11 +28,11 @@ func (cfg Repo) Validate() error {
     "title": "Repo",
     "description": "Config for the qri repository",
     "type": "object",
-    "required": ["middleware", "type"],
+    "required": ["type"],
     "properties": {
       "middleware": {
         "description": "Middleware packages that need to be applied to the repo",
-        "type": "array",
+        "type": ["array", "null"],
         "items": {
           "type": "string"
         }


### PR DESCRIPTION
closes #898.

Also makes `https://registry.qri.cloud` the new default.