### PR TITLE
feat(fsi): Api can set directory to create for init

### DIFF
--- a/api/fsi.go
+++ b/api/fsi.go
@@ -115,6 +115,7 @@ func (h *FSIHandlers) initHandler(routePrefix string) http.HandlerFunc {
 			Dir:            dir,
 			Name:           r.FormValue("name"),
 			Format:         r.FormValue("format"),
+			Mkdir:          r.FormValue("mkdir"),
 			SourceBodyPath: r.FormValue("sourcebodypath"),
 		}
 


### PR DESCRIPTION
A follow-up to https://github.com/qri-io/qri/pull/913, add the mkdir parameter to the api for init.