### PR TITLE
refactor(DatasetRef): add Foreign flag to dataset reference, show in qri list

### DIFF
--- a/base/dataset.go
+++ b/base/dataset.go
@@ -143,7 +143,12 @@ func ListDatasets(ctx context.Context, r repo.Repo, term string, limit, offset i
 		if ref.Path != "" {
 			ds, err := dsfs.LoadDataset(ctx, store, ref.Path)
 			if err != nil {
-				return nil, fmt.Errorf("error loading path: %s, err: %s", ref.Path, err.Error())
+				if strings.Contains(err.Error(), "not found") {
+					res[i].Foreign = true
+					err = nil
+					continue
+				}
+				return nil, fmt.Errorf("error loading ref: %s, err: %s", ref.String(), err.Error())
 			}
 			res[i].Dataset = ds
 			if RPC {

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -55,6 +55,7 @@ func (r refStringer) String() string {
 	w := &bytes.Buffer{}
 	title := color.New(color.FgGreen, color.Bold).SprintFunc()
 	path := color.New(color.Faint).SprintFunc()
+	warn := color.New(color.FgYellow).SprintFunc()
 	ds := r.Dataset
 	dsr := repo.DatasetRef(r)
 
@@ -66,6 +67,9 @@ func (r refStringer) String() string {
 		fmt.Fprintf(w, "\nlinked: %s", path(r.FSIPath))
 	} else if r.Path != "" {
 		fmt.Fprintf(w, "\n%s", path(r.Path))
+	}
+	if r.Foreign {
+		fmt.Fprintf(w, "\n%s", warn("foreign"))
 	}
 	if ds != nil && ds.Structure != nil {
 		fmt.Fprintf(w, "\n%s", humanize.Bytes(uint64(ds.Structure.Length)))

--- a/repo/ref.go
+++ b/repo/ref.go
@@ -62,6 +62,8 @@ type DatasetRef struct {
 	Dataset *dataset.Dataset `json:"dataset,omitempty"`
 	// Published indicates whether this reference is listed as an available dataset
 	Published bool `json:"published"`
+	// If true, this reference doesn't exist locally
+	Foreign bool `json:"foreign,omitempty"`
 }
 
 // String implements the Stringer interface for DatasetRef


### PR DESCRIPTION
DatasetRef grows again. The next phase of changes for Qri require a refrence be able to model the state of not being in the local qri repo. This lands support for such a change while also fixing `qri list`, which currently chokes on a foreign reference.