### PR TITLE
feat(add): add link flag to lib.Add, CLI, API

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -364,13 +364,19 @@ func (h *DatasetHandlers) addHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO (b5) - move this into lib.Add
 	if ref.Peername == "" || ref.Name == "" {
 		util.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("need peername and dataset name: '/add/[peername]/[datasetname]'"))
 		return
 	}
 
+	p := &lib.AddParams{
+		Ref:     ref.String(),
+		LinkDir: r.FormValue("dir"),
+	}
+
 	res := repo.DatasetRef{}
-	err = h.Add(&ref, &res)
+	err = h.Add(p, &res)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -767,11 +767,11 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 func TestDatasetRequestsAdd(t *testing.T) {
 	cases := []struct {
-		p   *repo.DatasetRef
+		p   *AddParams
 		res *repo.DatasetRef
 		err string
 	}{
-		{&repo.DatasetRef{Name: "abc", Path: "hash###"}, nil, "node is not online and no registry is configured"},
+		{&AddParams{Ref: "abc/hash###"}, nil, "node is not online and no registry is configured"},
 	}
 
 	mr, err := testrepo.NewTestRepo()
@@ -842,12 +842,15 @@ func TestDatasetRequestsAddP2P(t *testing.T) {
 				index, _ := strconv.ParseInt(num, 10, 32)
 				name := datasets[index]
 				ref := repo.DatasetRef{Peername: profile.Peername, Name: name}
+				p := &AddParams{
+					Ref: ref.AliasString(),
+				}
 
 				// Build requests for peer1 to peer2.
 				dsr := NewDatasetRequests(p0, nil)
 				got := &repo.DatasetRef{}
 
-				err := dsr.Add(&ref, got)
+				err := dsr.Add(p, got)
 				if err != nil {
 					pro1, _ := p0.Repo.Profile()
 					pro2, _ := p1.Repo.Profile()


### PR DESCRIPTION
closes #940
This allows adding a dataset & linking it to a directory in the same command. you can now pass `dir` as a query param to `POST /add/[name]/dataset` and provide a filepath