### PR TITLE
fix(search): update to new registry api search result format

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	util "github.com/qri-io/apiutil"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/lib"
-	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
 )
 
@@ -106,11 +104,7 @@ func (o *SearchOptions) Run() (err error) {
 		fmt.Fprintf(o.Out, "showing %d results for '%s'\n", len(results), o.Query)
 		items := make([]fmt.Stringer, len(results))
 		for i, result := range results {
-			ref, err := searchResultToRef(&result)
-			if err != nil {
-				return err
-			}
-			items[i] = refStringer(*ref)
+			items[i] = searchResultStringer(result)
 		}
 		o.StopSpinner()
 		printItems(o.Out, items, page.Offset())
@@ -130,26 +124,26 @@ func (o *SearchOptions) Run() (err error) {
 	return nil
 }
 
-func searchResultToRef(result *lib.SearchResult) (*repo.DatasetRef, error) {
-	ref := &repo.DatasetRef{
-		Dataset: &dataset.Dataset{},
-	}
-	raw, err := json.Marshal(result.Value)
-	if err != nil {
-		return nil, err
-	}
-	if err = json.Unmarshal(raw, ref.Dataset); err != nil {
-		return nil, err
-	}
-	ref.Path = ref.Dataset.Path
+// func searchResultToRef(result *lib.SearchResult) (*repo.DatasetRef, error) {
+// 	ref := &repo.DatasetRef{
+// 		Dataset: &dataset.Dataset{},
+// 	}
+// 	raw, err := json.Marshal(result.Value)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	if err = json.Unmarshal(raw, ref.Dataset); err != nil {
+// 		return nil, err
+// 	}
+// 	ref.Path = ref.Dataset.Path
 
-	id := strings.Split(result.ID, "/")
-	if len(id) != 2 {
-		ref.Peername = ref.Dataset.Peername
-		ref.Name = ref.Dataset.Name
-		return ref, nil
-	}
-	ref.Peername = id[0]
-	ref.Name = id[1]
-	return ref, nil
-}
+// 	id := strings.Split(result.ID, "/")
+// 	if len(id) != 2 {
+// 		ref.Peername = ref.Dataset.Peername
+// 		ref.Name = ref.Dataset.Name
+// 		return ref, nil
+// 	}
+// 	ref.Peername = id[0]
+// 	ref.Name = id[1]
+// 	return ref, nil
+// }

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -93,8 +93,7 @@ func TestSearchRun(t *testing.T) {
 	streams, in, out, errs := ioes.NewTestIOStreams()
 	setNoColor(true)
 
-	// mock registry server that returns fake response data
-	var mockResponse = []byte(`{"data":[{"Type":"","ID":"ramfox/test","Value":null},{"Type":"","ID":"b5/test","Value":{"commit":{"path":"/","signature":"JI/VSNqMuFGYVEwm3n8ZMjZmey+W2mhkD5if2337wDp+kaYfek9DntOyZiILXocW5JuOp48EqcsWf/BwhejQiYZ2utaIzR8VcMPo7u7c5nz2G6JTsoW+u9UUaKRVtl30jh6Kg1O2bnhYh9v4qW9VQgxOYfdhBl6zT4cYcjm1UkrblEe/wh494k9NziM5Bi2ATGRE2m71Lsf/TEDoNI549SebLQ1dsWXr1kM7lCeFqlDVjgbKQmGXowqcK/P9v+RBIRCnArnwFe/BQq4i1wmmnMEqpuUnfWR3xfJTE1DUMVaAid7U0jTWGVxROUdKk6mmTzlb1PiNdfruP+SFhjyQwQ==","timestamp":"2018-05-25T13:44:54.692493401Z","title":"created dataset"},"meta":{"citations":[{"url":"https://api.github.com/repos/qri-io/qri/releases"}],"qri":"md:0"},"path":"/ipfs/QmPi5wrPsY4xPwy2oRr7NRZyfFxTeupfmnrVDubzoABLNP","qri":"","structure":{"checksum":"QmQXfdYYubCvr9ePJtgABpp7N1fNsAnnywUJPYAJTvDhrn","errCount":0,"entries":7,"format":"json","length":19116,"qri":"","schema":{"type":"array"}},"transform":{"config":{"org":"qri-io","repo":"qri"},"path":"/","syntax":"starlark"},"Handle":"b5","Name":"test","PublicKey":"CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/W17VPFX+pjyM1MHI1CsvIe+JYQX45MJNITTd7hZZDX2rRWVavGXhsccmVDGU6ubeN3t6ewcBlgCxvyewwKhmZKCAs3/0xNGKXK/YMyZpRVjTWw9yPU9gOzjd9GuNJtL7d1Hl7dPt9oECa7WBCh0W9u2IoHTda4g8B2mK92awLOZTjXeA7vbhKKX+QVHKDxEI0U2/ooLYJUVxEoHRc+DUYNPahX5qRgJ1ZDP4ep1RRRoZR+HjGhwgJP+IwnAnO5cRCWUbZvE1UBJUZDvYMqW3QvDp+TtXwqUWVvt69tp8EnlBgfyXU91A58IEQtLgZ7klOzdSEJDP+S8HIwhG/vbTAgMBAAE="}},{"Type":"","ID":"EDGI/fib_6","Value":{"commit":{"path":"/","signature":"dG6NoEFlQ9ILFjVDrecSDlUbDPRSiwK9kFQ3vjTh/4tpfgrT5EOw6eGDx75lklx0DWx51s3AC2Qqytll2JwwCB6SMVVl0I9qnZJ4XQVG+MX4hGeIJ4crGCSts85unDvmiQCfc4EVqPYZKLzaVqjXa43zv5mJPfRA2ktTew3VGkOcg8RmyU6e2XWrZpkILcZg1jt2apKs5qHslx4klKBVPtQIr53/U61OW4tzME9kz08FYrk2F7I5FHWy45W7VU8DpzCbhw6kxJXu2KYD1QstsZGCKH93sZY3agP4XGY15HeEOTib465LK6+nsoBtrsroQSOTBHzVgyUZACNom5SUvQ==","timestamp":"2018-05-23T19:50:03.307982846Z","title":"created dataset"},"meta":{"description":"test of starlark as a transformation language","qri":"md:0","title":"Fibonacci(6)"},"path":"/ipfs/QmS6jJSEJYxZvCeo8cZqzVa7Ybu9yNQeFYfNZAHxM4eyDK","qri":"","structure":{"checksum":"QmdhDDZTAWoifKCWwFrZqzKUyXM6rN7ThdP1u67rkeJvTj","errCount":0,"entries":6,"format":"cbor","length":7,"qri":"","schema":{"type":"array"}},"transform":{"syntax":"starlark"},"Handle":"EDGI","Name":"fib_6","PublicKey":"CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCmTFRx/6dKmoxje8AG+jFv94IcGUGnjrupa7XEr12J/c4ZLn3aPrD8F0tjRbstt1y/J+bO7Qb69DGiu2iSIqyE21nl2oex5+14jtxbupRq9jRTbpUHRj+y9I7uUDwl0E2FS1IQpBBfEGzDPIBVavxbhguC3O3XA7Aq7vea2lpJ1tWpr0GDRYSNmJAybkHS6k7dz1eVXFK+JE8FGFJi/AThQZKWRijvWFdlZvb8RyNFRHzpbr9fh38bRMTqhZpw/YGO5Ly8PNSiOOE4Y5cNUHLEYwG2/lpT4l53iKScsaOazlRkJ6NmkM1il7riCa55fcIAQZDtaAx+CT5ZKfmek4P5AgMBAAE="}}],"meta":{"code":200}}`)
+	// mock registry server that returns cached response data
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(mockResponse)
 	}))
@@ -160,103 +159,69 @@ func TestSearchRun(t *testing.T) {
 	}
 }
 
-var textSearchResponse = `showing 3 results for 'test'
-1   ramfox/test
+var mockResponse = []byte(`{"data":[
+	{
+		"commit": {
+			"qri": "cm:0",
+			"timestamp": "2019-08-31T12:07:56.212858Z",
+			"title": "change to 10"
+		},
+		"meta": {
+			"keywords": [
+				"joke"
+			],
+			"qri": "md:0",
+			"title": "this is a d"
+		},
+		"name": "nuun",
+		"path": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
+		"peername": "nuun",
+		"qri": "ds:0",
+		"structure": {
+			"entries": 3,
+			"format": "csv",
+			"length": 36,
+			"qri": "st:0"
+		}
+	}
+],"meta":{"code":200}}`)
 
-2   b5/test
-    /ipfs/QmPi5wrPsY4xPwy2oRr7NRZyfFxTeupfmnrVDubzoABLNP
-    19 kB, 7 entries, 0 errors
-
-3   EDGI/fib_6
-    Fibonacci(6)
-    /ipfs/QmS6jJSEJYxZvCeo8cZqzVa7Ybu9yNQeFYfNZAHxM4eyDK
-    7 B, 6 entries, 0 errors
+var textSearchResponse = `showing 1 results for 'test'
+1   nuun/nuun
+    https://qri.cloud/nuun/nuun
+    /ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA
+    this is a d
+    36 B, 3 entries, 0 errors
 
 `
 
 var jsonSearchResponse = `[
   {
-    "Type": "",
-    "ID": "ramfox/test",
-    "Value": null
-  },
-  {
-    "Type": "",
-    "ID": "b5/test",
+    "Type": "dataset",
+    "ID": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
+    "URL": "https://qri.cloud/nuun/nuun",
     "Value": {
-      "Handle": "b5",
-      "Name": "test",
-      "PublicKey": "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/W17VPFX+pjyM1MHI1CsvIe+JYQX45MJNITTd7hZZDX2rRWVavGXhsccmVDGU6ubeN3t6ewcBlgCxvyewwKhmZKCAs3/0xNGKXK/YMyZpRVjTWw9yPU9gOzjd9GuNJtL7d1Hl7dPt9oECa7WBCh0W9u2IoHTda4g8B2mK92awLOZTjXeA7vbhKKX+QVHKDxEI0U2/ooLYJUVxEoHRc+DUYNPahX5qRgJ1ZDP4ep1RRRoZR+HjGhwgJP+IwnAnO5cRCWUbZvE1UBJUZDvYMqW3QvDp+TtXwqUWVvt69tp8EnlBgfyXU91A58IEQtLgZ7klOzdSEJDP+S8HIwhG/vbTAgMBAAE=",
       "commit": {
-        "path": "/",
-        "signature": "JI/VSNqMuFGYVEwm3n8ZMjZmey+W2mhkD5if2337wDp+kaYfek9DntOyZiILXocW5JuOp48EqcsWf/BwhejQiYZ2utaIzR8VcMPo7u7c5nz2G6JTsoW+u9UUaKRVtl30jh6Kg1O2bnhYh9v4qW9VQgxOYfdhBl6zT4cYcjm1UkrblEe/wh494k9NziM5Bi2ATGRE2m71Lsf/TEDoNI549SebLQ1dsWXr1kM7lCeFqlDVjgbKQmGXowqcK/P9v+RBIRCnArnwFe/BQq4i1wmmnMEqpuUnfWR3xfJTE1DUMVaAid7U0jTWGVxROUdKk6mmTzlb1PiNdfruP+SFhjyQwQ==",
-        "timestamp": "2018-05-25T13:44:54.692493401Z",
-        "title": "created dataset"
+        "qri": "cm:0",
+        "timestamp": "2019-08-31T12:07:56.212858Z",
+        "title": "change to 10"
       },
       "meta": {
-        "citations": [
-          {
-            "url": "https://api.github.com/repos/qri-io/qri/releases"
-          }
+        "keywords": [
+          "joke"
         ],
-        "qri": "md:0"
-      },
-      "path": "/ipfs/QmPi5wrPsY4xPwy2oRr7NRZyfFxTeupfmnrVDubzoABLNP",
-      "qri": "",
-      "structure": {
-        "checksum": "QmQXfdYYubCvr9ePJtgABpp7N1fNsAnnywUJPYAJTvDhrn",
-        "entries": 7,
-        "errCount": 0,
-        "format": "json",
-        "length": 19116,
-        "qri": "",
-        "schema": {
-          "type": "array"
-        }
-      },
-      "transform": {
-        "config": {
-          "org": "qri-io",
-          "repo": "qri"
-        },
-        "path": "/",
-        "syntax": "starlark"
-      }
-    }
-  },
-  {
-    "Type": "",
-    "ID": "EDGI/fib_6",
-    "Value": {
-      "Handle": "EDGI",
-      "Name": "fib_6",
-      "PublicKey": "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCmTFRx/6dKmoxje8AG+jFv94IcGUGnjrupa7XEr12J/c4ZLn3aPrD8F0tjRbstt1y/J+bO7Qb69DGiu2iSIqyE21nl2oex5+14jtxbupRq9jRTbpUHRj+y9I7uUDwl0E2FS1IQpBBfEGzDPIBVavxbhguC3O3XA7Aq7vea2lpJ1tWpr0GDRYSNmJAybkHS6k7dz1eVXFK+JE8FGFJi/AThQZKWRijvWFdlZvb8RyNFRHzpbr9fh38bRMTqhZpw/YGO5Ly8PNSiOOE4Y5cNUHLEYwG2/lpT4l53iKScsaOazlRkJ6NmkM1il7riCa55fcIAQZDtaAx+CT5ZKfmek4P5AgMBAAE=",
-      "commit": {
-        "path": "/",
-        "signature": "dG6NoEFlQ9ILFjVDrecSDlUbDPRSiwK9kFQ3vjTh/4tpfgrT5EOw6eGDx75lklx0DWx51s3AC2Qqytll2JwwCB6SMVVl0I9qnZJ4XQVG+MX4hGeIJ4crGCSts85unDvmiQCfc4EVqPYZKLzaVqjXa43zv5mJPfRA2ktTew3VGkOcg8RmyU6e2XWrZpkILcZg1jt2apKs5qHslx4klKBVPtQIr53/U61OW4tzME9kz08FYrk2F7I5FHWy45W7VU8DpzCbhw6kxJXu2KYD1QstsZGCKH93sZY3agP4XGY15HeEOTib465LK6+nsoBtrsroQSOTBHzVgyUZACNom5SUvQ==",
-        "timestamp": "2018-05-23T19:50:03.307982846Z",
-        "title": "created dataset"
-      },
-      "meta": {
-        "description": "test of starlark as a transformation language",
         "qri": "md:0",
-        "title": "Fibonacci(6)"
+        "title": "this is a d"
       },
-      "path": "/ipfs/QmS6jJSEJYxZvCeo8cZqzVa7Ybu9yNQeFYfNZAHxM4eyDK",
-      "qri": "",
+      "name": "nuun",
+      "path": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
+      "peername": "nuun",
+      "qri": "ds:0",
       "structure": {
-        "checksum": "QmdhDDZTAWoifKCWwFrZqzKUyXM6rN7ThdP1u67rkeJvTj",
-        "entries": 6,
-        "errCount": 0,
-        "format": "cbor",
-        "length": 7,
-        "qri": "",
-        "schema": {
-          "type": "array"
-        }
-      },
-      "transform": {
-        "syntax": "starlark"
+        "entries": 3,
+        "format": "csv",
+        "length": 36,
+        "qri": "st:0"
       }
     }
   }

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
+	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/update/cron"
 )
@@ -70,6 +72,46 @@ func (r refStringer) String() string {
 	}
 	if r.Foreign {
 		fmt.Fprintf(w, "\n%s", warn("foreign"))
+	}
+	if ds != nil && ds.Structure != nil {
+		fmt.Fprintf(w, "\n%s", humanize.Bytes(uint64(ds.Structure.Length)))
+		if ds.Structure.Entries == 1 {
+			fmt.Fprintf(w, ", %d entry", ds.Structure.Entries)
+		} else {
+			fmt.Fprintf(w, ", %d entries", ds.Structure.Entries)
+		}
+		if ds.Structure.ErrCount == 1 {
+			fmt.Fprintf(w, ", %d error", ds.Structure.ErrCount)
+		} else {
+			fmt.Fprintf(w, ", %d errors", ds.Structure.ErrCount)
+		}
+		if ds.NumVersions == 0 {
+			// nothing
+		} else if ds.NumVersions == 1 {
+			fmt.Fprintf(w, ", %d version", ds.NumVersions)
+		} else {
+			fmt.Fprintf(w, ", %d versions", ds.NumVersions)
+		}
+	}
+
+	fmt.Fprintf(w, "\n\n")
+	return w.String()
+}
+
+type searchResultStringer lib.SearchResult
+
+func (r searchResultStringer) String() string {
+	w := &strings.Builder{}
+	title := color.New(color.FgGreen, color.Bold).SprintFunc()
+	path := color.New(color.Faint).SprintFunc()
+	ds := r.Value.(*dataset.Dataset)
+
+	fmt.Fprintf(w, "%s/%s", title(ds.Peername), title(ds.Name))
+	fmt.Fprintf(w, "\n%s", r.URL)
+	fmt.Fprintf(w, "\n%s", path(ds.Path))
+
+	if ds != nil && ds.Meta != nil && ds.Meta.Title != "" {
+		fmt.Fprintf(w, "\n%s", ds.Meta.Title)
 	}
 	if ds != nil && ds.Structure != nil {
 		fmt.Fprintf(w, "\n%s", humanize.Bytes(uint64(ds.Structure.Length)))

--- a/lib/search.go
+++ b/lib/search.go
@@ -31,6 +31,7 @@ type SearchParams struct {
 // SearchResult struct
 type SearchResult struct {
 	Type, ID string
+	URL      string
 	Value    interface{}
 }
 
@@ -60,9 +61,14 @@ func (m *SearchMethods) Search(p *SearchParams, results *[]SearchResult) error {
 
 	searchResults := make([]SearchResult, len(regResults))
 	for i, result := range regResults {
-		searchResults[i].Type = result.Type
-		searchResults[i].ID = result.ID
-		searchResults[i].Value = result.Value
+		searchResults[i].Type = "dataset"
+		searchResults[i].ID = result.Path
+		searchResults[i].Value = result
+
+		// TODO (b5) - this is cloud specific, should be generalized
+		if m.inst.Config().Registry.Location == "https://registry.qri.cloud" {
+			searchResults[i].URL = fmt.Sprintf("https://qri.cloud/%s/%s", result.Peername, result.Name)
+		}
 	}
 	*results = searchResults
 	return nil

--- a/lib/search_test.go
+++ b/lib/search_test.go
@@ -11,8 +11,6 @@ import (
 	testrepo "github.com/qri-io/qri/repo/test"
 )
 
-var mockResponse = []byte(`{"data":[{"Type":"","ID":"ramfox/test","Value":null},{"Type":"","ID":"b5/test","Value":{"commit":{"path":"/","signature":"JI/VSNqMuFGYVEwm3n8ZMjZmey+W2mhkD5if2337wDp+kaYfek9DntOyZiILXocW5JuOp48EqcsWf/BwhejQiYZ2utaIzR8VcMPo7u7c5nz2G6JTsoW+u9UUaKRVtl30jh6Kg1O2bnhYh9v4qW9VQgxOYfdhBl6zT4cYcjm1UkrblEe/wh494k9NziM5Bi2ATGRE2m71Lsf/TEDoNI549SebLQ1dsWXr1kM7lCeFqlDVjgbKQmGXowqcK/P9v+RBIRCnArnwFe/BQq4i1wmmnMEqpuUnfWR3xfJTE1DUMVaAid7U0jTWGVxROUdKk6mmTzlb1PiNdfruP+SFhjyQwQ==","timestamp":"2018-05-25T13:44:54.692493401Z","title":"created dataset"},"meta":{"citations":[{"url":"https://api.github.com/repos/qri-io/qri/releases"}],"qri":"md:0"},"path":"/ipfs/QmPi5wrPsY4xPwy2oRr7NRZyfFxTeupfmnrVDubzoABLNP","qri":"","structure":{"checksum":"QmQXfdYYubCvr9ePJtgABpp7N1fNsAnnywUJPYAJTvDhrn","errCount":0,"entries":7,"format":"json","length":19116,"qri":"","schema":{"type":"array"}},"transform":{"config":{"org":"qri-io","repo":"qri"},"path":"/","syntax":"starlark"},"Handle":"b5","Name":"test","PublicKey":"CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/W17VPFX+pjyM1MHI1CsvIe+JYQX45MJNITTd7hZZDX2rRWVavGXhsccmVDGU6ubeN3t6ewcBlgCxvyewwKhmZKCAs3/0xNGKXK/YMyZpRVjTWw9yPU9gOzjd9GuNJtL7d1Hl7dPt9oECa7WBCh0W9u2IoHTda4g8B2mK92awLOZTjXeA7vbhKKX+QVHKDxEI0U2/ooLYJUVxEoHRc+DUYNPahX5qRgJ1ZDP4ep1RRRoZR+HjGhwgJP+IwnAnO5cRCWUbZvE1UBJUZDvYMqW3QvDp+TtXwqUWVvt69tp8EnlBgfyXU91A58IEQtLgZ7klOzdSEJDP+S8HIwhG/vbTAgMBAAE="}},{"Type":"","ID":"EDGI/fib_6","Value":{"commit":{"path":"/","signature":"dG6NoEFlQ9ILFjVDrecSDlUbDPRSiwK9kFQ3vjTh/4tpfgrT5EOw6eGDx75lklx0DWx51s3AC2Qqytll2JwwCB6SMVVl0I9qnZJ4XQVG+MX4hGeIJ4crGCSts85unDvmiQCfc4EVqPYZKLzaVqjXa43zv5mJPfRA2ktTew3VGkOcg8RmyU6e2XWrZpkILcZg1jt2apKs5qHslx4klKBVPtQIr53/U61OW4tzME9kz08FYrk2F7I5FHWy45W7VU8DpzCbhw6kxJXu2KYD1QstsZGCKH93sZY3agP4XGY15HeEOTib465LK6+nsoBtrsroQSOTBHzVgyUZACNom5SUvQ==","timestamp":"2018-05-23T19:50:03.307982846Z","title":"created dataset"},"meta":{"description":"test of starlark as a transformation language","qri":"md:0","title":"Fibonacci(6)"},"path":"/ipfs/QmS6jJSEJYxZvCeo8cZqzVa7Ybu9yNQeFYfNZAHxM4eyDK","qri":"","structure":{"checksum":"QmdhDDZTAWoifKCWwFrZqzKUyXM6rN7ThdP1u67rkeJvTj","errCount":0,"entries":6,"format":"cbor","length":7,"qri":"","schema":{"type":"array"}},"transform":{"syntax":"starlark"},"Handle":"EDGI","Name":"fib_6","PublicKey":"CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCmTFRx/6dKmoxje8AG+jFv94IcGUGnjrupa7XEr12J/c4ZLn3aPrD8F0tjRbstt1y/J+bO7Qb69DGiu2iSIqyE21nl2oex5+14jtxbupRq9jRTbpUHRj+y9I7uUDwl0E2FS1IQpBBfEGzDPIBVavxbhguC3O3XA7Aq7vea2lpJ1tWpr0GDRYSNmJAybkHS6k7dz1eVXFK+JE8FGFJi/AThQZKWRijvWFdlZvb8RyNFRHzpbr9fh38bRMTqhZpw/YGO5Ly8PNSiOOE4Y5cNUHLEYwG2/lpT4l53iKScsaOazlRkJ6NmkM1il7riCa55fcIAQZDtaAx+CT5ZKfmek4P5AgMBAAE="}}],"meta":{"code":200}}`)
-
 func TestSearch(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -31,27 +29,47 @@ func TestSearch(t *testing.T) {
 	inst := NewInstanceFromConfigAndNode(config.DefaultConfig(), node)
 	inst.registry = rc
 
-	cases := []struct {
-		description string
-		params      *SearchParams
-		numResults  int
-		err         string
-	}{
-		{"search datasets - 'cities'", &SearchParams{"cities", 0, 100}, 3, ""},
+	m := NewSearchMethods(inst)
+
+	p := &SearchParams{"nuun", 0, 100}
+	got := &[]SearchResult{}
+	if err = m.Search(p, got); err != nil {
+		t.Error(err)
 	}
 
-	for _, c := range cases {
-		m := NewSearchMethods(inst)
-
-		got := &[]SearchResult{}
-		err = m.Search(c.params, got)
-
-		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
-			t.Errorf("case '%s' error mismatch: expected: %s, got: %s", c.description, c.err, err)
-		}
-
-		if len(*got) != c.numResults {
-			t.Errorf("case '%s' result count mismatch: expected: %d results, got: %d", c.description, c.numResults, len(*got))
-		}
+	if 1 != len(*got) {
+		t.Errorf("expected: %d results, got: %d", 1, len(*got))
 	}
 }
+
+var mockResponse = []byte(`{"data":[
+  {
+    "Type": "dataset",
+    "ID": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
+    "URL": "https://qri.cloud/nuun/nuun",
+    "Value": {
+      "commit": {
+        "qri": "cm:0",
+        "timestamp": "2019-08-31T12:07:56.212858Z",
+        "title": "change to 10"
+      },
+      "meta": {
+        "keywords": [
+          "joke"
+        ],
+        "qri": "md:0",
+        "title": "this is a d"
+      },
+      "name": "nuun",
+      "path": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
+      "peername": "nuun",
+      "qri": "ds:0",
+      "structure": {
+        "entries": 3,
+        "format": "csv",
+        "length": 36,
+        "qri": "st:0"
+      }
+    }
+  }
+],"meta":{"code":200}}`)

--- a/registry/regclient/search.go
+++ b/registry/regclient/search.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/registry"
 )
 
@@ -36,7 +37,7 @@ type SearchParams struct {
 }
 
 // Search makes a registry search request
-func (c Client) Search(p *SearchParams) ([]*registry.Result, error) {
+func (c Client) Search(p *SearchParams) ([]*dataset.Dataset, error) {
 	params := &registry.SearchParams{
 		Q: p.QueryString,
 		//Filters: p.Filters,
@@ -80,7 +81,7 @@ func (c Client) prepGetReq(s *registry.SearchParams) (*http.Request, error) {
 	return req, nil
 }
 
-func (c Client) doJSONSearchReq(method string, s *registry.SearchParams) (results []*registry.Result, err error) {
+func (c Client) doJSONSearchReq(method string, s *registry.SearchParams) (results []*dataset.Dataset, err error) {
 	if c.cfg.Location == "" {
 		return nil, ErrNoRegistry
 	}
@@ -105,7 +106,7 @@ func (c Client) doJSONSearchReq(method string, s *registry.SearchParams) (result
 	}
 	// add response to an envelope
 	env := struct {
-		Data []*registry.Result
+		Data []*dataset.Dataset
 		Meta struct {
 			Error  string
 			Status string

--- a/registry/search.go
+++ b/registry/search.go
@@ -10,7 +10,7 @@ import (
 // Searchable is an opt-in interface for registries that wish to
 // support search
 type Searchable interface {
-	Search(p SearchParams) ([]Result, error)
+	Search(p SearchParams) ([]*dataset.Dataset, error)
 }
 
 // Indexer is an interface for adding registry values to a search index
@@ -27,13 +27,6 @@ type SearchParams struct {
 	Limit, Offset int
 }
 
-// Result is the interface that a search result implements
-type Result struct {
-	Type  string      // one of ["dataset", "profile"] for now
-	ID    string      // identifier to lookup
-	Value interface{} // Value returned
-}
-
 // ErrSearchNotSupported is the canonical error to indicate search
 // isn't implemented
 var ErrSearchNotSupported = fmt.Errorf("search not supported")
@@ -43,7 +36,7 @@ var ErrSearchNotSupported = fmt.Errorf("search not supported")
 type NilSearch bool
 
 // Search returns an error indicating that search is not supported
-func (ns NilSearch) Search(p SearchParams) ([]Result, error) {
+func (ns NilSearch) Search(p SearchParams) ([]*dataset.Dataset, error) {
 	return nil, ErrSearchNotSupported
 }
 
@@ -56,15 +49,14 @@ type MockSearch struct {
 }
 
 // Search is a trivial search implementation used for testing
-func (ms MockSearch) Search(p SearchParams) (results []Result, err error) {
+func (ms MockSearch) Search(p SearchParams) (results []*dataset.Dataset, err error) {
 	for _, ds := range ms.Datasets {
 		dsname := ""
 		if ds.Meta != nil {
 			dsname = strings.ToLower(ds.Meta.Title)
 		}
 		if strings.Contains(dsname, strings.ToLower(p.Q)) {
-			result := &Result{Value: ds}
-			results = append(results, *result)
+			results = append(results, ds)
 		}
 	}
 


### PR DESCRIPTION
putting in some work on #943, #908

Search is kinda gorked right now and should get a fix before we cut a release. This cleans up responses & brings us in line with the new search API response structure. For now we've moved to standard dataset responses only as search results. This defines a new search result stringer and makes room for a registry URL link.