### PR TITLE
refactor(dsref): rename rev package to dsref, a home for all ref string parsing

### DIFF
--- a/actions/recall.go
+++ b/actions/recall.go
@@ -7,7 +7,7 @@ import (
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
-	"github.com/qri-io/qri/rev"
+	"github.com/qri-io/qri/dsref"
 )
 
 // Recall loads revisions of a dataset from history
@@ -16,7 +16,7 @@ func Recall(ctx context.Context, node *p2p.QriNode, str string, ref repo.Dataset
 		return &dataset.Dataset{}, nil
 	}
 
-	revs, err := rev.ParseRevs(str)
+	revs, err := dsref.ParseRevs(str)
 	if err != nil {
 		return nil, err
 	}

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -20,7 +20,7 @@ import (
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
-	"github.com/qri-io/qri/rev"
+	"github.com/qri-io/qri/dsref"
 )
 
 // DatasetHandlers wraps a requests struct to interface with http.HandlerFunc
@@ -464,12 +464,12 @@ func (h *DatasetHandlers) saveHandler(w http.ResponseWriter, r *http.Request) {
 func (h *DatasetHandlers) removeHandler(w http.ResponseWriter, r *http.Request) {
 	p := lib.RemoveParams{
 		Ref:            HTTPPathToQriPath(r.URL.Path[len("/remove"):]),
-		Revision:       rev.Rev{Field: "ds", Gen: -1},
+		Revision:       dsref.Rev{Field: "ds", Gen: -1},
 		Unlink:         r.FormValue("unlink") == "true",
 		DeleteFSIFiles: r.FormValue("files") == "true",
 	}
 	if r.FormValue("all") == "true" {
-		p.Revision = rev.NewAllRevisions()
+		p.Revision = dsref.NewAllRevisions()
 	}
 
 	res := lib.RemoveResponse{}

--- a/base/revisions.go
+++ b/base/revisions.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsfs"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/repo"
-	"github.com/qri-io/qri/rev"
 )
 
 // LoadRevs grabs a component of a dataset that exists <n>th generation ancestor
 // of the referenced version, where presence of a component in a previous snapshot constitutes ancestry
-func LoadRevs(ctx context.Context, r repo.Repo, ref repo.DatasetRef, revs []*rev.Rev) (res *dataset.Dataset, err error) {
+func LoadRevs(ctx context.Context, r repo.Repo, ref repo.DatasetRef, revs []*dsref.Rev) (res *dataset.Dataset, err error) {
 	var ds *dataset.Dataset
 	res = &dataset.Dataset{}
 	for {
@@ -37,7 +37,7 @@ func LoadRevs(ctx context.Context, r repo.Repo, ref repo.DatasetRef, revs []*rev
 	return res, nil
 }
 
-func sel(r *rev.Rev, ds, res *dataset.Dataset) bool {
+func sel(r *dsref.Rev, ds, res *dataset.Dataset) bool {
 	switch r.Field {
 	case "ds":
 		r.Gen--

--- a/base/revisions_test.go
+++ b/base/revisions_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsfs"
 	"github.com/qri-io/qri/repo"
-	"github.com/qri-io/qri/rev"
+	"github.com/qri-io/qri/dsref"
 )
 
 func TestLoadRevisions(t *testing.T) {
@@ -38,7 +38,7 @@ func TestLoadRevisions(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		revs, err := rev.ParseRevs(c.revs)
+		revs, err := dsref.ParseRevs(c.revs)
 		if err != nil {
 			t.Errorf("case %d error parsing revs: %s", i, err)
 			continue

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/qri-io/ioes"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
-	"github.com/qri-io/qri/rev"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +57,7 @@ type RemoveOptions struct {
 	Args []string
 
 	RevisionsText  string
-	Revision       rev.Rev
+	Revision       dsref.Rev
 	All            bool
 	DeleteFSIFiles bool
 	Unlink         bool
@@ -72,12 +72,12 @@ func (o *RemoveOptions) Complete(f Factory, args []string) (err error) {
 		return err
 	}
 	if o.All {
-		o.Revision = rev.NewAllRevisions()
+		o.Revision = dsref.NewAllRevisions()
 	} else {
 		if o.RevisionsText == "" {
-			o.Revision = rev.Rev{Field: "ds", Gen: 0}
+			o.Revision = dsref.Rev{Field: "ds", Gen: 0}
 		} else {
-			revisions, err := rev.ParseRevs(o.RevisionsText)
+			revisions, err := dsref.ParseRevs(o.RevisionsText)
 			if err != nil {
 				return err
 			}
@@ -118,7 +118,7 @@ func (o *RemoveOptions) Run() (err error) {
 			}
 			return err
 		}
-		if res.NumDeleted == rev.AllGenerations {
+		if res.NumDeleted == dsref.AllGenerations {
 			printSuccess(o.Out, "removed entire dataset '%s'", res.Ref)
 		} else if res.NumDeleted != 0 {
 			printSuccess(o.Out, "removed %d revisions of dataset '%s'", res.NumDeleted, res.Ref)

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/qri-io/dataset/dsfs"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/lib"
-	"github.com/qri-io/qri/rev"
+	"github.com/qri-io/qri/dsref"
 )
 
 func TestRemoveComplete(t *testing.T) {
@@ -129,7 +129,7 @@ func TestRemoveRun(t *testing.T) {
 		opt := &RemoveOptions{
 			IOStreams:       streams,
 			Args:            c.args,
-			Revision:        rev.Rev{Field: "ds", Gen: c.revision},
+			Revision:        dsref.Rev{Field: "ds", Gen: c.revision},
 			DatasetRequests: dsr,
 		}
 

--- a/dsref/info.go
+++ b/dsref/info.go
@@ -1,0 +1,23 @@
+package dsref
+
+import (
+	"time"
+)
+
+// Info describes a version of a datsaet
+type Info struct {
+	// Refer
+	Ref Ref `json:"ref,omitempty"`
+
+	// FSIPath is this dataset's link to the local filesystem if one exists
+	FSIPath string `json:"fsiPath,omitempty"`
+	// Published indicates whether this reference is listed as an available dataset
+	Published bool `json:"published"`
+	// If true, this version doesn't exist locally
+	Foreign bool `json:"foreign,omitempty"`
+
+	// Creation timestamp
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	// Title field from dataset.commit component
+	CommitTitle string `json:"commitTitle,omitempty"`
+}

--- a/dsref/ref.go
+++ b/dsref/ref.go
@@ -1,0 +1,37 @@
+package dsref
+
+// Ref is a reference to a dataset
+type Ref struct {
+	// Username of dataset owner
+	Username string `json:"username,omitempty"`
+	// ProfileID of dataset owner
+	ProfileID string `json:"profileID,omitempty"`
+	// Unique name reference for this dataset
+	Name string `json:"name,omitempty"`
+	// Content-addressed path for this dataset
+	Path string `json:"path,omitempty"`
+}
+
+// Alias returns the alias components of a Ref as a string
+func (r Ref) Alias() (s string) {
+	s = r.Username
+	if r.Name != "" {
+		s += "/" + r.Name
+	}
+	return s
+}
+
+// String implements the Stringer interface for Ref
+func (r Ref) String() (s string) {
+	s = r.Alias()
+	if r.ProfileID != "" || r.Path != "" {
+		s += "@"
+	}
+	if r.ProfileID != "" {
+		s += r.ProfileID
+	}
+	if r.Path != "" {
+		s += r.Path
+	}
+	return s
+}

--- a/dsref/ref_test.go
+++ b/dsref/ref_test.go
@@ -1,0 +1,42 @@
+package dsref
+
+import (
+	"testing"
+)
+
+func TestRefAlias(t *testing.T) {
+	cases := []struct {
+		in     Ref
+		expect string
+	}{
+		{Ref{}, ""},
+		{Ref{Username: "a", Name: "b"}, "a/b"},
+		{Ref{Username: "a", Name: "b", Path: "foo"}, "a/b"},
+	}
+
+	for _, c := range cases {
+		got := c.in.Alias()
+		if c.expect != got {
+			t.Errorf("result mismatch. input:%#v \nwant: '%s'\ngot: '%s'", c.in, c.expect, got)
+		}
+	}
+}
+
+func TestRefString(t *testing.T) {
+	cases := []struct {
+		in     Ref
+		expect string
+	}{
+		{Ref{}, ""},
+		{Ref{Username: "a", Name: "b"}, "a/b"},
+		{Ref{Username: "a", Name: "b"}, "a/b"},
+		{Ref{Username: "a", Name: "b", Path: "/foo"}, "a/b@/foo"},
+	}
+
+	for _, c := range cases {
+		got := c.in.String()
+		if c.expect != got {
+			t.Errorf("result mismatch. input:%#v \nwant: '%s'\ngot: '%s'", c.in, c.expect, got)
+		}
+	}
+}

--- a/dsref/rev.go
+++ b/dsref/rev.go
@@ -1,10 +1,5 @@
-// Package rev defines structure and syntax for specifying revisions of a
-// dataset history. Much of this is inspired by git revisions:
-// https://git-scm.com/docs/gitrevisions
-//
-// Unlike git, Qri is aware of the underlying data model it's selecting against,
-// so revisions can have conventional names for specifying fields of a dataset
-package rev
+// Package dsref defines structure and syntax for referring to a dataset
+package dsref
 
 import (
 	"fmt"
@@ -12,7 +7,13 @@ import (
 	"strings"
 )
 
-// Rev names a field of a dataset at a snapshot
+// Rev names a field of a dataset at a snapshot relative to the latest version
+// in a history
+// Much of this is inspired by git revisions:
+// https://git-scm.com/docs/gitrevisions
+//
+// Unlike git, Qri is aware of the underlying data model it's selecting against,
+// so revisions can have conventional names for specifying fields of a dataset
 type Rev struct {
 	// field scopt, currently can only be a component name, or the entire dataset
 	Field string

--- a/dsref/rev_test.go
+++ b/dsref/rev_test.go
@@ -1,4 +1,4 @@
-package rev
+package dsref
 
 import (
 	"fmt"

--- a/go.sum
+++ b/go.sum
@@ -631,6 +631,8 @@ github.com/qri-io/dataset v0.1.5-0.20190914114227-5298f1c14165 h1:bmH81gg02f3utS
 github.com/qri-io/dataset v0.1.5-0.20190914114227-5298f1c14165/go.mod h1:Gn47Jz2Xl4PoNx8QgqjLoaiwUNPL/O1457FGt8eBBFw=
 github.com/qri-io/dataset v0.1.5-0.20191007113417-af14d7dff51a h1:/mQAOqauTwY5U2Odol0Y3HPmIfzwm0wPJzsojB3UOPI=
 github.com/qri-io/dataset v0.1.5-0.20191007113417-af14d7dff51a/go.mod h1:Gn47Jz2Xl4PoNx8QgqjLoaiwUNPL/O1457FGt8eBBFw=
+github.com/qri-io/dataset v0.1.5-0.20191007153417-af14d7dff51a h1:bUkKX9Cq+NVoCt1KVA4NHHxZy15tYdgr6UVm7ZlW58o=
+github.com/qri-io/dataset v0.1.5-0.20191007153417-af14d7dff51a/go.mod h1:Gn47Jz2Xl4PoNx8QgqjLoaiwUNPL/O1457FGt8eBBFw=
 github.com/qri-io/deepdiff v0.1.0 h1:1VXd/ePPrSrq4GRINC4YxmoPHuuLufg2ujMKvvEWsDc=
 github.com/qri-io/deepdiff v0.1.0/go.mod h1:/O1HQVAlm3yhgQvNwyzsKaECfM2vVSx6KxttgXQQGFw=
 github.com/qri-io/doggos v0.1.0 h1:B7Hn9ssRGDAonMhJ4UwDtPDmG9GtvLR8f7VFec7Rs7M=

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -19,7 +19,7 @@ import (
 	"github.com/qri-io/qri/fsi"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
-	"github.com/qri-io/qri/rev"
+	"github.com/qri-io/qri/dsref"
 )
 
 // DatasetRequests encapsulates business logic for working with Datasets on Qri
@@ -504,7 +504,7 @@ func (r *DatasetRequests) Rename(p *RenameParams, res *repo.DatasetRef) (err err
 // RemoveParams defines parameters for remove command
 type RemoveParams struct {
 	Ref            string
-	Revision       rev.Rev
+	Revision       dsref.Rev
 	Unlink         bool // If true, break any FSI link
 	DeleteFSIFiles bool // If true, delete tracked files from the designated FSI link
 }
@@ -582,12 +582,12 @@ func (r *DatasetRequests) Remove(p *RemoveParams, res *RemoveResponse) error {
 		if err := actions.DeleteDataset(ctx, r.node, &ref); err != nil {
 			return err
 		}
-		res.NumDeleted = rev.AllGenerations
+		res.NumDeleted = dsref.AllGenerations
 
 		return nil
 	}
 
-	if p.Revision.Gen == rev.AllGenerations {
+	if p.Revision.Gen == dsref.AllGenerations {
 		return removeEntireDataset()
 	} else if p.Revision.Gen < 1 {
 		return fmt.Errorf("invalid number of revisions to delete: %d", p.Revision.Gen)

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/p2p"
 	p2ptest "github.com/qri-io/qri/p2p/test"
 	"github.com/qri-io/qri/repo"
 	testrepo "github.com/qri-io/qri/repo/test"
-	"github.com/qri-io/qri/rev"
 )
 
 func TestDatasetRequestsSave(t *testing.T) {
@@ -642,7 +642,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 	// TODO (b5) - dataset requests require an instance to delete properly
 	// we should do the "DatasetMethods" refactor ASAP
 	req := NewDatasetRequestsInstance(inst)
-	allRevs := rev.Rev{Field: "ds", Gen: -1}
+	allRevs := dsref.Rev{Field: "ds", Gen: -1}
 
 	// we need some fsi stuff to fully test remove
 	fsim := NewFSIMethods(inst)
@@ -696,8 +696,8 @@ func TestDatasetRequestsRemove(t *testing.T) {
 	}{
 		{"repo: empty dataset reference", RemoveParams{Ref: "", Revision: allRevs}},
 		{"repo: not found", RemoveParams{Ref: "abc/ABC", Revision: allRevs}},
-		{"can only remove whole dataset versions, not individual components", RemoveParams{Ref: "abc/ABC", Revision: rev.Rev{Field: "st", Gen: -1}}},
-		{"invalid number of revisions to delete: 0", RemoveParams{Ref: "peer/movies", Revision: rev.Rev{Field: "ds", Gen: 0}}},
+		{"can only remove whole dataset versions, not individual components", RemoveParams{Ref: "abc/ABC", Revision: dsref.Rev{Field: "st", Gen: -1}}},
+		{"invalid number of revisions to delete: 0", RemoveParams{Ref: "peer/movies", Revision: dsref.Rev{Field: "ds", Gen: 0}}},
 		{"cannot unlink, dataset is not linked to a directory", RemoveParams{Ref: "peer/movies", Revision: allRevs, Unlink: true}},
 		{"can't delete files, dataset is not linked to a directory", RemoveParams{Ref: "peer/movies", Revision: allRevs, DeleteFSIFiles: true}},
 	}
@@ -726,7 +726,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 			RemoveResponse{NumDeleted: -1},
 		},
 		{"all generations, specifying more revs than log length",
-			RemoveParams{Ref: "peer/counter", Revision: rev.Rev{Field: "ds", Gen: 20}},
+			RemoveParams{Ref: "peer/counter", Revision: dsref.Rev{Field: "ds", Gen: 20}},
 			RemoveResponse{NumDeleted: -1},
 		},
 		{"all generations of peer/cities, remove link, delete files",
@@ -734,11 +734,11 @@ func TestDatasetRequestsRemove(t *testing.T) {
 			RemoveResponse{NumDeleted: -1, Unlinked: true, DeletedFSIFiles: true},
 		},
 		{"one commit of peer/craigslist, remove link, delete files",
-			RemoveParams{Ref: "peer/craigslist", Revision: rev.Rev{Field: "ds", Gen: 1}, Unlink: true, DeleteFSIFiles: true},
+			RemoveParams{Ref: "peer/craigslist", Revision: dsref.Rev{Field: "ds", Gen: 1}, Unlink: true, DeleteFSIFiles: true},
 			RemoveResponse{NumDeleted: 1, Unlinked: true, DeletedFSIFiles: true},
 		},
 		{"no history dataset, remove link, delete files",
-			RemoveParams{Ref: noHistoryName, Revision: rev.Rev{Field: "ds", Gen: 0}, DeleteFSIFiles: true},
+			RemoveParams{Ref: noHistoryName, Revision: dsref.Rev{Field: "ds", Gen: 0}, DeleteFSIFiles: true},
 			RemoveResponse{NumDeleted: 0, Unlinked: true, DeletedFSIFiles: true},
 		},
 	}


### PR DESCRIPTION
we need a place for housing both parsing & parsed dataset references. Other code needs this refactoring to sort out import cycles