### PR TITLE
fix(remote): `DeleteDataset` func will now delete an entire dataset's history

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -158,6 +158,11 @@ func (r *Remote) ResolveHeadRef(ctx context.Context, peername, name string) (*re
 }
 
 // RemoveDataset handles requests to remove a dataset
+// currently removes all versions of a dataset
+// TODO (ramfox): add `gen` params that indicates how many versions of the dataset, starting
+// with the most recent version, we should remove. This should remove the latest version of
+// the dataset ref from the refstore and add the (n + 1)th to the refstore
+// gen = -1 should indicate that we remove all the dataset versions
 func (r *Remote) RemoveDataset(ctx context.Context, params map[string]string) error {
 	pid, ref, err := r.pidAndRefFromMeta(params)
 	if err != nil {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -11,6 +11,7 @@ import (
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/dag"
 	"github.com/qri-io/dag/dsync"
+	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/logbook/logsync"
@@ -156,13 +157,20 @@ func (r *Remote) ResolveHeadRef(ctx context.Context, peername, name string) (*re
 	return ref, err
 }
 
-// RemoveDatasetRef handles requests to remove a dataset
-func (r *Remote) RemoveDatasetRef(ctx context.Context, params map[string]string) error {
+// RemoveDataset handles requests to remove a dataset
+func (r *Remote) RemoveDataset(ctx context.Context, params map[string]string) error {
 	pid, ref, err := r.pidAndRefFromMeta(params)
 	if err != nil {
 		return err
 	}
 	log.Debug("remove dataset ", ref)
+
+	// run pre check hook
+	if r.datasetRemovePreCheck != nil {
+		if err = r.datasetRemovePreCheck(ctx, pid, ref); err != nil {
+			return err
+		}
+	}
 
 	if err := repo.CanonicalizeDatasetRef(r.node.Repo, &ref); err != nil {
 		if err == repo.ErrNotFound {
@@ -172,13 +180,23 @@ func (r *Remote) RemoveDatasetRef(ctx context.Context, params map[string]string)
 		}
 	}
 
+	// remove all the versions of this dataset from the store
+	if err := base.RemoveNVersionsFromStore(ctx, r.node.Repo, &ref, -1); err != nil {
+		return err
+	}
+
+	// remove the dataset reference from the repo
+	if err := r.node.Repo.DeleteRef(ref); err != nil {
+		return err
+	}
+
+	// run completed hook
 	if r.datasetRemoved != nil {
 		if err := r.datasetRemoved(ctx, pid, ref); err != nil {
 			return err
 		}
 	}
-
-	return r.node.Repo.DeleteRef(ref)
+	return nil
 }
 
 func (r *Remote) dsPushPreCheck(ctx context.Context, info dag.Info, meta map[string]string) error {
@@ -259,8 +277,8 @@ func (r *Remote) dsRemovePreCheck(ctx context.Context, info dag.Info, meta map[s
 		return err
 	}
 
-	if r.datasetRemoved != nil {
-		if err = r.datasetRemoved(ctx, pid, ref); err != nil {
+	if r.datasetRemovePreCheck != nil {
+		if err = r.datasetRemovePreCheck(ctx, pid, ref); err != nil {
 			return err
 		}
 	}
@@ -365,7 +383,7 @@ func (r *Remote) RefsHTTPHandler() http.HandlerFunc {
 			for key := range req.URL.Query() {
 				params[key] = req.FormValue(key)
 			}
-			if err := r.RemoveDatasetRef(req.Context(), params); err != nil {
+			if err := r.RemoveDataset(req.Context(), params); err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte(err.Error()))
 				return

--- a/remote/signature.go
+++ b/remote/signature.go
@@ -1,0 +1,102 @@
+package remote
+
+import (
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	crypto "github.com/libp2p/go-libp2p-crypto"
+	"github.com/multiformats/go-multihash"
+	"github.com/qri-io/qri/repo"
+)
+
+var (
+	// nowFunc is an ps function for getting timestamps
+	nowFunc = time.Now
+)
+
+func sigParams(pk crypto.PrivKey, ref repo.DatasetRef) (map[string]string, error) {
+	pid, err := calcProfileID(pk)
+	if err != nil {
+		return nil, err
+	}
+
+	now := fmt.Sprintf("%d", nowFunc().In(time.UTC).Unix())
+	rss := requestSigningString(now, pid, ref.Path)
+	b64Sig, err := signString(pk, rss)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{
+		"peername":  ref.Peername,
+		"name":      ref.Name,
+		"profileID": ref.ProfileID.String(),
+		"path":      ref.Path,
+
+		"pid":       pid,
+		"timestamp": now,
+		"signature": b64Sig,
+	}, nil
+}
+
+// VerifySigParams takes a public key and a map[string]string params and verifies
+// the the signature is correct
+// TODO (ramfox): should be refactored to be private once remotes have their
+// own keystore and can make the replation between a pid and a public key
+// on their own
+func VerifySigParams(pubkey crypto.PubKey, params map[string]string) (bool, error) {
+	timestamp, ok := params["timestamp"]
+	if !ok {
+		return false, fmt.Errorf("params need key 'timestamp'")
+	}
+	pid, ok := params["pid"]
+	if !ok {
+		return false, fmt.Errorf("params need key 'pid'")
+	}
+	path, ok := params["path"]
+	if !ok {
+		return false, fmt.Errorf("params need key 'path'")
+	}
+	signature, ok := params["signature"]
+	if !ok {
+		return false, fmt.Errorf("params need key 'signature'")
+	}
+
+	sigBytes, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return false, err
+	}
+	str := base64.StdEncoding.EncodeToString(sigBytes)
+	if str != signature {
+		return false, fmt.Errorf("signature was '%s', after decode then encode it was '%s", signature, str)
+	}
+	rss := requestSigningString(timestamp, pid, path)
+	return pubkey.Verify([]byte(rss), sigBytes)
+}
+
+func requestSigningString(timestamp, peerID, cidStr string) string {
+	return fmt.Sprintf("%s.%s.%s", timestamp, peerID, cidStr)
+}
+
+func signString(privKey crypto.PrivKey, str string) (b64Sig string, err error) {
+	sigbytes, err := privKey.Sign([]byte(str))
+	if err != nil {
+		return "", fmt.Errorf("error signing %s", err.Error())
+	}
+	return base64.StdEncoding.EncodeToString(sigbytes), nil
+}
+
+func calcProfileID(privKey crypto.PrivKey) (string, error) {
+	pubkeybytes, err := privKey.GetPublic().Bytes()
+	if err != nil {
+		return "", fmt.Errorf("error getting pubkey bytes: %s", err.Error())
+	}
+
+	mh, err := multihash.Sum(pubkeybytes, multihash.SHA2_256, 32)
+	if err != nil {
+		return "", fmt.Errorf("error summing pubkey: %s", err.Error())
+	}
+
+	return mh.B58String(), nil
+}

--- a/remote/signature_test.go
+++ b/remote/signature_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestVerifySigParams(t *testing.T) {
-	peerInfo := test.GetTestPeerInfo(0)
-	pid, err := calcProfileID(peerInfo.PrivKey)
+	peerInfo0 := test.GetTestPeerInfo(0)
+	pid, err := calcProfileID(peerInfo0.PrivKey)
 	if err != nil {
 		t.Errorf(err.Error())
 		return
@@ -26,16 +26,28 @@ func TestVerifySigParams(t *testing.T) {
 		Name:      "baz",
 		ProfileID: profileID,
 	}
-	sigParams, err := sigParams(peerInfo.PrivKey, ref)
+	sigParams, err := sigParams(peerInfo0.PrivKey, ref)
 	if err != nil {
 		panic(err)
 	}
 
-	verified, err := VerifySigParams(peerInfo.PubKey, sigParams)
+	verified, err := VerifySigParams(peerInfo0.PubKey, sigParams)
 	if err != nil {
 		t.Errorf("case 'should verify', expected no error, got '%s'", err)
 	}
 	if verified == false {
-		t.Errorf("case 'should verify', expected verification to be true, was false")
+		t.Errorf("case 'should verify', expected verification to be true, but was false")
+	}
+
+	peerInfo1 := test.GetTestPeerInfo(1)
+	verified, err = VerifySigParams(peerInfo1.PubKey, sigParams)
+	if err == nil {
+		t.Errorf("case 'should not verify', expected error 'crypto/rsa: verification error', got no error")
+	}
+	if err != nil && err.Error() != "crypto/rsa: verification error" {
+		t.Errorf("case 'should not verify', expected error 'crypto/rsa: verification error', got error, '%s'", err)
+	}
+	if verified == true {
+		t.Errorf("case 'should not verify', expected verification to be false, but was true")
 	}
 }

--- a/remote/signature_test.go
+++ b/remote/signature_test.go
@@ -1,0 +1,41 @@
+package remote
+
+import (
+	"testing"
+
+	"github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/repo"
+	"github.com/qri-io/qri/repo/profile"
+)
+
+func TestVerifySigParams(t *testing.T) {
+	peerInfo := test.GetTestPeerInfo(0)
+	pid, err := calcProfileID(peerInfo.PrivKey)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	profileID, err := profile.NewB58ID(pid)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	ref := repo.DatasetRef{
+		Path:      "foo",
+		Peername:  "bar",
+		Name:      "baz",
+		ProfileID: profileID,
+	}
+	sigParams, err := sigParams(peerInfo.PrivKey, ref)
+	if err != nil {
+		panic(err)
+	}
+
+	verified, err := VerifySigParams(peerInfo.PubKey, sigParams)
+	if err != nil {
+		t.Errorf("case 'should verify', expected no error, got '%s'", err)
+	}
+	if verified == false {
+		t.Errorf("case 'should verify', expected verification to be true, was false")
+	}
+}


### PR DESCRIPTION
This pr renames `RemoveDatasetRef` to `RemoveDataset`. It calls on `base.RemoveNVersionsFromStore` to remove the blocks from the filestore, and uses `repo.DeleteRef` to remove the dataset reference from the repo

`RemoveDataset` calls the `datasetRemovePreCheck` function, if it exists, before it removes the dataset and its history.

`RemoveDataset` calls the `datasetRemoved` function, if it exists, after it removes the datasets and its history

This pr also moves all signature logic to a new `signature.go` file.

It adds a `VerifySigParams` that takes a publicKey, a `params` `map[string]string`, and returns a bool, error. Bool is true if the signature is verified. Basically the inverse of the `sigParams` func.

When remotes have their own keystore, we should make `VerifySigParams` private.