### PR TITLE
refactor(logbook): rename InitOpHash to ID, use lower-base32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,8 +39,6 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.2
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mr-tron/base58 v1.1.2
 	github.com/multiformats/go-multiaddr v0.1.1
 	github.com/multiformats/go-multicodec v0.1.6


### PR DESCRIPTION
We're going to use this `ID` thing in a bunch of places. While we're here I'd like to avoid some of the headaches caused by base64, switching to base32 encoding for id bytes for a few reasons:
* base64 uses the "/" character, which messes with paths
* can be used as URLS
* doesn't rely on case, which means it works in case-insensitive contexts
* lowercase is easier on the eyes

This builds on a number of hard lessons learned in the IPFS community.