### PR TITLE
refactor(logbook): working identifers into logbook

### DIFF
--- a/base/log.go
+++ b/base/log.go
@@ -33,6 +33,12 @@ func DatasetLog(ctx context.Context, r repo.Repo, ref repo.DatasetRef, limit, of
 		if versions, err := book.Versions(repo.ConvertToDsref(ref), offset, limit); err == nil {
 			items = make([]DatasetLogItem, len(versions))
 
+			// logs are ok with history not existing. This keeps FSI interaction behaviour consistent
+			// TODO (b5) - we should consider having "empty history" be an ok state, instead of marking as an error
+			if len(versions) == 0 {
+				return nil, repo.ErrNoHistory
+			}
+
 			for i, v := range versions {
 				items[i] = DatasetLogItem{
 					Ref:         v.Ref,

--- a/base/log.go
+++ b/base/log.go
@@ -22,7 +22,7 @@ type DatasetLogItem struct {
 	// Published indicates if this version has been published
 	Published bool `json:"published,omitempty"`
 	// Size of dataset in bytes
-	Size uint64 `json:"size,omitempty"`
+	Size int64 `json:"size,omitempty"`
 	// Local indicates the connected filesystem has this version available
 	Local bool `json:"local,omitempty"`
 }

--- a/base/ref.go
+++ b/base/ref.go
@@ -95,7 +95,7 @@ func ModifyDatasetRef(ctx context.Context, r repo.Repo, current, new *repo.Datas
 	if isRename {
 		new.Path = current.Path
 
-		if err = r.Logbook().WriteNameAmend(ctx, repo.ConvertToDsref(*current), new.Name); err != nil && err != logbook.ErrNoLogbook {
+		if err = r.Logbook().WriteDatasetRename(ctx, repo.ConvertToDsref(*current), new.Name); err != nil && err != logbook.ErrNoLogbook {
 			return err
 		}
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -239,7 +239,7 @@ func TestSaveRelativeBodyPath(t *testing.T) {
 		t.Skip(err.Error())
 	}
 
-	r := NewTestRepoRoot(t, "qri_test_save_relative_body")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_save_relative_body")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -274,7 +274,7 @@ func TestRemoveOnlyTwoRevisions(t *testing.T) {
 		t.Skip(err.Error())
 	}
 
-	r := NewTestRepoRoot(t, "qri_test_remove_only_two_revisions")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_remove_only_two_revisions")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -325,7 +325,7 @@ func TestRemoveAllRevisionsLongForm(t *testing.T) {
 		t.Skip(err.Error())
 	}
 
-	r := NewTestRepoRoot(t, "qri_test_remove_only_one_revision")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_remove_only_one_revision")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -368,7 +368,7 @@ func TestRemoveAllRevisionsShortForm(t *testing.T) {
 		t.Skip(err.Error())
 	}
 
-	r := NewTestRepoRoot(t, "qri_test_remove_only_one_revision")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_remove_only_one_revision")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -417,7 +417,7 @@ func TestSaveThenOverrideMetaComponent(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_save_then_override_meta")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_save_then_override_meta")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -458,7 +458,7 @@ func TestSaveTwoComponents(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_save_then_override_meta")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_save_then_override_meta")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -500,7 +500,7 @@ func TestSaveThenOverrideTransform(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_save_file_transform")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_save_file_transform")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -541,7 +541,7 @@ func TestSaveThenOverrideViz(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_save_file_transform")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_save_file_transform")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -582,7 +582,7 @@ func TestSaveThenOverrideMetaAndTransformAndViz(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_save_file_transform")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_save_file_transform")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -623,7 +623,7 @@ func TestSaveDatasetWithComponentError(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_save_then_override_meta")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_save_then_override_meta")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -653,7 +653,7 @@ func TestSaveConflictingComponents(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_save_then_override_meta")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_save_then_override_meta")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -689,7 +689,7 @@ func TestSaveTransformWithoutChanges(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_transform_same")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_transform_same")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -724,7 +724,7 @@ func TestTransformUsingGetBodyAndSetBody(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_save_transform_get_body")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_save_transform_get_body")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -765,7 +765,7 @@ func TestDiffRevisions(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_diff_revisions")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_diff_revisions")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -826,7 +826,7 @@ func TestDiffOnlyOneRevision(t *testing.T) {
 	defer func() { dsfs.Timestamp = prev }()
 	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
 
-	r := NewTestRepoRoot(t, "qri_test_diff_only_one")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_diff_only_one")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -870,7 +870,7 @@ type TestRepoRoot struct {
 }
 
 // NewTestRepoRoot constructs the test repo and initializes everything as cheaply as possible.
-func NewTestRepoRoot(t *testing.T, prefix string) TestRepoRoot {
+func NewTestRepoRoot(t *testing.T, peername, prefix string) TestRepoRoot {
 	rootPath, err := ioutil.TempDir("", prefix)
 	if err != nil {
 		t.Fatal(err)
@@ -896,7 +896,7 @@ func NewTestRepoRoot(t *testing.T, prefix string) TestRepoRoot {
 	}
 	// Create empty config.yaml into the test repo.
 	cfg := config.DefaultConfigForTesting().Copy()
-	cfg.Profile.Peername = "test_peer"
+	cfg.Profile.Peername = peername
 	err = cfg.WriteToFile(filepath.Join(qriPath, "config.yaml"))
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestFetchCommand(t *testing.T) {
-	r := NewTestRepoRoot(t, "qri_test_fetch_a")
+	r := NewTestRepoRoot(t, "peer_a", "qri_test_fetch_a")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())
@@ -25,7 +25,7 @@ func TestFetchCommand(t *testing.T) {
 	}
 
 	cmdR = r.CreateCommandRunner(ctx)
-	if err = executeCommand(cmdR, "qri log test_peer/test_movies"); err != nil {
+	if err = executeCommand(cmdR, "qri log peer_a/test_movies"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -50,11 +50,11 @@ func TestFetchCommand(t *testing.T) {
 	// TODO (b5) - this is horrible. we should block on a channel receive for connectedness
 	time.Sleep(time.Second * 5)
 
-	b := NewTestRepoRoot(t, "qri_test_fetch_b")
+	b := NewTestRepoRoot(t, "peer_b", "qri_test_fetch_b")
 	defer b.Delete()
 
 	cmdBr := b.CreateCommandRunner(ctx)
-	if err = executeCommand(cmdBr, "qri log test_peer/test_movies"); err == nil {
+	if err = executeCommand(cmdBr, "qri log peer_b/test_movies"); err == nil {
 		t.Fatal("expected fetch on non-existant log to error")
 	}
 
@@ -64,7 +64,7 @@ func TestFetchCommand(t *testing.T) {
 	}
 
 	cmdBr = b.CreateCommandRunner(ctx)
-	if err = executeCommand(cmdBr, "qri fetch test_peer/test_movies --remote a_node"); err != nil {
+	if err = executeCommand(cmdBr, "qri fetch peer_a/test_movies --remote a_node"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -77,7 +77,7 @@ func TestFetchCommand(t *testing.T) {
 	t.Logf("%s", text)
 
 	cmdBr = b.CreateCommandRunner(ctx)
-	if err = executeCommand(cmdBr, "qri log test_peer/test_movies"); err != nil {
+	if err = executeCommand(cmdBr, "qri log peer_a/test_movies"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/fsi_integration_test.go
+++ b/cmd/fsi_integration_test.go
@@ -30,7 +30,7 @@ type FSITestRunner struct {
 
 // NewFSITestRunner returns a new FSITestRunner.
 func NewFSITestRunner(t *testing.T, testName string) *FSITestRunner {
-	root := NewTestRepoRoot(t, testName)
+	root := NewTestRepoRoot(t, "test_peer", testName)
 
 	fr := FSITestRunner{}
 	fr.RepoRoot = &root

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLogbookCommand(t *testing.T) {
-	r := NewTestRepoRoot(t, "qri_test_logbook")
+	r := NewTestRepoRoot(t, "test_peer", "qri_test_logbook")
 	defer r.Delete()
 
 	ctx, done := context.WithCancel(context.Background())

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -247,7 +247,7 @@ func (s dslogItemStringer) String() string {
 		faint("Storage: "),
 		storage,
 		faint("Size:    "),
-		humanize.Bytes(s.Size),
+		humanize.Bytes(uint64(s.Size)),
 		s.CommitTitle,
 	)
 

--- a/fsi/init.go
+++ b/fsi/init.go
@@ -131,7 +131,7 @@ func (fsi *FSI) InitDataset(p InitParams) (name string, err error) {
 		}
 	}
 
-	if err = fsi.repo.Logbook().WriteDatasetInit(context.TODO(), name); err != nil {
+	if err = fsi.repo.Logbook().WriteDatasetInit(context.TODO(), ref.Name); err != nil {
 		if err == logbook.ErrNoLogbook {
 			err = nil
 			return name, nil

--- a/fsi/init.go
+++ b/fsi/init.go
@@ -131,7 +131,7 @@ func (fsi *FSI) InitDataset(p InitParams) (name string, err error) {
 		}
 	}
 
-	if err = fsi.repo.Logbook().WriteNameInit(context.TODO(), name); err != nil {
+	if err = fsi.repo.Logbook().WriteDatasetInit(context.TODO(), name); err != nil {
 		if err == logbook.ErrNoLogbook {
 			err = nil
 			return name, nil

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -1,0 +1,35 @@
+// Package identity defines interfaces & methods that describes users on qri
+package identity
+
+import (
+	"fmt"
+
+	crypto "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/multiformats/go-multihash"
+)
+
+// KeyIDFromPriv is a wrapper for calling KeyIDFromPub on a private key
+func KeyIDFromPriv(pk crypto.PrivKey) (string, error) {
+	return KeyIDFromPub(pk.GetPublic())
+}
+
+// KeyIDFromPub returns the base58btc-encoded multihash string of a public key
+// hash. hashes are 32-byte sha2-256 sums of public key bytes
+// KeyID is a unique identifier for a keypair
+func KeyIDFromPub(pubKey crypto.PubKey) (string, error) {
+	if pubKey == nil {
+		return "", fmt.Errorf("identity: public key is required")
+	}
+
+	pubkeybytes, err := pubKey.Bytes()
+	if err != nil {
+		return "", fmt.Errorf("getting pubkey bytes: %s", err.Error())
+	}
+
+	mh, err := multihash.Sum(pubkeybytes, multihash.SHA2_256, 32)
+	if err != nil {
+		return "", fmt.Errorf("summing pubkey: %s", err.Error())
+	}
+
+	return mh.B58String(), nil
+}

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -1,0 +1,89 @@
+package identity
+
+import (
+	"encoding/base64"
+	"testing"
+
+	crypto "github.com/libp2p/go-libp2p-core/crypto"
+)
+
+func TestKeyIDFromPriv(t *testing.T) {
+	tr, cleanup := newTestRunner(t)
+	defer cleanup()
+
+	expect := "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt"
+	got, err := KeyIDFromPriv(tr.AlicePrivKey)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if expect != got {
+		t.Errorf("ID mismatch. expected: '%s', got: '%s'", expect, got)
+	}
+}
+
+func TestKeyIDFromPub(t *testing.T) {
+	tr, cleanup := newTestRunner(t)
+	defer cleanup()
+
+	if _, err := KeyIDFromPub(nil); err == nil {
+		t.Errorf("expected error calculating the ID of nil")
+	}
+
+	expect := "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt"
+	got, err := KeyIDFromPub(tr.AlicePrivKey.GetPublic())
+	if err != nil {
+		t.Error(err)
+	}
+
+	if expect != got {
+		t.Errorf("ID mismatch. expected: '%s', got: '%s'", expect, got)
+	}
+}
+
+type testRunner struct {
+	AlicePrivKey crypto.PrivKey
+	BasitPrivKey crypto.PrivKey
+}
+
+func newTestRunner(t *testing.T) (tr *testRunner, cleanup func()) {
+	tr = &testRunner{
+		AlicePrivKey: testAlicePrivKey(t),
+		BasitPrivKey: testBasitPrivKey(t),
+	}
+
+	cleanup = func() {
+
+	}
+	return tr, cleanup
+}
+
+func testAlicePrivKey(t *testing.T) crypto.PrivKey {
+	// logbooks are encrypted at rest, we need a private key to interact with
+	// them, including to create a new logbook. This is a dummy Private Key
+	// you should never, ever use in real life. demo only folks.
+	testPk := `CAASpgkwggSiAgEAAoIBAQC/7Q7fILQ8hc9g07a4HAiDKE4FahzL2eO8OlB1K99Ad4L1zc2dCg+gDVuGwdbOC29IngMA7O3UXijycckOSChgFyW3PafXoBF8Zg9MRBDIBo0lXRhW4TrVytm4Etzp4pQMyTeRYyWR8e2hGXeHArXM1R/A/SjzZUbjJYHhgvEE4OZy7WpcYcW6K3qqBGOU5GDMPuCcJWac2NgXzw6JeNsZuTimfVCJHupqG/dLPMnBOypR22dO7yJIaQ3d0PFLxiDG84X9YupF914RzJlopfdcuipI+6gFAgBw3vi6gbECEzcohjKf/4nqBOEvCDD6SXfl5F/MxoHurbGBYB2CJp+FAgMBAAECggEAaVOxe6Y5A5XzrxHBDtzjlwcBels3nm/fWScvjH4dMQXlavwcwPgKhy2NczDhr4X69oEw6Msd4hQiqJrlWd8juUg6vIsrl1wS/JAOCS65fuyJfV3Pw64rWbTPMwO3FOvxj+rFghZFQgjg/i45uHA2UUkM+h504M5Nzs6Arr/rgV7uPGR5e5OBw3lfiS9ZaA7QZiOq7sMy1L0qD49YO1ojqWu3b7UaMaBQx1Dty7b5IVOSYG+Y3U/dLjhTj4Hg1VtCHWRm3nMOE9cVpMJRhRzKhkq6gnZmni8obz2BBDF02X34oQLcHC/Wn8F3E8RiBjZDI66g+iZeCCUXvYz0vxWAQQKBgQDEJu6flyHPvyBPAC4EOxZAw0zh6SF/r8VgjbKO3n/8d+kZJeVmYnbsLodIEEyXQnr35o2CLqhCvR2kstsRSfRz79nMIt6aPWuwYkXNHQGE8rnCxxyJmxV4S63GczLk7SIn4KmqPlCI08AU0TXJS3zwh7O6e6kBljjPt1mnMgvr3QKBgQD6fAkdI0FRZSXwzygx4uSg47Co6X6ESZ9FDf6ph63lvSK5/eue/ugX6p/olMYq5CHXbLpgM4EJYdRfrH6pwqtBwUJhlh1xI6C48nonnw+oh8YPlFCDLxNG4tq6JVo071qH6CFXCIank3ThZeW5a3ZSe5pBZ8h4bUZ9H8pJL4C7yQKBgFb8SN/+/qCJSoOeOcnohhLMSSD56MAeK7KIxAF1jF5isr1TP+rqiYBtldKQX9bIRY3/8QslM7r88NNj+aAuIrjzSausXvkZedMrkXbHgS/7EAPflrkzTA8fyH10AsLgoj/68mKr5bz34nuY13hgAJUOKNbvFeC9RI5g6eIqYH0FAoGAVqFTXZp12rrK1nAvDKHWRLa6wJCQyxvTU8S1UNi2EgDJ492oAgNTLgJdb8kUiH0CH0lhZCgr9py5IKW94OSM6l72oF2UrS6PRafHC7D9b2IV5Al9lwFO/3MyBrMocapeeyaTcVBnkclz4Qim3OwHrhtFjF1ifhP9DwVRpuIg+dECgYANwlHxLe//tr6BM31PUUrOxP5Y/cj+ydxqM/z6papZFkK6Mvi/vMQQNQkh95GH9zqyC5Z/yLxur4ry1eNYty/9FnuZRAkEmlUSZ/DobhU0Pmj8Hep6JsTuMutref6vCk2n02jc9qYmJuD7iXkdXDSawbEG6f5C4MUkJ38z1t1OjA==`
+	data, err := base64.StdEncoding.DecodeString(testPk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk, err := crypto.UnmarshalPrivateKey(data)
+	if err != nil {
+		t.Fatalf("error unmarshaling private key: %s", err.Error())
+	}
+	return pk
+}
+
+func testBasitPrivKey(t *testing.T) crypto.PrivKey {
+	// id: "QmTqawxrPeTRUKS4GSUURaC16o4etPSJv7Akq6a9xqGZUh"
+	testPk := `CAASpwkwggSjAgEAAoIBAQDACiqtbAeIR0gKZZfWuNgDssXnQnEQNrAlISlNMrtULuCtsLBk2tZ4C508T4/JQHfvbazZ/aPvkhr9KBaH8AzDU3FngHQnWblGtfm/0FAXbXPfn6DZ1rbA9rx9XpVZ+pUBDve0YxTSPOo5wOOR9u30JEvO47n1R/bF+wtMRHvDyRuoy4H86XxwMR76LYbgSlJm6SSKnrAVoWR9zqjXdaF1QljO77VbivnR5aS9vQ5Sd1mktwgb3SYUMlEGedtcMdLd3MPVCLFzq6cdjhSwVAxZ3RowR2m0hSEE/p6CKH9xz4wkMmjVrADfQTYU7spym1NBaNCrW1f+r4ScDEqI1yynAgMBAAECggEAWuJ04C5IQk654XHDMnO4h8eLsa7YI3w+UNQo38gqr+SfoJQGZzTKW3XjrC9bNTu1hzK4o1JOy4qyCy11vE/3Olm7SeiZECZ+cOCemhDUVsIOHL9HONFNHHWpLwwcUsEs05tpz400xWrezwZirSnX47tpxTgxQcwVFg2Bg07F5BntepqX+Ns7s2XTEc7YO8o77viYbpfPSjrsToahWP7ngIL4ymDjrZjgWTPZC7AzobDbhjTh5XuVKh60eUz0O7/Ezj2QK00NNkkD7nplU0tojZF10qXKCbECPn3pocVPAetTkwB1Zabq2tC2Y10dYlef0B2fkktJ4PAJyMszx4toQQKBgQD+69aoMf3Wcbw1Z1e9IcOutArrnSi9N0lVD7X2B6HHQGbHkuVyEXR10/8u4HVtbM850ZQjVnSTa4i9XJAy98FWwNS4zFh3OWVhgp/hXIetIlZF72GEi/yVFBhFMcKvXEpO/orEXMOJRdLb/7kNpMvl4MQ/fGWOmQ3InkKxLZFJ+wKBgQDA2jUTvSjjFVtOJBYVuTkfO1DKRGu7QQqNeF978ZEoU0b887kPu2yzx9pK0PzjPffpfUsa9myDSu7rncBX1FP0gNmSIAUja2pwMvJDU2VmE3Ua30Z1gVG1enCdl5ZWufum8Q+0AUqVkBdhPxw+XDJStA95FUArJzeZ2MTwbZH0RQKBgDG188og1Ys36qfPW0C6kNpEqcyAfS1I1rgLtEQiAN5GJMTOVIgF91vy11Rg2QVZrp9ryyOI/HqzAZtLraMCxWURfWn8D1RQkQCO5HaiAKM2ivRgVffvBHZd0M3NglWH/cWhxZW9MTRXtWLJX2DVvh0504s9yuAf4Jw6oG7EoAx5AoGBAJluAURO/jSMTTQB6cAmuJdsbX4+qSc1O9wJpI3LRp06hAPDM7ycdIMjwTw8wLVaG96bXCF7ZCGggCzcOKanupOP34kuCGiBkRDqt2tw8f8gA875S+k4lXU4kFgQvf8JwHi02LVxQZF0LeWkfCfw2eiKcLT4fzDV5ppzp1tREQmxAoGAGOXFomnMU9WPxJp6oaw1ZimtOXcAGHzKwiwQiw7AAWbQ+8RrL2AQHq0hD0eeacOAKsh89OXsdS9iW9GQ1mFR3FA7Kp5srjCMKNMgNSBNIb49iiG9O6P6UcO+RbYGg3CkSTG33W8l2pFIjBrtGktF5GoJudAPR4RXhVsRYZMiGag=`
+	data, err := base64.StdEncoding.DecodeString(testPk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk, err := crypto.UnmarshalPrivateKey(data)
+	if err != nil {
+		t.Fatalf("error unmarshaling private key: %s", err.Error())
+	}
+	return pk
+}

--- a/lib/log.go
+++ b/lib/log.go
@@ -116,7 +116,7 @@ type RawLogsParams struct {
 }
 
 // RawLogs is an alias for a human representation of a raw logbook
-type RawLogs = map[string][]logbook.Log
+type RawLogs = []logbook.Log
 
 // RawLogs encodes the full logbook as human-oriented json
 func (r *LogRequests) RawLogs(p *RawLogsParams, res *RawLogs) (err error) {

--- a/lib/log_test.go
+++ b/lib/log_test.go
@@ -56,7 +56,7 @@ func TestHistoryRequestsLog(t *testing.T) {
 		{"log list - offset 3 limit 3",
 			&LogParams{Ref: firstRef, ListParams: ListParams{Offset: 3, Limit: 3}}, items[3:], ""},
 		{"log list - offset 6 limit 3",
-			&LogParams{Ref: firstRef, ListParams: ListParams{Offset: 6, Limit: 3}}, []DatasetLogItem{}, ""},
+			&LogParams{Ref: firstRef, ListParams: ListParams{Offset: 6, Limit: 3}}, nil, "repo: no history"},
 	}
 
 	req := NewLogRequests(node, nil)

--- a/lib/log_test.go
+++ b/lib/log_test.go
@@ -35,7 +35,7 @@ func TestHistoryRequestsLog(t *testing.T) {
 			Published:   r.Published,
 			CommitTitle: r.Dataset.Commit.Title,
 			Local:       true,
-			Size:        uint64(r.Dataset.Structure.Length),
+			Size:        int64(r.Dataset.Structure.Length),
 		}
 	}
 
@@ -117,12 +117,12 @@ func TestHistoryRequestsLogEntries(t *testing.T) {
 	}
 
 	expect := []string{
-		`12:00AM	peer	init	`,
-		`12:00AM	peer	save	initial commit`,
-		`12:00AM	peer	save	initial commit`,
-		`12:00AM	peer	save	initial commit`,
-		`12:00AM	peer	save	initial commit`,
-		`12:00AM	peer	save	initial commit`,
+		`12:00AM	peer	init branch	main`,
+		`12:00AM	peer	save commit	initial commit`,
+		`12:00AM	peer	save commit	initial commit`,
+		`12:00AM	peer	save commit	initial commit`,
+		`12:00AM	peer	save commit	initial commit`,
+		`12:00AM	peer	save commit	initial commit`,
 	}
 
 	if diff := cmp.Diff(expect, result); diff != "" {

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	logger "github.com/ipfs/go-log"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qfs"
@@ -35,6 +36,9 @@ var (
 	// NewTimestamp generates the current unix nanosecond time.
 	// This is mainly here for tests to override
 	NewTimestamp = func() int64 { return time.Now().UnixNano() }
+
+	// package logger
+	log = logger.Logger("logbook")
 )
 
 const (
@@ -217,6 +221,7 @@ func (book *Book) WriteDatasetInit(ctx context.Context, name string) error {
 }
 
 func (book Book) initName(ctx context.Context, name string) *oplog.Log {
+	log.Debugf("initializing name: '%s'", name)
 	dsLog := oplog.InitLog(oplog.Op{
 		Type:      oplog.OpTypeInit,
 		Model:     datasetModel,
@@ -255,6 +260,7 @@ func (book *Book) WriteDatasetRename(ctx context.Context, ref dsref.Ref, newName
 	if book == nil {
 		return ErrNoLogbook
 	}
+	log.Debugf("WriteDatasetRename: '%s' -> '%s'", ref.Alias(), newName)
 
 	l, err := book.DatasetRef(ref)
 	if err != nil {
@@ -275,6 +281,7 @@ func (book *Book) WriteDatasetDelete(ctx context.Context, ref dsref.Ref) error {
 	if book == nil {
 		return ErrNoLogbook
 	}
+	log.Debugf("WriteDatasetDelete: '%s'", ref)
 
 	l, err := book.DatasetRef(ref)
 	if err != nil {
@@ -298,6 +305,7 @@ func (book *Book) WriteVersionSave(ctx context.Context, ds *dataset.Dataset) err
 	}
 
 	ref := refFromDataset(ds)
+	log.Debugf("WriteVersionSave: %s", ref)
 	branchLog, err := book.BranchRef(ref)
 	if err != nil {
 		if err == oplog.ErrNotFound {
@@ -335,8 +343,10 @@ func (book *Book) WriteVersionAmend(ctx context.Context, ds *dataset.Dataset) er
 	if book == nil {
 		return ErrNoLogbook
 	}
+	ref := refFromDataset(ds)
+	log.Debugf("WriteVersionAmend: '%s'", ref)
 
-	l, err := book.BranchRef(refFromDataset(ds))
+	l, err := book.BranchRef(ref)
 	if err != nil {
 		return err
 	}
@@ -361,6 +371,7 @@ func (book *Book) WriteVersionDelete(ctx context.Context, ref dsref.Ref, revisio
 	if book == nil {
 		return ErrNoLogbook
 	}
+	log.Debugf("WriteVersionDelete: %s, revisions: %d", ref, revisions)
 
 	l, err := book.BranchRef(ref)
 	if err != nil {
@@ -383,6 +394,7 @@ func (book *Book) WritePublish(ctx context.Context, ref dsref.Ref, revisions int
 	if book == nil {
 		return ErrNoLogbook
 	}
+	log.Debugf("WritePublish: %s, revisions: %d, destinations: %v", ref, revisions, destinations)
 
 	l, err := book.BranchRef(ref)
 	if err != nil {
@@ -406,6 +418,7 @@ func (book *Book) WriteUnpublish(ctx context.Context, ref dsref.Ref, revisions i
 	if book == nil {
 		return ErrNoLogbook
 	}
+	log.Debugf("WriteUnpublish: %s, revisions: %d, destinations: %v", ref, revisions, destinations)
 
 	l, err := book.BranchRef(ref)
 	if err != nil {
@@ -428,6 +441,7 @@ func (book *Book) WriteCronJobRan(ctx context.Context, number int64, ref dsref.R
 	if book == nil {
 		return ErrNoLogbook
 	}
+	log.Debugf("WriteCronJobRan: %s, number: %d", ref, number)
 
 	l, err := book.BranchRef(ref)
 	if err != nil {

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -115,9 +115,10 @@ func NewBook(pk crypto.PrivKey, username string, fs qfs.Filesystem, location str
 			return book, err
 		}
 		return nil, err
-	} else {
-		// TODO (b5) verify username integrity on load
 	}
+	// else {
+	// TODO (b5) verify username integrity on load
+	// }
 
 	return book, nil
 }

--- a/logbook/logbook_test.go
+++ b/logbook/logbook_test.go
@@ -179,7 +179,7 @@ func TestNewBook(t *testing.T) {
 	}
 }
 
-func TestErrNoLogbook(t *testing.T) {
+func TestNilCallable(t *testing.T) {
 	var (
 		book *Book
 		ctx  = context.Background()
@@ -232,13 +232,13 @@ func TestBookLogEntries(t *testing.T) {
 	}
 
 	expect := []string{
-		"12:02AM\ttest_author\tinit\t",
-		"12:00AM\ttest_author\tsave\tinitial commit",
-		"12:00AM\ttest_author\tsave\tadded body data",
+		"12:02AM\ttest_author\tinit branch\tmain",
+		"12:00AM\ttest_author\tsave commit\tinitial commit",
+		"12:00AM\ttest_author\tsave commit\tadded body data",
 		"12:00AM\ttest_author\tpublish\t",
 		"12:00AM\ttest_author\tunpublish\t",
-		"12:00AM\ttest_author\tremove\t",
-		"12:00AM\ttest_author\tamend\tadded meta info",
+		"12:00AM\ttest_author\tremove commit\t",
+		"12:00AM\ttest_author\tamend commit\tadded meta info",
 	}
 
 	if diff := cmp.Diff(expect, got); diff != "" {
@@ -246,22 +246,22 @@ func TestBookLogEntries(t *testing.T) {
 	}
 }
 
-func TestHeadRef(t *testing.T) {
+func TestUserDatasetRef(t *testing.T) {
 	tr, cleanup := newTestRunner(t)
 	defer cleanup()
 
 	tr.WriteRenameExample(t)
 
-	if _, err := tr.Book.HeadRef(dsref.Ref{}); err == nil {
+	if _, err := tr.Book.UserDatasetRef(dsref.Ref{}); err == nil {
 		t.Error("expected LogBytes with empty ref to fail")
 	}
-	if _, err := tr.Book.HeadRef(dsref.Ref{Username: tr.Username}); err == nil {
+	if _, err := tr.Book.UserDatasetRef(dsref.Ref{Username: tr.Username}); err == nil {
 		t.Error("expected LogBytes with empty name ref to fail")
 	}
-	lg := tr.Book.RawLogs(tr.Ctx)
-	t.Logf("%#v\n\n", tr.RenameRef().String())
-	t.Logf("%#v\n\n", lg)
-	if _, err := tr.Book.HeadRef(tr.RenameRef()); err != nil {
+	// lg := tr.Book.RawLogs(tr.Ctx)
+	// t.Logf("%#v\n\n", tr.RenameRef().String())
+	// t.Logf("%#v\n\n", lg)
+	if _, err := tr.Book.UserDatasetRef(tr.RenameRef()); err != nil {
 		t.Errorf("expected LogBytes with proper ref to not produce an error. got: %s", err)
 	}
 }
@@ -271,7 +271,7 @@ func TestLogBytes(t *testing.T) {
 	defer cleanup()
 
 	tr.WriteRenameExample(t)
-	log, err := tr.Book.HeadRef(tr.RenameRef())
+	log, err := tr.Book.UserDatasetRef(tr.RenameRef())
 	if err != nil {
 		t.Error(err)
 	}
@@ -292,7 +292,7 @@ func TestDsRefAliasForLog(t *testing.T) {
 	tr.WriteWorldBankExample(t)
 	tr.WriteRenameExample(t)
 	egRef := tr.RenameRef()
-	log, err := tr.Book.HeadRef(egRef)
+	log, err := tr.Book.UserDatasetRef(egRef)
 	if err != nil {
 		t.Error(err)
 	}
@@ -375,8 +375,8 @@ func TestBookRawLog(t *testing.T) {
 							Ops: []Op{
 								{
 									Type:      "init",
-									Model:     "name",
-									Name:      "author",
+									Model:     "branch",
+									Name:      "main",
 									AuthorID:  "tz7ffwfj6e6z2xvdqgh2pf6gjkza5nzlncbjrj54s5s5eh46ma3q",
 									Timestamp: mustTime("1999-12-31T19:02:00-05:00"),
 								},
@@ -446,7 +446,7 @@ func TestLogTransfer(t *testing.T) {
 
 	tr.WriteWorldBankExample(t)
 
-	log, err := tr.Book.HeadRef(tr.WorldBankRef())
+	log, err := tr.Book.UserDatasetRef(tr.WorldBankRef())
 	if err != nil {
 		t.Error(err)
 	}
@@ -504,10 +504,10 @@ func TestRenameDataset(t *testing.T) {
 	}
 
 	expect := []string{
-		"12:02AM\ttest_author\tinit\t",
-		"12:00AM\ttest_author\tsave\tinitial commit",
+		"12:02AM\ttest_author\tinit branch\tmain",
+		"12:00AM\ttest_author\tsave commit\tinitial commit",
 		"12:00AM\ttest_author\tran update\t",
-		"12:00AM\ttest_author\tsave\tadded meta info",
+		"12:00AM\ttest_author\tsave commit\tadded meta info",
 	}
 
 	if diff := cmp.Diff(expect, got); diff != "" {

--- a/logbook/logsync/http.go
+++ b/logbook/logsync/http.go
@@ -102,7 +102,8 @@ func (c *httpClient) del(ctx context.Context, author oplog.Author, ref dsref.Ref
 }
 
 func addAuthorHTTPHeaders(h http.Header, author oplog.Author) error {
-	h.Set("AuthorID", author.AuthorID())
+	h.Set("ID", author.AuthorID())
+
 	pubByteStr, err := author.AuthorPubKey().Bytes()
 	if err != nil {
 		return err
@@ -122,7 +123,7 @@ func senderFromHTTPHeaders(h http.Header) (oplog.Author, error) {
 		return nil, fmt.Errorf("decoding public key: %s", err)
 	}
 
-	return oplog.NewAuthor(h.Get("AuthorID"), pub), nil
+	return oplog.NewAuthor(h.Get("ID"), pub), nil
 }
 
 // HTTPHandler exposes a Dsync remote over HTTP by exposing a HTTP handler

--- a/logbook/logsync/http_test.go
+++ b/logbook/logsync/http_test.go
@@ -97,7 +97,7 @@ func TestHTTPClientErrors(t *testing.T) {
 		t.Error("expected error to exist")
 	}
 
-	c.URL = "https://not.a.url.sadfhajksldfjaskl"
+	c.URL = "https://not.a.url      .sadfhajksldfjaskl"
 	if _, _, err := c.get(tr.Ctx, tr.A.Author(), dsref.Ref{}); err == nil {
 		t.Error("expected error to exist")
 	}

--- a/logbook/logsync/logsync.go
+++ b/logbook/logsync/logsync.go
@@ -155,19 +155,23 @@ func (lsync *Logsync) DoRemove(ctx context.Context, ref dsref.Ref, remoteAddr st
 }
 
 func (lsync *Logsync) remoteClient(remoteAddr string) (rem remote, err error) {
+	if strings.HasPrefix(remoteAddr, "http") {
+		return &httpClient{URL: remoteAddr}, nil
+	}
+
+	// if we're given a logbook authorId, convert it to the active public key ID
+	if l, err := lsync.book.Log(remoteAddr); err == nil {
+		remoteAddr = l.Author()
+	}
+
 	// if a valid base58 peerID is passed, we're doing a p2p dsync
 	if id, err := peer.IDB58Decode(remoteAddr); err == nil {
 		if lsync.p2pHandler == nil {
 			return nil, fmt.Errorf("no p2p host provided to perform p2p logsync")
 		}
 		return &p2pClient{remotePeerID: id, p2pHandler: lsync.p2pHandler}, nil
-	} else if strings.HasPrefix(remoteAddr, "http") {
-		rem = &httpClient{URL: remoteAddr}
-	} else {
-		return nil, fmt.Errorf("unrecognized push address string: %s", remoteAddr)
 	}
-
-	return rem, nil
+	return nil, fmt.Errorf("unrecognized push address string: %s", remoteAddr)
 }
 
 // remove is an internal interface for methods available on foreign logbooks
@@ -242,7 +246,7 @@ func (lsync *Logsync) get(ctx context.Context, author oplog.Author, ref dsref.Re
 		}
 	}
 
-	l, err := lsync.book.Log(ref)
+	l, err := lsync.book.HeadRef(ref)
 	if err != nil {
 		return lsync.Author(), nil, err
 	}
@@ -293,7 +297,7 @@ type Push struct {
 
 // Do executes a push
 func (p *Push) Do(ctx context.Context) error {
-	log, err := p.book.Log(p.ref)
+	log, err := p.book.HeadRef(p.ref)
 	if err != nil {
 		return err
 	}

--- a/logbook/logsync/logsync.go
+++ b/logbook/logsync/logsync.go
@@ -246,7 +246,7 @@ func (lsync *Logsync) get(ctx context.Context, author oplog.Author, ref dsref.Re
 		}
 	}
 
-	l, err := lsync.book.HeadRef(ref)
+	l, err := lsync.book.UserDatasetRef(ref)
 	if err != nil {
 		return lsync.Author(), nil, err
 	}
@@ -297,7 +297,7 @@ type Push struct {
 
 // Do executes a push
 func (p *Push) Do(ctx context.Context) error {
-	log, err := p.book.HeadRef(p.ref)
+	log, err := p.book.UserDatasetRef(p.ref)
 	if err != nil {
 		return err
 	}

--- a/logbook/logsync/logsync_test.go
+++ b/logbook/logsync/logsync_test.go
@@ -406,7 +406,7 @@ func newTestbook(username string, pk crypto.PrivKey) (*logbook.Book, error) {
 
 func writeNasdaqLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, err error) {
 	name := "nasdaq"
-	if err = book.WriteNameInit(ctx, name); err != nil {
+	if err = book.WriteDatasetInit(ctx, name); err != nil {
 		return ref, err
 	}
 
@@ -440,7 +440,7 @@ func writeNasdaqLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, er
 
 func writeWorldBankLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, err error) {
 	name := "world_bank_population"
-	if err = book.WriteNameInit(ctx, name); err != nil {
+	if err = book.WriteDatasetInit(ctx, name); err != nil {
 		return ref, err
 	}
 

--- a/logbook/logsync/p2p.go
+++ b/logbook/logsync/p2p.go
@@ -98,11 +98,12 @@ func (c *p2pClient) del(ctx context.Context, author oplog.Author, ref dsref.Ref)
 }
 
 func addAuthorP2PHeaders(h []string, author oplog.Author) ([]string, error) {
-	pubByteStr, err := author.AuthorPubKey().Bytes()
+	pkb, err := author.AuthorPubKey().Bytes()
 	if err != nil {
-		return h, err
+		return nil, err
 	}
-	pubKey := base64.StdEncoding.EncodeToString(pubByteStr)
+	pubKey := base64.StdEncoding.EncodeToString(pkb)
+
 	return append(h, "author_id", author.AuthorID(), "pub_key", pubKey), nil
 }
 

--- a/logbook/logsync/p2p_test.go
+++ b/logbook/logsync/p2p_test.go
@@ -2,6 +2,7 @@ package logsync
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	libp2p "github.com/libp2p/go-libp2p"
@@ -44,6 +45,7 @@ func TestP2PLogsync(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	fmt.Printf("removing dataset: %s\n", tr.A.ActivePeerID())
 	if err := pull.Do(tr.Ctx); err != nil {
 		t.Error(err)
 	}

--- a/logbook/logsync/p2p_test.go
+++ b/logbook/logsync/p2p_test.go
@@ -2,7 +2,6 @@ package logsync
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	libp2p "github.com/libp2p/go-libp2p"
@@ -45,7 +44,6 @@ func TestP2PLogsync(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	fmt.Printf("removing dataset: %s\n", tr.A.ActivePeerID())
 	if err := pull.Do(tr.Ctx); err != nil {
 		t.Error(err)
 	}

--- a/logbook/logsync/p2p_test.go
+++ b/logbook/logsync/p2p_test.go
@@ -40,7 +40,7 @@ func TestP2PLogsync(t *testing.T) {
 	}
 
 	// pull logs to B from A
-	pull, err := lsB.NewPull(worldBankRef, tr.A.Author().AuthorID())
+	pull, err := lsB.NewPull(worldBankRef, tr.A.ActivePeerID())
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,7 +63,7 @@ func TestP2PLogsync(t *testing.T) {
 	}
 
 	// push logs from A to B
-	push, err := lsA.NewPush(nasdaqRef, tr.B.Author().AuthorID())
+	push, err := lsA.NewPush(nasdaqRef, tr.B.ActivePeerID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestP2PLogsync(t *testing.T) {
 	}
 
 	// A request B removes nasdaq
-	if err := lsA.DoRemove(tr.Ctx, nasdaqRef, tr.B.Author().AuthorID()); err != nil {
+	if err := lsA.DoRemove(tr.Ctx, nasdaqRef, tr.B.ActivePeerID()); err != nil {
 		t.Errorf("unexpected error doing remove request: %s", err)
 	}
 	if _, err = tr.B.Versions(nasdaqRef, 0, 10); err == nil {

--- a/logbook/oplog/log.fbs
+++ b/logbook/oplog/log.fbs
@@ -34,7 +34,7 @@ table Operation {
   authorID:string;    // identifier for author
 
   timestamp:long;     // operation timestamp, for annotation purposes only
-  size:ulong;         // size of the referenced value in bytes
+  size:long;          // size of the referenced value in bytes
   note:string;        // operation annotation for users. eg: commit title
 }
 

--- a/logbook/oplog/log.go
+++ b/logbook/oplog/log.go
@@ -607,7 +607,7 @@ type Op struct {
 	AuthorID  string   // identifier for author
 
 	Timestamp int64  // operation timestamp, for annotation purposes only
-	Size      uint64 // size of the referenced value in bytes
+	Size      int64  // size of the referenced value in bytes
 	Note      string // operation annotation for users. eg: commit title
 }
 

--- a/logbook/oplog/log.go
+++ b/logbook/oplog/log.go
@@ -392,7 +392,8 @@ func (lg Log) Name() string {
 	return lg.name
 }
 
-// Log fetches a log by ID, checking all descendants for a match
+// Log fetches a log by ID, checking the current log and all descendants for a
+// an exact match
 func (lg *Log) Log(id string) (*Log, error) {
 	if lg.ID() == id {
 		return lg, nil
@@ -423,6 +424,7 @@ func (lg *Log) HeadRef(names ...string) (*Log, error) {
 
 // AddChild appends a log as a direct descendant of this log
 func (lg *Log) AddChild(l *Log) {
+	l.parent = lg
 	lg.Logs = append(lg.Logs, l)
 }
 

--- a/logbook/oplog/log_bench_test.go
+++ b/logbook/oplog/log_bench_test.go
@@ -1,0 +1,34 @@
+package oplog
+
+import (
+	"testing"
+
+	"github.com/dustin/go-humanize"
+)
+
+func BenchmarkSave10kOpsOneAuthor(b *testing.B) {
+	tr, cleanup := newTestRunner(b)
+	defer cleanup()
+
+	init := Op{
+		Type:  OpTypeInit,
+		Model: 0xFFFF,
+	}
+
+	l := tr.RandomLog(init, 10000)
+	book := tr.Book
+	book.AppendLog(l)
+
+	data, err := book.FlatbufferCipher()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Logf("one simulated log with 10k ops weighs %s as encrypted data", humanize.Bytes(uint64(len(data))))
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if _, err := book.FlatbufferCipher(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/logbook/oplog/log_test.go
+++ b/logbook/oplog/log_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/qri-io/qri/logbook/oplog/logfb"
 )
@@ -61,7 +62,11 @@ func TestBookFlatbuffer(t *testing.T) {
 		t.Fatalf("unmarshalling flatbuffer bytes: %s", err.Error())
 	}
 
-	if diff := cmp.Diff(book, got, allowUnexported, cmp.Comparer(comparePrivKeys)); diff != "" {
+	// TODO (b5) - need to ignore log.parent here. causes a stack overflow in cmp.Diff
+	// we should file an issue with a test that demonstrates the error
+	ignoreCircularPointers := cmpopts.IgnoreUnexported(Log{})
+
+	if diff := cmp.Diff(book, got, allowUnexported, cmp.Comparer(comparePrivKeys), ignoreCircularPointers); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/logbook/oplog/logfb/Operation.go
+++ b/logbook/oplog/logfb/Operation.go
@@ -111,16 +111,16 @@ func (rcv *Operation) MutateTimestamp(n int64) bool {
 	return rcv._tab.MutateInt64Slot(18, n)
 }
 
-func (rcv *Operation) Size() uint64 {
+func (rcv *Operation) Size() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
 	if o != 0 {
-		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+		return rcv._tab.GetInt64(o + rcv._tab.Pos)
 	}
 	return 0
 }
 
-func (rcv *Operation) MutateSize(n uint64) bool {
-	return rcv._tab.MutateUint64Slot(20, n)
+func (rcv *Operation) MutateSize(n int64) bool {
+	return rcv._tab.MutateInt64Slot(20, n)
 }
 
 func (rcv *Operation) Note() []byte {
@@ -161,8 +161,8 @@ func OperationAddAuthorID(builder *flatbuffers.Builder, authorID flatbuffers.UOf
 func OperationAddTimestamp(builder *flatbuffers.Builder, timestamp int64) {
 	builder.PrependInt64Slot(7, timestamp, 0)
 }
-func OperationAddSize(builder *flatbuffers.Builder, size uint64) {
-	builder.PrependUint64Slot(8, size, 0)
+func OperationAddSize(builder *flatbuffers.Builder, size int64) {
+	builder.PrependInt64Slot(8, size, 0)
 }
 func OperationAddNote(builder *flatbuffers.Builder, note flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(note), 0)

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -14,6 +14,7 @@ import (
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/identity"
 	"github.com/qri-io/qri/logbook/logsync"
 	"github.com/qri-io/qri/logbook/oplog"
 	"github.com/qri-io/qri/p2p"
@@ -325,7 +326,11 @@ func (r *Remote) pidAndRefFromMeta(meta map[string]string) (profile.ID, repo.Dat
 func (r *Remote) logHook(h Hook) logsync.Hook {
 	return func(ctx context.Context, author logsync.Author, ref dsref.Ref, l *oplog.Log) error {
 		if h != nil {
-			pid, err := profile.IDB58Decode(author.AuthorID())
+			kid, err := identity.KeyIDFromPub(author.AuthorPubKey())
+			if err != nil {
+				return err
+			}
+			pid, err := profile.IDB58Decode(kid)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
closes #997

This PR lands a few key changes to logbooks:
* arranges logs into a cleaner hierarchy of user >> dataset >> branch, removing the top level arrange-by-model variation
* disambiguates what is written to each branch. User logs only contain operations that affect the user model, Dataset logs only contain operations that affect entire datasets, and Branch logs only contain operations for a line of commit activity
* introduces methods for fetching by _ head reference_ using names, and ID, using a log identifier
* renames "name" model to "dataset", so we now have `user`, `dataset`, and `branch` models
* renames `WriteNameInit` methods to match dataset business logic conventions. Now called: `WriteDatasetInit`, `WriteDatasetRename`, and `WriteDatasetDelete`
* adds logic to track oplog `Remove` operations. Fetching a log by head reference that has been removed will now return `ErrNotFound`. Deleted logs can still be fetched by `ID` reference