### PR TITLE
fix(remove): don't fail if remove encounters an issue traversing qfs history

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,8 +39,6 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.2
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mr-tron/base58 v1.1.2
 	github.com/multiformats/go-multiaddr v0.1.1
 	github.com/multiformats/go-multicodec v0.1.6


### PR DESCRIPTION


this is a bit of a stop-gap for now, but users are seeing bad errors when dataset histories aren't fully persisted & they attempt to delete. This may end up causing stray-pinning, and the long-term solution for that is to use logbook for this remove task. We can also use logbook to identify stray pins & reclaim the space

closes #989