### PR TITLE
fix(init): If init has errors, rollback changes

### DIFF
--- a/base/component/component.go
+++ b/base/component/component.go
@@ -13,7 +13,7 @@ import (
 type Component interface {
 	Base() *BaseComponent
 	Compare(Component) (bool, error)
-	WriteTo(dirPath string) error
+	WriteTo(dirPath string) (string, error)
 	RemoveFrom(dirPath string) error
 	DropDerivedValues()
 	LoadAndFill(*dataset.Dataset) error

--- a/base/component/component.go
+++ b/base/component/component.go
@@ -13,7 +13,7 @@ import (
 type Component interface {
 	Base() *BaseComponent
 	Compare(Component) (bool, error)
-	WriteTo(dirPath string) (string, error)
+	WriteTo(dirPath string) (targetFile string, err error)
 	RemoveFrom(dirPath string) error
 	DropDerivedValues()
 	LoadAndFill(*dataset.Dataset) error

--- a/base/component/kinds.go
+++ b/base/component/kinds.go
@@ -34,8 +34,8 @@ func (fc *FilesysComponent) IsEmpty() bool {
 }
 
 // WriteTo writes the component as a file to the directory
-func (fc *FilesysComponent) WriteTo(dirPath string) error {
-	return fmt.Errorf("cannot write filesys component")
+func (fc *FilesysComponent) WriteTo(dirPath string) (string, error) {
+	return "", fmt.Errorf("cannot write filesys component")
 }
 
 // RemoveFrom removes the component file from the directory
@@ -82,8 +82,8 @@ func (dc *DatasetComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (dc *DatasetComponent) WriteTo(dirPath string) error {
-	return fmt.Errorf("cannot write dataset component")
+func (dc *DatasetComponent) WriteTo(dirPath string) (string, error) {
+	return "", fmt.Errorf("cannot write dataset component")
 }
 
 // RemoveFrom removes the component file from the directory
@@ -134,6 +134,8 @@ func structToMap(value interface{}) (map[string]interface{}, error) {
 type MetaComponent struct {
 	BaseComponent
 	Value *dataset.Meta
+	// Prevent the component from being written. Used for testing.
+	DisableSerialization bool
 }
 
 // Compare compares to another component
@@ -152,15 +154,18 @@ func (mc *MetaComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (mc *MetaComponent) WriteTo(dirPath string) error {
+func (mc *MetaComponent) WriteTo(dirPath string) (string, error) {
+	if mc.DisableSerialization {
+		return "", fmt.Errorf("serialization is disabled")
+	}
 	if err := mc.LoadAndFill(nil); err != nil {
-		return err
+		return "", err
 	}
 	// Okay to output an empty meta, we do so for `qri init`.
 	if mc.Value != nil {
 		return writeComponentFile(mc.Value, dirPath, "meta.json")
 	}
-	return nil
+	return "", nil
 }
 
 // RemoveFrom removes the component file from the directory
@@ -234,14 +239,14 @@ func (sc *StructureComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (sc *StructureComponent) WriteTo(dirPath string) error {
+func (sc *StructureComponent) WriteTo(dirPath string) (string, error) {
 	if err := sc.LoadAndFill(nil); err != nil {
-		return err
+		return "", err
 	}
 	if sc.Value != nil && !sc.Value.IsEmpty() {
 		return writeComponentFile(sc.Value, dirPath, "structure.json")
 	}
-	return nil
+	return "", nil
 }
 
 // RemoveFrom removes the component file from the directory
@@ -313,14 +318,14 @@ func (cc *CommitComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (cc *CommitComponent) WriteTo(dirPath string) error {
+func (cc *CommitComponent) WriteTo(dirPath string) (string, error) {
 	if err := cc.LoadAndFill(nil); err != nil {
-		return err
+		return "", err
 	}
 	if cc.Value != nil && !cc.Value.IsEmpty() {
 		return writeComponentFile(cc.Value, dirPath, "commit.json")
 	}
-	return nil
+	return "", nil
 }
 
 // RemoveFrom removes the component file from the directory
@@ -489,23 +494,24 @@ func (bc *BodyComponent) StructuredData() (interface{}, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (bc *BodyComponent) WriteTo(dirPath string) error {
+func (bc *BodyComponent) WriteTo(dirPath string) (string, error) {
 	if bc.Value == nil {
 		err := bc.LoadAndFill(nil)
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 	body := bc.Value
 	if bc.Structure == nil {
-		return fmt.Errorf("cannot write body without a structure")
+		return "", fmt.Errorf("cannot write body without a structure")
 	}
 	data, err := SerializeBody(body, bc.Structure)
 	if err != nil {
-		return err
+		return "", err
 	}
 	bodyFilename := fmt.Sprintf("body.%s", bc.Format)
-	return ioutil.WriteFile(filepath.Join(dirPath, bodyFilename), data, os.ModePerm)
+	targetFile := filepath.Join(dirPath, bodyFilename)
+	return targetFile, ioutil.WriteFile(targetFile, data, os.ModePerm)
 }
 
 // RemoveFrom removes the component file from the directory
@@ -579,17 +585,17 @@ func (rc *ReadmeComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (rc *ReadmeComponent) WriteTo(dirPath string) error {
+func (rc *ReadmeComponent) WriteTo(dirPath string) (string, error) {
 	if err := rc.LoadAndFill(nil); err != nil {
-		return err
+		return "", err
 	}
 	if rc.Value != nil && !rc.Value.IsEmpty() {
-		filename := filepath.Join(dirPath, fmt.Sprintf("readme.%s", rc.Format))
-		if err := ioutil.WriteFile(filename, rc.Value.ScriptBytes, os.ModePerm); err != nil {
-			return err
+		targetFile := filepath.Join(dirPath, fmt.Sprintf("readme.%s", rc.Format))
+		if err := ioutil.WriteFile(targetFile, rc.Value.ScriptBytes, os.ModePerm); err != nil {
+			return targetFile, err
 		}
 	}
-	return nil
+	return "", nil
 }
 
 // RemoveFrom removes the component file from the directory
@@ -737,15 +743,16 @@ func compareComponentData(first interface{}, second interface{}) (bool, error) {
 	return string(left) == string(rite), nil
 }
 
-func writeComponentFile(value interface{}, dirPath string, basefile string) error {
+func writeComponentFile(value interface{}, dirPath string, basefile string) (string, error) {
 	data, err := json.MarshalIndent(value, "", " ")
 	if err != nil {
-		return err
+		return "", err
 	}
 	// TODO(dlong): How does this relate to Base.SourceFile? Should respect that.
-	err = ioutil.WriteFile(filepath.Join(dirPath, basefile), data, os.ModePerm)
+	targetFile := filepath.Join(dirPath, basefile)
+	err = ioutil.WriteFile(targetFile, data, os.ModePerm)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return targetFile, nil
 }

--- a/base/component/kinds.go
+++ b/base/component/kinds.go
@@ -34,7 +34,7 @@ func (fc *FilesysComponent) IsEmpty() bool {
 }
 
 // WriteTo writes the component as a file to the directory
-func (fc *FilesysComponent) WriteTo(dirPath string) (string, error) {
+func (fc *FilesysComponent) WriteTo(dirPath string) (targetFile string, err error) {
 	return "", fmt.Errorf("cannot write filesys component")
 }
 
@@ -82,7 +82,7 @@ func (dc *DatasetComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (dc *DatasetComponent) WriteTo(dirPath string) (string, error) {
+func (dc *DatasetComponent) WriteTo(dirPath string) (targetFile string, err error) {
 	return "", fmt.Errorf("cannot write dataset component")
 }
 
@@ -154,12 +154,12 @@ func (mc *MetaComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (mc *MetaComponent) WriteTo(dirPath string) (string, error) {
+func (mc *MetaComponent) WriteTo(dirPath string) (targetFile string, err error) {
 	if mc.DisableSerialization {
 		return "", fmt.Errorf("serialization is disabled")
 	}
-	if err := mc.LoadAndFill(nil); err != nil {
-		return "", err
+	if err = mc.LoadAndFill(nil); err != nil {
+		return
 	}
 	// Okay to output an empty meta, we do so for `qri init`.
 	if mc.Value != nil {
@@ -239,9 +239,9 @@ func (sc *StructureComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (sc *StructureComponent) WriteTo(dirPath string) (string, error) {
-	if err := sc.LoadAndFill(nil); err != nil {
-		return "", err
+func (sc *StructureComponent) WriteTo(dirPath string) (targetFile string, err error) {
+	if err = sc.LoadAndFill(nil); err != nil {
+		return
 	}
 	if sc.Value != nil && !sc.Value.IsEmpty() {
 		return writeComponentFile(sc.Value, dirPath, "structure.json")
@@ -318,9 +318,9 @@ func (cc *CommitComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (cc *CommitComponent) WriteTo(dirPath string) (string, error) {
-	if err := cc.LoadAndFill(nil); err != nil {
-		return "", err
+func (cc *CommitComponent) WriteTo(dirPath string) (targetFile string, err error) {
+	if err = cc.LoadAndFill(nil); err != nil {
+		return
 	}
 	if cc.Value != nil && !cc.Value.IsEmpty() {
 		return writeComponentFile(cc.Value, dirPath, "commit.json")
@@ -494,11 +494,11 @@ func (bc *BodyComponent) StructuredData() (interface{}, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (bc *BodyComponent) WriteTo(dirPath string) (string, error) {
+func (bc *BodyComponent) WriteTo(dirPath string) (targetFile string, err error) {
 	if bc.Value == nil {
-		err := bc.LoadAndFill(nil)
+		err = bc.LoadAndFill(nil)
 		if err != nil {
-			return "", err
+			return
 		}
 	}
 	body := bc.Value
@@ -510,7 +510,7 @@ func (bc *BodyComponent) WriteTo(dirPath string) (string, error) {
 		return "", err
 	}
 	bodyFilename := fmt.Sprintf("body.%s", bc.Format)
-	targetFile := filepath.Join(dirPath, bodyFilename)
+	targetFile = filepath.Join(dirPath, bodyFilename)
 	return targetFile, ioutil.WriteFile(targetFile, data, os.ModePerm)
 }
 
@@ -585,14 +585,14 @@ func (rc *ReadmeComponent) Compare(compare Component) (bool, error) {
 }
 
 // WriteTo writes the component as a file to the directory
-func (rc *ReadmeComponent) WriteTo(dirPath string) (string, error) {
-	if err := rc.LoadAndFill(nil); err != nil {
-		return "", err
+func (rc *ReadmeComponent) WriteTo(dirPath string) (targetFile string, err error) {
+	if err = rc.LoadAndFill(nil); err != nil {
+		return
 	}
 	if rc.Value != nil && !rc.Value.IsEmpty() {
-		targetFile := filepath.Join(dirPath, fmt.Sprintf("readme.%s", rc.Format))
-		if err := ioutil.WriteFile(targetFile, rc.Value.ScriptBytes, os.ModePerm); err != nil {
-			return targetFile, err
+		targetFile = filepath.Join(dirPath, fmt.Sprintf("readme.%s", rc.Format))
+		if err = ioutil.WriteFile(targetFile, rc.Value.ScriptBytes, os.ModePerm); err != nil {
+			return
 		}
 	}
 	return "", nil

--- a/cmd/log_integration_test.go
+++ b/cmd/log_integration_test.go
@@ -8,7 +8,7 @@ import (
 // LogTestRunner holds test info integration tests
 type LogTestRunner struct {
 	TestRunner
-	LocOrig     *time.Location
+	LocOrig *time.Location
 }
 
 // newLogTestRunner returns a new FSITestRunner.

--- a/fsi/fsi_test.go
+++ b/fsi/fsi_test.go
@@ -55,7 +55,7 @@ func TestCreateLink(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	link, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	link, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -89,11 +89,11 @@ func TestCreateLinkTwice(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	_, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	_, err = fsi.CreateLink(paths.secondDir, "me/test_second")
+	_, _, err = fsi.CreateLink(paths.secondDir, "me/test_second")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -142,11 +142,11 @@ func TestCreateLinkAlreadyLinked(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	_, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	_, err = fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err = fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err == nil {
 		t.Errorf("expected an error, did not get one")
 		return
@@ -163,13 +163,13 @@ func TestCreateLinkAgainOnceQriRefRemoved(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	_, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
 	// Remove the .qri-ref link file, then CreateLink again.
 	os.Remove(filepath.Join(paths.firstDir, ".qri-ref"))
-	_, err = fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err = fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -204,7 +204,7 @@ func TestUpdateLink(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	_, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -223,7 +223,7 @@ func TestUnlink(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	_, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/fsi/init.go
+++ b/fsi/init.go
@@ -41,8 +41,10 @@ func (fsi *FSI) InitDataset(p InitParams) (name string, err error) {
 		log.Debug("did rollback InitDataset due to error")
 	}
 	defer func() {
-		log.Debug("InitDataset rolling back...")
-		rollback()
+		if rollback != nil {
+			log.Debug("InitDataset rolling back...")
+			rollback()
+		}
 	}()
 
 	if p.Dir == "" {
@@ -76,9 +78,9 @@ func (fsi *FSI) InitDataset(p InitParams) (name string, err error) {
 			// steps fail.
 			rollback = concatFunc(
 				func() {
-					log.Debugf("removing directory \"%s\" during rollback", targetPath)
+					log.Debugf("removing directory %q during rollback", targetPath)
 					if err := os.Remove(targetPath); err != nil {
-						log.Debugf("error while removing directory %s: \"%s\"", targetPath, err)
+						log.Debugf("error while removing directory %q: %s", targetPath, err)
 					}
 				}, rollback)
 		}
@@ -174,9 +176,9 @@ func (fsi *FSI) InitDataset(p InitParams) (name string, err error) {
 			// If future steps fail, rollback the components that have been written
 			rollback = concatFunc(func() {
 				if wroteFile != "" {
-					log.Debugf("removing file \"%s\" during rollback", wroteFile)
+					log.Debugf("removing file %q during rollback", wroteFile)
 					if err := os.Remove(wroteFile); err != nil {
-						log.Debugf("error while removing file \"%s\": %s", wroteFile, err)
+						log.Debugf("error while removing file %q: %s", wroteFile, err)
 					}
 				}
 			}, rollback)
@@ -191,9 +193,8 @@ func (fsi *FSI) InitDataset(p InitParams) (name string, err error) {
 		return name, err
 	}
 
-	rollback = func() {
-		// Success, no need to rollback.
-	}
+	// Success, no need to rollback.
+	rollback = nil
 	return name, nil
 }
 

--- a/fsi/mapping.go
+++ b/fsi/mapping.go
@@ -74,10 +74,10 @@ func WriteComponents(ds *dataset.Dataset, dirPath string, resolver qfs.Filesyste
 }
 
 // WriteComponent writes the component with the given name to the directory
-func WriteComponent(comp component.Component, name string, dirPath string) error {
+func WriteComponent(comp component.Component, name string, dirPath string) (string, error) {
 	aComp := comp.Base().GetSubcomponent(name)
 	if aComp == nil {
-		return nil
+		return "", nil
 	}
 	return aComp.WriteTo(dirPath)
 }

--- a/fsi/status_test.go
+++ b/fsi/status_test.go
@@ -38,7 +38,7 @@ func TestStatusValid(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	_, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -82,7 +82,7 @@ func TestStatusInvalidDataset(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	_, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -106,7 +106,7 @@ func TestStatusInvalidMeta(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	_, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -128,7 +128,7 @@ func TestStatusNotFound(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo)
-	_, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -57,7 +57,7 @@ func (m *FSIMethods) CreateLink(p *LinkParams, res *string) (err error) {
 		return m.inst.rpc.Call("FSIMethods.CreateLink", p, res)
 	}
 
-	*res, err = m.inst.fsi.CreateLink(p.Dir, p.Ref)
+	*res, _, err = m.inst.fsi.CreateLink(p.Dir, p.Ref)
 	return err
 }
 
@@ -175,7 +175,7 @@ func (m *FSIMethods) Checkout(p *CheckoutParams, out *string) (err error) {
 	}
 
 	// Create the link file, containing the dataset reference.
-	if _, err = m.inst.fsi.CreateLink(p.Dir, p.Ref); err != nil {
+	if _, _, err = m.inst.fsi.CreateLink(p.Dir, p.Ref); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If init has errors, simply bailing with an error isn't good enough. It can leave our repo and working directory in unusable states. Instead, we create a cleanup function that will undo work done so far, calling any cleanup function that already exists.

Convert fsi_integration_test to new, simpler TestRunner methods.