### PR TITLE
refactor(oplog): Logstore interface

### DIFF
--- a/base/log.go
+++ b/base/log.go
@@ -30,7 +30,7 @@ type DatasetLogItem struct {
 // DatasetLog fetches the change version history of a dataset
 func DatasetLog(ctx context.Context, r repo.Repo, ref repo.DatasetRef, limit, offset int, loadDatasets bool) (items []DatasetLogItem, err error) {
 	if book := r.Logbook(); book != nil {
-		if versions, err := book.Versions(repo.ConvertToDsref(ref), offset, limit); err == nil {
+		if versions, err := book.Versions(ctx, repo.ConvertToDsref(ref), offset, limit); err == nil {
 			items = make([]DatasetLogItem, len(versions))
 
 			// logs are ok with history not existing. This keeps FSI interaction behaviour consistent

--- a/base/log_test.go
+++ b/base/log_test.go
@@ -96,7 +96,7 @@ func TestConstructDatasetLogFromHistory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	book, err := logbook.NewBook(p.PrivKey, p.Peername, r.Filesystem(), "/map/logbook")
+	book, err := logbook.NewJournal(p.PrivKey, p.Peername, r.Filesystem(), "/map/logbook")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/base/log_test.go
+++ b/base/log_test.go
@@ -105,7 +105,7 @@ func TestConstructDatasetLogFromHistory(t *testing.T) {
 	cities := repo.ConvertToDsref(ref)
 
 	// confirm no history exists:
-	if _, err = book.Versions(cities, 0, 100); err == nil {
+	if _, err = book.Versions(ctx, cities, 0, 100); err == nil {
 		t.Errorf("expected versions for nonexistent history to fail")
 	}
 
@@ -126,7 +126,7 @@ func TestConstructDatasetLogFromHistory(t *testing.T) {
 	}
 
 	// confirm history exists:
-	got, err := book.Versions(cities, 0, 100)
+	got, err := book.Versions(ctx, cities, 0, 100)
 	if err != nil {
 		t.Error(err)
 	}

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -8,6 +8,39 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
+// Author uses keypair cryptography to distinguish between different log sources
+// (authors)
+type Author interface {
+	AuthorID() string
+	AuthorPubKey() crypto.PubKey
+}
+
+type author struct {
+	id     string
+	pubKey crypto.PubKey
+}
+
+// NewAuthor creates an Author interface implementation, allowing outside
+// packages needing to satisfy the Author interface
+func NewAuthor(id string, pubKey crypto.PubKey) Author {
+	return author{
+		id:     id,
+		pubKey: pubKey,
+	}
+}
+
+func (a author) AuthorID() string {
+	return a.id
+}
+
+func (a author) AuthorPubKeyID() crypto.PubKey {
+	return a.pubKey
+}
+
+func (a author) AuthorPubKey() crypto.PubKey {
+	return a.pubKey
+}
+
 // KeyIDFromPriv is a wrapper for calling KeyIDFromPub on a private key
 func KeyIDFromPriv(pk crypto.PrivKey) (string, error) {
 	return KeyIDFromPub(pk.GetPublic())

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -601,6 +601,7 @@ func TestDatasetRequestsRename(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	ctx := context.Background()
 
 	bad := []struct {
 		p   *RenameParams
@@ -627,7 +628,7 @@ func TestDatasetRequestsRename(t *testing.T) {
 		}
 	}
 
-	log, err := mr.Logbook().DatasetRef(dsref.Ref{Username: "peer", Name: "movies"})
+	log, err := mr.Logbook().DatasetRef(ctx, dsref.Ref{Username: "peer", Name: "movies"})
 	if err != nil {
 		t.Errorf("error getting logbook head reference: %s", err)
 	}
@@ -648,7 +649,7 @@ func TestDatasetRequestsRename(t *testing.T) {
 	}
 
 	// get log by id this time
-	after, err := mr.Logbook().Log(log.ID())
+	after, err := mr.Logbook().Log(ctx, log.ID())
 	if err != nil {
 		t.Errorf("getting log by ID: %s", err)
 	}

--- a/lib/log.go
+++ b/lib/log.go
@@ -125,6 +125,6 @@ func (r *LogRequests) RawLogs(p *RawLogsParams, res *RawLogs) (err error) {
 	}
 	ctx := context.TODO()
 
-	*res = r.node.Repo.Logbook().RawLogs(ctx)
+	*res, err = r.node.Repo.Logbook().RawLogs(ctx)
 	return err
 }

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -153,8 +153,14 @@ func (book *Book) initialize(ctx context.Context) error {
 }
 
 // ActivePeerID returns the in-use PeerID of the logbook author
-func (book *Book) ActivePeerID() (id string) {
-	return book.authorID
+// TODO (b5) - remove the need for this context by caching the active PeerID
+// at key load / save / mutation points
+func (book *Book) ActivePeerID(ctx context.Context) (id string) {
+	lg, err := book.store.Log(ctx, book.authorID)
+	if err != nil {
+		panic(err)
+	}
+	return lg.Author()
 }
 
 // Author returns this book's author

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -56,7 +56,8 @@ const (
 // feature in qri, but logbook supports them
 const DefaultBranchName = "main"
 
-func modelString(m uint32) string {
+// ModelString gets a unique string descriptor for an integral model identifier
+func ModelString(m uint32) string {
 	switch m {
 	case authorModel:
 		return "user"
@@ -869,7 +870,7 @@ type Op struct {
 func newOp(op oplog.Op) Op {
 	return Op{
 		Type:      opTypeString(op.Type),
-		Model:     modelString(op.Model),
+		Model:     ModelString(op.Model),
 		Ref:       op.Ref,
 		Prev:      op.Prev,
 		Relations: op.Relations,

--- a/logbook/logbook_test.go
+++ b/logbook/logbook_test.go
@@ -142,7 +142,7 @@ func Example() {
 	// now for the fun bit. When we ask for the state of the log, it will
 	// play our opsets forward and get us the current state of tne log
 	// we can also get the state of a log from the book:
-	log, err := book.Versions(ref, 0, 100)
+	log, err := book.Versions(ctx, ref, 0, 100)
 	if err != nil {
 		panic(err)
 	}
@@ -255,16 +255,13 @@ func TestUserDatasetRef(t *testing.T) {
 
 	tr.WriteRenameExample(t)
 
-	if _, err := tr.Book.UserDatasetRef(dsref.Ref{}); err == nil {
+	if _, err := tr.Book.UserDatasetRef(tr.Ctx, dsref.Ref{}); err == nil {
 		t.Error("expected LogBytes with empty ref to fail")
 	}
-	if _, err := tr.Book.UserDatasetRef(dsref.Ref{Username: tr.Username}); err == nil {
+	if _, err := tr.Book.UserDatasetRef(tr.Ctx, dsref.Ref{Username: tr.Username}); err == nil {
 		t.Error("expected LogBytes with empty name ref to fail")
 	}
-	// lg := tr.Book.RawLogs(tr.Ctx)
-	// t.Logf("%#v\n\n", tr.RenameRef().String())
-	// t.Logf("%#v\n\n", lg)
-	if _, err := tr.Book.UserDatasetRef(tr.RenameRef()); err != nil {
+	if _, err := tr.Book.UserDatasetRef(tr.Ctx, tr.RenameRef()); err != nil {
 		t.Errorf("expected LogBytes with proper ref to not produce an error. got: %s", err)
 	}
 }
@@ -274,7 +271,7 @@ func TestLogBytes(t *testing.T) {
 	defer cleanup()
 
 	tr.WriteRenameExample(t)
-	log, err := tr.Book.UserDatasetRef(tr.RenameRef())
+	log, err := tr.Book.UserDatasetRef(tr.Ctx, tr.RenameRef())
 	if err != nil {
 		t.Error(err)
 	}
@@ -295,7 +292,7 @@ func TestDsRefAliasForLog(t *testing.T) {
 	tr.WriteWorldBankExample(t)
 	tr.WriteRenameExample(t)
 	egRef := tr.RenameRef()
-	log, err := tr.Book.UserDatasetRef(egRef)
+	log, err := tr.Book.UserDatasetRef(tr.Ctx, egRef)
 	if err != nil {
 		t.Error(err)
 	}
@@ -304,7 +301,7 @@ func TestDsRefAliasForLog(t *testing.T) {
 		t.Error("expected nil ref to error")
 	}
 
-	wrongModelLog, err := tr.Book.bk.HeadRef(tr.Username)
+	wrongModelLog, err := tr.Book.store.HeadRef(tr.Ctx, tr.Username)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +310,7 @@ func TestDsRefAliasForLog(t *testing.T) {
 		t.Error("expected converting log of wrong model to error")
 	}
 
-	ambiguousLog, err := tr.Book.bk.HeadRef(tr.Username)
+	ambiguousLog, err := tr.Book.store.HeadRef(tr.Ctx, tr.Username)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -415,7 +412,10 @@ func TestDatasetLogNaming(t *testing.T) {
 		},
 	}
 
-	got := tr.Book.RawLogs(tr.Ctx)
+	got, err := tr.Book.RawLogs(tr.Ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if diff := cmp.Diff(expect, got); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
@@ -428,7 +428,10 @@ func TestBookRawLog(t *testing.T) {
 
 	tr.WriteWorldBankExample(t)
 
-	got := tr.Book.RawLogs(tr.Ctx)
+	got, err := tr.Book.RawLogs(tr.Ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// data, err := json.MarshalIndent(got, "", "  ")
 	// if err != nil {
@@ -533,7 +536,7 @@ func TestLogTransfer(t *testing.T) {
 	tr.WriteWorldBankExample(t)
 	tr.WriteRenameExample(t)
 
-	log, err := tr.Book.UserDatasetRef(tr.WorldBankRef())
+	log, err := tr.Book.UserDatasetRef(tr.Ctx, tr.WorldBankRef())
 	if err != nil {
 		t.Error(err)
 	}
@@ -561,7 +564,7 @@ func TestLogTransfer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	revs, err := book2.Versions(tr.WorldBankRef(), 0, 30)
+	revs, err := book2.Versions(tr.Ctx, tr.WorldBankRef(), 0, 30)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -614,7 +617,7 @@ func TestVersions(t *testing.T) {
 	tr.WriteMoreWorldBankCommits(t)
 	book := tr.Book
 
-	versions, err := book.Versions(tr.WorldBankRef(), 0, 10)
+	versions, err := book.Versions(tr.Ctx, tr.WorldBankRef(), 0, 10)
 	if err != nil {
 		t.Error(err)
 	}
@@ -653,7 +656,7 @@ func TestVersions(t *testing.T) {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}
 
-	versions, err = book.Versions(tr.WorldBankRef(), 1, 1)
+	versions, err = book.Versions(tr.Ctx, tr.WorldBankRef(), 1, 1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -724,7 +727,7 @@ func TestConstructDatasetLog(t *testing.T) {
 	// now for the fun bit. When we ask for the state of the log, it will
 	// play our opsets forward and get us the current state of tne log
 	// we can also get the state of a log from the book:
-	versions, err := book.Versions(ref, 0, 100)
+	versions, err := book.Versions(tr.Ctx, ref, 0, 100)
 	if err != nil {
 		t.Errorf("getting versions: %s", err)
 	}

--- a/logbook/logbook_test.go
+++ b/logbook/logbook_test.go
@@ -879,11 +879,11 @@ func (tr *testRunner) WriteMoreWorldBankCommits(t *testing.T) {
 }
 
 func (tr *testRunner) RenameInitialRef() dsref.Ref {
-	return dsref.Ref{Username: tr.Book.bk.AuthorName(), Name: "dataset"}
+	return dsref.Ref{Username: tr.Book.AuthorName(), Name: "dataset"}
 }
 
 func (tr *testRunner) RenameRef() dsref.Ref {
-	return dsref.Ref{Username: tr.Book.bk.AuthorName(), Name: "renamed_dataset"}
+	return dsref.Ref{Username: tr.Book.AuthorName(), Name: "renamed_dataset"}
 }
 
 func (tr *testRunner) WriteRenameExample(t *testing.T) {
@@ -918,7 +918,7 @@ func (tr *testRunner) WriteRenameExample(t *testing.T) {
 	ds.PreviousPath = "QmHashOfVersion1"
 
 	// pretend we ran a cron job that created this version
-	ref := dsref.Ref{Username: book.bk.AuthorName(), Name: name}
+	ref := dsref.Ref{Username: book.AuthorName(), Name: name}
 	if err := book.WriteCronJobRan(tr.Ctx, 1, ref); err != nil {
 		t.Fatal(err)
 	}

--- a/logbook/logsync/http.go
+++ b/logbook/logsync/http.go
@@ -10,7 +10,7 @@ import (
 
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/qri-io/qri/dsref"
-	"github.com/qri-io/qri/logbook/oplog"
+	"github.com/qri-io/qri/identity"
 	"github.com/qri-io/qri/repo"
 )
 
@@ -24,7 +24,7 @@ type httpClient struct {
 var _ remote = (*httpClient)(nil)
 
 // Put
-func (c *httpClient) put(ctx context.Context, author oplog.Author, r io.Reader) error {
+func (c *httpClient) put(ctx context.Context, author identity.Author, r io.Reader) error {
 	req, err := http.NewRequest("PUT", c.URL, r)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (c *httpClient) put(ctx context.Context, author oplog.Author, r io.Reader) 
 	return nil
 }
 
-func (c *httpClient) get(ctx context.Context, author oplog.Author, ref dsref.Ref) (oplog.Author, io.Reader, error) {
+func (c *httpClient) get(ctx context.Context, author identity.Author, ref dsref.Ref) (identity.Author, io.Reader, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s?ref=%s", c.URL, ref), nil)
 	if err != nil {
 		return nil, nil, err
@@ -78,7 +78,7 @@ func (c *httpClient) get(ctx context.Context, author oplog.Author, ref dsref.Ref
 	return sender, res.Body, nil
 }
 
-func (c *httpClient) del(ctx context.Context, author oplog.Author, ref dsref.Ref) error {
+func (c *httpClient) del(ctx context.Context, author identity.Author, ref dsref.Ref) error {
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s?ref=%s", c.URL, ref), nil)
 	if err != nil {
 		return err
@@ -101,7 +101,7 @@ func (c *httpClient) del(ctx context.Context, author oplog.Author, ref dsref.Ref
 	return err
 }
 
-func addAuthorHTTPHeaders(h http.Header, author oplog.Author) error {
+func addAuthorHTTPHeaders(h http.Header, author identity.Author) error {
 	h.Set("ID", author.AuthorID())
 
 	pubByteStr, err := author.AuthorPubKey().Bytes()
@@ -112,7 +112,7 @@ func addAuthorHTTPHeaders(h http.Header, author oplog.Author) error {
 	return nil
 }
 
-func senderFromHTTPHeaders(h http.Header) (oplog.Author, error) {
+func senderFromHTTPHeaders(h http.Header) (identity.Author, error) {
 	data, err := base64.StdEncoding.DecodeString(h.Get("PubKey"))
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func senderFromHTTPHeaders(h http.Header) (oplog.Author, error) {
 		return nil, fmt.Errorf("decoding public key: %s", err)
 	}
 
-	return oplog.NewAuthor(h.Get("ID"), pub), nil
+	return identity.NewAuthor(h.Get("ID"), pub), nil
 }
 
 // HTTPHandler exposes a Dsync remote over HTTP by exposing a HTTP handler

--- a/logbook/logsync/http_test.go
+++ b/logbook/logsync/http_test.go
@@ -39,10 +39,10 @@ func TestSyncHTTP(t *testing.T) {
 	}
 
 	var expect, got []logbook.DatasetInfo
-	if expect, err = tr.A.Versions(ref, 0, 100); err != nil {
+	if expect, err = tr.A.Versions(tr.Ctx, ref, 0, 100); err != nil {
 		t.Error(err)
 	}
-	if got, err = tr.B.Versions(ref, 0, 100); err != nil {
+	if got, err = tr.B.Versions(tr.Ctx, ref, 0, 100); err != nil {
 		t.Error(err)
 	}
 
@@ -64,10 +64,10 @@ func TestSyncHTTP(t *testing.T) {
 		t.Error(err)
 	}
 
-	if expect, err = tr.B.Versions(worldBankRef, 0, 100); err != nil {
+	if expect, err = tr.B.Versions(tr.Ctx, worldBankRef, 0, 100); err != nil {
 		t.Error(err)
 	}
-	if got, err = tr.A.Versions(worldBankRef, 0, 100); err != nil {
+	if got, err = tr.A.Versions(tr.Ctx, worldBankRef, 0, 100); err != nil {
 		t.Error(err)
 	}
 	if diff := cmp.Diff(expect, got); diff != "" {
@@ -82,7 +82,7 @@ func TestSyncHTTP(t *testing.T) {
 		t.Errorf("delete err: %s", err)
 	}
 
-	if got, err = tr.A.Versions(worldBankRef, 0, 100); err == nil {
+	if got, err = tr.A.Versions(tr.Ctx, worldBankRef, 0, 100); err == nil {
 		t.Logf("%v\n", got)
 		t.Error("expected an err fetching removed reference")
 	}

--- a/logbook/logsync/logsync.go
+++ b/logbook/logsync/logsync.go
@@ -105,7 +105,7 @@ func (lsync *Logsync) NewPush(ref dsref.Ref, remoteAddr string) (*Push, error) {
 		return nil, ErrNoLogsync
 	}
 
-	rem, err := lsync.remoteClient(remoteAddr)
+	rem, err := lsync.remoteClient(context.TODO(), remoteAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (lsync *Logsync) NewPull(ref dsref.Ref, remoteAddr string) (*Pull, error) {
 		return nil, ErrNoLogsync
 	}
 
-	rem, err := lsync.remoteClient(remoteAddr)
+	rem, err := lsync.remoteClient(context.TODO(), remoteAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (lsync *Logsync) DoRemove(ctx context.Context, ref dsref.Ref, remoteAddr st
 		return ErrNoLogsync
 	}
 
-	rem, err := lsync.remoteClient(remoteAddr)
+	rem, err := lsync.remoteClient(ctx, remoteAddr)
 	if err != nil {
 		return err
 	}
@@ -150,13 +150,13 @@ func (lsync *Logsync) DoRemove(ctx context.Context, ref dsref.Ref, remoteAddr st
 	return rem.del(ctx, lsync.Author(), ref)
 }
 
-func (lsync *Logsync) remoteClient(remoteAddr string) (rem remote, err error) {
+func (lsync *Logsync) remoteClient(ctx context.Context, remoteAddr string) (rem remote, err error) {
 	if strings.HasPrefix(remoteAddr, "http") {
 		return &httpClient{URL: remoteAddr}, nil
 	}
 
 	// if we're given a logbook authorId, convert it to the active public key ID
-	if l, err := lsync.book.Log(remoteAddr); err == nil {
+	if l, err := lsync.book.Log(ctx, remoteAddr); err == nil {
 		remoteAddr = l.Author()
 	}
 
@@ -242,7 +242,7 @@ func (lsync *Logsync) get(ctx context.Context, author identity.Author, ref dsref
 		}
 	}
 
-	l, err := lsync.book.UserDatasetRef(ref)
+	l, err := lsync.book.UserDatasetRef(ctx, ref)
 	if err != nil {
 		return lsync.Author(), nil, err
 	}
@@ -293,7 +293,7 @@ type Push struct {
 
 // Do executes a push
 func (p *Push) Do(ctx context.Context) error {
-	log, err := p.book.UserDatasetRef(p.ref)
+	log, err := p.book.UserDatasetRef(ctx, p.ref)
 	if err != nil {
 		return err
 	}

--- a/logbook/logsync/logsync_test.go
+++ b/logbook/logsync/logsync_test.go
@@ -57,7 +57,7 @@ func Example() {
 	// johnathon creates a dataset with a bunch of history:
 	worldBankDatasetRef := makeWorldBankLogs(ctx, johnathonsLogbook)
 
-	ver, err := johnathonsLogbook.Versions(worldBankDatasetRef, 0, 100)
+	ver, err := johnathonsLogbook.Versions(ctx, worldBankDatasetRef, 0, 100)
 	if err != nil {
 		panic(err)
 	}
@@ -77,7 +77,7 @@ func Example() {
 
 	// wait for sync to complete
 	<-wait
-	if ver, err = basitsLogbook.Versions(worldBankDatasetRef, 0, 100); err != nil {
+	if ver, err = basitsLogbook.Versions(ctx, worldBankDatasetRef, 0, 100); err != nil {
 		panic(err)
 	}
 	fmt.Printf("basit has %d references for %s\n", len(ver), worldBankDatasetRef)
@@ -85,7 +85,7 @@ func Example() {
 	// this time basit creates a history
 	nasdaqDatasetRef := makeNasdaqLogs(ctx, basitsLogbook)
 
-	if ver, err = basitsLogbook.Versions(nasdaqDatasetRef, 0, 100); err != nil {
+	if ver, err = basitsLogbook.Versions(ctx, nasdaqDatasetRef, 0, 100); err != nil {
 		panic(err)
 	}
 	fmt.Printf("basit has %d references for %s\n", len(ver), nasdaqDatasetRef)
@@ -100,7 +100,7 @@ func Example() {
 		panic(err)
 	}
 
-	if ver, err = johnathonsLogbook.Versions(nasdaqDatasetRef, 0, 100); err != nil {
+	if ver, err = johnathonsLogbook.Versions(ctx, nasdaqDatasetRef, 0, 100); err != nil {
 		panic(err)
 	}
 	fmt.Printf("johnathon has %d references for %s\n", len(ver), nasdaqDatasetRef)

--- a/logbook/logsync/logsync_test.go
+++ b/logbook/logsync/logsync_test.go
@@ -402,7 +402,7 @@ func newTestbook(username string, pk crypto.PrivKey) (*logbook.Book, error) {
 	// logbook relies on a qfs.Filesystem for read & write. create an in-memory
 	// filesystem we can play with
 	fs := qfs.NewMemFS()
-	return logbook.NewBook(pk, username, fs, "/mem/logset")
+	return logbook.NewJournal(pk, username, fs, "/mem/logset")
 }
 
 func writeNasdaqLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, err error) {

--- a/logbook/logsync/logsync_test.go
+++ b/logbook/logsync/logsync_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/identity"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/logbook/oplog"
 )
@@ -34,14 +35,14 @@ func Example() {
 	basitLogsync := New(basitsLogbook, func(o *Options) {
 		// we MUST override the PreCheck function. In this example we're only going
 		// to allow pushes from johnathon
-		o.PushPreCheck = func(ctx context.Context, author oplog.Author, ref dsref.Ref, l *oplog.Log) error {
+		o.PushPreCheck = func(ctx context.Context, author identity.Author, ref dsref.Ref, l *oplog.Log) error {
 			if author.AuthorID() != johnathonsLogbook.Author().AuthorID() {
 				return fmt.Errorf("rejected for secret reasons")
 			}
 			return nil
 		}
 
-		o.Pushed = func(ctx context.Context, author oplog.Author, ref dsref.Ref, l *oplog.Log) error {
+		o.Pushed = func(ctx context.Context, author identity.Author, ref dsref.Ref, l *oplog.Log) error {
 			wait <- struct{}{}
 			return nil
 		}
@@ -116,7 +117,7 @@ func TestHookCalls(t *testing.T) {
 
 	hooksCalled := []string{}
 	callCheck := func(s string) Hook {
-		return func(ctx context.Context, a Author, ref dsref.Ref, l *oplog.Log) error {
+		return func(ctx context.Context, a identity.Author, ref dsref.Ref, l *oplog.Log) error {
 			hooksCalled = append(hooksCalled, s)
 			return nil
 		}
@@ -192,7 +193,7 @@ func TestHookErrors(t *testing.T) {
 
 	hooksCalled := []string{}
 	callCheck := func(s string) Hook {
-		return func(ctx context.Context, a Author, ref dsref.Ref, l *oplog.Log) error {
+		return func(ctx context.Context, a identity.Author, ref dsref.Ref, l *oplog.Log) error {
 			hooksCalled = append(hooksCalled, s)
 			return fmt.Errorf("hook failed")
 		}

--- a/logbook/logsync/p2p_test.go
+++ b/logbook/logsync/p2p_test.go
@@ -40,7 +40,12 @@ func TestP2PLogsync(t *testing.T) {
 	}
 
 	// pull logs to B from A
-	pull, err := lsB.NewPull(worldBankRef, tr.A.ActivePeerID(tr.Ctx))
+	aID, err := tr.A.ActivePeerID(tr.Ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pull, err := lsB.NewPull(worldBankRef, aID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,7 +68,12 @@ func TestP2PLogsync(t *testing.T) {
 	}
 
 	// push logs from A to B
-	push, err := lsA.NewPush(nasdaqRef, tr.B.ActivePeerID(tr.Ctx))
+	bID, err := tr.B.ActivePeerID(tr.Ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	push, err := lsA.NewPush(nasdaqRef, bID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +91,7 @@ func TestP2PLogsync(t *testing.T) {
 	}
 
 	// A request B removes nasdaq
-	if err := lsA.DoRemove(tr.Ctx, nasdaqRef, tr.B.ActivePeerID(tr.Ctx)); err != nil {
+	if err := lsA.DoRemove(tr.Ctx, nasdaqRef, bID); err != nil {
 		t.Errorf("unexpected error doing remove request: %s", err)
 	}
 	if _, err = tr.B.Versions(tr.Ctx, nasdaqRef, 0, 10); err == nil {

--- a/logbook/logsync/p2p_test.go
+++ b/logbook/logsync/p2p_test.go
@@ -40,7 +40,7 @@ func TestP2PLogsync(t *testing.T) {
 	}
 
 	// pull logs to B from A
-	pull, err := lsB.NewPull(worldBankRef, tr.A.ActivePeerID())
+	pull, err := lsB.NewPull(worldBankRef, tr.A.ActivePeerID(tr.Ctx))
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,7 +48,7 @@ func TestP2PLogsync(t *testing.T) {
 		t.Error(err)
 	}
 
-	vs, err := tr.B.Versions(worldBankRef, 0, 10)
+	vs, err := tr.B.Versions(tr.Ctx, worldBankRef, 0, 10)
 	if err != nil {
 		t.Errorf("expected no error fetching versions after pull. got: %s", err)
 	}
@@ -63,7 +63,7 @@ func TestP2PLogsync(t *testing.T) {
 	}
 
 	// push logs from A to B
-	push, err := lsA.NewPush(nasdaqRef, tr.B.ActivePeerID())
+	push, err := lsA.NewPush(nasdaqRef, tr.B.ActivePeerID(tr.Ctx))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestP2PLogsync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vs, err = tr.B.Versions(nasdaqRef, 0, 10)
+	vs, err = tr.B.Versions(tr.Ctx, nasdaqRef, 0, 10)
 	if err != nil {
 		t.Errorf("expected no error fetching versions after pull. got: %s", err)
 	}
@@ -81,10 +81,10 @@ func TestP2PLogsync(t *testing.T) {
 	}
 
 	// A request B removes nasdaq
-	if err := lsA.DoRemove(tr.Ctx, nasdaqRef, tr.B.ActivePeerID()); err != nil {
+	if err := lsA.DoRemove(tr.Ctx, nasdaqRef, tr.B.ActivePeerID(tr.Ctx)); err != nil {
 		t.Errorf("unexpected error doing remove request: %s", err)
 	}
-	if _, err = tr.B.Versions(nasdaqRef, 0, 10); err == nil {
+	if _, err = tr.B.Versions(tr.Ctx, nasdaqRef, 0, 10); err == nil {
 		t.Errorf("expected error fetching versions. got nil")
 	}
 }

--- a/logbook/oplog/log.fbs
+++ b/logbook/oplog/log.fbs
@@ -49,7 +49,7 @@ table Log {
 
 // Book is an author's journal of logs
 table Book {
-  name:string;        // book author name
+  name:string;        // book author name, not in use at the moment
   identifier:string;  // book author identifier
   logs:[Log];         // collection of logsets in this book
 }

--- a/logbook/oplog/log_bench_test.go
+++ b/logbook/oplog/log_bench_test.go
@@ -17,7 +17,9 @@ func BenchmarkSave10kOpsOneAuthor(b *testing.B) {
 
 	l := tr.RandomLog(init, 10000)
 	book := tr.Book
-	book.AppendLog(l)
+	if err := book.AppendLog(tr.Ctx, l); err != nil {
+		b.Fatal(err)
+	}
 
 	data, err := book.FlatbufferCipher(tr.PrivKey)
 	if err != nil {

--- a/logbook/oplog/log_bench_test.go
+++ b/logbook/oplog/log_bench_test.go
@@ -19,7 +19,7 @@ func BenchmarkSave10kOpsOneAuthor(b *testing.B) {
 	book := tr.Book
 	book.AppendLog(l)
 
-	data, err := book.FlatbufferCipher()
+	data, err := book.FlatbufferCipher(tr.PrivKey)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -27,7 +27,7 @@ func BenchmarkSave10kOpsOneAuthor(b *testing.B) {
 	b.Logf("one simulated log with 10k ops weighs %s as encrypted data", humanize.Bytes(uint64(len(data))))
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if _, err := book.FlatbufferCipher(); err != nil {
+		if _, err := book.FlatbufferCipher(tr.PrivKey); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/logbook/oplog/log_bench_test.go
+++ b/logbook/oplog/log_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkSave10kOpsOneAuthor(b *testing.B) {
 	}
 
 	l := tr.RandomLog(init, 10000)
-	book := tr.Book
+	book := tr.Journal
 	if err := book.AppendLog(tr.Ctx, l); err != nil {
 		b.Fatal(err)
 	}

--- a/logbook/oplog/log_bench_test.go
+++ b/logbook/oplog/log_bench_test.go
@@ -17,7 +17,7 @@ func BenchmarkSave10kOpsOneAuthor(b *testing.B) {
 
 	l := tr.RandomLog(init, 10000)
 	book := tr.Journal
-	if err := book.AppendLog(tr.Ctx, l); err != nil {
+	if err := book.MergeLog(tr.Ctx, l); err != nil {
 		b.Fatal(err)
 	}
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -324,7 +324,7 @@ func (r *Remote) pidAndRefFromMeta(meta map[string]string) (profile.ID, repo.Dat
 }
 
 func (r *Remote) logHook(h Hook) logsync.Hook {
-	return func(ctx context.Context, author logsync.Author, ref dsref.Ref, l *oplog.Log) error {
+	return func(ctx context.Context, author identity.Author, ref dsref.Ref, l *oplog.Log) error {
 		if h != nil {
 			kid, err := identity.KeyIDFromPub(author.AuthorPubKey())
 			if err != nil {

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -4,7 +4,6 @@ package fsrepo
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	golog "github.com/ipfs/go-log"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
@@ -42,7 +41,9 @@ type Repo struct {
 }
 
 // NewRepo creates a new file-based repository
-func NewRepo(store cafs.Filestore, fsys qfs.Filesystem, pro *profile.Profile, base string) (repo.Repo, error) {
+//
+// Deprecated: use CreateRepo instead
+func NewRepo(store cafs.Filestore, fsys qfs.Filesystem, book *logbook.Book, pro *profile.Profile, base string) (repo.Repo, error) {
 	if err := os.MkdirAll(base, os.ModePerm); err != nil {
 		return nil, err
 	}
@@ -51,13 +52,6 @@ func NewRepo(store cafs.Filestore, fsys qfs.Filesystem, pro *profile.Profile, ba
 	if pro.PrivKey == nil {
 		return nil, fmt.Errorf("Expected: PrivateKey")
 	}
-
-	book, err := logbook.NewBook(pro.PrivKey, pro.Peername, fsys, filepath.Join(base, "logbook.qfb"))
-	if err != nil {
-		log.Errorf("initializing logbook: %s", err)
-		return nil, err
-	}
-
 	r := &Repo{
 		profile: pro,
 

--- a/repo/fs/fs_test.go
+++ b/repo/fs/fs_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
 	"github.com/qri-io/qri/repo/test"
@@ -18,16 +19,22 @@ func TestRepo(t *testing.T) {
 
 	rmf := func(t *testing.T) (repo.Repo, func()) {
 		if err := os.RemoveAll(path); err != nil {
-			t.Fatalf("error removing files: %s", err.Error())
+			t.Fatalf("error removing files: %q", err)
 		}
 
 		pro, err := profile.NewProfile(config.DefaultProfileForTesting())
 		if err != nil {
-			t.Fatal(err.Error())
+			t.Fatal(err)
+		}
+
+		fs := qfs.NewMemFS()
+		book, err := logbook.NewJournal(pro.PrivKey, pro.Peername, fs, path)
+		if err != nil {
+			t.Fatal(err)
 		}
 
 		store := cafs.NewMapstore()
-		r, err := NewRepo(store, qfs.NewMemFS(), pro, path)
+		r, err := NewRepo(store, fs, book, pro, path)
 		if err != nil {
 			t.Fatalf("error creating repo: %s", err.Error())
 		}

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -27,7 +27,7 @@ type MemRepo struct {
 // TODO (b5) - need a better mem-repo constructor, we don't need a logbook for
 // all test cases
 func NewMemRepo(p *profile.Profile, store cafs.Filestore, fsys qfs.Filesystem, ps profile.Store) (*MemRepo, error) {
-	book, err := logbook.NewBook(p.PrivKey, p.Peername, fsys, "/map/logbook")
+	book, err := logbook.NewJournal(p.PrivKey, p.Peername, fsys, "/map/logbook")
 	if err != nil {
 		return nil, err
 	}

--- a/stats/cache.go
+++ b/stats/cache.go
@@ -39,7 +39,7 @@ var _ Cache = (*osCache)(nil)
 
 // NewOSCache creates a cache in a local direcory
 func NewOSCache(rootDir string, maxSize uint64) Cache {
-	if err := os.MkdirAll(rootDir, 0x667); err != nil {
+	if err := os.MkdirAll(rootDir, os.ModePerm); err != nil {
 		// log.Errorf("stat: %s", args ...interface{})
 	}
 	return osCache{


### PR DESCRIPTION
when initially implementing logbook, I'd intented for oplog to be a "thicker" API that had a strong notion of authorship. In practice the details of author attribution have happened at the logbook layer as as part of declarative method names. This refactor makes that change explicit, removing private key and author details from oplog.

I've also taken this chance to move the author stuff into the identity package, where it belongs. I'm sure the name "Author" will be refactored over time, but at least it's in the right place.