### PR TITLE
fix(remove): Remove works on foreign datasets, even if logbook missing

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -9,8 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TODO: Tests.
-
 // NewAddCommand creates an add command
 func NewAddCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &AddOptions{IOStreams: ioStreams}

--- a/remote/mock_client.go
+++ b/remote/mock_client.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/qri-io/dataset"
-	cfgtest "github.com/qri-io/qri/config/test"
 	"github.com/qri-io/qri/base/dsfs"
+	cfgtest "github.com/qri-io/qri/config/test"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
@@ -53,9 +53,8 @@ func (c *MockClient) AddDataset(ctx context.Context, ref *repo.DatasetRef, remot
 
 	// Construct a simple dataset
 	ds := dataset.Dataset{
-		Commit: &dataset.Commit {
-		},
-		Structure: &dataset.Structure {
+		Commit: &dataset.Commit{},
+		Structure: &dataset.Structure{
 			Format: "json",
 			Schema: dataset.BaseSchemaObject,
 		},


### PR DESCRIPTION
When removing a dataset, ignore logbook "not found" errors, since we're removing the dataset anyway, it doesn't matter if something is missing. Fmt the mock_client added in the previous PR.