### PR TITLE
fix(fsi): When working directory is moved or deleted, update FSI Path

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -45,12 +45,17 @@ type CheckoutOptions struct {
 
 // Complete configures the checkout command
 func (o *CheckoutOptions) Complete(f Factory, args []string) (err error) {
-	o.Refs, err = GetCurrentRefSelect(f, args, 1)
+	o.FSIMethods, err = f.FSIMethods()
 	if err != nil {
 		return err
 	}
-	o.FSIMethods, err = f.FSIMethods()
-	return err
+
+	o.Refs, err = GetCurrentRefSelect(f, args, 1, o.FSIMethods)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Run executes the `checkout` command

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -84,11 +84,14 @@ func (o *DiffOptions) Complete(f Factory, args []string) (err error) {
 		}
 	}
 	o.DatasetRequests, err = f.DatasetRequests()
-
-	if o.Refs, err = GetCurrentRefSelect(f, args, 2); err != nil {
-		return
+	if err != nil {
+		return err
 	}
-	return
+
+	if o.Refs, err = GetCurrentRefSelect(f, args, 2, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Run executes the diff command

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -65,7 +65,7 @@ type ExportOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *ExportOptions) Complete(f Factory, args []string) (err error) {
-	if o.Refs, err = GetCurrentRefSelect(f, args, 1); err != nil {
+	if o.Refs, err = GetCurrentRefSelect(f, args, 1, nil); err != nil {
 		if err != repo.ErrEmptyRef {
 			return err
 		}

--- a/cmd/fsi.go
+++ b/cmd/fsi.go
@@ -63,16 +63,19 @@ func (o *FSIOptions) Complete(f Factory, args []string) (err error) {
 	if len(args) < 1 {
 		return fmt.Errorf("please provide the name of a dataset")
 	}
-	if o.Refs, err = GetCurrentRefSelect(f, args, -1); err != nil {
-		return
+	o.FSIMethods, err = f.FSIMethods()
+	if err != nil {
+		return err
+	}
+	if o.Refs, err = GetCurrentRefSelect(f, args, -1, o.FSIMethods); err != nil {
+		return err
 	}
 
 	if len(args) > 1 {
 		o.Path = args[1]
 	}
 
-	o.FSIMethods, err = f.FSIMethods()
-	return err
+	return nil
 }
 
 // Link creates a FSI link

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -93,7 +93,7 @@ func (o *GetOptions) Complete(f Factory, args []string) (err error) {
 			args = args[1:]
 		}
 	}
-	if o.Refs, err = GetCurrentRefSelect(f, args, -1); err != nil {
+	if o.Refs, err = GetCurrentRefSelect(f, args, -1, nil); err != nil {
 		return
 	}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -111,6 +111,7 @@ func (o *ListOptions) Run() (err error) {
 		Offset:          page.Offset(),
 		Published:       o.Published,
 		ShowNumVersions: o.ShowNumVersions,
+		EnsureFSIExists: true,
 	}
 	if err = o.DatasetRequests.List(p, &refs); err != nil {
 		return err

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -61,7 +61,7 @@ type LogOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *LogOptions) Complete(f Factory, args []string) (err error) {
-	if o.Refs, err = GetCurrentRefSelect(f, args, 1); err != nil {
+	if o.Refs, err = GetCurrentRefSelect(f, args, 1, nil); err != nil {
 		return err
 	}
 	o.LogRequests, err = f.LogRequests()
@@ -154,7 +154,7 @@ func (o *LogbookOptions) Complete(f Factory, args []string) (err error) {
 			return fmt.Errorf("can't use dataset reference. the raw flag shows the entire logbook")
 		}
 	} else {
-		if o.Refs, err = GetCurrentRefSelect(f, args, 1); err != nil {
+		if o.Refs, err = GetCurrentRefSelect(f, args, 1, nil); err != nil {
 			return err
 		}
 	}

--- a/cmd/ref_select_test.go
+++ b/cmd/ref_select_test.go
@@ -143,7 +143,7 @@ func TestGetCurrentRefSelect(t *testing.T) {
 	defer os.Chdir(pwd)
 
 	// Explicit argument
-	refs, err := GetCurrentRefSelect(f, []string{"me/explicit_ds"}, -1)
+	refs, err := GetCurrentRefSelect(f, []string{"me/explicit_ds"}, -1, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -157,7 +157,7 @@ func TestGetCurrentRefSelect(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	refs, err = GetCurrentRefSelect(f, []string{}, -1)
+	refs, err = GetCurrentRefSelect(f, []string{}, -1, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -166,7 +166,7 @@ func TestGetCurrentRefSelect(t *testing.T) {
 	}
 
 	// Explicit has higher precedence than linked
-	refs, err = GetCurrentRefSelect(f, []string{"me/explicit_ds"}, -1)
+	refs, err = GetCurrentRefSelect(f, []string{"me/explicit_ds"}, -1, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -180,7 +180,7 @@ func TestGetCurrentRefSelect(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	refs, err = GetCurrentRefSelect(f, []string{}, -1)
+	refs, err = GetCurrentRefSelect(f, []string{}, -1, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -192,7 +192,7 @@ func TestGetCurrentRefSelect(t *testing.T) {
 	os.Remove(filepath.Join(workPath, ".qri-ref"))
 
 	// Use dataset
-	refs, err = GetCurrentRefSelect(f, []string{}, -1)
+	refs, err = GetCurrentRefSelect(f, []string{}, -1, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -201,7 +201,7 @@ func TestGetCurrentRefSelect(t *testing.T) {
 	}
 
 	// Explicit has higher precedence than use dataset
-	refs, err = GetCurrentRefSelect(f, []string{"me/explicit_ds"}, -1)
+	refs, err = GetCurrentRefSelect(f, []string{"me/explicit_ds"}, -1, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -218,7 +218,7 @@ func TestGetCurrentRefSelectUsingTwoArgs(t *testing.T) {
 	}
 
 	// If two are allowed, refs be have length 2
-	refs, err := GetCurrentRefSelect(f, []string{"me/first_ds", "me/second_ds"}, 2)
+	refs, err := GetCurrentRefSelect(f, []string{"me/first_ds", "me/second_ds"}, 2, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -71,7 +71,7 @@ func (o *RemoveOptions) Complete(f Factory, args []string) (err error) {
 	if o.DatasetRequests, err = f.DatasetRequests(); err != nil {
 		return err
 	}
-	if o.Refs, err = GetCurrentRefSelect(f, args, -1); err != nil {
+	if o.Refs, err = GetCurrentRefSelect(f, args, -1, nil); err != nil {
 		return err
 	}
 	if o.All {

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -66,10 +66,10 @@ func (o *RenderOptions) Complete(f Factory, args []string) (err error) {
 	if o.RenderRequests, err = f.RenderRequests(); err != nil {
 		return err
 	}
-	if o.Refs, err = GetCurrentRefSelect(f, args, 1); err != nil {
+	if o.Refs, err = GetCurrentRefSelect(f, args, 1, nil); err != nil {
 		return err
 	}
-	return
+	return nil
 }
 
 // Run executes the render command

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -89,12 +89,13 @@ func (o *RestoreOptions) Complete(f Factory, args []string) (err error) {
 		return fmt.Errorf("unknown argument \"%s\"", arg)
 	}
 
-	o.Refs, err = GetCurrentRefSelect(f, dsRefList, 1)
-	if err != nil {
+	if o.FSIMethods, err = f.FSIMethods(); err != nil {
 		return err
 	}
-	o.FSIMethods, err = f.FSIMethods()
-	return err
+	if o.Refs, err = GetCurrentRefSelect(f, dsRefList, 1, o.FSIMethods); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Run executes the `restore` command

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -108,7 +108,7 @@ func (o *SaveOptions) Complete(f Factory, args []string) (err error) {
 		return
 	}
 
-	if o.Refs, err = GetCurrentRefSelect(f, args, 1); err != nil {
+	if o.Refs, err = GetCurrentRefSelect(f, args, 1, nil); err != nil {
 		// Not an error to use an empty reference, it will be inferred later on.
 		if err != repo.ErrEmptyRef {
 			return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -50,13 +50,17 @@ type StatusOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *StatusOptions) Complete(f Factory, args []string) (err error) {
-	o.Refs, err = GetCurrentRefSelect(f, args, 1)
+	o.FSIMethods, err = f.FSIMethods()
 	if err != nil {
 		return err
 	}
 
-	o.FSIMethods, err = f.FSIMethods()
-	return
+	o.Refs, err = GetCurrentRefSelect(f, args, 1, o.FSIMethods)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ColumnPositionForMtime is the column position at which to display mod times, if requested

--- a/cmd/test_runner.go
+++ b/cmd/test_runner.go
@@ -108,6 +108,18 @@ func (run *TestRunner) MustReadFile(t *testing.T, filename string) string {
 	return string(bytes)
 }
 
+// Must asserts that the function result passed to it is not an error
+func (run *TestRunner) Must(t *testing.T, err error) {
+	if err != nil {
+		_, callerFile, callerLine, ok := runtime.Caller(1)
+		if !ok {
+			t.Fatal(err)
+		} else {
+			t.Fatalf("%s:%d: %s", callerFile, callerLine, err)
+		}
+	}
+}
+
 // GetCommandOutput returns the standard output from the previously executed command
 func (run *TestRunner) GetCommandOutput() string {
 	return run.RepoRoot.GetOutput()

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -96,7 +96,7 @@ func (o *ValidateOptions) Complete(f Factory, args []string) (err error) {
 		return
 	}
 
-	o.Refs, err = GetCurrentRefSelect(f, args, 1)
+	o.Refs, err = GetCurrentRefSelect(f, args, 1, nil)
 	if err == repo.ErrEmptyRef {
 		// It is not an error to call validate without a dataset reference. Might be
 		// validating a body file against a schema file directly.

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -62,30 +62,6 @@ func (m *FSIMethods) CreateLink(p *LinkParams, res *string) (err error) {
 	return err
 }
 
-// ModifyLink changes an existing link by either updating the ref for a directory, or vice versa
-func (m *FSIMethods) ModifyLink(p *LinkParams, res *bool) (err error) {
-	// absolutize path name
-	path, err := filepath.Abs(p.Dir)
-	if err != nil {
-		return err
-	}
-
-	p.Dir = path
-
-	if m.inst.rpc != nil {
-		return m.inst.rpc.Call("FSIMethods.ModifyLink", p, res)
-	}
-
-	if p.ToModify == "dir" {
-		*res = true
-		return m.inst.fsi.ModifyLinkDirectory(p.Dir, p.Ref)
-	} else if p.ToModify == "ref" {
-		*res = true
-		return m.inst.fsi.ModifyLinkReference(p.Dir, p.Ref)
-	}
-	return fmt.Errorf("ToModify has unknown value %q", p.ToModify)
-}
-
 // Unlink rmeoves a connection between a working drirectory and a dataset history
 func (m *FSIMethods) Unlink(p *LinkParams, res *string) (err error) {
 	if m.inst.rpc != nil {
@@ -394,4 +370,19 @@ func (m *FSIMethods) InitDataset(p *InitFSIDatasetParams, name *string) (err err
 
 	*name, err = m.inst.fsi.InitDataset(*p)
 	return err
+}
+
+// EnsureParams holds values for EnsureRef call
+type EnsureParams struct {
+	Dir string
+	Ref string
+}
+
+// EnsureRef will modify the directory path in the repo for the given reference
+func (m *FSIMethods) EnsureRef(p *EnsureParams, out *bool) error {
+	if m.inst.rpc != nil {
+		return m.inst.rpc.Call("FSIMethods.EnsureRef", p, out)
+	}
+
+	return m.inst.fsi.ModifyLinkDirectory(p.Dir, p.Ref)
 }

--- a/lib/params.go
+++ b/lib/params.go
@@ -29,6 +29,8 @@ type ListParams struct {
 	Published bool
 	// ShowNumVersions only applies to listing datasets
 	ShowNumVersions bool
+	// EnsureFSIExists controls whether to ensure references in the repo have correct FSIPaths
+	EnsureFSIExists bool
 }
 
 // NewListParams creates a ListParams from page & pagesize, pages are 1-indexed

--- a/repo/ref.go
+++ b/repo/ref.go
@@ -115,6 +115,33 @@ func (r DatasetRef) String() (s string) {
 	return
 }
 
+// DebugString returns a string that describes every field in the reference, useful for tests
+func (r DatasetRef) DebugString() string {
+	builder := strings.Builder{}
+	builder.WriteString("{peername:")
+	builder.WriteString(r.Peername)
+	builder.WriteString(",profileID:")
+	builder.WriteString(r.ProfileID.String())
+	builder.WriteString(",name:")
+	builder.WriteString(r.Name)
+	if r.Path != "" {
+		builder.WriteString(",path:")
+		builder.WriteString(r.Path)
+	}
+	if r.FSIPath != "" {
+		builder.WriteString(",fsiPath:")
+		builder.WriteString(r.FSIPath)
+	}
+	if r.Published {
+		builder.WriteString(",published:true")
+	}
+	if r.Foreign {
+		builder.WriteString(",foreign:true")
+	}
+	builder.WriteString("}")
+	return builder.String()
+}
+
 // Absolute implements the same thing as String(), but append ProfileID if it exist
 func (r DatasetRef) Absolute() (s string) {
 	s = r.AliasString()


### PR DESCRIPTION
Whenever the user manually moves or deletes a working directory, we get into a situation where the fsiPath in the qri repo is now out of date with the .qri-ref (or lack thereof) in that working directory. We should detect this situation as best we can. For now, if the user runs another command in the folder's new location, use that opportunity to update the fsiPath. Or, if the user runs `qri list`, check the folders in the repo's references to make sure everything is still properly linked. In the future, we can watch the file system to make this process more reliable. But for now, this establishes the .qri-ref linkfile as the primary source of truth.

Fixes https://github.com/qri-io/qri/issues/938 and https://github.com/qri-io/qri/issues/890