### PR TITLE
feat(doggo): Setup flag that only creates a nick and displays it

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -58,6 +58,7 @@ including all your datasets, and de-registers your peername from the registry.`,
 	cmd.Flags().StringVarP(&o.Peername, "peername", "", "", "choose your desired peername")
 	cmd.Flags().StringVarP(&o.IPFSConfigData, "ipfs-config", "", "", "json-encoded configuration data, specify a filepath with '@' prefix")
 	cmd.Flags().StringVarP(&o.ConfigData, "config-data", "", "", "json-encoded configuration data, specify a filepath with '@' prefix")
+	cmd.Flags().BoolVar(&o.GimmeDoggo, "gimme-doggo", false, "create and display a doggo name only")
 
 	return cmd
 }
@@ -74,6 +75,7 @@ type SetupOptions struct {
 	Registry       string
 	IPFSConfigData string
 	ConfigData     string
+	GimmeDoggo     bool
 
 	QriRepoPath string
 	IpfsFsPath  string
@@ -90,6 +92,10 @@ func (o *SetupOptions) Complete(f Factory, args []string) (err error) {
 
 // Run executes the setup command
 func (o *SetupOptions) Run(f Factory) error {
+	if o.GimmeDoggo {
+		return o.CreateAndDisplayDoggo()
+	}
+
 	if o.Remove {
 		cfg, err := f.Config()
 		if err != nil {
@@ -205,6 +211,14 @@ func (o *SetupOptions) DoSetup(f Factory) (err error) {
 		break
 	}
 	return f.Init()
+}
+
+// CreateAndDisplayDoggo creates and display a doggo name
+func (o *SetupOptions) CreateAndDisplayDoggo() error {
+	_, peerID := o.Generator.GeneratePrivateKeyAndPeerID()
+	dognick := o.Generator.GenerateNickname(peerID)
+	printSuccess(o.Out, dognick)
+	return nil
 }
 
 // QRIRepoInitialized checks to see if a repository has been initialized at $QRI_PATH

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/qri-io/ioes"
 )
 
@@ -21,4 +22,14 @@ func TestSetupComplete(t *testing.T) {
 	}
 
 	opt.Complete(f, nil)
+}
+
+func TestSetupGimmeDoggo(t *testing.T) {
+	run := NewTestRunner(t, "test_peer", "")
+
+	actual := run.MustExec(t, "qri setup --gimme-doggo")
+	expect := "testnick\n"
+	if diff := cmp.Diff(expect, actual); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
 }


### PR DESCRIPTION
We need to create a doggo nickname during the release process, in order to name the release. It takes a bit of effort to do so (make a temporary directory, set environment variables, run `qri setup`, cleanup the temp), so this makes it easier by removing some steps.