### PR TITLE
fix(validate): Improve validate so it works with FSI

### DIFF
--- a/base/validate_test.go
+++ b/base/validate_test.go
@@ -3,6 +3,8 @@ package base
 import (
 	"context"
 	"testing"
+
+	"github.com/qri-io/qri/base/dsfs"
 )
 
 func TestValidate(t *testing.T) {
@@ -10,7 +12,17 @@ func TestValidate(t *testing.T) {
 	r := newTestRepo(t)
 	cities := addCitiesDataset(t, r)
 
-	errs, err := Validate(ctx, r, cities, nil, nil)
+	ds, err := dsfs.LoadDataset(ctx, r.Store(), cities.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = OpenDataset(ctx, r.Filesystem(), ds); err != nil {
+		t.Fatal(err)
+	}
+	body := ds.BodyFile()
+
+	errs, err := Validate(ctx, r, body, ds.Structure)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,9 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	golog "github.com/ipfs/go-log"
@@ -120,13 +118,4 @@ func parseCmdLineDatasetRef(ref string) (repo.DatasetRef, error) {
 		ref = "me/" + ref
 	}
 	return repo.ParseDatasetRef(ref)
-}
-
-// currentPath is used for test purposes to get the path from which qri is executing
-func currentPath() (string, bool) {
-	_, filename, _, ok := runtime.Caller(1)
-	if !ok {
-		return "", ok
-	}
-	return path.Dir(filename), true
 }

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -120,12 +120,6 @@ func TestSaveRun(t *testing.T) {
 		return
 	}
 
-	_, ok := currentPath()
-	if !ok {
-		t.Errorf("error getting path to current folder")
-		return
-	}
-
 	cases := []struct {
 		description string
 		ref         string

--- a/cmd/testdata/movies/schema_only.json
+++ b/cmd/testdata/movies/schema_only.json
@@ -1,0 +1,15 @@
+{
+  "type": "array",
+  "items": {
+    "items": [
+      {
+        "title": "name",
+        "type": "string"
+      },
+      {
+        "title": "duration",
+        "type": "integer"
+      }
+    ]
+  }
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -21,27 +21,27 @@ func NewValidateCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 			"group": "dataset",
 		},
 		Long: `
-Validate checks data for errors using a schema and then printing a list of 
-issues. By default validate checks a dataset's body against it’s own schema. 
-Validate is a flexible command that works with data and schemas either 
-inside or outside of qri by providing one or both of --body and --schema 
-arguments. 
+Validate checks data for errors using a schema and then printing a list of
+issues. By default validate checks a dataset's body against it’s own schema.
+Validate is a flexible command that works with data and schemas either
+inside or outside of qri by providing the --body and --schema or --structure
+flags.
 
-Providing --schema and --body is an “external validation" that uses nothing 
-stored in qri. When only one of schema or body args are provided, the other 
-comes from a dataset reference. For example, to check how a file “data.csv” 
-validates against a dataset "foo”, we would run:
+Providing either --schema or --structure and --body is an “external
+validation" that uses nothing stored in qri. When only one of these flags,
+are provided, the other comes from a dataset reference. For example, to
+check how a file “data.csv” validates against a dataset "foo”, we would run:
 
   $ qri validate --body data.csv me/foo
 
 In this case, qri will will print any validation as if data.csv was foo’s data.
 
-To see how changes to a schema will validate against a 
-dataset in qri, we would run:
+To see how changes to a schema will validate against a dataset in qri, we
+would run:
 
   $ qri validate --schema schema.json me/foo
 
-In this case, qri will print validation errors as if stucture.json was the
+In this case, qri will print validation errors as if schema.json was the
 schema for dataset "me/foo"
 
 Using validate this way is a great way to see how changes to data or schema
@@ -50,7 +50,8 @@ will affect a dataset before saving changes to a dataset.
 You can get the current schema of a dataset by running the ` + "`qri get structure.schema`" + `
 command.
 
-Note: --body and --schema flags will override the dataset if both flags are provided.`,
+Note: --body and --schema or --structure flags will override the dataset
+if these flags are provided.`,
 		Example: `  # show errors in an existing dataset:
   qri validate b5/comics
 
@@ -71,6 +72,7 @@ Note: --body and --schema flags will override the dataset if both flags are prov
 	// cmd.Flags().StringVarP(&o.URL, "url", "u", "", "url to file to initialize from")
 	cmd.Flags().StringVarP(&o.BodyFilepath, "body", "b", "", "body file to validate")
 	cmd.Flags().StringVarP(&o.SchemaFilepath, "schema", "", "", "json schema file to use for validation")
+	cmd.Flags().StringVarP(&o.StructureFilepath, "structure", "", "", "json structure file to use for validation")
 
 	return cmd
 }
@@ -79,10 +81,11 @@ Note: --body and --schema flags will override the dataset if both flags are prov
 type ValidateOptions struct {
 	ioes.IOStreams
 
-	Refs           *RefSelect
-	BodyFilepath   string
-	SchemaFilepath string
-	URL            string
+	Refs              *RefSelect
+	BodyFilepath      string
+	SchemaFilepath    string
+	StructureFilepath string
+	URL               string
 
 	DatasetRequests *lib.DatasetRequests
 }
@@ -115,9 +118,10 @@ func (o *ValidateOptions) Run() (err error) {
 		Ref: ref,
 		// TODO: restore
 		// URL:          addDsURL,
-		BodyFilename:   o.BodyFilepath,
-		SchemaFilename: o.SchemaFilepath,
-		UseFSI:         o.Refs.IsLinked(),
+		BodyFilename:      o.BodyFilepath,
+		SchemaFilename:    o.SchemaFilepath,
+		StructureFilename: o.StructureFilepath,
+		UseFSI:            o.Refs.IsLinked(),
 	}
 
 	res := []jsonschema.ValError{}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -70,12 +70,6 @@ func TestValidateRun(t *testing.T) {
 		return
 	}
 
-	path, ok := currentPath()
-	if !ok {
-		t.Errorf("error getting path to current folder")
-		return
-	}
-
 	cases := []struct {
 		description    string
 		ref            string
@@ -91,8 +85,8 @@ func TestValidateRun(t *testing.T) {
 		// {"", "", "", "url", "", "bad arguments provided", "if you are validating data from a url, please include a dataset name or supply the --schema flag with a file path that Qri can validate against"},
 		{"movie problems", "peer/movies", "", "", "", movieOutput, "", ""},
 		{"dataset not found", "peer/bad_dataset", "", "", "", "", "cannot find dataset: peer/bad_dataset", ""},
-		{"body file not found", "", "bad/filepath", "testdata/days_of_week_schema.json", "", "", "open " + path + "/bad/filepath: no such file or directory", "error opening body file: could not open " + path + "/bad/filepath: no such file or directory"},
-		{"schema file not found", "", "testdata/days_of_week.csv", "bad/schema_filepath", "", "", "open " + path + "/bad/schema_filepath: no such file or directory", "error opening schema file: could not open " + path + "/bad/schema_filepath: no such file or directory"},
+		{"body file not found", "", "bad/filepath", "testdata/days_of_week_schema.json", "", "", "error opening body file: bad/filepath", ""},
+		{"schema file not found", "", "testdata/days_of_week.csv", "bad/schema_filepath", "", "", "error opening schema file: bad/schema_filepath", ""},
 		{"validate successfully", "", "testdata/days_of_week.csv", "testdata/days_of_week_schema.json", "", "✔ All good!\n", "", ""},
 		// TODO: pull from url
 	}

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -237,8 +237,19 @@ func newTestRunner(t *testing.T) (tr *testRunner, cleanup func()) {
 
 func (tr *testRunner) writeFile(t *testing.T, filename, data string) (path string) {
 	path = filepath.Join(tr.Dir, filename)
-	if err := ioutil.WriteFile(path, []byte(data), 0x777); err != nil {
+	if err := ioutil.WriteFile(path, []byte(data), 0644); err != nil {
 		t.Fatal(err)
 	}
 	return path
 }
+
+func (tr *testRunner) MustWriteFile(t *testing.T, filename, data string) {
+	if err := ioutil.WriteFile(filename, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (tr *testRunner) MakeFilename(filename string) (path string) {
+	return filepath.Join(tr.Dir, filename)
+}
+


### PR DESCRIPTION
FSI broke validate because we switched from schema.json back to structure.json. The old functionality was looking specifically for schema.json (in the cmd package, no less) and did not survive this change. Instead, we should use the FSI package which correctly finds relevant component files.

Cleanup the lower levels of how validate works. Before, it was converting things back and forth, between cmd -> lib -> base -> dataset -> jsonschema. No need to do all of that unnecessary work.