### PR TITLE
fix(log): Add --log-all flag to enable logging everywhere

### DIFF
--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/rpc"
+	"os"
 	"sync"
 
 	"github.com/qri-io/ioes"
@@ -37,6 +38,7 @@ https://github.com/qri-io/qri/issues`,
 	cmd.PersistentFlags().BoolVarP(&opt.NoColor, "no-color", "", false, "disable colorized output")
 	cmd.PersistentFlags().StringVar(&opt.RepoPath, "repo", qriPath, "provide a path to load qri from")
 	cmd.PersistentFlags().StringVar(&opt.IpfsPath, "ipfs-path", ipfsPath, "override IPFS path location")
+	cmd.PersistentFlags().BoolVarP(&opt.LogAll, "log-all", "", false, "log all activity")
 
 	cmd.AddCommand(
 		NewAddCommand(opt, ioStreams),
@@ -98,6 +100,8 @@ type QriOptions struct {
 	NoColor bool
 	// path to configuration object
 	ConfigPath string
+	// Whether to log all activity by enabling logging for all packages
+	LogAll bool
 
 	inst        *lib.Instance
 	initialized sync.Once
@@ -121,8 +125,10 @@ func (o *QriOptions) Init() (err error) {
 			lib.OptIOStreams(o.IOStreams), // transfer iostreams to instance
 			lib.OptSetIPFSPath(o.IpfsPath),
 			lib.OptCheckConfigMigrations(""),
+			lib.OptSetLogAll(o.LogAll),
 		}
 		o.inst, err = lib.NewInstance(o.ctx, o.RepoPath, opts...)
+		log.Debugf("running cmd %q", os.Args)
 	}
 	o.initialized.Do(initBody)
 	return

--- a/fsi/fsi.go
+++ b/fsi/fsi.go
@@ -115,6 +115,8 @@ func (fsi *FSI) CreateLink(dirPath, refStr string) (alias string, rollback func(
 		}
 	}
 
+	// Link the FSIPath to the reference before putting it into the repo
+	log.Debugf("fsi.CreateLink: linking ref=%q, FSIPath=%q", ref, dirPath)
 	ref.FSIPath = dirPath
 	if err = fsi.repo.PutRef(ref); err != nil {
 		return "", rollback, err
@@ -133,9 +135,9 @@ func (fsi *FSI) CreateLink(dirPath, refStr string) (alias string, rollback func(
 	}
 	// If future steps fail, remove the link file we just wrote to
 	removeLinkAndRemoveRefFunc := func() {
-		log.Debugf("removing linkFile \"%s\" during rollback", linkFile)
+		log.Debugf("removing linkFile %q during rollback", linkFile)
 		if err := os.Remove(linkFile); err != nil {
-			log.Debugf("error while removing linkFile %s: \"%s\"", linkFile, err)
+			log.Debugf("error while removing linkFile %q: %s", linkFile, err)
 		}
 		removeRefFunc()
 	}
@@ -160,6 +162,7 @@ func (fsi *FSI) ModifyLinkDirectory(dirPath, refStr string) error {
 		return nil
 	}
 
+	log.Debugf("fsi.ModifyLinkDirectory: modify ref=%q, FSIPath was %q, changing to %q", ref, ref.FSIPath, dirPath)
 	ref.FSIPath = dirPath
 	return fsi.repo.PutRef(ref)
 }
@@ -175,6 +178,7 @@ func (fsi *FSI) ModifyLinkReference(dirPath, refStr string) error {
 		return err
 	}
 
+	log.Debugf("fsi.ModifyLinkReference: modify linkfile at %q, ref=%q", dirPath, ref)
 	if _, err = writeLinkFile(dirPath, ref.AliasString()); err != nil {
 		return err
 	}
@@ -250,6 +254,7 @@ func DeleteComponentFiles(dir string) error {
 		}
 		err = os.Remove(comp.Base().SourceFile)
 		if err != nil {
+			log.Errorf("deleting file %q, error: %s", comp.Base().SourceFile, err)
 			return err
 		}
 	}

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -106,6 +106,7 @@ type InstanceOptions struct {
 	regclient  *regclient.Client
 	statsCache *stats.Cache
 	logbook    *logbook.Book
+	logAll     bool
 
 	remoteMockClient bool
 	// use OptRemoteOptions to set this
@@ -189,6 +190,14 @@ func OptCheckConfigMigrations(cfgPath string) Option {
 		if migrated {
 			return o.Cfg.WriteToFile(cfgPath)
 		}
+		return nil
+	}
+}
+
+// OptSetLogAll sets the logAll value so that logging is enabled for all packages
+func OptSetLogAll(logAll bool) Option {
+	return func(o *InstanceOptions) error {
+		o.logAll = logAll
 		return nil
 	}
 }
@@ -304,6 +313,16 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		for name, level := range cfg.Logging.Levels {
 			golog.SetLogLevel(name, level)
 		}
+	}
+
+	// if logAll is enabled, turn on logging for all packages. Packages need to be explicitly
+	// enumerated here
+	if o.logAll {
+		allPackages := []string{"qriapi", "qrip2p", "base", "cmd", "config", "dsref", "fsi", "lib", "logbook", "repo"}
+		for _, name := range allPackages {
+			golog.SetLogLevel(name, "debug")
+		}
+		log.Debugf("--log-all set: turning on logging for all activity")
 	}
 
 	if inst.cron, err = newCron(cfg, inst.repoPath); err != nil {

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -194,7 +194,7 @@ func OptCheckConfigMigrations(cfgPath string) Option {
 	}
 }
 
-// OptSetLogAll sets the logAll value so that logging is enabled for all packages
+// OptSetLogAll sets the logAll value so that debug level logging is enabled for all qri packages
 func OptSetLogAll(logAll bool) Option {
 	return func(o *InstanceOptions) error {
 		o.logAll = logAll
@@ -315,8 +315,8 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		}
 	}
 
-	// if logAll is enabled, turn on logging for all packages. Packages need to be explicitly
-	// enumerated here
+	// if logAll is enabled, turn on debug level logging for all qri packages. Packages need to
+	// be explicitly enumerated here
 	if o.logAll {
 		allPackages := []string{"qriapi", "qrip2p", "base", "cmd", "config", "dsref", "fsi", "lib", "logbook", "repo"}
 		for _, name := range allPackages {


### PR DESCRIPTION
The --log-all flag can be used by Desktop to log more information to the default file we create at startup. Add logging to lib.Get errors and fsi.Checkout so we can check errors that occur in the wild.