### PR TITLE
fix(logbook): use AddChild instead of directly appending to oplog.Log.Logs

### DIFF
--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -306,10 +306,10 @@ func (book Book) initName(ctx context.Context, name string) *oplog.Log {
 		Timestamp: NewTimestamp(),
 	})
 
-	dsLog.Logs = append(dsLog.Logs, branch)
+	dsLog.AddChild(branch)
 
-	ns := book.authorLog(ctx)
-	ns.Logs = append(ns.Logs, dsLog)
+	nameLog := book.authorLog(ctx)
+	nameLog.AddChild(dsLog)
 	return branch
 }
 
@@ -564,10 +564,9 @@ func (book Book) UserDatasetRef(ctx context.Context, ref dsref.Ref) (*oplog.Log,
 	}
 
 	// construct a sparse oplog of just user, dataset, and branches
-	return &oplog.Log{
-		Ops:  author.Ops,
-		Logs: []*oplog.Log{ds},
-	}, nil
+	sparseLog := &oplog.Log{Ops: author.Ops}
+	sparseLog.AddChild(ds)
+	return sparseLog, nil
 }
 
 // DatasetRef gets a dataset log and all branches. Dataset logs describe
@@ -605,7 +604,10 @@ func (book Book) BranchRef(ctx context.Context, ref dsref.Ref) (*oplog.Log, erro
 
 // LogBytes signs a log with this book's private key and writes to a flatbuffer
 func (book Book) LogBytes(log *oplog.Log) ([]byte, error) {
-	return log.SignedFlatbufferBytes(book.pk)
+	if err := log.Sign(book.pk); err != nil {
+		return nil, err
+	}
+	return log.FlatbufferBytes(), nil
 }
 
 // DsrefAliasForLog parses log data into a dataset alias reference, populating

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -97,9 +97,9 @@ type Book struct {
 	fs         qfs.Filesystem
 }
 
-// NewBook creates a book with an unattributed logstore
-func NewBook(store oplog.Logstore) *Book {
-	return &Book{store: store}
+// NewBook creates a book with a user-provided logstore
+func NewBook(pk crypto.PrivKey, store oplog.Logstore) *Book {
+	return &Book{pk: pk, store: store}
 }
 
 // NewJournal initializes a logbook owned by a single author, reading any

--- a/logbook/oplog/log.go
+++ b/logbook/oplog/log.go
@@ -529,7 +529,7 @@ LOOP:
 			}
 		}
 		// no match, append!
-		lg.Logs = append(lg.Logs, x)
+		lg.AddChild(x)
 	}
 }
 
@@ -567,16 +567,12 @@ func (lg Log) SigningBytes() []byte {
 	return hasher.Sum(nil)
 }
 
-// SignedFlatbufferBytes signs a log then marshals it to a flatbuffer
-func (lg Log) SignedFlatbufferBytes(pk crypto.PrivKey) ([]byte, error) {
-	if err := lg.Sign(pk); err != nil {
-		return nil, err
-	}
-
+// FlatbufferBytes marshals a log to flabuffer-formatted bytes
+func (lg Log) FlatbufferBytes() []byte {
 	builder := flatbuffers.NewBuilder(0)
 	log := lg.MarshalFlatbuffer(builder)
 	builder.Finish(log)
-	return builder.FinishedBytes(), nil
+	return builder.FinishedBytes()
 }
 
 // MarshalFlatbuffer writes log to a flatbuffer, returning the ending byte

--- a/logbook/oplog/log.go
+++ b/logbook/oplog/log.go
@@ -35,7 +35,7 @@ var (
 // Logstore persists a set of operations organized into hierarchical append-only
 // logs
 type Logstore interface {
-	// Merge adds a Log to the store, controlling for conflicts
+	// MergeLog adds a Log to the store, controlling for conflicts
 	// * logs that are already known to the store are merged with a
 	//   longest-log-wins strategy, adding all descendants
 	// * new top level logs are appended to the store, including all descendants

--- a/logbook/oplog/log_test.go
+++ b/logbook/oplog/log_test.go
@@ -192,10 +192,10 @@ func TestJournalSignLog(t *testing.T) {
 	}, 400)
 
 	pk := tr.PrivKey
-	data, err := lg.SignedFlatbufferBytes(pk)
-	if err != nil {
+	if err := lg.Sign(pk); err != nil {
 		t.Fatal(err)
 	}
+	data := lg.FlatbufferBytes()
 
 	received, err := FromFlatbufferBytes(data)
 	if err != nil {
@@ -274,6 +274,8 @@ func TestLogNameTracking(t *testing.T) {
 	}
 }
 
+// NB: This test currently doesn't / can't confirm merging sets Log.parent.
+// the cmp package can't deal with cyclic references
 func TestLogMerge(t *testing.T) {
 	left := &Log{
 		Signature: []byte{1, 2, 3},
@@ -383,7 +385,7 @@ func TestLogMerge(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(expect, left, allowUnexported); diff != "" {
+	if diff := cmp.Diff(expect, left, allowUnexported, cmpopts.IgnoreUnexported(Log{})); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
ensures parent property is set correctly