### PR TITLE
feat(remote): ephemeral log fetching with remoteClient.FetchLogs

### DIFF
--- a/api/remote.go
+++ b/api/remote.go
@@ -42,11 +42,13 @@ func (h *RemoteClientHandlers) NewFetchHandler(prefix string) http.HandlerFunc {
 			Ref:        ref.String(),
 			RemoteName: r.FormValue("remote"),
 		}
-		var res repo.DatasetRef
+		res := []lib.DatasetLogItem{}
 		if err := h.Fetch(p, &res); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
+
+		util.WriteResponse(w, res)
 	}
 }
 

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -49,7 +49,7 @@ func (s Server) ServeWebsocket(ctx context.Context) {
 					InsecureSkipVerify: true,
 				})
 				if err != nil {
-					log.Infof("Websocket accept error: %s", err)
+					log.Debugf("Websocket accept error: %s", err)
 					return
 				}
 				connections = append(connections, c)

--- a/base/hidden_file_windows.go
+++ b/base/hidden_file_windows.go
@@ -36,13 +36,13 @@ func WriteHiddenFile(path, content string) error {
 		return err
 	}
 	h, err := syscall.CreateFile(
-		filenamePtr, // filename
+		filenamePtr,           // filename
 		syscall.GENERIC_WRITE, // access
-		uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE), // share mode
-		nil, // security attributes
-		syscall.CREATE_ALWAYS, // creation disposition
+		uint32(syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE), // share mode
+		nil,                           // security attributes
+		syscall.CREATE_ALWAYS,         // creation disposition
 		syscall.FILE_ATTRIBUTE_HIDDEN, // flags and attributes
-		0, // template file handle
+		0,                             // template file handle
 	)
 	if err != nil {
 		return err

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -34,6 +34,7 @@ the name of the peer that originally added the dataset. You must have
 	}
 
 	cmd.Flags().StringVar(&o.LinkDir, "link", "", "path to directory to link dataset to")
+	cmd.Flags().BoolVar(&o.LogsOnly, "logs-only", false, "only fetch logs, skipping HEAD data")
 
 	return cmd
 }
@@ -42,6 +43,7 @@ the name of the peer that originally added the dataset. You must have
 type AddOptions struct {
 	ioes.IOStreams
 	LinkDir         string
+	LogsOnly        bool
 	DatasetRequests *lib.DatasetRequests
 }
 
@@ -67,8 +69,9 @@ func (o *AddOptions) Run(args []string) error {
 
 	for _, arg := range args {
 		p := &lib.AddParams{
-			Ref:     arg,
-			LinkDir: o.LinkDir,
+			Ref:      arg,
+			LinkDir:  o.LinkDir,
+			LogsOnly: o.LogsOnly,
 		}
 
 		res := repo.DatasetRef{}

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/qri-io/ioes"
-	repotest "github.com/qri-io/qri/repo/test"
 	regmock "github.com/qri-io/qri/registry/regserver"
+	repotest "github.com/qri-io/qri/repo/test"
 )
 
 func TestConnect(t *testing.T) {

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/lib"
-	repotest "github.com/qri-io/qri/repo/test"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/gen"
 	"github.com/qri-io/qri/repo/test"
+	repotest "github.com/qri-io/qri/repo/test"
 )
 
 // TestFactory is an implementation of the Factory interface for testing purposes

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/lib"
-	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +54,7 @@ func (o *FetchOptions) Complete(f Factory, args []string) (err error) {
 
 // Run executes the fetch command
 func (o *FetchOptions) Run() error {
-	var res repo.DatasetRef
+	res := []lib.DatasetLogItem{}
 	for _, ref := range o.Refs {
 		p := lib.FetchParams{
 			Ref:        ref,
@@ -62,7 +63,13 @@ func (o *FetchOptions) Run() error {
 		if err := o.RemoteMethods.Fetch(&p, &res); err != nil {
 			return err
 		}
-		printInfo(o.Out, "fetched dataset %s", res)
+
+		items := make([]fmt.Stringer, len(res))
+		for i, r := range res {
+			items[i] = dslogItemStringer(r)
+		}
+
+		printItems(o.Out, items, 0)
 	}
 	return nil
 }

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -75,12 +75,4 @@ func TestFetchCommand(t *testing.T) {
 
 	text = b.GetCommandOutput()
 	t.Logf("%s", text)
-
-	cmdBr = b.CreateCommandRunner(ctx)
-	if err = executeCommand(cmdBr, "qri log peer_a/test_movies"); err != nil {
-		t.Fatal(err)
-	}
-
-	text = b.GetCommandOutput()
-	t.Logf("expect log: '%s'", text)
 }

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -831,6 +831,7 @@ type AddParams struct {
 	Ref        string
 	LinkDir    string
 	RemoteAddr string // remote to attempt to pull from
+	LogsOnly   bool   // only fetch logbook data
 }
 
 // Add adds an existing dataset to a peer's repository
@@ -853,12 +854,9 @@ func (r *DatasetRequests) Add(p *AddParams, res *repo.DatasetRef) (err error) {
 		p.RemoteAddr = r.inst.cfg.Registry.Location
 	}
 
-	// TODO (b5) - we're early in log syncronization days. This is going to fail a bunch
-	// while we work to upgrade the stack. Long term we may want to consider a mechanism
-	// for allowing partial completion where only one of logs or dataset pulling works
-	// by doing both in parallel and reporting issues on both
-	if pullLogsErr := r.inst.RemoteClient().PullLogs(ctx, repo.ConvertToDsref(ref), p.RemoteAddr); pullLogsErr != nil {
-		log.Errorf("pulling logs: %s", pullLogsErr)
+	mergeLogsError := r.inst.RemoteClient().CloneLogs(ctx, repo.ConvertToDsref(ref), p.RemoteAddr)
+	if p.LogsOnly {
+		return mergeLogsError
 	}
 
 	if err = r.inst.RemoteClient().AddDataset(ctx, &ref, p.RemoteAddr); err != nil {

--- a/logbook/logsync/http_test.go
+++ b/logbook/logsync/http_test.go
@@ -33,8 +33,9 @@ func TestSyncHTTP(t *testing.T) {
 	if err != nil {
 		t.Errorf("creating pull: %s", err)
 	}
+	pull.Merge = true
 
-	if err := pull.Do(tr.Ctx); err != nil {
+	if _, err := pull.Do(tr.Ctx); err != nil {
 		t.Fatalf("pulling nasdaq logs %s", err.Error())
 	}
 

--- a/logbook/logsync/logsync_test.go
+++ b/logbook/logsync/logsync_test.go
@@ -95,8 +95,10 @@ func Example() {
 	if err != nil {
 		panic(err)
 	}
+	// setting merge=true will persist logs to the logbook if the pull succeeds
+	pull.Merge = true
 
-	if err = pull.Do(ctx); err != nil {
+	if _, err = pull.Do(ctx); err != nil {
 		panic(err)
 	}
 
@@ -147,7 +149,9 @@ func TestHookCalls(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := pull.Do(tr.Ctx); err != nil {
+	pull.Merge = true
+
+	if _, err := pull.Do(tr.Ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -225,7 +229,9 @@ func TestHookErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := pull.Do(tr.Ctx); err == nil {
+	pull.Merge = true
+
+	if _, err := pull.Do(tr.Ctx); err == nil {
 		t.Fatal(err)
 	}
 	push, err := lsB.NewPush(worldBankRef, s.URL)
@@ -257,7 +263,9 @@ func TestHookErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := pull.Do(tr.Ctx); err != nil {
+	pull.Merge = true
+
+	if _, err := pull.Do(tr.Ctx); err != nil {
 		t.Fatal(err)
 	}
 	push, err = lsB.NewPush(worldBankRef, s.URL)

--- a/logbook/logsync/p2p_test.go
+++ b/logbook/logsync/p2p_test.go
@@ -49,7 +49,9 @@ func TestP2PLogsync(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if err := pull.Do(tr.Ctx); err != nil {
+	pull.Merge = true
+
+	if _, err := pull.Do(tr.Ctx); err != nil {
 		t.Error(err)
 	}
 

--- a/remote/client.go
+++ b/remote/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/logbook/oplog"
 	"github.com/qri-io/qri/repo"
 )
 
@@ -17,7 +18,8 @@ type Client interface {
 	AddDataset(ctx context.Context, ref *repo.DatasetRef, remoteAddr string) error
 
 	PushLogs(ctx context.Context, ref dsref.Ref, remoteAddr string) error
-	PullLogs(ctx context.Context, ref dsref.Ref, remoteAddr string) error
+	FetchLogs(ctx context.Context, ref dsref.Ref, remoteAddr string) (*oplog.Log, error)
+	CloneLogs(ctx context.Context, ref dsref.Ref, remoteAddr string) error
 	RemoveLogs(ctx context.Context, ref dsref.Ref, remoteAddr string) error
 
 	ResolveHeadRef(ctx context.Context, ref *repo.DatasetRef, remoteAddr string) error

--- a/remote/mock_client.go
+++ b/remote/mock_client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/qri-io/qri/base/dsfs"
 	cfgtest "github.com/qri-io/qri/config/test"
 	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/logbook/oplog"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
@@ -36,8 +37,13 @@ func (c *MockClient) PushDataset(ctx context.Context, ref repo.DatasetRef, remot
 	return ErrNotImplemented
 }
 
-// PullLogs is not implemented
-func (c *MockClient) PullLogs(ctx context.Context, ref dsref.Ref, remoteAddr string) error {
+// FetchLogs is not implemented
+func (c *MockClient) FetchLogs(ctx context.Context, ref dsref.Ref, remoteAddr string) (*oplog.Log, error) {
+	return nil, ErrNotImplemented
+}
+
+// CloneLogs is not implemented
+func (c *MockClient) CloneLogs(ctx context.Context, ref dsref.Ref, remoteAddr string) error {
 	return ErrNotImplemented
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -93,7 +93,7 @@ func TestDatasetPullPushDeleteHTTP(t *testing.T) {
 		t.Errorf("resolve mismatch. expected:\n%s\ngot:\n%s", worldBankRef, relRef)
 	}
 
-	if err := cli.PullLogs(tr.Ctx, repo.ConvertToDsref(*relRef), server.URL); err != nil {
+	if _, err := cli.FetchLogs(tr.Ctx, repo.ConvertToDsref(*relRef), server.URL); err != nil {
 		t.Error(err)
 	}
 	if err := cli.PullDataset(tr.Ctx, &worldBankRef, server.URL); err != nil {


### PR DESCRIPTION
we need a way to fetch logs & _not_ persist them. This does that.

I've also added a --logs-only flag to add which brings back the old fetch behaviour of persisting logs on fetch. Long term I'd like to merge all log pulling into "qri log" (for ephemeral fetching) and "qri clone" (for persisted fetching)