### PR TITLE
fix(logbook): addChild should not create duplicate children

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -17,7 +17,9 @@ github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cB
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
 github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
@@ -967,6 +969,7 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -60,10 +60,10 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	PublishToRegistry(t, nasim, ref.AliasString())
 
 	// 7. hinshun logsyncs with the registry for world bank dataset, sees multiple versions
-	// TODO (b5) - this needs a lib method
-	regAddress := tr.RegistryHTTPServer.URL
-	if err := hinshun.RemoteClient().PullLogs(tr.Ctx, repo.ConvertToDsref(*ref), regAddress); err != nil {
-		t.Errorf("pulling logs: %s", err)
+	dsm := NewDatasetRequestsInstance(hinshun)
+	res := &repo.DatasetRef{}
+	if err := dsm.Add(&AddParams{LogsOnly: true, Ref: ref.String()}, res); err != nil {
+		t.Errorf("cloning logs: %s", err)
 	}
 
 	if err := AssertLogsEqual(nasim, hinshun, ref); err != nil {


### PR DESCRIPTION
follow up to #1082, which contains a build error 😢.

This test found a nasty bug that crops out of recent refactoring work. Logsync fetches were producing logs with multiple children that have the same ID. This is caused by the recent `AddChild` switch. To fix the issue, I've added a check in `oplog.AddChild` that does a miniature version of merging: checking for an ID match & using the log with more operations.

There's a better fix for this, but we have divergent behaviour between two implementations of oplog.Logstore that need to be reconciled first. One implementation fetches children, the other doesn't. This creates problems.