### PR TITLE
fix(dscache): Add refs in dsref that logbook is missing. More tests.

### DIFF
--- a/dscache/logbook_temp_builder_test.go
+++ b/dscache/logbook_temp_builder_test.go
@@ -53,6 +53,15 @@ func (b *Builder) DatasetRename(ctx context.Context, t *testing.T, ref dsref.Ref
 	return dsref.Ref{Username: b.AuthorName, Name: newName, Path: ref.Path}
 }
 
+// DatasetDelete deletes a dataset
+func (b *Builder) DatasetDelete(ctx context.Context, t *testing.T, ref dsref.Ref) {
+	b.ensureAuthorAllowed(t, ref.Username)
+	if err := b.Book.WriteDatasetDelete(ctx, ref); err != nil {
+		t.Fatal(err)
+	}
+	delete(b.Dsrefs, ref.Name)
+}
+
 // Commit adds a commit to a dataset
 func (b *Builder) Commit(ctx context.Context, t *testing.T, ref dsref.Ref, title, ipfsHash string) dsref.Ref {
 	b.ensureAuthorAllowed(t, ref.Username)


### PR DESCRIPTION
Our repos may contain datasets that are in dsref but not in logbook. This can happen from datasets created before logbook was implemented, or due to deleting logbook (which was necessary to work around bugs for a little while), or from the registry not syncing logs yet. For now, such dsrefs should still be added to dscache, but this behavior will not be needed in the future once we move over to dscache all the time.

Also add some more tests for dscache building, which eliminates a few TODOs.