### PR TITLE
feat(dscache): Dscache will get updated by save, if it exists in the repo

### DIFF
--- a/base/save.go
+++ b/base/save.go
@@ -200,8 +200,17 @@ func CreateDataset(ctx context.Context, r repo.Repo, streams ioes.IOStreams, ds,
 	ds.ProfileID = pro.ID.String()
 	ds.Peername = pro.Peername
 	ds.Path = path
-	if err = r.Logbook().WriteVersionSave(ctx, ds); err != nil && err != logbook.ErrNoLogbook {
+	action, err := r.Logbook().WriteVersionSave(ctx, ds)
+	if err != nil && err != logbook.ErrNoLogbook {
 		return
+	}
+	dscache := r.Dscache()
+	if dscache != nil && !dscache.IsEmpty() {
+		log.Info("dscache: update and save new version")
+		err = dscache.Update(action)
+		if err != nil {
+			log.Error(err)
+		}
 	}
 
 	if err = ReadDataset(ctx, r, &ref); err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -59,7 +59,7 @@ must have ` + "`qri connect`" + ` running in a separate terminal window.`,
 	cmd.Flags().BoolVarP(&o.ShowNumVersions, "num-versions", "n", false, "show number of versions")
 	cmd.Flags().StringVar(&o.Peername, "peer", "", "peer whose datasets to list")
 	cmd.Flags().BoolVarP(&o.Raw, "raw", "r", false, "to show raw references")
-	cmd.Flags().BoolVarP(&o.ViaDscache, "via-dscache", "", false, "build and use dscache to list")
+	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "build and use dscache to list")
 
 	return cmd
 }
@@ -76,7 +76,7 @@ type ListOptions struct {
 	Published       bool
 	ShowNumVersions bool
 	Raw             bool
-	ViaDscache      bool
+	UseDscache      bool
 
 	DatasetRequests *lib.DatasetRequests
 }
@@ -98,7 +98,7 @@ func (o *ListOptions) Run() (err error) {
 	if o.Raw {
 		var text string
 		p := &lib.ListParams{
-			ViaDscache: o.ViaDscache,
+			UseDscache: o.UseDscache,
 		}
 		if err = o.DatasetRequests.ListRawRefs(p, &text); err != nil {
 			return err
@@ -116,7 +116,7 @@ func (o *ListOptions) Run() (err error) {
 		Published:       o.Published,
 		ShowNumVersions: o.ShowNumVersions,
 		EnsureFSIExists: true,
-		ViaDscache:      o.ViaDscache,
+		UseDscache:      o.UseDscache,
 	}
 	if err = o.DatasetRequests.List(p, &refs); err != nil {
 		return err

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/base/dsfs"
+	"github.com/qri-io/qri/dscache"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/registry"
 	"github.com/qri-io/qri/registry/regserver"
@@ -166,6 +167,15 @@ func (run *TestRunner) DatasetMarshalJSON(t *testing.T, ref string) (data string
 		t.Fatal(err)
 	}
 	return data
+}
+
+// Dscache returns the dscache from the repo
+func (run *TestRunner) Dscache(t *testing.T) *dscache.Dscache {
+	repo, err := run.RepoRoot.Repo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo.Dscache()
 }
 
 // MustExec runs a command, returning standard output, failing the test if there's an error

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/base/dsfs"
-	"github.com/qri-io/qri/dscache"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/registry"
 	"github.com/qri-io/qri/registry/regserver"
@@ -167,15 +166,6 @@ func (run *TestRunner) DatasetMarshalJSON(t *testing.T, ref string) (data string
 		t.Fatal(err)
 	}
 	return data
-}
-
-// Dscache returns the dscache from the repo
-func (run *TestRunner) Dscache(t *testing.T) *dscache.Dscache {
-	repo, err := run.RepoRoot.Repo()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return repo.Dscache()
 }
 
 // MustExec runs a command, returning standard output, failing the test if there's an error

--- a/dscache/build/from_repo.go
+++ b/dscache/build/from_repo.go
@@ -1,0 +1,25 @@
+package build
+
+import (
+	"context"
+
+	"github.com/qri-io/qri/dscache"
+	"github.com/qri-io/qri/repo"
+)
+
+// DscacheFromRepo creates a dscache, building it from the repo's logbook and profiles and dsrefs.
+func DscacheFromRepo(ctx context.Context, r repo.Repo) (*dscache.Dscache, error) {
+	num, err := r.RefCount()
+	if err != nil {
+		return nil, err
+	}
+	refs, err := r.References(0, num)
+	if err != nil {
+		return nil, err
+	}
+	profiles := r.Profiles()
+	logbook := r.Logbook()
+	store := r.Store()
+	filesys := r.Filesystem()
+	return dscache.BuildDscacheFromLogbookAndProfilesAndDsref(ctx, refs, profiles, logbook, store, filesys)
+}

--- a/dscache/dscache.go
+++ b/dscache/dscache.go
@@ -1,13 +1,17 @@
 package dscache
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
 
+	flatbuffers "github.com/google/flatbuffers/go"
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/dataset"
+	"github.com/qri-io/qfs"
 	dscachefb "github.com/qri-io/qri/dscache/dscachefb"
+	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/repo/profile"
 	reporef "github.com/qri-io/qri/repo/ref"
 )
@@ -18,28 +22,48 @@ var (
 
 // Dscache represents an in-memory serialized dscache flatbuffer
 type Dscache struct {
+	Filename            string
 	Root                *dscachefb.Dscache
 	Buffer              []byte
 	ProfileIDToUsername map[string]string
 }
 
-// LoadDscacheFromFile will load a dscache from the given filename
-func LoadDscacheFromFile(filename string) (*Dscache, error) {
-	buffer, err := ioutil.ReadFile(filename)
+// NewDscache will construct a dscache from the given file, or will construct an empty dscache
+// that will save to the given filename
+func NewDscache(fsys qfs.Filesystem, filename string) *Dscache {
+	ctx := context.TODO()
+	f, err := fsys.Get(ctx, filename)
 	if err != nil {
-		return nil, err
+		// Ignore error, as dscache loading is optional
+		return &Dscache{Filename: filename}
+	}
+	defer f.Close()
+	buffer, err := ioutil.ReadAll(f)
+	if err != nil {
+		// Ignore error, as dscache loading is optional
+		return &Dscache{Filename: filename}
 	}
 	root := dscachefb.GetRootAsDscache(buffer, 0)
-	return &Dscache{Root: root, Buffer: buffer}, nil
+	return &Dscache{Filename: filename, Root: root, Buffer: buffer}
 }
 
-// SaveTo writes the serialized bytes to the given filename
-func (d *Dscache) SaveTo(filename string) error {
-	return ioutil.WriteFile(filename, d.Buffer, 0644)
+// IsEmpty returns whether the dscache has any constructed data in it
+func (d *Dscache) IsEmpty() bool {
+	return d.Root == nil
+}
+
+// Assign assigns the data from one dscache to this one
+func (d *Dscache) Assign(other *Dscache) error {
+	d.Root = other.Root
+	d.Buffer = other.Buffer
+	return d.save()
 }
 
 // VerboseString is a convenience function that returns a readable string, for testing and debugging
 func (d *Dscache) VerboseString(showEmpty bool) string {
+	if d.IsEmpty() {
+		return "dscache: cannot not stringify an empty dscache"
+	}
 	out := strings.Builder{}
 	out.WriteString("Dscache:\n")
 	out.WriteString(" Dscache.Users:\n")
@@ -126,6 +150,57 @@ func (d *Dscache) ListRefs() ([]reporef.DatasetRef, error) {
 	return refs, nil
 }
 
+// Update modifies the dscache according to the provided action.
+func (d *Dscache) Update(act *logbook.Action) error {
+	if d.IsEmpty() {
+		return fmt.Errorf("dscache: cannot Update an empty dscache")
+	}
+
+	if act.Type != logbook.ActionMoveCursor {
+		return fmt.Errorf("dscache: only ActionMoveCursor is supported")
+	}
+
+	// Flatbuffers for go do not allow mutation (for complex types like strings). So we construct
+	// a new flatbuffer entirely, copying the old one while replacing the entry we care to change.
+	builder := flatbuffers.NewBuilder(0)
+	users := d.copyUserAssociationList(builder)
+	refs := d.copyReferenceListWithReplacement(
+		builder,
+		func(r *dscachefb.RefCache) bool {
+			return string(r.InitID()) == act.InitID
+		},
+		func(refStartMutationFunc func(builder *flatbuffers.Builder)) {
+			var metaTitle flatbuffers.UOffsetT
+			if act.Dataset != nil && act.Dataset.Meta != nil {
+				metaTitle = builder.CreateString(act.Dataset.Meta.Title)
+			}
+			hashRef := builder.CreateString(string(act.HeadRef))
+			// Start building a ref object, by mutating an existing ref object.
+			refStartMutationFunc(builder)
+			// Add only the fields we want to change.
+			dscachefb.RefCacheAddTopIndex(builder, int32(act.TopIndex))
+			dscachefb.RefCacheAddCursorIndex(builder, int32(act.TopIndex))
+			if act.Dataset != nil && act.Dataset.Meta != nil {
+				dscachefb.RefCacheAddMetaTitle(builder, metaTitle)
+			}
+			if act.Dataset != nil && act.Dataset.Commit != nil {
+				dscachefb.RefCacheAddCommitTime(builder, act.Dataset.Commit.Timestamp.Unix())
+			}
+			if act.Dataset != nil && act.Dataset.Structure != nil {
+				dscachefb.RefCacheAddBodySize(builder, int64(act.Dataset.Structure.Length))
+				dscachefb.RefCacheAddBodyRows(builder, int32(act.Dataset.Structure.Entries))
+				dscachefb.RefCacheAddNumErrors(builder, int32(act.Dataset.Structure.ErrCount))
+			}
+			dscachefb.RefCacheAddHeadRef(builder, hashRef)
+			// Don't call RefCacheEnd, that is handled by copyReferenceListWithReplacement
+		},
+	)
+	root, serialized := d.finishBuilding(builder, users, refs)
+	d.Root = root
+	d.Buffer = serialized
+	return d.save()
+}
+
 func (d *Dscache) ensureProToUserMap() {
 	if d.ProfileIDToUsername != nil {
 		return
@@ -138,4 +213,13 @@ func (d *Dscache) ensureProToUserMap() {
 		profileID := userAssoc.ProfileID()
 		d.ProfileIDToUsername[string(profileID)] = string(username)
 	}
+}
+
+// save writes the serialized bytes to the given filename
+func (d *Dscache) save() error {
+	if d.Filename == "" {
+		log.Infof("dscache: no filename set, will not save")
+		return nil
+	}
+	return ioutil.WriteFile(d.Filename, d.Buffer, 0644)
 }

--- a/dscache/dscache_test.go
+++ b/dscache/dscache_test.go
@@ -1,5 +1,33 @@
 package dscache
 
-// TODO(dlong): Test LoadDscacheFromFile
-// TODO(dlong): Test SaveTo
-// TODO(dlong): Test ListRefs
+import (
+	"strings"
+	"testing"
+
+	"github.com/qri-io/qri/logbook"
+)
+
+// TODO(dlong): Test NewDscache, IsEmpty, Assign, ListRefs, Update
+
+func TestNilCallable(t *testing.T) {
+	var (
+		cache *Dscache
+		err   error
+	)
+
+	if !cache.IsEmpty() {
+		t.Errorf("expected IsEmpty: got !IsEmpty")
+	}
+	if err = cache.Assign(&Dscache{}); err != ErrNoDscache {
+		t.Errorf("expected '%s': got '%s'", ErrNoDscache, err)
+	}
+	if str := cache.VerboseString(true); !strings.Contains(str, "empty dscache") {
+		t.Errorf("expected str to Contain 'empty dscache': got '%s'", str)
+	}
+	if _, err = cache.ListRefs(); err != ErrNoDscache {
+		t.Errorf("expected '%s': got '%s'", ErrNoDscache, err)
+	}
+	if err = cache.Update(&logbook.Action{}); err != ErrNoDscache {
+		t.Errorf("expected '%s': got '%s'", ErrNoDscache, err)
+	}
+}

--- a/dscache/logbook_temp_builder_test.go
+++ b/dscache/logbook_temp_builder_test.go
@@ -75,7 +75,7 @@ func (b *Builder) Commit(ctx context.Context, t *testing.T, ref dsref.Ref, title
 		Path:         ipfsHash,
 		PreviousPath: ref.Path,
 	}
-	if err := b.Book.WriteVersionSave(ctx, &ds); err != nil {
+	if _, err := b.Book.WriteVersionSave(ctx, &ds); err != nil {
 		t.Fatal(err)
 	}
 	b.Dsrefs[ref.Name] = append(b.Dsrefs[ref.Name], ipfsHash)

--- a/dscache/mutator.go
+++ b/dscache/mutator.go
@@ -1,0 +1,101 @@
+package dscache
+
+import (
+	flatbuffers "github.com/google/flatbuffers/go"
+	dscachefb "github.com/qri-io/qri/dscache/dscachefb"
+)
+
+func (d *Dscache) copyUserAssociationList(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	userList := make([]flatbuffers.UOffsetT, 0, d.Root.UsersLength())
+	for i := 0; i < d.Root.UsersLength(); i++ {
+		up := dscachefb.UserAssoc{}
+		d.Root.Users(&up, i)
+		d.copyUserAssoc(builder, &up)
+		user := dscachefb.UserAssocEnd(builder)
+		userList = append(userList, user)
+	}
+	dscachefb.DscacheStartUsersVector(builder, len(userList))
+	for i := len(userList) - 1; i >= 0; i-- {
+		u := userList[i]
+		builder.PrependUOffsetT(u)
+	}
+	return builder.EndVector(len(userList))
+}
+
+func (d *Dscache) copyReferenceListWithReplacement(
+	builder *flatbuffers.Builder,
+	findMatchFunc func(*dscachefb.RefCache) bool,
+	replaceRefFunc func(func(*flatbuffers.Builder))) flatbuffers.UOffsetT {
+
+	// Construct refs, with all pertinent information for each dataset ref
+	refList := make([]flatbuffers.UOffsetT, 0, d.Root.RefsLength())
+	for i := 0; i < d.Root.RefsLength(); i++ {
+		r := dscachefb.RefCache{}
+		d.Root.Refs(&r, i)
+		// Check if this entry is the one that we want to modify.
+		if findMatchFunc(&r) {
+			// This is due to the flatbuffers API being a bit awkward to use.
+			// The replace func may want to create some slots (such as strings) before the
+			// builder starts on construction. This means we can't call copyReference now, instead,
+			// pass it as a func to the callback, let it start construction when it is ready.
+			startRefBuildFunc := func(_ *flatbuffers.Builder) {
+				d.copyReference(builder, &r)
+			}
+			replaceRefFunc(startRefBuildFunc)
+			ref := dscachefb.RefCacheEnd(builder)
+			refList = append(refList, ref)
+			continue
+		}
+		d.copyReference(builder, &r)
+		ref := dscachefb.RefCacheEnd(builder)
+		refList = append(refList, ref)
+	}
+	dscachefb.DscacheStartRefsVector(builder, len(refList))
+	for i := len(refList) - 1; i >= 0; i-- {
+		r := refList[i]
+		builder.PrependUOffsetT(r)
+	}
+	return builder.EndVector(len(refList))
+}
+
+func (d *Dscache) finishBuilding(builder *flatbuffers.Builder, users, refs flatbuffers.UOffsetT) (*dscachefb.Dscache, []byte) {
+	dscachefb.DscacheStart(builder)
+	dscachefb.DscacheAddUsers(builder, users)
+	dscachefb.DscacheAddRefs(builder, refs)
+	cache := dscachefb.DscacheEnd(builder)
+	builder.Finish(cache)
+	serialized := builder.FinishedBytes()
+	return dscachefb.GetRootAsDscache(serialized, 0), serialized
+}
+
+func (d *Dscache) copyUserAssoc(builder *flatbuffers.Builder, ua *dscachefb.UserAssoc) {
+	username := builder.CreateString(string(ua.Username()))
+	profileID := builder.CreateString(string(ua.ProfileID()))
+	dscachefb.UserAssocStart(builder)
+	dscachefb.UserAssocAddUsername(builder, username)
+	dscachefb.UserAssocAddProfileID(builder, profileID)
+}
+
+func (d *Dscache) copyReference(builder *flatbuffers.Builder, r *dscachefb.RefCache) {
+	initID := builder.CreateString(string(r.InitID()))
+	profileID := builder.CreateString(string(r.ProfileID()))
+	prettyName := builder.CreateString(string(r.PrettyName()))
+	metaTitle := builder.CreateString(string(r.MetaTitle()))
+	themeList := builder.CreateString(string(r.ThemeList()))
+	hashRef := builder.CreateString(string(r.HeadRef()))
+	fsiPath := builder.CreateString(string(r.FsiPath()))
+	dscachefb.RefCacheStart(builder)
+	dscachefb.RefCacheAddInitID(builder, initID)
+	dscachefb.RefCacheAddProfileID(builder, profileID)
+	dscachefb.RefCacheAddTopIndex(builder, int32(r.TopIndex()))
+	dscachefb.RefCacheAddCursorIndex(builder, int32(r.CursorIndex()))
+	dscachefb.RefCacheAddPrettyName(builder, prettyName)
+	dscachefb.RefCacheAddMetaTitle(builder, metaTitle)
+	dscachefb.RefCacheAddThemeList(builder, themeList)
+	dscachefb.RefCacheAddBodySize(builder, int64(r.BodySize()))
+	dscachefb.RefCacheAddBodyRows(builder, int32(r.BodyRows()))
+	dscachefb.RefCacheAddCommitTime(builder, r.CommitTime())
+	dscachefb.RefCacheAddNumErrors(builder, int32(r.NumErrors()))
+	dscachefb.RefCacheAddHeadRef(builder, hashRef)
+	dscachefb.RefCacheAddFsiPath(builder, fsiPath)
+}

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -364,7 +364,7 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 	}
 
 	if inst.dscache == nil {
-		inst.dscache, err = newDscache(inst.qfs, cfg, inst.repoPath)
+		inst.dscache, err = newDscache(ctx, inst.qfs, cfg, inst.repoPath)
 		if err != nil {
 			return nil, fmt.Errorf("newDsache: %w", err)
 		}
@@ -474,9 +474,9 @@ func newLogbook(fs qfs.Filesystem, cfg *config.Config, repoPath string) (book *l
 	return logbook.NewJournal(pro.PrivKey, pro.Peername, fs, logbookPath)
 }
 
-func newDscache(fs qfs.Filesystem, cfg *config.Config, repoPath string) (*dscache.Dscache, error) {
+func newDscache(ctx context.Context, fs qfs.Filesystem, cfg *config.Config, repoPath string) (*dscache.Dscache, error) {
 	dscachePath := filepath.Join(repoPath, "dscache.qfb")
-	dscache := dscache.NewDscache(fs, dscachePath)
+	dscache := dscache.NewDscache(ctx, fs, dscachePath)
 	return dscache, nil
 }
 

--- a/lib/params.go
+++ b/lib/params.go
@@ -31,8 +31,8 @@ type ListParams struct {
 	ShowNumVersions bool
 	// EnsureFSIExists controls whether to ensure references in the repo have correct FSIPaths
 	EnsureFSIExists bool
-	// ViaDscache controls whether to build a dscache to use to list the references
-	ViaDscache bool
+	// UseDscache controls whether to build a dscache to use to list the references
+	UseDscache bool
 }
 
 // NewListParams creates a ListParams from page & pagesize, pages are 1-indexed

--- a/logbook/action.go
+++ b/logbook/action.go
@@ -1,0 +1,22 @@
+package logbook
+
+import (
+	"github.com/qri-io/dataset"
+)
+
+// ActionType is the type of action that a logbook just completed
+type ActionType byte
+
+const (
+	// ActionMoveCursor is an action that moves the cursor for a dataset
+	ActionMoveCursor ActionType = iota
+)
+
+// Action represents the result of an action that logbook just completed
+type Action struct {
+	Type     ActionType
+	InitID   string
+	TopIndex int
+	HeadRef  string
+	Dataset  *dataset.Dataset
+}

--- a/logbook/logbook_test.go
+++ b/logbook/logbook_test.go
@@ -73,7 +73,7 @@ func Example() {
 
 	// create a log record of the version of a dataset. In practice this'll be
 	// part of the overall save routine that created the above ds variable
-	if err := book.WriteVersionSave(ctx, ds); err != nil {
+	if _, err := book.WriteVersionSave(ctx, ds); err != nil {
 		panic(err)
 	}
 
@@ -93,7 +93,7 @@ func Example() {
 	}
 
 	// once again, write to the log
-	if err := book.WriteVersionSave(ctx, ds2); err != nil {
+	if _, err := book.WriteVersionSave(ctx, ds2); err != nil {
 		panic(err)
 	}
 
@@ -136,7 +136,7 @@ func Example() {
 	}
 
 	// once again, write to the log
-	if err := book.WriteVersionSave(ctx, ds3); err != nil {
+	if _, err := book.WriteVersionSave(ctx, ds3); err != nil {
 		panic(err)
 	}
 
@@ -226,7 +226,7 @@ func TestNilCallable(t *testing.T) {
 	if err = book.WriteVersionDelete(ctx, dsref.Ref{}, 0); err != ErrNoLogbook {
 		t.Errorf("expected '%s', got: %v", ErrNoLogbook, err)
 	}
-	if err = book.WriteVersionSave(ctx, nil); err != ErrNoLogbook {
+	if _, err = book.WriteVersionSave(ctx, nil); err != ErrNoLogbook {
 		t.Errorf("expected '%s', got: %v", ErrNoLogbook, err)
 	}
 }
@@ -858,7 +858,7 @@ func (tr *testRunner) WriteWorldBankExample(t *testing.T) {
 		PreviousPath: "",
 	}
 
-	if err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
+	if _, err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
 		panic(err)
 	}
 
@@ -870,7 +870,7 @@ func (tr *testRunner) WriteWorldBankExample(t *testing.T) {
 	ds.Path = "QmHashOfVersion2"
 	ds.PreviousPath = "QmHashOfVersion1"
 
-	if err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
+	if _, err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
 		t.Fatal(err)
 	}
 
@@ -909,7 +909,7 @@ func (tr *testRunner) WriteMoreWorldBankCommits(t *testing.T) {
 		PreviousPath: "QmHashOfVersion3",
 	}
 
-	if err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
+	if _, err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
 		panic(err)
 	}
 
@@ -924,7 +924,7 @@ func (tr *testRunner) WriteMoreWorldBankCommits(t *testing.T) {
 		PreviousPath: "QmHashOfVersion4",
 	}
 
-	if err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
+	if _, err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
 		panic(err)
 	}
 }
@@ -959,7 +959,7 @@ func (tr *testRunner) WriteRenameExample(t *testing.T) {
 		PreviousPath: "",
 	}
 
-	if err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
+	if _, err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
 		panic(err)
 	}
 
@@ -974,7 +974,7 @@ func (tr *testRunner) WriteRenameExample(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
+	if _, err := book.WriteVersionSave(tr.Ctx, ds); err != nil {
 		t.Fatal(err)
 	}
 

--- a/logbook/logsync/logsync_test.go
+++ b/logbook/logsync/logsync_test.go
@@ -430,14 +430,14 @@ func writeNasdaqLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, er
 		PreviousPath: "",
 	}
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if _, err = book.WriteVersionSave(ctx, ds); err != nil {
 		return ref, err
 	}
 
 	ds.Path = "v1"
 	ds.PreviousPath = "v0"
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if _, err = book.WriteVersionSave(ctx, ds); err != nil {
 		return ref, err
 	}
 
@@ -464,21 +464,21 @@ func writeWorldBankLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref,
 		PreviousPath: "",
 	}
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if _, err = book.WriteVersionSave(ctx, ds); err != nil {
 		return ref, err
 	}
 
 	ds.Path = "v1"
 	ds.PreviousPath = "v0"
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if _, err = book.WriteVersionSave(ctx, ds); err != nil {
 		return ref, err
 	}
 
 	ds.Path = "v2"
 	ds.PreviousPath = "v1"
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if _, err = book.WriteVersionSave(ctx, ds); err != nil {
 		return ref, err
 	}
 

--- a/repo/buildrepo/build.go
+++ b/repo/buildrepo/build.go
@@ -71,7 +71,7 @@ func New(ctx context.Context, path string, cfg *config.Config) (repo.Repo, error
 			return nil, err
 		}
 
-		cache, err := newDscache(fs, path)
+		cache, err := newDscache(ctx, fs, path)
 		if err != nil {
 			return nil, err
 		}
@@ -153,11 +153,11 @@ func newLogbook(fs qfs.Filesystem, pro *profile.Profile, repoPath string) (book 
 	return logbook.NewJournal(pro.PrivKey, pro.Peername, fs, logbookPath)
 }
 
-func newDscache(fs qfs.Filesystem, repoPath string) (*dscache.Dscache, error) {
+func newDscache(ctx context.Context, fs qfs.Filesystem, repoPath string) (*dscache.Dscache, error) {
 	// This seems to be a bug, the repoPath does not end in "qri" in some tests.
 	if !strings.HasSuffix(repoPath, "qri") {
 		repoPath = repoPath + "/qri"
 	}
 	dscachePath := filepath.Join(repoPath, "dscache.qfb")
-	return dscache.NewDscache(fs, dscachePath), nil
+	return dscache.NewDscache(ctx, fs, dscachePath), nil
 }

--- a/repo/fs/files.go
+++ b/repo/fs/files.go
@@ -46,6 +46,8 @@ const (
 	// FileJSONRefs is a file for the user's local namespace
 	// No longer in use
 	FileJSONRefs
+	// FileDscache is a flatbuffer file of this repo's dataset cache
+	FileDscache
 	// FileRefs is a flatbuffer file of this repo's dataset references
 	FileRefs
 	// FilePeers holds peer repositories
@@ -69,6 +71,7 @@ var paths = map[File]string{
 	FileDatasets:       "/datasets.json",
 	FileEventLogs:      "/events.json",
 	FileJSONRefs:       "/ds_refs.json",
+	FileDscache:        "/dscache.fbs",
 	FileRefs:           "/refs.fbs",
 	FilePeers:          "/peers.json",
 	FileAnalytics:      "/analytics.json",

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qri-io/dataset/dsgraph"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
+	"github.com/qri-io/qri/dscache"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
@@ -33,6 +34,7 @@ type Repo struct {
 	fsys    qfs.Filesystem
 	graph   map[string]*dsgraph.Node
 	logbook *logbook.Book
+	dscache *dscache.Dscache
 
 	profiles *ProfileStore
 }
@@ -40,7 +42,7 @@ type Repo struct {
 // NewRepo creates a new file-based repository
 //
 // Deprecated: use CreateRepo instead
-func NewRepo(store cafs.Filestore, fsys qfs.Filesystem, book *logbook.Book, pro *profile.Profile, base string) (repo.Repo, error) {
+func NewRepo(store cafs.Filestore, fsys qfs.Filesystem, book *logbook.Book, cache *dscache.Dscache, pro *profile.Profile, base string) (repo.Repo, error) {
 	if err := os.MkdirAll(base, os.ModePerm); err != nil {
 		return nil, err
 	}
@@ -56,6 +58,7 @@ func NewRepo(store cafs.Filestore, fsys qfs.Filesystem, book *logbook.Book, pro 
 		fsys:     fsys,
 		basepath: bp,
 		logbook:  book,
+		dscache:  cache,
 
 		Refstore: Refstore{basepath: bp, store: store, file: FileRefs},
 
@@ -104,6 +107,11 @@ func (r *Repo) Profile() (*profile.Profile, error) {
 // Logbook stores operation logs for coordinating state across peers
 func (r *Repo) Logbook() *logbook.Book {
 	return r.logbook
+}
+
+// Dscache returns a dscache
+func (r *Repo) Dscache() *dscache.Dscache {
+	return r.dscache
 }
 
 // SetProfile updates this repo's peer profile info

--- a/repo/fs/fs_test.go
+++ b/repo/fs/fs_test.go
@@ -1,6 +1,7 @@
 package fsrepo
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +35,8 @@ func TestRepo(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cache := dscache.NewDscache(fs, "")
+		ctx := context.Background()
+		cache := dscache.NewDscache(ctx, fs, "")
 
 		store := cafs.NewMapstore()
 		r, err := NewRepo(store, fs, book, cache, pro, path)

--- a/repo/fs/fs_test.go
+++ b/repo/fs/fs_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/dscache"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
@@ -33,8 +34,10 @@ func TestRepo(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		cache := dscache.NewDscache(fs, "")
+
 		store := cafs.NewMapstore()
-		r, err := NewRepo(store, fs, book, pro, path)
+		r, err := NewRepo(store, fs, book, cache, pro, path)
 		if err != nil {
 			t.Fatalf("error creating repo: %s", err.Error())
 		}

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -5,6 +5,7 @@ import (
 	"github.com/qri-io/dataset/dsgraph"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
+	"github.com/qri-io/qri/dscache"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/repo/profile"
 )
@@ -18,6 +19,7 @@ type MemRepo struct {
 	graph      map[string]*dsgraph.Node
 	refCache   *MemRefstore
 	logbook    *logbook.Book
+	dscache    *dscache.Dscache
 
 	profile  *profile.Profile
 	profiles profile.Store
@@ -37,6 +39,7 @@ func NewMemRepo(p *profile.Profile, store cafs.Filestore, fsys qfs.Filesystem, p
 		MemRefstore: &MemRefstore{},
 		refCache:    &MemRefstore{},
 		logbook:     book,
+		dscache:     dscache.NewDscache(fsys, ""),
 		profile:     p,
 		profiles:    ps,
 	}, nil
@@ -55,6 +58,11 @@ func (r *MemRepo) Filesystem() qfs.Filesystem {
 // Logbook accesses the mem repo logbook
 func (r *MemRepo) Logbook() *logbook.Book {
 	return r.logbook
+}
+
+// Dscache returns a dscache
+func (r *MemRepo) Dscache() *dscache.Dscache {
+	return r.dscache
 }
 
 // RemoveLogbook drops a MemRepo's logbook pointer. MemRepo gets used in tests

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -1,6 +1,8 @@
 package repo
 
 import (
+	"context"
+
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/qri-io/dataset/dsgraph"
 	"github.com/qri-io/qfs"
@@ -33,13 +35,14 @@ func NewMemRepo(p *profile.Profile, store cafs.Filestore, fsys qfs.Filesystem, p
 	if err != nil {
 		return nil, err
 	}
+	ctx := context.Background()
 	return &MemRepo{
 		store:       store,
 		filesystem:  fsys,
 		MemRefstore: &MemRefstore{},
 		refCache:    &MemRefstore{},
 		logbook:     book,
-		dscache:     dscache.NewDscache(fsys, ""),
+		dscache:     dscache.NewDscache(ctx, fsys, ""),
 		profile:     p,
 		profiles:    ps,
 	}, nil

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -65,13 +65,13 @@ type Repo interface {
 	Filesystem() qfs.Filesystem
 
 	// All Repos must keep a Refstore, defining a store of known datasets
+	// NOTE(dlong): Refstore is going away soon, everything is going to move to Dscache
 	Refstore
+	// Dscache is a cache of datasets that have been built according to logbook
+	Dscache() *dscache.Dscache
 
 	// Repos have a logbook for recording & storing operation logs
 	Logbook() *logbook.Book
-
-	// Dscache is a cache of datasets that have been built according to logbook
-	Dscache() *dscache.Dscache
 
 	// A repository must maintain profile information about the owner of this dataset.
 	// The value returned by Profile() should represent the peer.

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -10,6 +10,7 @@ import (
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
+	"github.com/qri-io/qri/dscache"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/repo/profile"
 	reporef "github.com/qri-io/qri/repo/ref"
@@ -68,6 +69,9 @@ type Repo interface {
 
 	// Repos have a logbook for recording & storing operation logs
 	Logbook() *logbook.Book
+
+	// Dscache is a cache of datasets that have been built according to logbook
+	Dscache() *dscache.Dscache
 
 	// A repository must maintain profile information about the owner of this dataset.
 	// The value returned by Profile() should represent the peer.

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -248,7 +248,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 	ds.ProfileID = pro.ID.String()
 	ds.Peername = pro.Peername
 	ds.Path = path
-	if err = r.Logbook().WriteVersionSave(ctx, ds); err != nil && err != logbook.ErrNoLogbook {
+	if _, err = r.Logbook().WriteVersionSave(ctx, ds); err != nil && err != logbook.ErrNoLogbook {
 		return
 	}
 


### PR DESCRIPTION
Add a logbook.Action that describes a change to logbook when a save happens.

Add dscache.Update which receives an action, and modifies the dscache (by copying, since flatbuffers don't support mutation), and saves the result to the repo.

Change dscache constructor so that a non-null dscache is always returned, but it'll just be "empty" if there's nothing in the repo. That allows us to "save" since a filename within the repo should always exist.

Rename --via-dscache flag to --use-dscache.

Make an integration test that demonstrates using `list` to make a dscache, then `save` to update it.