### PR TITLE
test(circleci): Switch to 8 cpus for docker build on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           GOSUMDB: "off"
     environment:
       TEST_RESULTS: /tmp/test-results
+      GOFLAGS: -p=8
     # resource_class requires a paid circleci plan:
     resource_class: medium+
     steps:


### PR DESCRIPTION
Trying to fix the `[build failed]` error. Inspired by this thread: https://github.com/influxdata/flux/issues/1179