### PR TITLE
fix(cli): remove extraneous logging from `qri registry prove`

### DIFF
--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -209,7 +209,7 @@ func (o *RegistryOptions) Prove() error {
 	if err := o.RegistryClientMethods.ProveProfileKey(p, &ok); err != nil {
 		return err
 	}
-
+	printSuccess(o.ErrOut, "proved user %s to registry, connected local key", o.Username)
 	return nil
 }
 

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -59,7 +59,7 @@ func (m RegistryClientMethods) ProveProfileKey(p *RegistryProfile, ok *bool) err
 		return err
 	}
 
-	log.Errorf("prove profile response: %v", pro)
+	log.Debugf("prove profile response: %v", pro)
 	*p = *pro
 
 	return m.updateConfig(pro)


### PR DESCRIPTION
also added a stderr success printout. logging is still accessible if lib's logging level is debug

closes #1096