### PR TITLE
Fix: Go version in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.4
+FROM golang:1.13.7
 LABEL maintainer="sparkle_pony_2000@qri.io"
 
 ADD . /go/src/github.com/qri-io/qri


### PR DESCRIPTION
This updates the Go version used as the base container for the main `Dockerfile`, to avoid an error wherein the container image build complains that the Go version must be at least `1.13`. Fixes and closes #1117.