### PR TITLE
fix(profileID): Disambiguate profileID construction to avoid subtle bugs

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -300,7 +300,7 @@ func (h *DatasetHandlers) getHandler(w http.ResponseWriter, r *http.Request) {
 	// TODO (b5) - remove this. res.Ref should be used instead
 	ref := reporef.DatasetRef{
 		Peername:  res.Dataset.Peername,
-		ProfileID: profile.ID(res.Dataset.ProfileID),
+		ProfileID: profile.IDB58DecodeOrEmpty(res.Dataset.ProfileID),
 		Name:      res.Dataset.Name,
 		Path:      res.Dataset.Path,
 		FSIPath:   res.Ref.FSIPath,

--- a/api/fsi.go
+++ b/api/fsi.go
@@ -154,7 +154,7 @@ func (h *FSIHandlers) initHandler(routePrefix string) http.HandlerFunc {
 		// TODO (b5) - why is this necessary?
 		ref := reporef.DatasetRef{
 			Peername:  res.Dataset.Peername,
-			ProfileID: profile.ID(res.Dataset.ProfileID),
+			ProfileID: profile.IDB58DecodeOrEmpty(res.Dataset.ProfileID),
 			Name:      res.Dataset.Name,
 			Path:      res.Dataset.Path,
 			FSIPath:   res.Ref.FSIPath,

--- a/api/root.go
+++ b/api/root.go
@@ -79,7 +79,7 @@ func (mh *RootHandler) Handler(w http.ResponseWriter, r *http.Request) {
 	// TODO (b5) - why is this necessary?
 	ref = reporef.DatasetRef{
 		Peername:  res.Dataset.Peername,
-		ProfileID: profile.ID(res.Dataset.ProfileID),
+		ProfileID: profile.IDB58DecodeOrEmpty(res.Dataset.ProfileID),
 		Name:      res.Dataset.Name,
 		Path:      res.Dataset.Path,
 		FSIPath:   res.Ref.FSIPath,

--- a/base/ref_test.go
+++ b/base/ref_test.go
@@ -24,7 +24,7 @@ func TestInLocalNamespace(t *testing.T) {
 		t.Errorf("expected %s false", ref.String())
 	}
 
-	ref = &reporef.DatasetRef{ProfileID: profile.ID("fake")}
+	ref = &reporef.DatasetRef{ProfileID: profile.IDRawBytes("fake")}
 	if InLocalNamespace(r, ref) {
 		t.Errorf("expected %s false", ref.String())
 	}

--- a/base/ref_test.go
+++ b/base/ref_test.go
@@ -24,7 +24,7 @@ func TestInLocalNamespace(t *testing.T) {
 		t.Errorf("expected %s false", ref.String())
 	}
 
-	ref = &reporef.DatasetRef{ProfileID: profile.IDRawBytes("fake")}
+	ref = &reporef.DatasetRef{ProfileID: profile.IDRawByteString("fake")}
 	if InLocalNamespace(r, ref) {
 		t.Errorf("expected %s false", ref.String())
 	}

--- a/base/remove.go
+++ b/base/remove.go
@@ -50,7 +50,7 @@ func RemoveEntireDataset(ctx context.Context, r repo.Repo, ref dsref.Ref, histor
 		Peername:  ref.Username,
 		Name:      ref.Name,
 		Path:      ref.Path,
-		ProfileID: profile.ID(ref.ProfileID),
+		ProfileID: profile.IDB58DecodeOrEmpty(ref.ProfileID),
 	}
 	if _, err := r.GetRef(datasetRef); err == nil {
 		didRemove = appendString(didRemove, "refstore")
@@ -100,7 +100,7 @@ func RemoveNVersionsFromStore(ctx context.Context, r repo.Repo, curr dsref.Ref, 
 			Peername:  curr.Username,
 			Name:      curr.Name,
 			Path:      curr.Path,
-			ProfileID: profile.ID(curr.ProfileID),
+			ProfileID: profile.IDB58DecodeOrEmpty(curr.ProfileID),
 		}
 		if err = UnpinDataset(ctx, r, datasetRef); err != nil && !strings.Contains(err.Error(), "not pinned") {
 			return curr, err

--- a/dscache/convert_test.go
+++ b/dscache/convert_test.go
@@ -18,9 +18,9 @@ import (
 
 // Test the buildDscacheFlatbuffer function, which converts plain-old-data structures into dscache
 func TestBuildDscacheFlatbuffer(t *testing.T) {
-	pid0 := profile.ID(testPeers.GetTestPeerInfo(0).PeerID)
-	pid1 := profile.ID(testPeers.GetTestPeerInfo(1).PeerID)
-	pid2 := profile.ID(testPeers.GetTestPeerInfo(2).PeerID)
+	pid0 := profile.IDFromPeerID(testPeers.GetTestPeerInfo(0).PeerID)
+	pid1 := profile.IDFromPeerID(testPeers.GetTestPeerInfo(1).PeerID)
+	pid2 := profile.IDFromPeerID(testPeers.GetTestPeerInfo(2).PeerID)
 
 	userList := []userProfilePair{
 		userProfilePair{
@@ -152,14 +152,14 @@ func TestConvertLogbookAndRefsBasic(t *testing.T) {
 	dsrefs := []reporef.DatasetRef{
 		reporef.DatasetRef{
 			Peername:  "test_user",
-			ProfileID: profile.ID(peerInfo.PeerID),
+			ProfileID: profile.IDFromPeerID(peerInfo.PeerID),
 			Name:      "first_new_name",
 			Path:      "QmHashOfVersion2",
 			FSIPath:   "/path/to/first_workspace",
 		},
 		reporef.DatasetRef{
 			Peername:  "test_user",
-			ProfileID: profile.ID(peerInfo.PeerID),
+			ProfileID: profile.IDFromPeerID(peerInfo.PeerID),
 			Name:      "second_name",
 			Path:      "QmHashOfVersion6",
 			FSIPath:   "/path/to/second_workspace",
@@ -210,7 +210,7 @@ func TestConvertLogbookAndRefsMissingDsref(t *testing.T) {
 	dsrefs := []reporef.DatasetRef{
 		reporef.DatasetRef{
 			Peername:  "test_user",
-			ProfileID: profile.ID(peerInfo.PeerID),
+			ProfileID: profile.IDFromPeerID(peerInfo.PeerID),
 			Name:      "first_new_name",
 			Path:      "QmHashOfVersion2",
 			FSIPath:   "/path/to/first_workspace",
@@ -264,21 +264,21 @@ func TestConvertLogbookAndRefsMissingFromLogbook(t *testing.T) {
 	dsrefs := []reporef.DatasetRef{
 		reporef.DatasetRef{
 			Peername:  "test_user",
-			ProfileID: profile.ID(peerInfo.PeerID),
+			ProfileID: profile.IDFromPeerID(peerInfo.PeerID),
 			Name:      "first_new_name",
 			Path:      "QmHashOfVersion2",
 			FSIPath:   "/path/to/first_workspace",
 		},
 		reporef.DatasetRef{
 			Peername:  "test_user",
-			ProfileID: profile.ID(peerInfo.PeerID),
+			ProfileID: profile.IDFromPeerID(peerInfo.PeerID),
 			Name:      "second_name",
 			Path:      "QmHashOfVersion6",
 			FSIPath:   "/path/to/second_workspace",
 		},
 		reporef.DatasetRef{
 			Peername:  "test_user",
-			ProfileID: profile.ID(peerInfo.PeerID),
+			ProfileID: profile.IDFromPeerID(peerInfo.PeerID),
 			Name:      "third_name",
 			Path:      "QmHashOfVersion100",
 			FSIPath:   "/path/to/third_workspace",
@@ -335,19 +335,19 @@ func TestConvertLogbookAndRefsWithNoHistoryDatasetAndDeletedDataset(t *testing.T
 	dsrefs := []reporef.DatasetRef{
 		reporef.DatasetRef{
 			Peername:  "test_user",
-			ProfileID: profile.ID(peerInfo.PeerID),
+			ProfileID: profile.IDFromPeerID(peerInfo.PeerID),
 			Name:      "first_ds",
 			Path:      "QmHashOfVersion1001",
 		},
 		reporef.DatasetRef{
 			Peername:  "test_user",
-			ProfileID: profile.ID(peerInfo.PeerID),
+			ProfileID: profile.IDFromPeerID(peerInfo.PeerID),
 			Name:      "third_ds",
 			FSIPath:   "/path/to/third_workspace",
 		},
 		reporef.DatasetRef{
 			Peername:  "test_user",
-			ProfileID: profile.ID(peerInfo.PeerID),
+			ProfileID: profile.IDFromPeerID(peerInfo.PeerID),
 			Name:      "fourth_ds",
 			Path:      "QmHashOfVersion1005",
 			FSIPath:   "/path/to/fourth_workspace",
@@ -408,7 +408,7 @@ func TestBuildDscacheFromLogbookAndProfilesAndDsrefAlphabetized(t *testing.T) {
 	// Add association between profileID and username
 	profiles := profile.NewMemStore()
 	profiles.PutProfile(&profile.Profile{
-		ID:       profile.ID(peerInfo.PeerID),
+		ID:       profile.IDFromPeerID(peerInfo.PeerID),
 		Peername: "test_user",
 	})
 
@@ -476,7 +476,7 @@ func TestBuildDscacheFromLogbookAndProfilesAndDsrefFillInfo(t *testing.T) {
 	// Add association between profileID and username
 	profiles := profile.NewMemStore()
 	profiles.PutProfile(&profile.Profile{
-		ID:       profile.ID(peerInfo.PeerID),
+		ID:       profile.IDFromPeerID(peerInfo.PeerID),
 		Peername: "test_user",
 	})
 

--- a/dscache/dscache_test.go
+++ b/dscache/dscache_test.go
@@ -54,7 +54,7 @@ func TestDscacheAssignSaveAndLoad(t *testing.T) {
 
 	// Construct a dscache, will not save without a filename
 	builder := NewBuilder()
-	builder.AddUser("test_user", profile.ID(peerInfo.PeerID).String())
+	builder.AddUser("test_user", profile.IDFromPeerID(peerInfo.PeerID).String())
 	builder.AddDsVersionInfo("abcd1", dsref.VersionInfo{})
 	builder.AddDsVersionInfo("efgh2", dsref.VersionInfo{})
 	constructed := builder.Build()

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewNode(t *testing.T) {
 	info := cfgtest.GetTestPeerInfo(0)
-	r, err := test.NewTestRepoFromProfileID(profile.ID(info.PeerID), 0, -1)
+	r, err := test.NewTestRepoFromProfileID(profile.IDFromPeerID(info.PeerID), 0, -1)
 	if err != nil {
 		t.Errorf("error creating test repo: %s", err.Error())
 		return

--- a/p2p/test/ipfs.go
+++ b/p2p/test/ipfs.go
@@ -28,7 +28,7 @@ import (
 // MakeRepoFromIPFSNode wraps an ipfs node with a mock qri repo
 func MakeRepoFromIPFSNode(node *core.IpfsNode, username string) (qrirepo.Repo, error) {
 	p := &profile.Profile{
-		ID:       profile.ID(node.Identity),
+		ID:       profile.IDFromPeerID(node.Identity),
 		Peername: username,
 		PrivKey:  node.PrivateKey,
 	}

--- a/p2p/test/p2ptest.go
+++ b/p2p/test/p2ptest.go
@@ -74,7 +74,7 @@ func NewTestNetwork(ctx context.Context, f *TestNodeFactory, num int) ([]Testabl
 	nodes := make([]TestablePeerNode, num)
 	for i := 0; i < num; i++ {
 		info := f.NextInfo()
-		r, err := test.NewTestRepoFromProfileID(profile.ID(info.PeerID), i, i)
+		r, err := test.NewTestRepoFromProfileID(profile.IDFromPeerID(info.PeerID), i, i)
 		if err != nil {
 			return nil, fmt.Errorf("error creating test repo: %s", err.Error())
 		}

--- a/remote/mock_client.go
+++ b/remote/mock_client.go
@@ -75,7 +75,7 @@ func (c *MockClient) AddDataset(ctx context.Context, ref *reporef.DatasetRef, re
 	}
 
 	// Fill in details for the reference
-	ref.ProfileID = profile.ID(info.PeerID)
+	ref.ProfileID = profile.IDFromPeerID(info.PeerID)
 	ref.Path = path
 
 	// Store ref for a mock dataset.

--- a/remote/peer_sync_client_test.go
+++ b/remote/peer_sync_client_test.go
@@ -130,7 +130,7 @@ func newMemRepoTestNode(t *testing.T) *p2p.QriNode {
 	pi := cfgtest.GetTestPeerInfo(0)
 	pro := &profile.Profile{
 		Peername: "remote_test_peer",
-		ID:       profile.ID(pi.PeerID),
+		ID:       profile.IDFromPeerID(pi.PeerID),
 		PrivKey:  pi.PrivKey,
 	}
 	mr, err := repo.NewMemRepo(pro, ms, newTestFS(ms), profile.NewMemStore())

--- a/repo/profile/id.go
+++ b/repo/profile/id.go
@@ -45,10 +45,29 @@ func (id *ID) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
 	return
 }
 
+// IDRawBytes constructs an ID from raw bytes. No decoding happens. Should only be used in tests
+func IDRawBytes(data string) ID {
+	return ID(data)
+}
+
+// IDFromPeerID type casts a peer.ID from ipfs into an ID
+func IDFromPeerID(pid peer.ID) ID {
+	return ID(pid)
+}
+
 // IDB58Decode proxies a lower level API b/c I'm lazy & don't like
 func IDB58Decode(proid string) (ID, error) {
 	pid, err := peer.IDB58Decode(proid)
 	return ID(pid), err
+}
+
+// IDB58DecodeOrEmpty decodes an ID, or returns an empty ID if decoding fails
+func IDB58DecodeOrEmpty(proid string) ID {
+	pid, err := peer.IDB58Decode(proid)
+	if err != nil {
+		pid = ""
+	}
+	return ID(pid)
 }
 
 // IDB58MustDecode panics if an ID doesn't decode. useful for testing

--- a/repo/profile/id.go
+++ b/repo/profile/id.go
@@ -45,8 +45,9 @@ func (id *ID) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
 	return
 }
 
-// IDRawBytes constructs an ID from raw bytes. No decoding happens. Should only be used in tests
-func IDRawBytes(data string) ID {
+// IDRawByteString constructs an ID from a raw byte string. No decoding happens. Should only
+// be used in tests
+func IDRawByteString(data string) ID {
 	return ID(data)
 }
 

--- a/repo/profile/id_test.go
+++ b/repo/profile/id_test.go
@@ -44,7 +44,7 @@ func TestPeerID(t *testing.T) {
 		t.Errorf("unexpected value for encoded peerID, got %s", wellformedProfileID1)
 	}
 
-	wellformedProfileID2 := IDRawBytes(string(peerInfo.PeerID))
+	wellformedProfileID2 := IDRawByteString(string(peerInfo.PeerID))
 	if wellformedProfileID2.String() != idStr {
 		t.Errorf("unexpected value for encoded peerID, got %s", wellformedProfileID2)
 	}

--- a/repo/profile/id_test.go
+++ b/repo/profile/id_test.go
@@ -3,6 +3,8 @@ package profile
 import (
 	"bytes"
 	"testing"
+
+	testPeers "github.com/qri-io/qri/config/test"
 )
 
 func TestIDJSON(t *testing.T) {
@@ -14,5 +16,36 @@ func TestIDJSON(t *testing.T) {
 	expect := []byte(`"QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1"`)
 	if !bytes.Equal(idbytes, expect) {
 		t.Errorf("byte mistmatch. expected: %s, got: %s", string(expect), string(idbytes))
+	}
+}
+
+func TestPeerID(t *testing.T) {
+	peerInfo := testPeers.GetTestPeerInfo(0)
+
+	idStr := peerInfo.EncodedPeerID
+	if idStr != "QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B" {
+		t.Errorf("unexpected value for encoded peerID")
+	}
+
+	mistakenDecode := "9tmzz8FC9hjBrY1J9NFFt4gjAzGZWCGrKwB4pcdwuSHC7Y4Y7oPPAkrV48ryPYu"
+
+	badlyConstructedProfileID := ID(idStr)
+	if badlyConstructedProfileID.String() != mistakenDecode {
+		t.Errorf("unexpected value for encoded peerID, got %s", badlyConstructedProfileID)
+	}
+
+	wellformedProfileID0 := IDB58DecodeOrEmpty(idStr)
+	if wellformedProfileID0.String() != idStr {
+		t.Errorf("unexpected value for encoded peerID, got %s", wellformedProfileID0)
+	}
+
+	wellformedProfileID1 := IDFromPeerID(peerInfo.PeerID)
+	if wellformedProfileID1.String() != idStr {
+		t.Errorf("unexpected value for encoded peerID, got %s", wellformedProfileID1)
+	}
+
+	wellformedProfileID2 := IDRawBytes(string(peerInfo.PeerID))
+	if wellformedProfileID2.String() != idStr {
+		t.Errorf("unexpected value for encoded peerID, got %s", wellformedProfileID2)
 	}
 }

--- a/repo/store_test.go
+++ b/repo/store_test.go
@@ -93,7 +93,7 @@ var cases = []struct {
 	// TODO - this used to be me@badId, which isn't very useful, but at least provided coding parity
 	// might be worth revisiting
 	{reporef.DatasetRef{
-		ProfileID: profile.IDRawBytes("badID"),
+		ProfileID: profile.IDRawByteString("badID"),
 		Peername:  "me",
 	}, "me", "me@C6mUq3y", "me"},
 }
@@ -341,7 +341,7 @@ func TestIsEmpty(t *testing.T) {
 		{reporef.DatasetRef{Peername: "a"}, false},
 		{reporef.DatasetRef{Name: "a"}, false},
 		{reporef.DatasetRef{Path: "a"}, false},
-		{reporef.DatasetRef{ProfileID: profile.IDRawBytes("a")}, false},
+		{reporef.DatasetRef{ProfileID: profile.IDRawByteString("a")}, false},
 	}
 
 	for i, c := range cases {
@@ -375,8 +375,8 @@ func TestCompareDatasets(t *testing.T) {
 }
 
 func TestCanonicalizeDatasetRef(t *testing.T) {
-	lucille := &profile.Profile{ID: profile.IDRawBytes("a"), Peername: "lucille", PrivKey: privKey}
-	carla := &profile.Profile{ID: profile.IDRawBytes("b"), Peername: "carla"}
+	lucille := &profile.Profile{ID: profile.IDRawByteString("a"), Peername: "lucille", PrivKey: privKey}
+	carla := &profile.Profile{ID: profile.IDRawByteString("b"), Peername: "carla"}
 
 	store := cafs.NewMapstore()
 	memRepo, err := NewMemRepo(lucille, store, qfs.NewMemFS(), profile.NewMemStore())
@@ -441,7 +441,7 @@ func TestCanonicalizeDatasetRef(t *testing.T) {
 
 func TestCanonicalizeDatasetRefFSI(t *testing.T) {
 	peer := "lucille"
-	prof := &profile.Profile{ID: profile.IDRawBytes("a"), Peername: peer, PrivKey: privKey}
+	prof := &profile.Profile{ID: profile.IDRawByteString("a"), Peername: peer, PrivKey: privKey}
 	store := cafs.NewMapstore()
 	memRepo, err := NewMemRepo(prof, store, qfs.NewMemFS(), profile.NewMemStore())
 	if err != nil {
@@ -526,7 +526,7 @@ func TestCanonicalizeProfile(t *testing.T) {
 	}
 
 	badProfileIDGoodName := reporef.DatasetRef{
-		ProfileID: profile.IDRawBytes("badID"),
+		ProfileID: profile.IDRawByteString("badID"),
 		Peername:  "me",
 	}
 

--- a/repo/store_test.go
+++ b/repo/store_test.go
@@ -93,7 +93,7 @@ var cases = []struct {
 	// TODO - this used to be me@badId, which isn't very useful, but at least provided coding parity
 	// might be worth revisiting
 	{reporef.DatasetRef{
-		ProfileID: profile.ID("badID"),
+		ProfileID: profile.IDRawBytes("badID"),
 		Peername:  "me",
 	}, "me", "me@C6mUq3y", "me"},
 }
@@ -341,7 +341,7 @@ func TestIsEmpty(t *testing.T) {
 		{reporef.DatasetRef{Peername: "a"}, false},
 		{reporef.DatasetRef{Name: "a"}, false},
 		{reporef.DatasetRef{Path: "a"}, false},
-		{reporef.DatasetRef{ProfileID: profile.ID("a")}, false},
+		{reporef.DatasetRef{ProfileID: profile.IDRawBytes("a")}, false},
 	}
 
 	for i, c := range cases {
@@ -375,8 +375,8 @@ func TestCompareDatasets(t *testing.T) {
 }
 
 func TestCanonicalizeDatasetRef(t *testing.T) {
-	lucille := &profile.Profile{ID: profile.ID("a"), Peername: "lucille", PrivKey: privKey}
-	carla := &profile.Profile{ID: profile.ID("b"), Peername: "carla"}
+	lucille := &profile.Profile{ID: profile.IDRawBytes("a"), Peername: "lucille", PrivKey: privKey}
+	carla := &profile.Profile{ID: profile.IDRawBytes("b"), Peername: "carla"}
 
 	store := cafs.NewMapstore()
 	memRepo, err := NewMemRepo(lucille, store, qfs.NewMemFS(), profile.NewMemStore())
@@ -441,7 +441,7 @@ func TestCanonicalizeDatasetRef(t *testing.T) {
 
 func TestCanonicalizeDatasetRefFSI(t *testing.T) {
 	peer := "lucille"
-	prof := &profile.Profile{ID: profile.ID("a"), Peername: peer, PrivKey: privKey}
+	prof := &profile.Profile{ID: profile.IDRawBytes("a"), Peername: peer, PrivKey: privKey}
 	store := cafs.NewMapstore()
 	memRepo, err := NewMemRepo(prof, store, qfs.NewMemFS(), profile.NewMemStore())
 	if err != nil {
@@ -526,7 +526,7 @@ func TestCanonicalizeProfile(t *testing.T) {
 	}
 
 	badProfileIDGoodName := reporef.DatasetRef{
-		ProfileID: profile.ID("badID"),
+		ProfileID: profile.IDRawBytes("badID"),
 		Peername:  "me",
 	}
 

--- a/repo/test/spec/test_refstore.go
+++ b/repo/test/spec/test_refstore.go
@@ -21,13 +21,13 @@ func testRefstoreInvalidRefs(t *testing.T, rmf RepoMakerFunc) {
 		return
 	}
 
-	err = r.PutRef(reporef.DatasetRef{ProfileID: profile.IDRawBytes("badProfileID"), Peername: "peer", Path: "/path/to/a/thing"})
+	err = r.PutRef(reporef.DatasetRef{ProfileID: profile.IDRawByteString("badProfileID"), Peername: "peer", Path: "/path/to/a/thing"})
 	if err != repo.ErrNameRequired {
 		t.Errorf("attempting to put empty name in refstore should return repo.ErrNameRequired, got: %s", err)
 		return
 	}
 
-	err = r.PutRef(reporef.DatasetRef{ProfileID: profile.IDRawBytes("badProfileID"), Peername: "peer", Name: "a", Path: ""})
+	err = r.PutRef(reporef.DatasetRef{ProfileID: profile.IDRawByteString("badProfileID"), Peername: "peer", Name: "a", Path: ""})
 	if err != repo.ErrPathRequired {
 		t.Errorf("attempting to put empty path in refstore should return repo.ErrPathRequired, got: %s", err)
 		return

--- a/repo/test/spec/test_refstore.go
+++ b/repo/test/spec/test_refstore.go
@@ -21,13 +21,13 @@ func testRefstoreInvalidRefs(t *testing.T, rmf RepoMakerFunc) {
 		return
 	}
 
-	err = r.PutRef(reporef.DatasetRef{ProfileID: profile.ID("badProfileID"), Peername: "peer", Path: "/path/to/a/thing"})
+	err = r.PutRef(reporef.DatasetRef{ProfileID: profile.IDRawBytes("badProfileID"), Peername: "peer", Path: "/path/to/a/thing"})
 	if err != repo.ErrNameRequired {
 		t.Errorf("attempting to put empty name in refstore should return repo.ErrNameRequired, got: %s", err)
 		return
 	}
 
-	err = r.PutRef(reporef.DatasetRef{ProfileID: profile.ID("badProfileID"), Peername: "peer", Name: "a", Path: ""})
+	err = r.PutRef(reporef.DatasetRef{ProfileID: profile.IDRawBytes("badProfileID"), Peername: "peer", Name: "a", Path: ""})
 	if err != repo.ErrPathRequired {
 		t.Errorf("attempting to put empty path in refstore should return repo.ErrPathRequired, got: %s", err)
 		return


### PR DESCRIPTION
There's a potential for bugs related to how we construct profileIDs. I've run into this bug a few times, and the issue is getting worse during the switch to dscache. This change will help to solve the problem going forward.

We use a few different types around profileIDs:

1) ipfs's peerID which is a string of bytes derived from cryptographic information

2) repo/profile.ID which is an alias of peerID, moved into our own namespace

3) a string of a base58 encoded profileID that starts with "Qm..."

The issue originates from the fact that all three are basically strings, but with different semantics. (1) and (2) are byte sequences with the same contents, but occassionally need conversion due to having different go types. (3) is a base58 encoded string, meaning it exists as different bytes in memory, and needs decoding work done to convert it to (1) or (2). Due to the fact that all three are actually sequences of bytes, the go type system fails to catch a certain class of errors.

Many places in our code construct a profileID using a call to profile.ID(). These breakdown into three cases:

1) profile.ID(peerID)

   This is always valid, as a peerID is an alias for profile.ID. It's just a type cast.

2) profile.ID(raw bytes)

   This is mostly used in tests, as a way to construct an invalid profileID. For example profile.ID("bad"). This works because it's a simple type conversion from bytes to strings.

3) profile.ID(base58EncodedProfileID)

   This is a bug. The string should be decoded (using IDB58Decode) but here it is simply being reinterpretted.

This change proposes that we ban calls to "profile.ID" completely in our code (except in the one file that needs it, repo/profile/id.go). It's not clear from looking at the code quickly whether the call is a simple conversion between aliases or an inappropriate cast when decoding was needed.

Instead, we should have separate functions that call out these three use cases explicitly:

1) profile.IDFromPeerID(peer.ID)

   Takes a peer.ID as a parameter, so the compiler guarantees type safety

2) profile.IDRawBytes(raw bytes)

   Should only be used in tests. It will be immediately obvious if this is used with anything aside from raw strings

3) profile.IDB58Decode

   The current decoding function. We also have IDB58DecodeOrEmpty for convenience.

Finding all callsites of profile.ID:
```
grep -n -r "profile\.ID(" * 
```