### PR TITLE
refactor(event): wiring watchfs up to FSI events

### DIFF
--- a/api/websocket.go
+++ b/api/websocket.go
@@ -31,7 +31,7 @@ const (
 func (s Server) ServeWebsocket(ctx context.Context) {
 	// Watch the filesystem. Events will be sent to websocket connections.
 	node := s.Node()
-	fsmessages, err := s.startFilesysWatcher(node)
+	fsmessages, err := s.startFilesysWatcher(ctx, node)
 	if err != nil {
 		log.Infof("Watching filesystem error: %s", err)
 		return
@@ -113,7 +113,7 @@ func (s Server) ServeWebsocket(ctx context.Context) {
 	}()
 }
 
-func (s Server) startFilesysWatcher(node *p2p.QriNode) (chan watchfs.FilesysEvent, error) {
+func (s Server) startFilesysWatcher(ctx context.Context, node *p2p.QriNode) (chan watchfs.FilesysEvent, error) {
 	refs, err := node.Repo.References(0, 100)
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func (s Server) startFilesysWatcher(node *p2p.QriNode) (chan watchfs.FilesysEven
 	}
 	// Watch those paths.
 	// TODO(dlong): When datasets are removed or renamed update the watchlist.
-	s.Instance.Watcher = watchfs.NewFilesysWatcher()
+	s.Instance.Watcher = watchfs.NewFilesysWatcher(ctx, s.Instance.Bus())
 	fsmessages := s.Instance.Watcher.Begin(paths)
 	return fsmessages, nil
 }

--- a/dscache/dscache.go
+++ b/dscache/dscache.go
@@ -178,12 +178,13 @@ func (d *Dscache) ListRefs() ([]reporef.DatasetRef, error) {
 }
 
 func (d *Dscache) update(act *logbook.Action) {
-	if act.Type == logbook.ActionDatasetNameInit {
-		if err := d.updateInitDataset(act); err != nil {
+	switch act.Type {
+	case logbook.ActionDatasetNameInit:
+		if err := d.updateInitDataset(act); err != nil && err != ErrNoDscache {
 			log.Error(err)
 		}
-	} else if act.Type == logbook.ActionDatasetChange {
-		if err := d.updateMoveCursor(act); err != nil {
+	case logbook.ActionDatasetChange:
+		if err := d.updateMoveCursor(act); err != nil && err != ErrNoDscache {
 			log.Error(err)
 		}
 	}

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 	"fmt"
+	"testing"
 )
 
 func Example() {
@@ -50,4 +51,29 @@ func Example() {
 	// hello
 	// hello
 	// it didn't work?
+}
+
+func TestSubscribeUnsubscribe(t *testing.T) {
+	ctx := context.Background()
+	const testTopic = Topic("test_event")
+
+	b := NewBus(ctx)
+	ch1 := b.Subscribe(testTopic)
+	ch2 := b.Subscribe(testTopic)
+
+	if b.NumSubscribers() != 2 {
+		t.Errorf("expected 2 subscribers, got %d", b.NumSubscribers())
+	}
+
+	b.Unsubscribe(ch1)
+
+	if b.NumSubscribers() != 1 {
+		t.Errorf("expected 1 subscribers, got %d", b.NumSubscribers())
+	}
+
+	b.Unsubscribe(ch2)
+
+	if b.NumSubscribers() != 0 {
+		t.Errorf("expected 1 subscribers, got %d", b.NumSubscribers())
+	}
 }

--- a/fsi/fsi_test.go
+++ b/fsi/fsi_test.go
@@ -55,7 +55,7 @@ func TestCreateLink(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	link, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -89,7 +89,7 @@ func TestCreateLinkTwice(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -142,7 +142,7 @@ func TestCreateLinkAlreadyLinked(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -163,7 +163,7 @@ func TestCreateLinkAgainOnceQriRefRemoved(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -205,7 +205,7 @@ func TestModifyLinkReference(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatal(err)
@@ -248,7 +248,7 @@ func TestModifyLinkDirectory(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/another_dataset")
 	if err != nil {
 		t.Fatal(err)
@@ -277,7 +277,7 @@ func TestUnlink(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/fsi/status_test.go
+++ b/fsi/status_test.go
@@ -37,7 +37,7 @@ func TestStatusValid(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -81,7 +81,7 @@ func TestStatusInvalidDataset(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -105,7 +105,7 @@ func TestStatusInvalidMeta(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -127,7 +127,7 @@ func TestStatusNotFound(t *testing.T) {
 	paths := NewTmpPaths()
 	defer paths.Close()
 
-	fsi := NewFSI(paths.testRepo)
+	fsi := NewFSI(paths.testRepo, nil)
 	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -10,7 +10,6 @@ import (
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/base/component"
 	"github.com/qri-io/qri/base/dsfs"
-	"github.com/qri-io/qri/event"
 	"github.com/qri-io/qri/fsi"
 	"github.com/qri-io/qri/repo"
 	reporef "github.com/qri-io/qri/repo/ref"
@@ -189,14 +188,6 @@ func (m *FSIMethods) Checkout(p *CheckoutParams, out *string) (err error) {
 		log.Debugf("Checkout, fsi.WriteComponents failed, error: %s", ref)
 	}
 	log.Debugf("Checkout wrote components, successfully checked out dataset")
-
-	// Send an event to the bus about this checkout
-	m.inst.Bus().Publish(event.ETFSICreateLinkEvent, event.FSICreateLinkEvent{
-		FSIPath:  p.Dir,
-		Username: ref.Peername,
-		Dsname:   ref.Name,
-	})
-	log.Debugf("Checkout published an event")
 
 	log.Debugf("Checkout successfully checked out dataset")
 	return nil

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -302,6 +302,7 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		streams:  o.Streams,
 		registry: o.regclient,
 		logbook:  o.logbook,
+		bus:      event.NewBus(ctx),
 	}
 	qri = inst
 
@@ -371,10 +372,6 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		}
 	}
 
-	if inst.bus == nil {
-		inst.bus = newEventBus(ctx)
-	}
-
 	if inst.registry == nil {
 		inst.registry = newRegClient(ctx, cfg)
 	}
@@ -400,7 +397,7 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		// were somewhere else we could move it there
 		_ = base.SetFileHidden(inst.repoPath)
 
-		inst.fsi = fsi.NewFSI(inst.repo)
+		inst.fsi = fsi.NewFSI(inst.repo, inst.bus)
 	}
 
 	if inst.node == nil {
@@ -590,8 +587,8 @@ func NewInstanceFromConfigAndNode(cfg *config.Config, node *p2p.QriNode) *Instan
 		inst.repo = node.Repo
 		inst.store = node.Repo.Store()
 		inst.qfs = node.Repo.Filesystem()
-		inst.fsi = fsi.NewFSI(inst.repo)
 		inst.bus = event.NewBus(ctx)
+		inst.fsi = fsi.NewFSI(inst.repo, inst.bus)
 	}
 
 	return inst

--- a/watchfs/watchfs.go
+++ b/watchfs/watchfs.go
@@ -1,11 +1,13 @@
 package watchfs
 
 import (
+	"context"
 	"path/filepath"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 	golog "github.com/ipfs/go-log"
+	"github.com/qri-io/qri/event"
 )
 
 var log = golog.Logger("watchfs")
@@ -32,12 +34,45 @@ type FilesysWatcher struct {
 }
 
 // NewFilesysWatcher returns a new FilesysWatcher
-func NewFilesysWatcher() *FilesysWatcher {
+func NewFilesysWatcher(ctx context.Context, bus event.Bus) *FilesysWatcher {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)
 	}
-	return &FilesysWatcher{Watcher: watcher}
+
+	w := FilesysWatcher{Watcher: watcher}
+	if bus != nil {
+		w.subscribe(ctx, bus)
+	}
+	return &w
+}
+
+func (w *FilesysWatcher) subscribe(ctx context.Context, bus event.Bus) {
+	eventsCh := bus.Subscribe(event.ETFSICreateLinkEvent)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				bus.Unsubscribe(eventsCh)
+				break
+			case e, ok := <-eventsCh:
+				if !ok {
+					// bus is closed, break
+					break
+				}
+				go func() {
+					log.Debugf("bus event: %s\n", e)
+					if fce, ok := e.Payload.(event.FSICreateLinkEvent); ok {
+						w.Add(EventPath{
+							Path:     fce.FSIPath,
+							Username: fce.Username,
+							Dsname:   fce.Dsname,
+						})
+					}
+				}()
+			}
+		}
+	}()
 }
 
 // Begin will start watching the given directory paths

--- a/watchfs/watchfs_test.go
+++ b/watchfs/watchfs_test.go
@@ -1,11 +1,13 @@
 package watchfs
 
 import (
-	"github.com/google/go-cmp/cmp"
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFilesysWatcher(t *testing.T) {
@@ -15,10 +17,12 @@ func TestFilesysWatcher(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
+	ctx := context.Background()
+
 	// Create a directory, and watch it
 	watchdir := filepath.Join(tmpdir, "watch_me")
 	_ = os.Mkdir(watchdir, 0755)
-	w := NewFilesysWatcher()
+	w := NewFilesysWatcher(ctx, nil)
 	messages := w.Begin([]EventPath{
 		{
 			Username: "test_peer",


### PR DESCRIPTION
* Adds in a bunch of `event` package changes from #1133, including `Unsubscribe` and `Publisher` interface.
* Refactors `NewFSI` constructor to accept a publisher
* Refactors `watchfs` to use the subscribe pattern