### PR TITLE
fix(cmd/list): show username with no datasets to list

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -128,10 +128,15 @@ func (o *ListOptions) Run() (err error) {
 	}
 
 	if len(infos) == 0 {
+		pn := fmt.Sprintf("%s has", o.Peername)
+		if o.Peername == "" {
+			pn = "you have"
+		}
+
 		if o.Term == "" {
-			printInfo(o.Out, "%s has no datasets", o.Peername)
+			printInfo(o.Out, "%s no datasets", pn)
 		} else {
-			printInfo(o.Out, "%s has no datasets that match \"%s\"", o.Peername, o.Term)
+			printInfo(o.Out, "%s no datasets that match \"%s\"", pn, o.Term)
 		}
 		return
 	}


### PR DESCRIPTION
This is a very superficial fix for the username not displaying on a call to `qri list` without providing specific peer as an argument. 

It is not perfect because `repo/store.go#CanonicalizeProfile` shows that it is also possible to refer to one's own datasets by using `me` as a magic peername.  So running `qri list --peer me` now still gives a weird (meme worthy) message: `me has no datasets`. If that also needs to be taken into account the rabbit hole starts to become pretty deep for a simple feedback message. 

I would say that it is not worth complexity and just return the message "found no datasets". 