### PR TITLE
Document CLI args for fsi commands

### DIFF
--- a/cmd/fsi.go
+++ b/cmd/fsi.go
@@ -20,8 +20,8 @@ func NewFSICommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	}
 
 	link := &cobra.Command{
-		Use:   "link",
-		Short: "link a .qri-ref",
+		Use:   "link DATASET PATH",
+		Short: "link a dataset to a directory on disk",
 		Example: `link a dataset to the current working directory:
   $ qri fsi link peername/dataset .`,
 		Args: cobra.MinimumNArgs(2),
@@ -34,8 +34,8 @@ func NewFSICommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	}
 
 	unlink := &cobra.Command{
-		Use:   "unlink",
-		Short: "unlink a .qri-ref",
+		Use:   "unlink [DATASET]",
+		Short: "unlink a dataset from a directory on disk",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/fsi.go
+++ b/cmd/fsi.go
@@ -24,7 +24,7 @@ func NewFSICommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 		Short: "link a dataset to a directory on disk",
 		Example: `link a dataset to the current working directory:
   $ qri fsi link peername/dataset .`,
-		Args: cobra.MinimumNArgs(2),
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -36,6 +36,7 @@ func NewFSICommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	unlink := &cobra.Command{
 		Use:   "unlink [DATASET]",
 		Short: "unlink a dataset from a directory on disk",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -67,7 +68,7 @@ func (o *FSIOptions) Complete(f Factory, args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	if o.Refs, err = GetCurrentRefSelect(f, args, -1, o.FSIMethods); err != nil {
+	if o.Refs, err = GetCurrentRefSelect(f, args, 1, o.FSIMethods); err != nil {
 		return err
 	}
 

--- a/cmd/fsi_test.go
+++ b/cmd/fsi_test.go
@@ -45,6 +45,11 @@ func TestFSILinkingCommands(t *testing.T) {
 
 	// TODO (b5) - get output of qri list, confirm dataset is unlinked
 
+	// Link *must* specify the directory to link to
+	if err := runner.ExecCommand("qri fsi link me/save_and_unlink"); err == nil {
+		t.Error("`qri fsi link` did not get an explicit directory, but did not fail")
+	}
+
 	// Link the dataset to the pwd
 	if err := runner.ExecCommand("qri fsi link me/save_and_unlink ."); err != nil {
 		t.Errorf("unlinking dataset: %s", err.Error())

--- a/cmd/ref_select.go
+++ b/cmd/ref_select.go
@@ -108,8 +108,8 @@ func (r *RefSelect) String() string {
 // selected by the `use` command. This order is also the precendence, from most important to least.
 // This is the recommended method for command-line commands to get references, unless they have a
 // special way of interacting with datasets (for example, `qri status`).
-// If fsi pointer is passed in, use it to ensure that the ref in the .qri-ref linkfile matches
-// what is in the repo
+// If an fsi pointer is passed in, use it to ensure that the ref in the .qri-ref linkfile matches
+// what is in the repo.
 func GetCurrentRefSelect(f Factory, args []string, allowed int, fsi *lib.FSIMethods) (*RefSelect, error) {
 	// TODO(dlong): Respect `allowed`, number of refs the command uses. -1 means any.
 	// TODO(dlong): For example, `get` allows -1, `diff` allows 2, `save` allows 1


### PR DESCRIPTION
I was poking around at the fsi commands this morning while misusing Qri Desktop and noticed that the arguments felt a little under-documented. This just adds positional argument info to the usage string for `qri fsi link` and `qri fsi unlink` to make them slightly clearer.

I thought about adding a longer description with more info, but since these are low-level commands that don’t normally show up when you run `qri --help`, that didn’t really seem worthwhile.