### PR TITLE
docs(cmd): DATASET is required in `fsi unlink`

### DIFF
--- a/cmd/fsi.go
+++ b/cmd/fsi.go
@@ -34,9 +34,10 @@ func NewFSICommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	}
 
 	unlink := &cobra.Command{
-		Use:   "unlink [DATASET]",
+		Use:   "unlink DATASET",
 		Short: "unlink a dataset from a directory on disk",
-		Args:  cobra.MaximumNArgs(1),
+		// Use max instead of exact args so we can provide a nicer error.
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err


### PR DESCRIPTION
This is a follow-on to #1170. We merged that one a bit too hastily and the usage string implied that DATASET was optional, when it actually isn't.

The last bit of conversation (https://github.com/qri-io/qri/pull/1170#discussion_r391354964) implied we might want to change the functionality to make this optional, though, so feel free to throw out this PR if you just want to move straight ahead with that instead.