### PR TITLE
docs(developer.md): fix section header links

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -3,9 +3,8 @@
 * [Development Setup](#setup)
 * [Coding Rules](#rules)
 * [Commit Message Guidelines](#commits)
-* [Writing Documentation](#documentation)
 
-## <a name="setup"> Development Setup
+## <a name="setup"></a> Development Setup
 
 This document describes how to set up your development environment to build and test Qri, and
 explains the basic mechanics of using `git`, `golint` and `go test`.


### PR DESCRIPTION
The table of contents listed and linked to a non-existent section, which I removed here. This also fixes the anchor syntax for the "development setup" heading, which was causing funny rendering on some browsers.

<img width="922" alt="Screen Shot 2020-03-12 at 12 30 31 AM" src="https://user-images.githubusercontent.com/74178/76497860-0891c980-63f9-11ea-81a7-fa740c851a32.png">
