### PR TITLE
docs(cmd): improve CLI docs for `dag` commands

### DIFF
--- a/cmd/dag_test.go
+++ b/cmd/dag_test.go
@@ -79,7 +79,7 @@ func TestDAGComplete(t *testing.T) {
 			IOStreams: streams,
 		}
 
-		opt.Complete(f, c.args)
+		opt.Complete(f, c.args, true)
 		if c.err != errs.String() {
 			t.Errorf("case %d, error mismatch. Expected: '%s', Got: '%s'", i, c.err, errs.String())
 			ioReset(in, out, errs)


### PR DESCRIPTION
Make the usage docs and argument parsing a little clearer for the `qri dag` family of commands:
- Only hide the top level command, so `qri dag --help` actually lists the subcommands.
- List optional and required positional arguments in usage string.
- Mark required flags as required.
- Only parse a "label" style argument when it's actually applicable.

I'm not deeply familiar with any of these commands, so I didn't actually try to spruce up the description strings. I mainly just followed the logic to understand what arguments were required (and what those arguments should generally represent).