### PR TITLE
docs(cmd): add argument names to CLI help text

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -13,17 +13,16 @@ import (
 func NewAddCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &AddOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:   "add",
-		Short: "Add a dataset from another peer",
+		Use:   "add DATASET [DATASET...]",
+		Short: "add datasets from other peers",
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Long: `
-Add retrieves a dataset owned by another peer and adds it to your repo. 
-The dataset reference of the dataset will remain the same, including 
+		Long: `Add retrieves datasets owned by other peers and adds them to your repo. 
+The reference names of the datasets will remain the same, including 
 the name of the peer that originally added the dataset. You must have 
 ` + "`qri connect`" + ` running in another terminal to use this command.`,
-		Example: `  add a dataset named their_data, owned by other_peer:
+		Example: `  # Add a dataset named their_data, owned by other_peer:
   $ qri add other_peer/their_data`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f); err != nil {

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -16,13 +16,15 @@ import (
 func NewCheckoutCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &CheckoutOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:     "checkout",
-		Short:   "checkout creates a linked directory and writes dataset files to that directory",
-		Long:    ``,
-		Example: ``,
+		Use:   "checkout DATASET",
+		Short: "checkout creates a linked directory and writes dataset files to that directory",
+		Long:  ``,
+		Example: `  # Place a copy of me/annual_pop in the ./annual_pop directory:
+  $ qri checkout me/annual_pop`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,12 +20,11 @@ func NewConfigCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := ConfigOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "Get and set local configuration information",
+		Short: "get and set local configuration information",
 		Annotations: map[string]string{
 			"group": "other",
 		},
-		Long: `
-'qri config' encapsulates all settings that control the behaviour of qri.
+		Long: `'qri config' encapsulates all settings that control the behaviour of qri.
 This includes all kinds of stuff: your profile details; enabling & disabling 
 different services; what kind of output qri logs to; 
 which ports on qri serves on; etc.
@@ -35,20 +34,20 @@ runtime via command a line argument.
 
 For details on each config field checkout: 
 https://github.com/qri-io/qri/blob/master/config/readme.md`,
-		Example: `  # get your profile information
+		Example: `  # Get your profile information:
   $ qri config get profile
 
-  # set your api port to 4444
+  # Set your API port to 4444:
   $ qri config set api.port 4444
 
-  # disable rpc connections:
+  # Disable RPC connections:
   $ qri config set rpc.enabled false`,
 	}
 
 	get := &cobra.Command{
-		Use:   "get",
+		Use:   "get [FIELD]",
 		Short: "get configuration settings",
-		Long: `get outputs your current configuration file with private keys 
+		Long: `'qri config get' outputs your current configuration file with private keys 
 removed by default, making it easier to share your qri configuration settings.
 
 You can get particular parts of the config by using dot notation to
@@ -58,14 +57,14 @@ https://github.com/qri-io/qri/blob/master/config/readme.md
 The --with-private-keys option will show private keys.
 PLEASE PLEASE PLEASE NEVER SHARE YOUR PRIVATE KEYS WITH ANYONE. EVER.
 Anyone with your private keys can impersonate you on qri.`,
-		Example: `  # get the entire config
-  qri config get
+		Example: `  # Get the entire config:
+  $ qri config get
 
-  # get the config profile
-  qri config get profile
+  # Get the config profile:
+  $ qri config get profile
 
-  # get the profile description
-  qri config get profile.description`,
+  # Get the profile description:
+  $ qri config get profile.description`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f); err != nil {
@@ -76,8 +75,8 @@ Anyone with your private keys can impersonate you on qri.`,
 	}
 
 	set := &cobra.Command{
-		Use:   "set",
-		Short: "Set configuration options",
+		Use:   "set FIELD VALUE [FIELD VALUE ...]",
+		Short: "set configuration options",
 		Long: `'qri config set' allows you to set configuration options. You can set 
 particular parts of the config by using dot notation to traverse the 
 config object. 
@@ -89,12 +88,20 @@ If the config object were a tree and each field a branch, you can only
 set the leaves of the branches. In other words, the you cannot set a 
 field that is itself an object or array. For details on each config 
 field checkout: https://github.com/qri-io/qri/blob/master/config/readme.md`,
-		Example: `  # set a profile description
-  qri config set profile.description "This is my new description that I
+		Example: `  # Set a profile description:
+  $ qri config set profile.description "This is my new description that I
   am very proud of and want displayed in my profile"
 
-  # disable rpc communication
-  qri config set rpc.enabled false`,
+  # Disable rpc communication:
+  $ qri config set rpc.enabled false`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args)%2 != 0 {
+				return fmt.Errorf("wrong number of arguments. arguments must be in the form: [path value]")
+			} else if len(args) < 2 {
+				return fmt.Errorf("please provide at least one field-value pair to set")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			if err := o.Complete(f); err != nil {
@@ -172,9 +179,6 @@ func (o *ConfigOptions) Get(args []string) (err error) {
 
 // Set a configuration option
 func (o *ConfigOptions) Set(args []string) (err error) {
-	if len(args)%2 != 0 {
-		return fmt.Errorf("wrong number of arguments. arguments must be in the form: [path value]")
-	}
 	ip := config.ImmutablePaths()
 	photoPaths := map[string]bool{
 		"profile.photo":  true,
@@ -204,7 +208,7 @@ func (o *ConfigOptions) Set(args []string) (err error) {
 			}
 			profileChanged = true
 		} else {
-			// TODO (b5): I think this'll resule in configuration not getting set. should investigate
+			// TODO (b5): I think this'll result in configuration not getting set. should investigate
 			if err = o.inst.Config().Set(path, value); err != nil {
 				return err
 			}

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -14,12 +14,11 @@ func NewConnectCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := ConnectOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "connect",
-		Short: "Connect to the distributed web by spinning up a Qri node",
+		Short: "connect to the distributed web by spinning up a Qri node",
 		Annotations: map[string]string{
 			"group": "network",
 		},
-		Long: `
-While it’s not totally accurate, connect is like starting a server. Running 
+		Long: `While it’s not totally accurate, connect is like starting a server. Running 
 connect will start a process and stay there until you exit the process 
 (ctrl+c from the terminal, or killing the process using tools like activity 
 monitor on the mac, or the aptly-named “kill” command). Connect does three main 
@@ -30,6 +29,7 @@ things:
 
 When you run connect you are connecting to the distributed web, interacting with
 peers & swapping data.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -13,9 +13,9 @@ import (
 func NewDiffCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := DiffOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:   "diff",
-		Short: "Compare differences between two data sources",
-		Long: `diff is a new & experimental feature, please report bugs here:
+		Use:   "diff ([COMPONENT] [DATASET [DATASET]])|(PATH PATH)",
+		Short: "compare differences between two data sources",
+		Long: `'qri diff' is a new & experimental feature, please report bugs here:
 https://github.com/qri-io/deepdiff
 
 Diff compares two data sources & generates a description of the difference
@@ -29,22 +29,22 @@ qri diff works on structured data. qri diffs are measured in elements
 elements), delete (removed elements), or update (changed values).
 
 Each change has a path that locates it within the document`,
-		Example: `  diff between a latest version & the next one back:
+		Example: `  # Diff between a latest version & the next one back:
   $ qri diff me/annual_pop
 
-  diff current "qri use" selection:
+  # Diff current "qri use" selection:
   $ qri diff
 
-  diff dataset body against it's last version
+  # Diff dataset body against its last version:
   $ qri diff body me/annual_pop
 
-  diff two dataset meta sections:
+  # Diff two dataset meta components:
   $ qri diff meta me/population_2016 me/population_2017
 
-  diff two local json files:
+  # Diff two local json files:
   $ qri diff a.json b.json
 
-  diff a json & csv file
+  # Diff a json & csv file:
   $ qri diff some_table.csv b.json`,
 		Annotations: map[string]string{
 			"group": "dataset",

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -15,16 +15,16 @@ func NewExportCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &ExportOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "export DATASET",
-		Short: "Copy datasets to your local filesystem",
-		Long: `
-Export gets datasets out of qri. By default it exports the dataset body, as ` + "`body.csv`" + `, header as` + "`dataset.json`" + `, and ref, as ` + "`ref.txt`" + ` files. 
+		Short: "copy datasets to your local filesystem",
+		Long: `Export gets datasets out of qri. By default it exports the dataset body, as
+` + "`body.csv`" + `, header as` + "`dataset.json`" + `, and ref, as ` + "`ref.txt`" + ` files.
 
 To export to a specific directory, use the --output flag.`,
-		Example: `  # export dataset
-  qri export me/annual_pop
+		Example: `  # Export dataset:
+  $ qri export me/annual_pop
 
-  # export to a specific directory
-  qri export -o ~/new_directory me/annual_pop`,
+  # Export to a specific directory:
+  $ qri export -o ~/new_directory me/annual_pop`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -13,13 +13,14 @@ import (
 func NewFetchCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &FetchOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:     "fetch",
-		Short:   "fetch logbook info for a dataset reference",
+		Use:     "fetch DATASET [DATASET...]",
+		Short:   "show log of remote dataset commits",
 		Long:    ``,
 		Example: ``,
 		Annotations: map[string]string{
 			"group": "network",
 		},
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/fsi.go
+++ b/cmd/fsi.go
@@ -22,7 +22,7 @@ func NewFSICommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	link := &cobra.Command{
 		Use:   "link DATASET PATH",
 		Short: "link a dataset to a directory on disk",
-		Example: `link a dataset to the current working directory:
+		Example: `  # Link a dataset to the current working directory:
   $ qri fsi link peername/dataset .`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -16,32 +16,27 @@ import (
 func NewGetCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &GetOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:   "get",
-		Short: "Get elements of qri datasets",
-		Long: `Get the qri dataset (except for the body). You can also get portions of 
+		Use:   "get [COMPONENT] [DATASET]",
+		Short: "get components of qri datasets",
+		Long: `Get the qri dataset (except for the body). You can also get components of 
 the dataset: meta, structure, viz, transform, and commit. To narrow down
 further to specific fields in each section, use dot notation. The get 
 command prints to the console in yaml format, by default.
 
-You can get pertinent information on multiple datasets at the same time
-by supplying more than one dataset reference.
-
 Check out https://qri.io/docs/reference/dataset/ to learn about each section of the 
 dataset and its fields.`,
-		Example: `  # print the entire dataset to the console
-  qri get me/annual_pop
+		Example: `  # Print the entire dataset to the console:
+  $ qri get me/annual_pop
 
-  # print the meta to the console
-  qri get meta me/annual_pop
+  # Print the meta to the console:
+  $ qri get meta me/annual_pop
 
-  # print the dataset body size to the console
-  qri get structure.length me/annual_pop
-
-  # print the dataset body size for two different datasets
-  qri get structure.length me/annual_pop me/annual_gdp`,
+  # Print the dataset body size to the console:
+  $ qri get structure.length me/annual_pop`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
+		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Special case for --pretty, check if it was passed vs if the default was used.
 			if cmd.Flags().Changed("pretty") {
@@ -135,7 +130,6 @@ func (o *GetOptions) Run() (err error) {
 
 	// convert Page and PageSize to Limit and Offset
 	page := util.NewPage(o.Page, o.PageSize)
-	// TODO(dlong): Restore ability to `get` from multiple datasets at once.
 	p := lib.GetParams{
 		Path:         o.Refs.Ref(),
 		Selector:     o.Selector,

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,9 +16,10 @@ import (
 func NewInitCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &InitOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:     "init",
-		Short:   "initialize a dataset directory",
-		Long:    ``,
+		Use:   "init [PATH]",
+		Short: "initialize a dataset directory",
+		Long: `'initialize' creates a new dataset, links it to the current or specified
+directory, and creates starter files for the dataset's components.`,
 		Example: ``,
 		Annotations: map[string]string{
 			"group": "dataset",

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,11 +17,10 @@ import (
 func NewListCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &ListOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:     "list",
+		Use:     "list [FILTER]",
 		Aliases: []string{"ls"},
-		Short:   "Show a list of datasets",
-		Long: `
-List shows lists of datasets, including names and current hashes. 
+		Short:   "show a list of datasets",
+		Long: `List shows lists of datasets, including names and current hashes. 
 
 The default list is the latest version of all datasets you have on your local 
 qri repository. The first argument can be used to find datasets with a certain 
@@ -29,21 +28,21 @@ substring in their name.
 
 When used in conjunction with ` + "`qri connect`" + `, list can list a peer's dataset. You
 must have ` + "`qri connect`" + ` running in a separate terminal window.`,
-		Example: `  # show all of your datasets:
-  qri list
+		Example: `  # Show all of your datasets:
+  $ qri list
 
-  # show datasets with the substring "new" in their name
-  qri list new
+  # Show datasets with the substring "new" in their name:
+  $ qri list new
 
-  # to view the list of your peer's dataset,
-  # in one terminal window:
-  qri connect
-
-  # in a separate terminal window, to show all of b5's datasets:
-  qri list --peer b5`,
+  # To view the list of a peer's datasets...
+  # In one terminal window:
+  $ qri connect
+  # In a separate terminal window, show all of b5's datasets:
+  $ qri list --peer b5`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -17,11 +17,10 @@ import (
 func NewLogCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &LogOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:     "log",
+		Use:     "log [DATASET]",
 		Aliases: []string{"history"},
-		Short:   "Show log of dataset commits",
-		Long: `
-` + "`qri log`" + ` lists dataset commits over time. Each entry in the log is a 
+		Short:   "show log of dataset commits",
+		Long: "`qri log`" + ` lists dataset commits over time. Each entry in the log is a 
 snapshot of a dataset taken at the moment it was saved that keeps exact details 
 about how that dataset looked at at that point in time. 
 
@@ -29,11 +28,12 @@ We call these snapshots versions. Each version has an author (the peer that
 created the version) and a message explaining what changed. Log prints these 
 details in order of occurrence, starting with the most recent known version, 
 working backwards in time.`,
-		Example: `  show log for the dataset b5/precip:
+		Example: `  # Show log for the dataset b5/precip:
   $ qri log b5/precip`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -105,10 +105,10 @@ func (o *LogOptions) Run() error {
 func NewLogbookCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &LogbookOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:   "logbook",
-		Short: "Show a detailed list of changes on a dataset name",
-		Example: `  show log for the dataset bob/precip:
-		$ qri logbook bob/precip`,
+		Use:   "logbook [DATASET]",
+		Short: "show a detailed list of changes on a dataset name",
+		Example: `  # Show log for the dataset bob/precip:
+  $ qri logbook bob/precip`,
 		Long: `Logbooks are records of changes to a dataset. The logbook is more detailed
 than a dataset history, recording the steps taken to construct a dataset history
 without including dataset data. Logbooks can be synced with other users.

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -17,12 +17,11 @@ func NewPeersCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &PeersOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "peers",
-		Short: "Commands for working with peers",
-		Long: `
-The ` + "`peers`" + ` commands allow you to interact with other peers on the Qri network.
-In order for these commands to work, you must be running a Qri node. This 
-node allows you to communicate on the network. To spin up a Qri node, run
-` + "`qri connect`" + ` in a separate terminal. This will connect you to the network, 
+		Short: "commands for working with peers",
+		Long: `The ` + "`peers`" + ` commands interact with other peers on the Qri network. In
+order for these commands to work, you must be running a Qri node, which is
+responsible for peer-to-peer communication. To spin up a Qri node, run
+` + "`qri connect`" + ` in a separate terminal. This connects you to the network
 until you choose to close the connection by ending the session or closing 
 the terminal.`,
 		Annotations: map[string]string{
@@ -31,21 +30,20 @@ the terminal.`,
 	}
 
 	info := &cobra.Command{
-		Use:   "info",
-		Short: `Get info on a Qri peer`,
-		Long: `
-The peers info command returns a peer's profile information. The default
+		Use:   "info PEER",
+		Short: `get info on a Qri peer`,
+		Long: `The peers info command returns a peer's profile information. The default
 format is yaml.
 
 Using the ` + "`--verbose`" + ` flag, you can also view a peer's network information.
 
 You must have ` + "`qri connect`" + ` running in another terminal.`,
-		Example: `  show info on a peer named "b5":
+		Example: `  # Show info on a peer named "b5":
   $ qri peers info b5
 
-  show info in json:
+  # Show info in json:
   $ qri peers info b5 --format json`,
-		Args: cobra.MinimumNArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -54,25 +52,28 @@ You must have ` + "`qri connect`" + ` running in another terminal.`,
 		},
 	}
 
+	info.Flags().BoolVarP(&o.Verbose, "verbose", "v", false, "show verbose profile info")
+	info.Flags().StringVarP(&o.Format, "format", "", "yaml", "output format. formats: yaml, json")
+
 	list := &cobra.Command{
 		Use:   "list",
-		Short: "List known qri peers",
-		Long: `
-Lists the peers to which your Qri node is connected. 
+		Short: "list known qri peers",
+		Long: `Lists the peers to which your Qri node is connected. 
 
 You must have ` + "`qri connect`" + ` running in another terminal.
 
 To find peers that are not online, but to which your node has previously been 
 connected, use the ` + "`--cached`" + ` flag.`,
-		Example: `  # spin up a Qri node
-  qri connect
+		Example: `  # Spin up a Qri node:
+  $ qri connect
 
-  # thenin a separate terminal, to list qri peers:
-  qri peers list
+  # Then in a separate terminal, to list qri peers:
+  $ qri peers list
 
-  # to ensure you get a cached version of the list:
-  qri peers list --cached`,
+  # To ensure you get a cached version of the list:
+  $ qri peers list --cached`,
 		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -81,24 +82,29 @@ connected, use the ` + "`--cached`" + ` flag.`,
 		},
 	}
 
+	list.Flags().BoolVarP(&o.Cached, "cached", "c", false, "show peers that aren't online, but previously seen")
+	list.Flags().StringVarP(&o.Network, "network", "n", "", "specify network to show peers from (qri|ipfs) (defaults to qri)")
+	// TODO (ramfox): when we determine the best way to order and paginate peers, restore!
+	// list.Flags().IntVar(&o.PageSize, "page-size", 200, "max page size number of peers to show, default 200")
+	// list.Flags().IntVar(&o.Page, "page", 1, "page number of peers, default 1")
+
 	connect := &cobra.Command{
-		Use:   "connect",
-		Short: "Connect to a peer",
-		Long: `
-Connect to a peer using a peername, peer ID, or multiaddress. Qri will use this name, id, or address
+		Use:   "connect (NAME|ADDRESS)",
+		Short: "connect to a peer",
+		Long: `Connect to a peer using a peername, peer ID, or multiaddress. Qri will use this name, id, or address
 to find a peer to which it has not automatically connected. 
 
 You must have a Qri node running (` + "`qri connect`" + `) in a separate terminal. You will only be able 
-to connect to a peer that also has spun up it's own Qri node.
+to connect to a peer that also has spun up its own Qri node.
 
 A multiaddress, or multiaddr, is the most specific way to refer to a peer's location, and is therefore
-the most sure-fire way to connect to a peer. `,
-		Example: `  # spin up a Qri node
-  qri connect
+the most sure-fire way to connect to a peer.`,
+		Example: `  # Spin up a Qri node:
+  $ qri connect
 
-  # in a separate terminal, connect to a specific peer
-  qri peers connect /ip4/192.168.0.194/tcp/4001/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`,
-		Args: cobra.MinimumNArgs(1),
+  # In a separate terminal, connect to a specific peer:
+  $ qri peers connect /ip4/192.168.0.194/tcp/4001/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -108,11 +114,10 @@ the most sure-fire way to connect to a peer. `,
 	}
 
 	disconnect := &cobra.Command{
-		Use:   "disconnect",
-		Short: "Explicitly close a connection to a peer",
-		Args:  cobra.MinimumNArgs(1),
-		Long: `
-Explicitly close a connection to a peer using a peername, peer id, or multiaddress. 
+		Use:   "disconnect (NAME|ADDRESS)",
+		Short: "explicitly close a connection to a peer",
+		Args:  cobra.ExactArgs(1),
+		Long: `Explicitly close a connection to a peer using a peername, peer id, or multiaddress. 
 
 You can close all connections to the Qri network by ending your Qri node session. 
 
@@ -125,8 +130,8 @@ Once you close a connection to a peer, you or that peer can immediately open ano
 connection.
 
 You must have ` + "`qri connect`" + ` running in another terminal.`,
-		Example: `  # disconnect from a peer using a multiaddr
-  qri peers disconnect /ip4/192.168.0.194/tcp/4001/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`,
+		Example: `  # Disconnect from a peer using a multiaddr:
+  $ qri peers disconnect /ip4/192.168.0.194/tcp/4001/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -134,15 +139,6 @@ You must have ` + "`qri connect`" + ` running in another terminal.`,
 			return o.Disconnect()
 		},
 	}
-
-	info.Flags().BoolVarP(&o.Verbose, "verbose", "v", false, "show verbose profile info")
-	info.Flags().StringVarP(&o.Format, "format", "", "yaml", "output format. formats: yaml, json")
-
-	list.Flags().BoolVarP(&o.Cached, "cached", "c", false, "show peers that aren't online, but previously seen")
-	list.Flags().StringVarP(&o.Network, "network", "n", "", "specify network to show peers from [ipfs]")
-	// TODO (ramfox): when we determine the best way to order and paginate peers, restore!
-	// list.Flags().IntVar(&o.PageSize, "page-size", 200, "max page size number of peers to show, default 200")
-	// list.Flags().IntVar(&o.Page, "page", 1, "page number of peers, default 1")
 
 	cmd.AddCommand(info, list, connect, disconnect)
 

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -11,27 +11,38 @@ import (
 func NewPublishCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &PublishOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:   "publish",
-		Short: "Set dataset publicity",
+		Use:   "publish [DATASET]",
+		Short: "set dataset publicity",
 		Long: `Publish makes your dataset available to others. While online, peers that connect 
 to you can only see datasets and versions that you've published. Publishing a 
 dataset always makes all previous history entries available, and any updates
 to a published dataset will be immediately visible to connected peers.
+
+Publishing a dataset also uploads it to the Qri Cloud registry
+(https://qri.cloud/).
+
+Note that publishing makes a single version of the dataset public (by default,
+that's the current version). When you update a dataset, those updates need to
+be explicitly published to be made public.
+
+Use the --unpublish option to make a dataset private and remove it from a
+registry.
 `,
-		Example: `  # publish a dataset
+		Example: `  # Publish a dataset:
   $ qri publish me/dataset
 
-  # publish a few datasets
+  # Publish a few datasets:
   $ qri publish me/dataset me/other_dataset
 
-  # unpublish a dataset
+  # Unpublish a dataset:
   $ qri publish --unpublish me/dataset
 
-  # publish a few dataset on p2p only
+  # Publish a few dataset on p2p only:
   $ qri publish --no-registry me/dataset_2`,
 		Annotations: map[string]string{
 			"group": "network",
 		},
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -20,8 +20,7 @@ func NewQriCommand(ctx context.Context, pf PathFactory, generator gen.CryptoGene
 	cmd := &cobra.Command{
 		Use:   "qri",
 		Short: "qri GDVCS CLI",
-		Long: `
-qri ("query") is a global dataset version control system 
+		Long: `qri ("query") is a global dataset version control system 
 on the distributed web.
 
 https://qri.io

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -13,22 +13,21 @@ import (
 // configured registry
 // TODO (b5) - registry publish commands are currently removed in favor of the
 // newer "qri publish" command.
-// we should consider refactoring this code (espcially it's documentation) &
+// we should consider refactoring this code (espcially its documentation) &
 // use it for registry-specific publication & search interaction
 func NewRegistryCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &RegistryOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "registry",
-		Short: "Commands for working with a qri registry (qri.cloud)",
-		Long: `
-Registries are federated public records of datasets and peers.
+		Short: "commands for working with a qri registry (qri.cloud)",
+		Long: `Registries are federated public records of datasets and peers.
 These records form a public facing central lookup for your datasets, so others
 can find them through search tools and via web links. You can use registry 
 commands to control how your datasets are published to registries, opting 
 in or out on a dataset-by-dataset basis.
 
 Unpublished dataset info will be held locally so you can still interact
-with it. And your datasets will be available to others peers when you run 
+with it. And your datasets will be available to other peers when you run 
 "qri connect", but will not show up in search results, and will not be 
 displayed on lists of registry datasets.
 
@@ -47,12 +46,11 @@ $ qri config set registry.location ""`,
 
 	// status represents the status command
 	status := &cobra.Command{
-		Use:   "status",
+		Use:   "status DATASET",
 		Short: "get the status of a reference on the registry",
-		Long: `
-  use status to see what version of a dataset the registry has on-record, if any`,
-		Example: `  Get status of a dataset reference::
-		$ qri registry status me/dataset_name`,
+		Long:  `Use status to see what version of a dataset the registry has on-record, if any.`,
+		Example: `  # Get status of a dataset reference:
+  $ qri registry status me/dataset_name`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
@@ -111,16 +109,16 @@ $ qri config set registry.location ""`,
 
 	signup := &cobra.Command{
 		Use:   "signup",
-		Short: "create a registery profile & connect your repo keypair",
-		Long: `  signup creates a profile for your repo on the configured registry.
-  (qri is configred to use qri.cloud as a registry by default)
+		Short: "create a registery profile & connect your local keypair",
+		Long: `Signup creates a profile for you on the configured registry.
+(qri is configred to use qri.cloud as a registry by default.)
 
-  registry signup reserves a unique username, and connects your local keypair,
-  allowing you to use your repo keypair to make authenticated requests on your
-  behalf.
+Registry signup reserves a unique username, and connects your local keypair,
+allowing your local copy of qri to make authenticated requests on your behalf.
 
-  You'll need to sign up before you can publish to a registry.
-		`,
+You'll need to sign up before you can use ` + "`qri publish`" + ` to publish a
+dataset on a registry.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -138,16 +136,18 @@ $ qri config set registry.location ""`,
 
 	prove := &cobra.Command{
 		Use:   "prove",
-		Short: "connect your repo keypair to an existing registry profile",
-		Long: `  If you have an existing account on a registry, and a repo that is
-  not yet connected to a registry profile, ` + "`prove`" + ` can connect them.
+		Short: "authorize your local keypair for an existing registry profile",
+		Long: `If you have an existing account on a registry, and local keypair
+that is not yet connected to a registry profile, ` + "`prove`" + ` can connect
+them.
 
-  The prove command connects the local repo to the registry by sending a signed
-  request to the registry containing login credentials, proving access to both
-  the unregistred keypair and your cloud account. Your repo username will be
-  matched to the on-registry username.
+The prove command connects the local repo to the registry by sending a signed
+request to the registry containing login credentials, proving access to both
+the unregistred keypair and your registry account. Your repo username will be
+matched to the on-registry username.
 
-	A repo can only be associated with one registry profile.`,
+A repo can only be associated with one registry profile.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -13,22 +13,24 @@ func NewRenameCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rename",
 		Aliases: []string{"mv"},
-		Short:   "Change the name of a dataset",
-		Long: `
-Rename changes the name of a dataset.
+		Short:   "change the name of a dataset",
+		Long: `Rename changes the name of a dataset.
 
 Note that if someone has added your dataset to their qri node, and then
 you rename your local dataset, your peer's version of your dataset will
 not have the updated name. While this won't break anything, it will
 confuse anyone who has added your dataset before the change. Try to keep
 renames to a minimum.`,
-		Example: `  rename a dataset named annual_pop to annual_population:
+		Example: `  # Rename a dataset named annual_pop to annual_population:
   $ qri rename me/annual_pop me/annual_population`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
 				return err
 			}
 			return o.Run()

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -15,9 +15,8 @@ func NewRenderCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &RenderOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "render",
-		Short: "Render a dataset readme or a dataset template",
-		Long: `
-Render a dataset either by converting its readme from markdown to
+		Short: "render a dataset readme or a dataset template",
+		Long: `Render a dataset either by converting its readme from markdown to
 html, or by filling in a template using the go/html template style.
 
 Use the ` + "`--output`" + ` flag to save the rendered html to a file.
@@ -26,10 +25,10 @@ Use the ` + "`--viz`" + ` flag to render the viz. Default is to use readme.
 
 Use the ` + "`--template`" + ` flag to use a custom template. If no template is
 provided, Qri will render the dataset with a default template.`,
-		Example: `  render the readme of a dataset called me/schools:
+		Example: `  # Render the readme of a dataset called me/schools:
   $ qri render -o=schools.html me/schools
 
-  render a dataset with a custom template:
+  # Render a dataset with a custom template:
   $ qri render --viz --template=template.html me/schools`,
 		Annotations: map[string]string{
 			"group": "dataset",
@@ -74,8 +73,11 @@ func (o *RenderOptions) Complete(f Factory, args []string) (err error) {
 
 // Run executes the render command
 func (o *RenderOptions) Run() error {
+	// NOTE: `--viz` is required even if we could infer it from `--template` in
+	// order to make extra sure the user is not mixing up possible args when
+	// rendering the readme.
 	if o.Template != "" && !o.UseViz {
-		return fmt.Errorf("can not specify both --template without --viz flag")
+		return fmt.Errorf("you must specify --viz when using --template")
 	}
 
 	if o.UseViz {

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -14,10 +14,32 @@ import (
 func NewRestoreCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &RestoreOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:     "restore",
-		Short:   "restore returns part or all of a dataset to a previous state",
-		Long:    ``,
-		Example: ``,
+		Use:   "restore [DATASET] [VERSION] [COMPONENT]",
+		Short: "restore a checked out dataset's files to a previous state",
+		Long: `Restore resets some or all the files in a checked out dataset to a previous
+state (it does not alter the dataset's history or commits). It will operate on
+the current directory unless a DATASET name is specified, in which case it will
+alter the directory that dataset is checked out to.
+
+Specify a specific VERSION (e.g. ` + "`/ipfs/QmU...`" + `) to restore to that
+version. (Use ` + "`qri log`" + ` to find a version's name.)
+
+Specify a COMPONENT to only restore a particular component (e.g. ` + "`structure`" + `).
+Note this is the *component* name, not the file name (e.g. ` + "`structure`" + `,
+not ` + "`structure.json`" + `)`,
+		Example: `  # Discard all the changes in the current directory:
+  $ qri restore
+  
+  # Reset the files in a directory to an earlier version (note you need to run
+  # ` + "`qri save`" + ` afterward to actually save a commit reverting the
+  # dataset to this version):
+  $ qri restore /ipfs/QmU1grTDSM375BvdNirYLgLTgNkUHPss3FnGxkHHVXwQmk
+  
+  # Discard just the changes to structure.json:
+  $ qri restore structure
+  
+  # Reset the structure.json file to a specific version:
+  $ qri restore /ipfs/QmU1grTDSM375BvdNirYLgLTgNkUHPss3FnGxkHHVXwQmk structure`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -17,11 +17,10 @@ import (
 func NewSaveCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &SaveOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:     "save",
+		Use:     "save [DATASET]",
 		Aliases: []string{"commit"},
-		Short:   "Save changes to a dataset",
-		Long: `
-Save is how you change a dataset, updating one or more of data, metadata, and structure. 
+		Short:   "save changes to a dataset",
+		Long: `Save is how you change a dataset, updating one or more of data, metadata, and structure. 
 You can also update your data via url. Every time you run save, an entry is added to 
 your dataset’s log (which you can see by running ` + "`qri log <dataset_reference>`" + `).
 
@@ -36,17 +35,18 @@ peer, the dataset gets renamed from ` + "`peers_name/dataset_name`" + ` to ` + "
 
 The ` + "`--message`" + `" and ` + "`--title`" + ` flags allow you to add a 
 commit message and title to the save.`,
-		Example: `  # save updated data to dataset annual_pop:
-  qri save --body /path/to/data.csv me/annual_pop
+		Example: `  # Save updated data to dataset annual_pop:
+  $ qri save --body /path/to/data.csv me/annual_pop
 
-  # save updated dataset (no data) to annual_pop:
-  qri save --file /path/to/dataset.yaml me/annual_pop
+  # Save updated dataset (no data) to annual_pop:
+  $ qri save --file /path/to/dataset.yaml me/annual_pop
   
-  # re-execute a dataset that has a transform:
-  qri save me/tf_dataset`,
+  # Re-execute a dataset that has a transform:
+  $ qri save me/tf_dataset`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -16,18 +16,17 @@ import (
 func NewSearchCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &SearchOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:   "search",
-		Short: "Search qri",
-		Long: `
-Search datasets & peers that match your query. Search pings the qri registry. 
+		Use:   "search QUERY",
+		Short: "search the registry for datasets",
+		Long: `Search datasets & peers that match your query. Search pings the qri registry. 
 
 Any dataset that has been published to the registry is available for search.`,
-		Example: `
-  # search 
+		Example: `  # Search for datasets featuring "annual population":
   $ qri search "annual population"`,
 		Annotations: map[string]string{
 			"group": "network",
 		},
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -21,9 +21,8 @@ func NewSetupCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &SetupOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "Initialize qri and IPFS repositories, provision a new qri ID",
-		Long: `
-Setup is the first command you run to get a fresh install of Qri. If you’ve 
+		Short: "initialize qri and IPFS repositories, provision a new qri ID",
+		Long: `Setup is the first command you run to get a fresh install of Qri. If you’ve 
 never run qri before, you’ll need to run setup before you can do anything. 
 
 Setup does a few things:
@@ -37,11 +36,12 @@ overwrite this info.
 
 Use the ` + "`--remove`" + ` to remove your Qri repo. This deletes your entire repo, 
 including all your datasets, and de-registers your peername from the registry.`,
-		Example: `  run setup with a peername of your choosing:
+		Example: `  # Run setup with a peername of your choosing:
   $ qri setup --peername=your_great_peername`,
 		Annotations: map[string]string{
 			"group": "other",
 		},
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -12,15 +12,15 @@ import (
 func NewStatsCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &StatsOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:   "stats",
-		Short: "Get aggregated stats for a dataset",
-		Long: `
-Run the ` + "`stats`" + ` to generate and view stats for a dataset using a dataset reference.`,
-		Example: `  # get stats for me/dataset_name:
-  qri stats me/dataset_name`,
+		Use:   "stats DATASET",
+		Short: "get aggregated stats for a dataset",
+		Long:  `Run the ` + "`stats`" + ` to generate and view stats for a dataset using a dataset reference.`,
+		Example: `  # Get stats for me/dataset_name:
+  $ qri stats me/dataset_name`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				fmt.Println("errorrrr")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,13 +15,28 @@ import (
 func NewStatusCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &StatusOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:     "status",
-		Short:   "Show status of working directory",
-		Long:    ``,
-		Example: ``,
+		Use:   "status [DATASET]",
+		Short: "show what components of a dataset have been changed",
+		Long: `List what components and files of the working directory's dataset have been
+added, removed, or changed.
+
+If you specify a DATASET, this will list what components were changed in a
+particular commit (or the latest commit if none is specified). You can specify
+a commit alongside a dataset like:
+
+    me/dataset_name@/ipfs/Qmu...`,
+		Example: `  # List what components in the working directory have changed:
+  $ qri status
+  
+  # List what changed in version /ipfs/Qmuabcd of me/my_dataset:
+  $ qri status me/my_dataset@/ipfs/Qmuabcd
+  
+  # List what changed in the latest commit of the working directory:
+  $ qri status $(cat .qri-ref)`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -18,7 +18,7 @@ func NewUpdateCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &UpdateOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Schedule dataset updates",
+		Short: "schedule dataset updates",
 		Long: `The qri update commands allow you to schedule automatic,
 periodic udates to your dataset. It also allows you to start & stop the
 updating daemon, to view the log of past updates and list of upcoming
@@ -31,8 +31,8 @@ updates.
 	}
 
 	scheduleCmd := &cobra.Command{
-		Use:   "schedule",
-		Short: "Schedule an update",
+		Use:   "schedule DATASET [PERIOD]",
+		Short: "schedule an update",
 		Long: `Schedule a dataset using all the same flags as the save command,
 except you must provide a periodicity (or have a periodicity set in your 
 dataset's Meta component. The given periodicity must be in the ISO 8601
@@ -47,17 +47,17 @@ a dataset you are creating for the first time, or a shell script that
 calls "qri save" to update a dataset.
 
 IMPORTANT: use the "qri update service" status command to ensure that the process
-responsible for executing your scheduled updates is currently active.
-	`,
-		Example: `  schedule the weekly update of a dataset you have already created
-	$ qri update schedule b5/my_dataset R/P1W
-	qri scheduled b5/my_dataset, next update: 2019-05-14 20:15:13.191602 +0000 UTC
-	
-	schedule the daily update of a dataset that you are creating for the first 
-	time:
-	$ qri update schedule --file dataset.yaml b5/my_dataset R/P1D
-	qri scheduled b5/my_dataset, next update: 2019-05-08 20:15:13.191602 +0000 UTC
-	`,
+responsible for executing your scheduled updates is currently active.`,
+		Example: `  # Schedule the weekly update of a dataset you have already created:
+  $ qri update schedule b5/my_dataset R/P1W
+  qri scheduled b5/my_dataset, next update: 2019-05-14 20:15:13.191602 +0000 UTC
+
+  # Schedule the daily update of a dataset that you are creating for the first 
+  # time:
+  $ qri update schedule --file dataset.yaml b5/my_dataset R/P1D
+  qri scheduled b5/my_dataset, next update: 2019-05-08 20:15:13.191602 +0000 UTC
+  `,
+		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -80,16 +80,16 @@ responsible for executing your scheduled updates is currently active.
 	scheduleCmd.Flags().StringVar(&o.RepoPath, "use-repo", "", "experiment. run update on behalf of another repo")
 
 	unscheduleCmd := &cobra.Command{
-		Use:   "unschedule",
-		Short: "Unschedule an update",
+		Use:   "unschedule DATASET",
+		Short: "unschedule an update",
 		Long: `Unscheduling an update removes that dataset from the list of
 scheduled updates.
 	`,
-		Example: `  unschedule an update using the dataset name
-	$ qri update unschedule b5/my_dataset
-	unscheduled b5/my_dataset
-	
-	`,
+		Example: `  # Unschedule an update using the dataset name:
+  $ qri update unschedule b5/my_dataset
+  unscheduled b5/my_dataset
+  `,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -100,19 +100,19 @@ scheduled updates.
 	listCmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List scheduled updates",
+		Short:   "list scheduled updates",
 		Long: `Update list gives you a view into the upcoming scheduled updates, starting
 with the most immediate update.
 	`,
-		Example: `  list the upcoming updates:
+		Example: `  # List the upcoming updates:
   $ qri update list
   1. b5/my_dataset
   in 4 hours 4:19PM | dataset
 
   2. b5/my_next_dataset
   in 2 days 5:22PM | dataset
-
-	`,
+  `,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -125,9 +125,9 @@ with the most immediate update.
 	listCmd.Flags().IntVar(&o.PageSize, "page-size", 25, "page size of results, default 25")
 
 	logsCmd := &cobra.Command{
-		Use:     "logs",
+		Use:     "logs [LOGNAME]",
 		Aliases: []string{"log"},
-		Short:   "Show log of dataset updates",
+		Short:   "show log of dataset updates",
 		Long: `Update logs shows the log of the updates that have already run,
 starting with the most recent. The log includes a timestamped name, the type of
 update that occured (dataset or shell), and the time it occured.
@@ -135,7 +135,7 @@ update that occured (dataset or shell), and the time it occured.
 Using the name of a specific log as a parameter gives you the output of that
 update.
 	`,
-		Example: `  list the log of previous updates:
+		Example: `  # List the log of previous updates:
   $ qri update logs
   1. 1557173933-my_dataset
   1 day ago | no changes to save
@@ -144,10 +144,11 @@ update.
   1 day ago | no changes to save
   ...
 
-  get the output of one specific update:
+  # Get the output of one specific update:
   $ qri update log 1557173933-my_dataset
-  dataset saved: b5/my_dataset@MSN9/ipfs/BntM
+  dataset saved: b5/my_dataset@MSN9/ipfs/BntM
 	`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -160,19 +161,19 @@ update.
 	logsCmd.Flags().IntVar(&o.PageSize, "page-size", 25, "page size of results, default 25")
 
 	runCmd := &cobra.Command{
-		Use:   "run",
-		Short: "Execute an update immediately",
+		Use:   "run DATASET",
+		Short: "execute an update immediately",
 		Long: `Run allows you to execute an update immediately, rather then wait for
 its scheduled time. Run uses the same parameters as the Save command, but
 but assumes you want to recall the most recent transform in the dataset.
 	`,
-		Example: `  run an update
+		Example: `  # Run an update:
   $ qri update run b5/my_dataset
   🤖  running transform...
   ✅ transform complete
   dataset saved: b5/my_dataset@MSN9/ipfs/2BntM
-
 	`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -195,14 +196,15 @@ but assumes you want to recall the most recent transform in the dataset.
 
 	serviceCmd := &cobra.Command{
 		Use:   "service",
-		Short: "Control qri update daemon",
+		Short: "control qri update daemon",
 		Long: `The qri service commands allow you to start, stop, and check the 
-status of update daemon that executes the dataset updates.`,
+status of the update daemon that executes the dataset updates.`,
 	}
 
 	serviceStatusCmd := &cobra.Command{
 		Use:   "status",
-		Short: "Show update daemon status",
+		Short: "show update daemon status",
+		Args:  cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err
@@ -212,11 +214,12 @@ status of update daemon that executes the dataset updates.`,
 	}
 	serviceStartCmd := &cobra.Command{
 		Use:   "start",
-		Short: "Start update daemon",
+		Short: "start update daemon",
 		Long: `Use the "qri update service start" command to begin the process 
 responsible for executing your scheduled updates. Any updates that were
 scheduled before the update daemon has started will be run as soon as the 
 updating process initiates.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// warning: need to be very careful to *not* initialize an instance here
 			// which is usually done by calling complete to trigger initialization
@@ -229,10 +232,11 @@ updating process initiates.`,
 
 	serviceStopCmd := &cobra.Command{
 		Use:   "stop",
-		Short: "Stop update daemon",
+		Short: "stop update daemon",
 		Long: `Use the "qri update service stop" command to end the process 
 responsible for executing your scheduled updates. With this process terminated,
 your scheduled updates will not run.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -21,27 +21,31 @@ const FileSelectedRefs = "/selected_refs.json"
 func NewUseCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &UseOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:   "use",
-		Short: "Select datasets for use with the qri get command",
-		Long: `
-Run the ` + "`use`" + ` command to have Qri remember references to a specific datasets. 
+		Use:   "use [DATASET]",
+		Short: "select datasets for use with the qri get command",
+		Long: `Run the ` + "`use`" + ` command to have Qri remember references to a specific datasets. 
 These datasets will be referenced for future commands, if no dataset reference 
-is explicitly given for those commands.
+is explicitly given for those commands or they are not run from the checkout
+directory of a dataset.
+
+To show the current reference, use the ` + "`--list`" + ` option instead of
+providing a DATASET name. To forget the current reference, use the ` + "`--clear`" + `
+option.
 
 We created this command to ease the typing/copy and pasting burden while using
 Qri to explore a dataset.`,
-		Example: `  # use dataset me/dataset_name, then get meta.title:
-  qri use me/dataset_name
-  qri get meta.title
+		Example: `  # Use dataset me/dataset_name, then get meta.title:
+  $ qri use me/dataset_name
+  $ qri get meta.title
 
-  # clear current selection:
-  qri use --clear
+  # Clear current selection:
+  $ qri use --clear
 
-  # show current selected dataset references:
-  qri use --list
+  # Show current selected dataset references:
+  $ qri use --list
 
-  # add multiple references to the remembered list
-  qri use me/population_2017 me/population_2018`,
+  # Add multiple references to the remembered list:
+  $ qri use me/population_2017 me/population_2018`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -15,13 +15,12 @@ import (
 func NewValidateCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	o := &ValidateOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
-		Use:   "validate",
-		Short: "Show schema validation errors",
+		Use:   "validate [DATASET]",
+		Short: "show schema validation errors",
 		Annotations: map[string]string{
 			"group": "dataset",
 		},
-		Long: `
-Validate checks data for errors using a schema and then printing a list of
+		Long: `Validate checks data for errors using a schema and then printing a list of
 issues. By default validate checks a dataset's body against it’s own schema.
 Validate is a flexible command that works with data and schemas either
 inside or outside of qri by providing the --body and --schema or --structure
@@ -52,14 +51,15 @@ command.
 
 Note: --body and --schema or --structure flags will override the dataset
 if these flags are provided.`,
-		Example: `  # show errors in an existing dataset:
-  qri validate b5/comics
+		Example: `  # Show errors in an existing dataset:
+  $ qri validate b5/comics
 
-  # validate a new body against an existing schema
-  qri validate --body new_data.csv me/annual_pop
+  # Validate a new body against an existing schema:
+  $ qri validate --body new_data.csv me/annual_pop
 
-  # validate data against a new schema
-  qri validate --body data.csv --schema schema.json`,
+  # Validate data against a new schema:
+  $ qri validate --body data.csv --schema schema.json`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(f, args); err != nil {
 				return err

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,14 +10,14 @@ import (
 func NewVersionCommand(_ Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number",
-		Long: `
-Qri uses semantic versioning.
+		Short: "print the version number",
+		Long: `Qri uses semantic versioning.
 
 For updates & further information check https://github.com/qri-io/qri/releases`,
 		Annotations: map[string]string{
 			"group": "other",
 		},
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printInfo(ioStreams.Out, version.String)
 			return nil


### PR DESCRIPTION
Add positional argument information to all commands and clean up the descriptions and examples a bit.

~This is only half the commands and *very* much needs a second pass (lots of things I learned or decided partway through), but posting it here for safekeeping and if anyone wants to review early.~

The descriptions and examples now follow some basic styles for consistency:

  - No leading/trailing blank lines. (This is pretty arbitrary; I was mainly trying to make things consistent. We could make other choices about this.)

  - Short descriptions are phrases, not complete sentences — they start with a lower-case letter and do not end with a period. (Also arbitrary; was trying to go with what seemed most common.)

  - Long descriptions are full sentences and paragraphs. They start with a capital unless the first word is the name of a command or special word that should never be upper-case.

  - Examples:
    - Indented with two spaces.
    - Example descriptions start with `#`.
    - Lines that should be typed start with `$`.

I also fixed a few typos and added more detailed descriptions where the obviously didn't fully address what the command does, but otherwise tried to leave descriptive information alone here.