### PR TITLE
fix(startf): script print statements print to stderr

### DIFF
--- a/base/save.go
+++ b/base/save.go
@@ -97,7 +97,7 @@ func SaveDataset(ctx context.Context, r repo.Repo, str ioes.IOStreams, changes *
 		opts := []func(*startf.ExecOpts){
 			startf.AddQriRepo(r),
 			startf.AddMutateFieldCheck(mutateCheck),
-			startf.SetOutWriter(scriptOut),
+			startf.SetErrWriter(scriptOut),
 			startf.SetSecrets(secrets),
 		}
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -393,6 +394,12 @@ func TestSaveTransformWithoutChanges(t *testing.T) {
 
 	// Save a version, then another with no changes
 	run.MustExec(t, "qri save --file=testdata/movies/tf_123.star me/test_ds")
+
+	errOut := run.GetCommandErrOutput()
+	if !strings.Contains(errOut, "setting body") {
+		t.Errorf("expected ErrOutput to contain print statement from transform script. errOutput:\n%s", errOut)
+	}
+
 	err := run.ExecCommand("qri save --file=testdata/movies/tf_123.star me/test_ds")
 	expect := `error saving: no changes`
 	if err == nil {

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -160,6 +160,7 @@ func (o *SaveOptions) Run() (err error) {
 		Title:    o.Title,
 		Message:  o.Message,
 
+		ScriptOutput:        o.ErrOut,
 		ReadFSI:             o.UsingFSI,
 		WriteFSI:            o.UsingFSI,
 		FilePaths:           o.FilePaths,

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -147,7 +147,6 @@ func TestSaveRun(t *testing.T) {
 		{"add rows, save", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "Added 10 more rows", "Adding to the number of rows in dataset", true, false, true, "dataset saved: peer/movies@/map/Qmf516nREprnwE3YnBpZd1y9DkS6e2ktKYDLMtz4L4MgMX\nthis dataset has 1 validation errors\n", "", ""},
 		{"no changes", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "trying to add again", "hopefully this errors", false, false, true, "", "error saving: no changes", ""},
 		{"add viz", "me/movies", "testdata/movies/dataset_with_viz.json", "", "", "", false, false, false, "dataset saved: peer/movies@/map/QmXDKr4ryBuzXFhpKPUAe6GmqEacCjgPkG76NyVLpmPDSt\nthis dataset has 1 validation errors\n", "", ""},
-		{"add transform", "me/movies", "testdata/movies/dataset_with_tf.json", "", "", "", false, false, false, "dataset saved: peer/movies@/map/QmaYNBGZUxJJZVFFf9LkqomSZQ5kLRCaprKtNDwGUJ2bYy\nthis dataset has 1 validation errors\n", "", ""},
 	}
 
 	for _, c := range cases {

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -222,9 +222,16 @@ func (run *TestRunner) Must(t *testing.T, err error) {
 	}
 }
 
-// GetCommandOutput returns the standard output from the previously executed command
+// GetCommandOutput returns the standard output from the previously executed
+// command
 func (run *TestRunner) GetCommandOutput() string {
 	return run.RepoRoot.GetOutput()
+}
+
+// GetCommandErrOutput fetches the stderr value from the previously executed
+// command
+func (run *TestRunner) GetCommandErrOutput() string {
+	return run.RepoRoot.GetErrOutput()
 }
 
 func executeCommand(root *cobra.Command, cmd string) error {

--- a/cmd/testdata/movies/tf_123.star
+++ b/cmd/testdata/movies/tf_123.star
@@ -1,3 +1,4 @@
 # transform that sets a simple body
 def transform(ds, ctx):
+  print("setting body")
   ds.set_body([1,2,3])

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -436,6 +436,7 @@ func (p *SaveParams) AbsolutizePaths() error {
 // TODO - need to make sure users aren't forking by referencing commits other than tip
 func (r *DatasetRequests) Save(p *SaveParams, res *reporef.DatasetRef) (err error) {
 	if r.cli != nil {
+		p.ScriptOutput = nil
 		return r.cli.Call("DatasetRequests.Save", p, res)
 	}
 	ctx := context.TODO()

--- a/repo/test/temp_repo.go
+++ b/repo/test/temp_repo.go
@@ -121,6 +121,15 @@ func (r *TempRepo) GetOutput() string {
 	return ""
 }
 
+// GetErrOutput returns the "stderr" output from the previously executed command
+func (r *TempRepo) GetErrOutput() string {
+	buffer, ok := r.Streams.ErrOut.(*bytes.Buffer)
+	if ok {
+		return buffer.String()
+	}
+	return ""
+}
+
 // GetPathForDataset returns the path to where the index'th dataset is stored on CAFS.
 func (r *TempRepo) GetPathForDataset(index int) (string, error) {
 	dsRefs := filepath.Join(r.QriPath, "refs.fbs")

--- a/startf/transform_test.go
+++ b/startf/transform_test.go
@@ -33,13 +33,13 @@ func TestOpts(t *testing.T) {
 	o := &ExecOpts{}
 	SetSecrets(nil)(o)
 	SetSecrets(map[string]string{"a": "b"})(o)
-	SetOutWriter(nil)(o)
+	SetErrWriter(nil)(o)
 	AddQriRepo(nil)(o)
 	AddMutateFieldCheck(nil)(o)
 
 	expect := &ExecOpts{
 		Secrets:   map[string]interface{}{"a": "b"},
-		OutWriter: nil,
+		ErrWriter: nil,
 	}
 
 	if diff := cmp.Diff(expect, o); diff != "" {
@@ -55,7 +55,7 @@ func TestExecScript(t *testing.T) {
 	ds.Transform.SetScriptFile(scriptFile(t, "testdata/tf.star"))
 
 	stderr := &bytes.Buffer{}
-	err := ExecScript(ctx, ds, nil, SetOutWriter(stderr))
+	err := ExecScript(ctx, ds, nil, SetErrWriter(stderr))
 	if err != nil {
 		t.Error(err.Error())
 		return


### PR DESCRIPTION
cleans up some crossed wires, adds the necessary methods to test `ErrOutput` within `cmd` package tests.

closes #1194 