### PR TITLE
fix(update): Change default port for update service

### DIFF
--- a/config/testdata/default.yaml
+++ b/config/testdata/default.yaml
@@ -37,7 +37,7 @@ webapp:
 update:
   type: fs
   daemonize: true
-  address: "127.0.0.1:2506"
+  address: "127.0.0.1:2507"
 rpc:
   enabled: true
   port: 2504

--- a/config/update.go
+++ b/config/update.go
@@ -10,7 +10,7 @@ type Update struct {
 }
 
 // DefaultUpdateAddress is the local address Update serves on by default
-var DefaultUpdateAddress = "127.0.0.1:2506"
+var DefaultUpdateAddress = "127.0.0.1:2507"
 
 // DefaultUpdate creates a new default Update configuration
 func DefaultUpdate() *Update {


### PR DESCRIPTION
Oops! As per https://github.com/qri-io/qri/issues/1159, TestUpdateMethods is flaky, because it's using the same port as Websockets. I didn't realize when adding Websockets that 2506 was already in use. I am trying out changing the update port because it's probably easier for Desktop that way, since Desktop is currently hardcoding the Websockets port number but isn't using update at all.

This change will fix one of the two reasons why TestUpdateMethods is flaky, the other being `qri connect` being run by other tests.