### PR TITLE
fix(unlink): Fsi unlink handles more edge-cases, acts more sane.

### DIFF
--- a/cmd/fsi.go
+++ b/cmd/fsi.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/qri-io/ioes"
@@ -62,9 +61,6 @@ type FSIOptions struct {
 // Complete adds any missing configuration that can only be added just before
 // calling Run
 func (o *FSIOptions) Complete(f Factory, args []string) (err error) {
-	if len(args) < 1 {
-		return fmt.Errorf("please provide the name of a dataset")
-	}
 	o.FSIMethods, err = f.FSIMethods()
 	if err != nil {
 		return err
@@ -108,10 +104,8 @@ func (o *FSIOptions) Unlink() error {
 		printRefSelect(o.ErrOut, o.Refs)
 
 		p := &lib.LinkParams{
-			Dir: o.Refs.Dir(),
 			Ref: ref,
 		}
-
 		if err := o.FSIMethods.Unlink(p, &res); err != nil {
 			printErr(o.ErrOut, err)
 			return nil

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -182,10 +182,7 @@ func (run *TestRunner) LookupVersionInfo(refStr string) *dsref.VersionInfo {
 	if err != nil {
 		return nil
 	}
-	datasetRef := reporef.DatasetRef{
-		Peername: dr.Username,
-		Name:     dr.Name,
-	}
+	datasetRef := reporef.RefFromDsref(dr)
 	// TODO(dustmop): Work-around for https://github.com/qri-io/qri/issues/1209
 	// Would rather do `run.RepoRoot.Repo()` but that doesn't work.
 	ctx := context.Background()
@@ -210,10 +207,7 @@ func (run *TestRunner) ClearFSIPath(t *testing.T, refStr string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	datasetRef := reporef.DatasetRef{
-		Peername: dr.Username,
-		Name:     dr.Name,
-	}
+	datasetRef := reporef.RefFromDsref(dr)
 	// TODO(dustmop): Work-around for https://github.com/qri-io/qri/issues/1209
 	// Would rather do `run.RepoRoot.Repo()` but that doesn't work.
 	ctx := context.Background()

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/registry"
 	"github.com/qri-io/qri/registry/regserver"
+	"github.com/qri-io/qri/repo"
+	reporef "github.com/qri-io/qri/repo/ref"
 	repotest "github.com/qri-io/qri/repo/test"
 	"github.com/spf13/cobra"
 )
@@ -161,6 +163,73 @@ func (run *TestRunner) CreateCommandRunner(ctx context.Context) *cobra.Command {
 	cmd := NewQriCommand(ctx, run.pathFactory, run.RepoRoot.TestCrypto, run.RepoRoot.Streams)
 	cmd.SetOutput(out)
 	return cmd
+}
+
+// FileExists returns whether the file exists
+func (run *TestRunner) FileExists(file string) bool {
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// LookupVersionInfo returns a versionInfo for the ref, or nil if not found
+func (run *TestRunner) LookupVersionInfo(refStr string) *dsref.VersionInfo {
+	// TODO(dustmop): Could directly parse reporef.DatasetRef instead, but we should transition
+	// to dsref's data structures where possible. This will make it easier to switch to dscache
+	// once it exists.
+	dr, err := dsref.Parse(refStr)
+	if err != nil {
+		return nil
+	}
+	datasetRef := reporef.DatasetRef{
+		Peername: dr.Username,
+		Name:     dr.Name,
+	}
+	// TODO(dustmop): Work-around for https://github.com/qri-io/qri/issues/1209
+	// Would rather do `run.RepoRoot.Repo()` but that doesn't work.
+	ctx := context.Background()
+	inst, err := lib.NewInstance(
+		ctx,
+		run.RepoRoot.QriPath,
+		lib.OptStdIOStreams(),
+		lib.OptSetIPFSPath(run.RepoRoot.IPFSPath),
+	)
+	r := inst.Repo()
+	err = repo.CanonicalizeDatasetRef(r, &datasetRef)
+	if err != nil {
+		return nil
+	}
+	vinfo := reporef.ConvertToVersionInfo(&datasetRef)
+	return &vinfo
+}
+
+// ClearFSIPath clears the FSIPath for a reference in the refstore
+func (run *TestRunner) ClearFSIPath(t *testing.T, refStr string) {
+	dr, err := dsref.Parse(refStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	datasetRef := reporef.DatasetRef{
+		Peername: dr.Username,
+		Name:     dr.Name,
+	}
+	// TODO(dustmop): Work-around for https://github.com/qri-io/qri/issues/1209
+	// Would rather do `run.RepoRoot.Repo()` but that doesn't work.
+	ctx := context.Background()
+	inst, err := lib.NewInstance(
+		ctx,
+		run.RepoRoot.QriPath,
+		lib.OptStdIOStreams(),
+		lib.OptSetIPFSPath(run.RepoRoot.IPFSPath),
+	)
+	r := inst.Repo()
+	err = repo.CanonicalizeDatasetRef(r, &datasetRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	datasetRef.FSIPath = ""
+	r.PutRef(datasetRef)
 }
 
 // GetPathForDataset fetches a path for dataset index

--- a/dsref/parse.go
+++ b/dsref/parse.go
@@ -134,6 +134,15 @@ func ParseHumanFriendly(text string) (Ref, error) {
 	return r, nil
 }
 
+// MustParse parses a dsref from a string, or panics if it fails
+func MustParse(text string) Ref {
+	ref, err := Parse(text)
+	if err != nil {
+		panic(err)
+	}
+	return ref
+}
+
 // IsRefString returns whether the string parses as a valid reference
 func IsRefString(text string) bool {
 	_, err := Parse(text)

--- a/fsi/fsi.go
+++ b/fsi/fsi.go
@@ -22,8 +22,10 @@ import (
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/base/component"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
 	"github.com/qri-io/qri/repo"
+	"github.com/qri-io/qri/repo/profile"
 	reporef "github.com/qri-io/qri/repo/ref"
 )
 
@@ -199,27 +201,32 @@ func (fsi *FSI) ModifyLinkReference(dirPath, refStr string) error {
 	return nil
 }
 
-// Unlink breaks the connection between a directory and a dataset
-func (fsi *FSI) Unlink(dirPath, refStr string) error {
-	ref, err := repo.ParseDatasetRef(refStr)
-	if err != nil {
-		return err
-	}
-
+// Unlink removes the link file (.qri-ref) in the directory, and removes the fsi path
+// from the reference in the refstore
+func (fsi *FSI) Unlink(dirPath string, ref dsref.Ref) error {
 	if removeLinkErr := removeLinkFile(dirPath); removeLinkErr != nil {
 		log.Debugf("removing link file: %s", removeLinkErr.Error())
 	}
 
-	if err = repo.CanonicalizeDatasetRef(fsi.repo, &ref); err != nil {
-		if err == repo.ErrNoHistory {
-			// if we're unlinking a ref without history, delete it
-			return fsi.repo.DeleteRef(ref)
-		}
-		return err
+	// Ref may be empty, which will mean only the link file should be removed
+	if ref.IsEmpty() {
+		return nil
 	}
 
-	ref.FSIPath = ""
-	return fsi.repo.PutRef(ref)
+	// The FSIPath is *not* set, which removes it from the refstore
+	datasetRef := reporef.DatasetRef{
+		Peername:  ref.Username,
+		ProfileID: profile.IDB58DecodeOrEmpty(ref.ProfileID),
+		Name:      ref.Name,
+		Path:      ref.Path,
+	}
+
+	// if we're unlinking a ref without history, delete it
+	if datasetRef.Path == "" {
+		return fsi.repo.DeleteRef(datasetRef)
+	}
+	// Otherwise just update the refstore
+	return fsi.repo.PutRef(datasetRef)
 }
 
 // Remove attempts to remove the dataset directory

--- a/fsi/fsi.go
+++ b/fsi/fsi.go
@@ -25,7 +25,6 @@ import (
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
 	"github.com/qri-io/qri/repo"
-	"github.com/qri-io/qri/repo/profile"
 	reporef "github.com/qri-io/qri/repo/ref"
 )
 
@@ -214,12 +213,7 @@ func (fsi *FSI) Unlink(dirPath string, ref dsref.Ref) error {
 	}
 
 	// The FSIPath is *not* set, which removes it from the refstore
-	datasetRef := reporef.DatasetRef{
-		Peername:  ref.Username,
-		ProfileID: profile.IDB58DecodeOrEmpty(ref.ProfileID),
-		Name:      ref.Name,
-		Path:      ref.Path,
-	}
+	datasetRef := reporef.RefFromDsref(ref)
 
 	// if we're unlinking a ref without history, delete it
 	if datasetRef.Path == "" {

--- a/fsi/fsi_test.go
+++ b/fsi/fsi_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/qri-io/qri/base"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/repo"
 	testrepo "github.com/qri-io/qri/repo/test"
 )
@@ -278,16 +279,16 @@ func TestUnlink(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, _, err := fsi.CreateLink(paths.firstDir, "me/test_ds")
+	_, _, err := fsi.CreateLink(paths.firstDir, "peer/test_ds")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
 
-	if err := fsi.Unlink(paths.firstDir, "me/mismatched_reference"); err == nil {
+	if err := fsi.Unlink(paths.firstDir, dsref.MustParse("peer/mismatched_reference")); err == nil {
 		t.Errorf("expected unlinking mismatched reference to error")
 	}
 
-	if err := fsi.Unlink(paths.firstDir, "me/test_ds"); err != nil {
+	if err := fsi.Unlink(paths.firstDir, dsref.MustParse("peer/test_ds")); err != nil {
 		t.Errorf("unlinking valid reference: %s", err.Error())
 	}
 }

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -828,7 +828,8 @@ func (r *DatasetRequests) Remove(p *RemoveParams, res *RemoveResponse) error {
 	if p.Revision.Gen == dsref.AllGenerations {
 		// removing all revisions of a dataset must unlink it
 		if ref.FSIPath != "" {
-			if err := r.inst.fsi.Unlink(ref.FSIPath, ref.AliasString()); err == nil {
+			dr := reporef.ConvertToDsref(ref)
+			if err := r.inst.fsi.Unlink(ref.FSIPath, dr); err == nil {
 				res.Unlinked = true
 			} else {
 				log.Errorf("during Remove, dataset did not unlink: %s", err)

--- a/repo/ref/convert.go
+++ b/repo/ref/convert.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/repo/profile"
 )
 
 // ConvertToVersionInfo converts an old style DatasetRef to the newly preferred dsref.VersionInfo
@@ -52,5 +53,16 @@ func ConvertToDsref(ref DatasetRef) dsref.Ref {
 		Name:      ref.Name,
 		ProfileID: ref.ProfileID.String(),
 		Path:      ref.Path,
+	}
+}
+
+// RefFromDsref creates a datasetRef from a dsref.Ref. The profileID field will be
+// an empty string if the input profileID is blank or otherwise cannot be decoded.
+func RefFromDsref(r dsref.Ref) DatasetRef {
+	return DatasetRef{
+		Peername:  r.Username,
+		ProfileID: profile.IDB58DecodeOrEmpty(r.ProfileID),
+		Name:      r.Name,
+		Path:      r.Path,
 	}
 }

--- a/repo/ref/convert_test.go
+++ b/repo/ref/convert_test.go
@@ -1,0 +1,72 @@
+package reporef
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/repo/profile"
+	testPeers "github.com/qri-io/qri/config/test"
+)
+
+func TestRefFromDsref(t *testing.T) {
+	d := dsref.Ref{
+		Username:  "test_peer",
+		ProfileID: "",
+		Name:      "my_ds",
+		Path:      "/mem/QmExaMpLe",
+	}
+
+	ref := RefFromDsref(d)
+	expectRef := DatasetRef{
+		Peername:  "test_peer",
+		ProfileID: profile.IDRawByteString(""),
+		Name:      "my_ds",
+		Path:      "/mem/QmExaMpLe",
+	}
+	if diff := cmp.Diff(expectRef, ref); diff != "" {
+		t.Errorf("mismatch (-want, +got)\ndiff:%v", diff)
+	}
+}
+
+func TestRefFromDsrefCantDecode(t *testing.T) {
+	d := dsref.Ref{
+		Username:  "a_user",
+		ProfileID: "testProfileID",
+		Name:      "some_name",
+		Path:      "/mem/QmExaMpLe2",
+	}
+
+	ref := RefFromDsref(d)
+	expectRef := DatasetRef{
+		Peername:  "a_user",
+		ProfileID: profile.IDRawByteString(""),
+		Name:      "some_name",
+		Path:      "/mem/QmExaMpLe2",
+	}
+	if diff := cmp.Diff(expectRef, ref); diff != "" {
+		t.Errorf("mismatch (-want, +got)\ndiff:%v", diff)
+	}
+}
+
+func TestRefFromDsrefCorrectProfileID(t *testing.T) {
+	info := testPeers.GetTestPeerInfo(0)
+
+	d := dsref.Ref{
+		Username:  "someone",
+		ProfileID: info.EncodedPeerID,
+		Name:      "example",
+		Path:      "/mem/QmExaMpLe3",
+	}
+
+	ref := RefFromDsref(d)
+	expectRef := DatasetRef{
+		Peername:  "someone",
+		ProfileID: profile.IDFromPeerID(info.PeerID),
+		Name:      "example",
+		Path:      "/mem/QmExaMpLe3",
+	}
+	if diff := cmp.Diff(expectRef, ref); diff != "" {
+		t.Errorf("mismatch (-want, +got)\ndiff:%v", diff)
+	}
+}


### PR DESCRIPTION
Fsi unlink command will delete the appropriate link file, regardless of how it is called. Better handle edge cases, like inconsistent folder state. Add lots of tests to cover all of the types of behavior fsi unlink has.