### PR TITLE
fix(search): change type from interface to dataset so rpc can serialize

### DIFF
--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
-	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
@@ -159,7 +158,7 @@ func (r searchResultStringer) String() string {
 	w := &strings.Builder{}
 	title := color.New(color.FgGreen, color.Bold).SprintFunc()
 	path := color.New(color.Faint).SprintFunc()
-	ds := r.Value.(*dataset.Dataset)
+	ds := r.Value
 
 	fmt.Fprintf(w, "%s/%s", title(ds.Peername), title(ds.Name))
 	fmt.Fprintf(w, "\n%s", r.URL)

--- a/lib/search.go
+++ b/lib/search.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"fmt"
 
+	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/registry/regclient"
 	"github.com/qri-io/qri/repo"
 )
@@ -32,7 +33,7 @@ type SearchParams struct {
 type SearchResult struct {
 	Type, ID string
 	URL      string
-	Value    interface{}
+	Value    *dataset.Dataset
 }
 
 // Search queries for items on qri related to given parameters


### PR DESCRIPTION
Ensures `rpc` can serialize the response. A quick skim through the codebase, this should not be present anywhere else.

Related issue:
https://github.com/qri-io/qri/issues/1193