### PR TITLE
fix(cmd): pass node when not making online request for peers

### DIFF
--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -227,7 +227,7 @@ func (o *QriOptions) PeerRequests() (*lib.PeerRequests, error) {
 	if err := o.Init(); err != nil {
 		return nil, err
 	}
-	return lib.NewPeerRequests(nil, o.inst.RPC()), nil
+	return lib.NewPeerRequests(o.inst.Node(), o.inst.RPC()), nil
 }
 
 // ProfileMethods generates a lib.ProfileMethods from internal state

--- a/lib/peers.go
+++ b/lib/peers.go
@@ -30,9 +30,6 @@ func (d PeerRequests) CoreRequestsName() string { return "peers" }
 // NewPeerRequests creates a PeerRequests pointer from either a
 // qri Node or an rpc.Client
 func NewPeerRequests(node *p2p.QriNode, cli *rpc.Client) *PeerRequests {
-	if node != nil && cli != nil {
-		panic(fmt.Errorf("both node and client supplied to NewPeerRequests"))
-	}
 
 	return &PeerRequests{
 		qriNode: node,


### PR DESCRIPTION
Fixes https://github.com/qri-io/qri/issues/1179

The issue was when running 'offline' we will neither trigger an RPC call nor do we pass the instance/Node along which always drops the request due to 'not being connected'. In reality we want to check against the instance created by the `qri` command if we're not going to query against a live `qri connect` session and execute an RPC call if there is. RPC always takes precedence vs command local execution.