### PR TITLE
refactor(test): TestRunner owns timestamp and stringer functions

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -34,7 +34,7 @@ func TestAddAndListRefs(t *testing.T) {
 	expect := `0 Peername:  test_peer
   ProfileID: QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
   Name:      my_dataset
-  Path:      /ipfs/QmeyznW4FBaLY8rk5xpZyFHXixrq8qFJrFf8v1REZzmLLg
+  Path:      /ipfs/QmTNy5ZpjdaLLqWBuuX9GhjdoxgHdGksyhV4VFQNtXTcHu
   FSIPath:   
   Published: false
 
@@ -50,13 +50,13 @@ func TestAddAndListRefs(t *testing.T) {
 	expect = `0 Peername:  other_peer
   ProfileID: QmWYgD49r9HnuXEppQEq1a7SUUryja4QNs9E6XCH2PayCD
   Name:      their_dataset
-  Path:      /ipfs/QmeD7XLpUoz6EKzBBGHQ4dMEsA8veRJDz4Ky2WAjkBM5kt
+  Path:      /ipfs/QmeQC8QdAVtruVyEyAejZBHFDBhqy99pDhDpdPXkALfhfD
   FSIPath:   
   Published: false
 1 Peername:  test_peer
   ProfileID: QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
   Name:      my_dataset
-  Path:      /ipfs/QmeyznW4FBaLY8rk5xpZyFHXixrq8qFJrFf8v1REZzmLLg
+  Path:      /ipfs/QmTNy5ZpjdaLLqWBuuX9GhjdoxgHdGksyhV4VFQNtXTcHu
   FSIPath:   
   Published: false
 
@@ -82,7 +82,7 @@ func TestAddWithCheckout(t *testing.T) {
 	expect := `0 Peername:  other_peer
   ProfileID: QmWYgD49r9HnuXEppQEq1a7SUUryja4QNs9E6XCH2PayCD
   Name:      their_dataset
-  Path:      /ipfs/QmbCV8415B6uM4A1UC6YpPCzGpUd5Kx4txWTcPLoXjEcQP
+  Path:      /ipfs/QmeD7XLpUoz6EKzBBGHQ4dMEsA8veRJDz4Ky2WAjkBM5kt
   FSIPath:   /tmp/workdir
   Published: false
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -9,12 +9,10 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/qri/config"
-	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/startf"
 )
 
@@ -227,7 +225,7 @@ func TestSaveThenOverrideMetaComponent(t *testing.T) {
 	actual := run.DatasetMarshalJSON(t, dsPath)
 
 	// This dataset is ds_ten.yaml, with the meta replaced by meta_override.yaml.
-	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta:\n\tupdated title","path":"/ipfs/QmeYjmGoCVkrkn95KWq6fcs4Y5JcHcKHvSSkXTskidoNod","qri":"cm:0","signature":"njCFxpGqq0xJSrjgxC289KncjflqA0e00txweEqIyUTvEKSUBKHcfQmx4OQIJzJqQJdcjIEzFrwP9cdquozRgsnrpsSfKb+wBWdtbnrg8zfat0X/Dqjro6JD7afJf0gU9s5SDi/s8g/qZOLwWh1nuoH4UAeUX+l3DH0ocFjeD6r/YkMJ0KXaWaFloKP8UPasfqoei9PxxmYQuAnFMqpXFisB7mKFAbgbpF3eL80UcbQPTih7WF11SBym/AzJhGNvOivOjmRxKGEuqEH9g3NPTEQr+LnP415X4qiaZA6MVmOO66vC0diUN4vJUMvhTsWnVEBtgqjTRYlSaYwabHv/gA==","timestamp":"2001-01-01T01:02:01.000000001Z","title":"meta updated title"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/QmYvBrUG2F4gr8a63EdikKxQU7NZ5SkqFAFGhMbNNHeNUy","peername":"me","previousPath":"/ipfs/QmVdDACqmUoFGCotChqSuYJMnocPwkXPifEB6kGqiTjhiL","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmXkN5J5yCAtF8GCxwRXARzAQhj3bPaSv1VHoyCCXzQRzN","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
+	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta:\n\tupdated title","path":"/ipfs/QmNXFe16gtuauonvyZMLRc412bR6obpq27LKKdPFzSe9FV","qri":"cm:0","signature":"m1bUTtNnrbAtn6zv0eXjJmXN6a4yOAhPhvg5B+lccir/A0TrCuW1zTx17gEtcZ0OHEYh5mhGrJZjmj6F0Vb9qI4fE7kct3SmahokWarhgszOGvAr5Y35IXkkGXDrOM3VzUWRVjMNTajufvaTxpJr/eyPpBWhsxXz8G8cUa9DT2Xwimy0vA278WukIOdVAcQI0E4n8lwz88e5wWu/TQkkn0SD7tB7KiH/PmO6EDPlXtHwFsPkwKoMkSJFjFAoM95qgv+SQQnVsBKIJ87P6G5/v5o16luR3bL+VZlDrk325ib/Fzb0XB3Qe5OpuTUpwI8Br8XvbbwlM52bNq+EUR7QgQ==","timestamp":"2001-01-01T01:05:01.000000001Z","title":"meta updated title"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/QmQ9UJJhe6YXcap971BkipY1wgN8XuHtxpzygy2nXTYqgB","peername":"me","previousPath":"/ipfs/QmS4Hryg9f1pLggaJ2M5LkQp3LEW6RVnSBB854Qr7qp3tN","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmdeM4EomnkiUYamnjqHsRGX2t7j4pxWgkoexopfHNo5gN","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("dataset (-want +got):\n%s", diff)
 	}
@@ -251,7 +249,7 @@ func TestSaveWithBodyThenAddMetaComponent(t *testing.T) {
 	actual := run.DatasetMarshalJSON(t, dsPath)
 
 	// This version has a commit message about the meta being added
-	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta added","path":"/ipfs/QmVieZLxyvYRPyGPt6MKDwTMoNb6EfqJshg4kcVmrxfJEZ","qri":"cm:0","signature":"njCFxpGqq0xJSrjgxC289KncjflqA0e00txweEqIyUTvEKSUBKHcfQmx4OQIJzJqQJdcjIEzFrwP9cdquozRgsnrpsSfKb+wBWdtbnrg8zfat0X/Dqjro6JD7afJf0gU9s5SDi/s8g/qZOLwWh1nuoH4UAeUX+l3DH0ocFjeD6r/YkMJ0KXaWaFloKP8UPasfqoei9PxxmYQuAnFMqpXFisB7mKFAbgbpF3eL80UcbQPTih7WF11SBym/AzJhGNvOivOjmRxKGEuqEH9g3NPTEQr+LnP415X4qiaZA6MVmOO66vC0diUN4vJUMvhTsWnVEBtgqjTRYlSaYwabHv/gA==","timestamp":"2001-01-01T01:02:01.000000001Z","title":"meta added"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/QmeGqv8UiU9x1dd7gPWfNvtQcbizfq9CATvhizoEyvPtn4","peername":"me","previousPath":"/ipfs/QmV8boFBdLupyTiB8evgWZ9j12JopfXMp42NBnLFpBz1Mu","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmQu9hptYCMAupEuEL7cje9bx7Wcg5HtxV4j4xbDtuuFot","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
+	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta added","path":"/ipfs/QmP6DX3RBb6Nqcmyt5jz3YUhXvJ4931rwG2BPNE1KZibHZ","qri":"cm:0","signature":"m1bUTtNnrbAtn6zv0eXjJmXN6a4yOAhPhvg5B+lccir/A0TrCuW1zTx17gEtcZ0OHEYh5mhGrJZjmj6F0Vb9qI4fE7kct3SmahokWarhgszOGvAr5Y35IXkkGXDrOM3VzUWRVjMNTajufvaTxpJr/eyPpBWhsxXz8G8cUa9DT2Xwimy0vA278WukIOdVAcQI0E4n8lwz88e5wWu/TQkkn0SD7tB7KiH/PmO6EDPlXtHwFsPkwKoMkSJFjFAoM95qgv+SQQnVsBKIJ87P6G5/v5o16luR3bL+VZlDrk325ib/Fzb0XB3Qe5OpuTUpwI8Br8XvbbwlM52bNq+EUR7QgQ==","timestamp":"2001-01-01T01:05:01.000000001Z","title":"meta added"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/QmfQ5C9bsDy2TEyuxsYb67WC8YJ1us2sUCdpNzyuJ5GaHR","peername":"me","previousPath":"/ipfs/QmU9V3XSqrwryNcAqnZXHwdnBucrZjzbeLy1erTe3MEn1G","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmbtNBSeDMtAUYk84XUS8cLMgfAPYSUZsj1ttp8gDG6PdU","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("dataset (-want +got):\n%s", diff)
 	}
@@ -275,7 +273,7 @@ func TestSaveWithBodyThenAddMetaAndSmallBodyChange(t *testing.T) {
 	actual := run.DatasetMarshalJSON(t, dsPath)
 
 	// This version has a commit message about the meta being added and body changing
-	expect := `{"bodyPath":"/ipfs/QmeLmPMNSCxVxCdDmdunBCfiN1crb3C2eUnZex6QgHpFiB","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta added\nbody:\n\tchanged by 54%","path":"/ipfs/QmWjDi8FrAjtSt3drCR4Vh6FDvCbKrN24sM5vtLyEJu8VJ","qri":"cm:0","signature":"eLr+Pk3wg8JSoeARoelNzdKLeiYFqL1k87YpXtSXigO39cAXFHg8FQki/+zt+gLPCBmPfD/mfQbR3R2mQmxyR4F+wQ1wbwkzJfumWbluyPfBsKbPQ55XLhkYUg6Ho5HqVsBn7sZ28WJ/1+GPC5xMaFYeMLTRnD2jflB5NR33eYxVQL/IDUybhgmlV5D2GOeZAOjQcCtgf0Me8o/HMqn9TsW9mNzilf7GF7lxyV+Jrz1pYjvOPlXoJGqRGRBnDbIzvEwmH7XBGHZvsbCntFw1XEEJIQslTm5mFbVrGTzqvmsPIB/SfbTjWL4Elq4uAocr7Mnu9TFKD15XNaZ8pMhaQw==","timestamp":"2001-01-01T01:02:01.000000001Z","title":"updated meta and body"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/Qmav44x9ye7NQp4CWg8SBt82txB1vZLnjHJMEWCeU5Pv5s","peername":"me","previousPath":"/ipfs/QmV8boFBdLupyTiB8evgWZ9j12JopfXMp42NBnLFpBz1Mu","qri":"ds:0","structure":{"checksum":"QmSa4i985cF3dxNHxD5mSN7c6q1eYa83uNo1pLRmPZgTsa","depth":2,"errCount":1,"entries":18,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":532,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmQu9hptYCMAupEuEL7cje9bx7Wcg5HtxV4j4xbDtuuFot","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
+	expect := `{"bodyPath":"/ipfs/QmeLmPMNSCxVxCdDmdunBCfiN1crb3C2eUnZex6QgHpFiB","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta added\nbody:\n\tchanged by 54%","path":"/ipfs/QmZy4BMhRizbAmQwP3ibHJLiasq31cVV9UKyAMxJNZ2cG7","qri":"cm:0","signature":"K/01QGH9pPdWigsVON/0INfeWWpoeN6ad97bBSpuRC050dyOP/086eHz19lWX6wZ0T0lFvViCEsq3XsOGrQ4a+BFxS5ut661uQxuuIE+40VsJ42XOGj1j1Y0XKl2bACGXV5MT0cpMYgrHBV2kgr/aliAi0SgW5ZbFukAR2Vnvjn37zTwLtVarTq1zFOOKuaLD3maJ4+5rgVEFErJCORxrCmQhiJt3hqwVzf0+kG65Y81iY6qnqiYjf94LgKFH8Nmq0Y7bdG02stxHtVtLMvea3nO8B/tNITgS1NolflAgIaJc6ylU4TNb1Z2Q3L63P6fRUf39E8cLD8631o6jWkWew==","timestamp":"2001-01-01T01:05:01.000000001Z","title":"updated meta and body"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/QmamCSG3C46pUSWuKnYsz81JqYTCE6CQNTQwsH8as6JHSH","peername":"me","previousPath":"/ipfs/QmU9V3XSqrwryNcAqnZXHwdnBucrZjzbeLy1erTe3MEn1G","qri":"ds:0","structure":{"checksum":"QmSa4i985cF3dxNHxD5mSN7c6q1eYa83uNo1pLRmPZgTsa","depth":2,"errCount":1,"entries":18,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":532,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmbtNBSeDMtAUYk84XUS8cLMgfAPYSUZsj1ttp8gDG6PdU","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("dataset (-want +got):\n%s", diff)
 	}
@@ -300,7 +298,7 @@ func TestSaveTwoComponents(t *testing.T) {
 
 	// This dataset is ds_ten.yaml, with the meta replaced by meta_override ("different title") and
 	// the structure replaced by structure_override (lazyQuotes: false && title: "name").
-	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta:\n\tupdated title\nstructure:\n\tupdated formatConfig.lazyQuotes\n\tupdated schema.items.items.0.title","path":"/ipfs/Qmf51CD3zW64ffoWja32bKh3BSyMwvMSbh9A8PtrA7fDJi","qri":"cm:0","signature":"njCFxpGqq0xJSrjgxC289KncjflqA0e00txweEqIyUTvEKSUBKHcfQmx4OQIJzJqQJdcjIEzFrwP9cdquozRgsnrpsSfKb+wBWdtbnrg8zfat0X/Dqjro6JD7afJf0gU9s5SDi/s8g/qZOLwWh1nuoH4UAeUX+l3DH0ocFjeD6r/YkMJ0KXaWaFloKP8UPasfqoei9PxxmYQuAnFMqpXFisB7mKFAbgbpF3eL80UcbQPTih7WF11SBym/AzJhGNvOivOjmRxKGEuqEH9g3NPTEQr+LnP415X4qiaZA6MVmOO66vC0diUN4vJUMvhTsWnVEBtgqjTRYlSaYwabHv/gA==","timestamp":"2001-01-01T01:02:01.000000001Z","title":"updated meta and structure"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/QmcSJnaS6xwcJXMKS3SPbyCnvorTefpMeMMJeXyMfxtTq8","peername":"me","previousPath":"/ipfs/QmVdDACqmUoFGCotChqSuYJMnocPwkXPifEB6kGqiTjhiL","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":false},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"name","type":"string"},{"title":"duration","type":"integer"}]},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmXkN5J5yCAtF8GCxwRXARzAQhj3bPaSv1VHoyCCXzQRzN","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
+	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta:\n\tupdated title\nstructure:\n\tupdated formatConfig.lazyQuotes\n\tupdated schema.items.items.0.title","path":"/ipfs/QmX6K7j2NYQB6YSTQZtJ7GQjwFCPZCN5W9iKXMnmqehsx2","qri":"cm:0","signature":"m1bUTtNnrbAtn6zv0eXjJmXN6a4yOAhPhvg5B+lccir/A0TrCuW1zTx17gEtcZ0OHEYh5mhGrJZjmj6F0Vb9qI4fE7kct3SmahokWarhgszOGvAr5Y35IXkkGXDrOM3VzUWRVjMNTajufvaTxpJr/eyPpBWhsxXz8G8cUa9DT2Xwimy0vA278WukIOdVAcQI0E4n8lwz88e5wWu/TQkkn0SD7tB7KiH/PmO6EDPlXtHwFsPkwKoMkSJFjFAoM95qgv+SQQnVsBKIJ87P6G5/v5o16luR3bL+VZlDrk325ib/Fzb0XB3Qe5OpuTUpwI8Br8XvbbwlM52bNq+EUR7QgQ==","timestamp":"2001-01-01T01:05:01.000000001Z","title":"updated meta and structure"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/QmXnMLvVZMQYuuL2PnKV6rG8dZW6TKbGLzCxFjbwnNUgkH","peername":"me","previousPath":"/ipfs/QmS4Hryg9f1pLggaJ2M5LkQp3LEW6RVnSBB854Qr7qp3tN","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":false},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"name","type":"string"},{"title":"duration","type":"integer"}]},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmdeM4EomnkiUYamnjqHsRGX2t7j4pxWgkoexopfHNo5gN","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("dataset (-want +got):\n%s", diff)
 	}
@@ -331,7 +329,7 @@ func TestSaveThenOverrideTransform(t *testing.T) {
 	actual := run.DatasetMarshalJSON(t, dsPath)
 
 	// This dataset is ds_ten.yaml, with an added transform section
-	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"transform added","path":"/ipfs/QmWq1C8kx6d4Fe5hBsUaqXFh2VDUMzaE5ewTNjqgGnXivV","qri":"cm:0","signature":"njCFxpGqq0xJSrjgxC289KncjflqA0e00txweEqIyUTvEKSUBKHcfQmx4OQIJzJqQJdcjIEzFrwP9cdquozRgsnrpsSfKb+wBWdtbnrg8zfat0X/Dqjro6JD7afJf0gU9s5SDi/s8g/qZOLwWh1nuoH4UAeUX+l3DH0ocFjeD6r/YkMJ0KXaWaFloKP8UPasfqoei9PxxmYQuAnFMqpXFisB7mKFAbgbpF3eL80UcbQPTih7WF11SBym/AzJhGNvOivOjmRxKGEuqEH9g3NPTEQr+LnP415X4qiaZA6MVmOO66vC0diUN4vJUMvhTsWnVEBtgqjTRYlSaYwabHv/gA==","timestamp":"2001-01-01T01:02:01.000000001Z","title":"transform added"},"meta":{"qri":"md:0","title":"example movie data"},"path":"/ipfs/Qmam5mmFaxmHegRv9rqBjYo6sJ5szfY1ZP7Tc1eSUehxaJ","peername":"me","previousPath":"/ipfs/QmVdDACqmUoFGCotChqSuYJMnocPwkXPifEB6kGqiTjhiL","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"transform":{"qri":"tf:0","scriptPath":"/ipfs/QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH","syntax":"starlark","syntaxVersion":"test_version"},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmXkN5J5yCAtF8GCxwRXARzAQhj3bPaSv1VHoyCCXzQRzN","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
+	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"transform added","path":"/ipfs/QmUZ5V3GZtjFCVW2hhWhXHgNKqBfzxjtfvtUtoYx5PoCwd","qri":"cm:0","signature":"m1bUTtNnrbAtn6zv0eXjJmXN6a4yOAhPhvg5B+lccir/A0TrCuW1zTx17gEtcZ0OHEYh5mhGrJZjmj6F0Vb9qI4fE7kct3SmahokWarhgszOGvAr5Y35IXkkGXDrOM3VzUWRVjMNTajufvaTxpJr/eyPpBWhsxXz8G8cUa9DT2Xwimy0vA278WukIOdVAcQI0E4n8lwz88e5wWu/TQkkn0SD7tB7KiH/PmO6EDPlXtHwFsPkwKoMkSJFjFAoM95qgv+SQQnVsBKIJ87P6G5/v5o16luR3bL+VZlDrk325ib/Fzb0XB3Qe5OpuTUpwI8Br8XvbbwlM52bNq+EUR7QgQ==","timestamp":"2001-01-01T01:05:01.000000001Z","title":"transform added"},"meta":{"qri":"md:0","title":"example movie data"},"path":"/ipfs/QmV9NKKnJt6uLMYzqB8ifGJbv3KVrHxDt4e7VyeTbTiJdx","peername":"me","previousPath":"/ipfs/QmS4Hryg9f1pLggaJ2M5LkQp3LEW6RVnSBB854Qr7qp3tN","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"transform":{"qri":"tf:0","scriptPath":"/ipfs/QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH","syntax":"starlark","syntaxVersion":"test_version"},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmdeM4EomnkiUYamnjqHsRGX2t7j4pxWgkoexopfHNo5gN","scriptPath":"/ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor"}}`
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("dataset (-want +got):\n%s", diff)
 	}
@@ -355,7 +353,7 @@ func TestSaveThenOverrideViz(t *testing.T) {
 	actual := run.DatasetMarshalJSON(t, dsPath)
 
 	// This dataset is ds_ten.yaml, with an added viz section
-	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"viz:\n\tupdated scriptPath","path":"/ipfs/QmUqJPrAUPQHTbnoYvbcuHDYpLLa3cLJucfPS5gDYP7YPF","qri":"cm:0","signature":"njCFxpGqq0xJSrjgxC289KncjflqA0e00txweEqIyUTvEKSUBKHcfQmx4OQIJzJqQJdcjIEzFrwP9cdquozRgsnrpsSfKb+wBWdtbnrg8zfat0X/Dqjro6JD7afJf0gU9s5SDi/s8g/qZOLwWh1nuoH4UAeUX+l3DH0ocFjeD6r/YkMJ0KXaWaFloKP8UPasfqoei9PxxmYQuAnFMqpXFisB7mKFAbgbpF3eL80UcbQPTih7WF11SBym/AzJhGNvOivOjmRxKGEuqEH9g3NPTEQr+LnP415X4qiaZA6MVmOO66vC0diUN4vJUMvhTsWnVEBtgqjTRYlSaYwabHv/gA==","timestamp":"2001-01-01T01:02:01.000000001Z","title":"viz updated scriptPath"},"meta":{"qri":"md:0","title":"example movie data"},"path":"/ipfs/QmNaJ1Wi774Ghh1fviRz1GNQ2UFAcCb96z4kTPszZkKAGt","peername":"me","previousPath":"/ipfs/QmVdDACqmUoFGCotChqSuYJMnocPwkXPifEB6kGqiTjhiL","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmVrEH7T7XmdJLym8YL9DjwCALbz264h7GQTrjkSGmbvry","scriptPath":"/ipfs/QmRaVGip3V9fVBJheZN6FbUajD3ZLNjHhXdjrmfg2JPoo5"}}`
+	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"viz:\n\tupdated scriptPath","path":"/ipfs/QmRSJMKPQ7SnFJEXjE4Ui27ZURmK1m7ZaPpEAqreXBXZEK","qri":"cm:0","signature":"m1bUTtNnrbAtn6zv0eXjJmXN6a4yOAhPhvg5B+lccir/A0TrCuW1zTx17gEtcZ0OHEYh5mhGrJZjmj6F0Vb9qI4fE7kct3SmahokWarhgszOGvAr5Y35IXkkGXDrOM3VzUWRVjMNTajufvaTxpJr/eyPpBWhsxXz8G8cUa9DT2Xwimy0vA278WukIOdVAcQI0E4n8lwz88e5wWu/TQkkn0SD7tB7KiH/PmO6EDPlXtHwFsPkwKoMkSJFjFAoM95qgv+SQQnVsBKIJ87P6G5/v5o16luR3bL+VZlDrk325ib/Fzb0XB3Qe5OpuTUpwI8Br8XvbbwlM52bNq+EUR7QgQ==","timestamp":"2001-01-01T01:05:01.000000001Z","title":"viz updated scriptPath"},"meta":{"qri":"md:0","title":"example movie data"},"path":"/ipfs/QmQzeNPYB5uu9pMh1mxBxYC69CJSMnScJ6WDJkEgzRip67","peername":"me","previousPath":"/ipfs/QmS4Hryg9f1pLggaJ2M5LkQp3LEW6RVnSBB854Qr7qp3tN","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmVrEH7T7XmdJLym8YL9DjwCALbz264h7GQTrjkSGmbvry","scriptPath":"/ipfs/QmRaVGip3V9fVBJheZN6FbUajD3ZLNjHhXdjrmfg2JPoo5"}}`
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("dataset (-want +got):\n%s", diff)
 	}
@@ -386,7 +384,7 @@ func TestSaveThenOverrideMetaAndTransformAndViz(t *testing.T) {
 	actual := run.DatasetMarshalJSON(t, dsPath)
 
 	// This dataset is ds_ten.yaml, with an added meta component, and transform, and viz
-	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta:\n\tupdated title\nviz:\n\tupdated scriptPath\ntransform added","path":"/ipfs/QmPtYLgM886MQCQhsyJDgb4FnNqNH8FBBDE1NqwJpJi4Js","qri":"cm:0","signature":"njCFxpGqq0xJSrjgxC289KncjflqA0e00txweEqIyUTvEKSUBKHcfQmx4OQIJzJqQJdcjIEzFrwP9cdquozRgsnrpsSfKb+wBWdtbnrg8zfat0X/Dqjro6JD7afJf0gU9s5SDi/s8g/qZOLwWh1nuoH4UAeUX+l3DH0ocFjeD6r/YkMJ0KXaWaFloKP8UPasfqoei9PxxmYQuAnFMqpXFisB7mKFAbgbpF3eL80UcbQPTih7WF11SBym/AzJhGNvOivOjmRxKGEuqEH9g3NPTEQr+LnP415X4qiaZA6MVmOO66vC0diUN4vJUMvhTsWnVEBtgqjTRYlSaYwabHv/gA==","timestamp":"2001-01-01T01:02:01.000000001Z","title":"updated meta, viz, and transform"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/QmYGCCSFQXc634QMTtGF2YykMyaYQPiUVovQrkFdEqQP75","peername":"me","previousPath":"/ipfs/QmVdDACqmUoFGCotChqSuYJMnocPwkXPifEB6kGqiTjhiL","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"transform":{"qri":"tf:0","scriptPath":"/ipfs/QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH","syntax":"starlark","syntaxVersion":"test_version"},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmVrEH7T7XmdJLym8YL9DjwCALbz264h7GQTrjkSGmbvry","scriptPath":"/ipfs/QmRaVGip3V9fVBJheZN6FbUajD3ZLNjHhXdjrmfg2JPoo5"}}`
+	expect := `{"bodyPath":"/ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn","commit":{"author":{"id":"QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"},"message":"meta:\n\tupdated title\nviz:\n\tupdated scriptPath\ntransform added","path":"/ipfs/QmRug4rgEPQKjL5R65qbS9Guosk4uMLNpSHzFKau7GcTk7","qri":"cm:0","signature":"m1bUTtNnrbAtn6zv0eXjJmXN6a4yOAhPhvg5B+lccir/A0TrCuW1zTx17gEtcZ0OHEYh5mhGrJZjmj6F0Vb9qI4fE7kct3SmahokWarhgszOGvAr5Y35IXkkGXDrOM3VzUWRVjMNTajufvaTxpJr/eyPpBWhsxXz8G8cUa9DT2Xwimy0vA278WukIOdVAcQI0E4n8lwz88e5wWu/TQkkn0SD7tB7KiH/PmO6EDPlXtHwFsPkwKoMkSJFjFAoM95qgv+SQQnVsBKIJ87P6G5/v5o16luR3bL+VZlDrk325ib/Fzb0XB3Qe5OpuTUpwI8Br8XvbbwlM52bNq+EUR7QgQ==","timestamp":"2001-01-01T01:05:01.000000001Z","title":"updated meta, viz, and transform"},"meta":{"qri":"md:0","title":"different title"},"path":"/ipfs/QmVYnh8cbyUSMi9KqQtG9fEAYiycWNaV6R46JyPsLQZytT","peername":"me","previousPath":"/ipfs/QmS4Hryg9f1pLggaJ2M5LkQp3LEW6RVnSBB854Qr7qp3tN","qri":"ds:0","structure":{"checksum":"QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf","depth":2,"errCount":1,"entries":8,"format":"csv","formatConfig":{"headerRow":true,"lazyQuotes":true},"length":224,"qri":"st:0","schema":{"items":{"items":[{"title":"movie_title","type":"string"},{"title":"duration","type":"integer"}],"type":"array"},"type":"array"}},"transform":{"qri":"tf:0","scriptPath":"/ipfs/QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH","syntax":"starlark","syntaxVersion":"test_version"},"viz":{"format":"html","qri":"vz:0","renderedPath":"/ipfs/QmVrEH7T7XmdJLym8YL9DjwCALbz264h7GQTrjkSGmbvry","scriptPath":"/ipfs/QmRaVGip3V9fVBJheZN6FbUajD3ZLNjHhXdjrmfg2JPoo5"}}`
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("dataset (-want +got):\n%s", diff)
 	}
@@ -493,41 +491,19 @@ func TestSaveTransformModifiedButSameBody(t *testing.T) {
 	run := NewTestRunner(t, "test_peer", "qri_test_transform_modified")
 	defer run.Delete()
 
-	// Hook timestamp generation.
-	prevTimestampFunc := logbook.NewTimestamp
-	logbook.NewTimestamp = func() int64 {
-		return 1000
-	}
-	defer func() {
-		logbook.NewTimestamp = prevTimestampFunc
-	}()
-
-	// Set the location to New York so that timezone printing is consistent
-	location, err := time.LoadLocation("America/New_York")
-	if err != nil {
-		panic(err)
-	}
-	locOrig := StringerLocation
-	StringerLocation = location
-
-	// Restore the location function
-	run.Teardown = func() {
-		StringerLocation = locOrig
-	}
-
 	// Save a version
 	run.MustExec(t, "qri save --file=testdata/movies/tf_123.star me/test_ds")
 
 	// Save another version with a modified transform that produces the same body
-	err = run.ExecCommand("qri save --file=testdata/movies/tf_modified.star me/test_ds")
+	err := run.ExecCommand("qri save --file=testdata/movies/tf_modified.star me/test_ds")
 
 	if err != nil {
 		t.Errorf("unexpected error: %q", err)
 	}
 
 	output := run.MustExec(t, "qri log me/test_ds")
-	expect := `1   Commit:  /ipfs/QmUfc7udMMsdjA3UqYyaqD4owm7kMYFsvsVrPrLLEUmrh6
-    Date:    Sun Dec 31 20:02:01 EST 2000
+	expect := `1   Commit:  /ipfs/QmVLCqqaV4Rg9gL5gLJ8kAGrQLvDip4Gpv2pjceDwu4Eus
+    Date:    Sun Dec 31 20:05:01 EST 2000
     Storage: local
     Size:    7 B
 
@@ -535,8 +511,8 @@ func TestSaveTransformModifiedButSameBody(t *testing.T) {
     transform:
     	updated scriptBytes
 
-2   Commit:  /ipfs/QmXj4aEusqp63sGMaB4YWX2JPJQigTmgK73Sh55YvQYtgJ
-    Date:    Sun Dec 31 20:01:01 EST 2000
+2   Commit:  /ipfs/QmYjmt2L8sgD9EeppVhU6sVRT3WQM9wmnh8J2ud9yRjfiR
+    Date:    Sun Dec 31 20:02:01 EST 2000
     Storage: local
     Size:    7 B
 
@@ -665,7 +641,7 @@ func TestRenameAfterRegistration(t *testing.T) {
 	expect := `0 Peername:  test_peer
   ProfileID: QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
   Name:      first_name
-  Path:      /ipfs/QmezSToWr8oAvqFbMGFrMuKj5srNK5YPsN4tHUw2JGnWra
+  Path:      /ipfs/QmUja5xcsz5utUP9QRAyKVCnjDU6T7hK5wCGr8pZMvoJwS
   FSIPath:   
   Published: false
 
@@ -686,7 +662,7 @@ func TestRenameAfterRegistration(t *testing.T) {
 	expect = `0 Peername:  real_peer
   ProfileID: QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
   Name:      first_name
-  Path:      /ipfs/QmezSToWr8oAvqFbMGFrMuKj5srNK5YPsN4tHUw2JGnWra
+  Path:      /ipfs/QmUja5xcsz5utUP9QRAyKVCnjDU6T7hK5wCGr8pZMvoJwS
   FSIPath:   
   Published: false
 
@@ -702,7 +678,7 @@ func TestRenameAfterRegistration(t *testing.T) {
 	expect = `0 Peername:  real_peer
   ProfileID: QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
   Name:      second_name
-  Path:      /ipfs/QmezSToWr8oAvqFbMGFrMuKj5srNK5YPsN4tHUw2JGnWra
+  Path:      /ipfs/QmUja5xcsz5utUP9QRAyKVCnjDU6T7hK5wCGr8pZMvoJwS
   FSIPath:   
   Published: false
 
@@ -718,7 +694,7 @@ func TestRenameAfterRegistration(t *testing.T) {
 	expect = `0 Peername:  real_peer
   ProfileID: QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
   Name:      third_name
-  Path:      /ipfs/QmezSToWr8oAvqFbMGFrMuKj5srNK5YPsN4tHUw2JGnWra
+  Path:      /ipfs/QmUja5xcsz5utUP9QRAyKVCnjDU6T7hK5wCGr8pZMvoJwS
   FSIPath:   
   Published: false
 

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"testing"
-
-	"github.com/qri-io/ioes"
 )
 
 func TestGetComplete(t *testing.T) {
-	streams, in, out, errs := ioes.NewTestIOStreams()
-	setNoColor(true)
+	run := NewTestRunner(t, "test_peer", "qri_test_get_complete")
+	defer run.Delete()
 
 	f, err := NewTestFactory()
 	if err != nil {
@@ -36,34 +34,34 @@ func TestGetComplete(t *testing.T) {
 
 	for i, c := range cases {
 		opt := &GetOptions{
-			IOStreams: streams,
+			IOStreams: run.Streams,
 		}
 
 		opt.Complete(f, c.args)
 
-		if c.err != errs.String() {
-			t.Errorf("case %d, error mismatch. Expected: '%s', Got: '%s'", i, c.err, errs.String())
-			ioReset(in, out, errs)
+		if c.err != run.ErrStream.String() {
+			t.Errorf("case %d, error mismatch. Expected: '%s', Got: '%s'", i, c.err, run.ErrStream.String())
+			run.IOReset()
 			continue
 		}
 
 		if !testSliceEqual(c.refs, opt.Refs.RefList()) {
 			t.Errorf("case %d, opt.Refs not set correctly. Expected: '%q', Got: '%q'", i, c.refs, opt.Refs.RefList())
-			ioReset(in, out, errs)
+			run.IOReset()
 			continue
 		}
 
 		if c.selector != opt.Selector {
 			t.Errorf("case %d, opt.Selector not set correctly. Expected: '%s', Got: '%s'", i, c.selector, opt.Selector)
-			ioReset(in, out, errs)
+			run.IOReset()
 			continue
 		}
 
 		if opt.DatasetRequests == nil {
 			t.Errorf("case %d, opt.DatasetRequests not set.", i)
-			ioReset(in, out, errs)
+			run.IOReset()
 			continue
 		}
-		ioReset(in, out, errs)
+		run.IOReset()
 	}
 }

--- a/cmd/log_integration_test.go
+++ b/cmd/log_integration_test.go
@@ -2,40 +2,11 @@ package cmd
 
 import (
 	"testing"
-	"time"
 )
-
-// LogTestRunner holds test info integration tests
-type LogTestRunner struct {
-	TestRunner
-	LocOrig *time.Location
-}
-
-// newLogTestRunner returns a new FSITestRunner.
-func newLogTestRunner(t *testing.T, peerName, testName string) *LogTestRunner {
-	run := LogTestRunner{
-		TestRunner: *NewTestRunner(t, peerName, testName),
-	}
-
-	// Set the location to New York so that timezone printing is consistent
-	location, err := time.LoadLocation("America/New_York")
-	if err != nil {
-		panic(err)
-	}
-	run.LocOrig = location
-	StringerLocation = location
-
-	// Restore the location function
-	run.Teardown = func() {
-		StringerLocation = run.LocOrig
-	}
-
-	return &run
-}
 
 // Test that deleting an entire dataset works properly with the logbook.
 func TestLogAndDeletes(t *testing.T) {
-	run := newLogTestRunner(t, "test_peer", "qri_test_log_and_deletes")
+	run := NewTestRunner(t, "test_peer", "qri_test_log_and_deletes")
 	defer run.Delete()
 
 	// Save a dataset containing a body.json, no meta, nothing special.
@@ -50,8 +21,8 @@ func TestLogAndDeletes(t *testing.T) {
 		t.Fatal(err)
 	}
 	output := run.GetCommandOutput()
-	expect := `1   Commit:  /ipfs/QmeDCtiNtcomDT6tm1kBCFD16pyHsZW5dRZGSo7Uwk4QKg
-    Date:    Sun Dec 31 20:01:01 EST 2000
+	expect := `1   Commit:  /ipfs/QmUZ5CjiQ7hgAk9oRRQmwsUXrpm71Xg2DXpZNVTcpWxf9E
+    Date:    Sun Dec 31 20:02:01 EST 2000
     Storage: local
     Size:    79 B
 
@@ -74,8 +45,8 @@ func TestLogAndDeletes(t *testing.T) {
 		t.Fatal(err)
 	}
 	output = run.GetCommandOutput()
-	expect = `1   Commit:  /ipfs/Qmc8y4MH4pZcMxPuiw9PTF4S4D3iKu8Mg5QVGjBzTXf2Jt
-    Date:    Sun Dec 31 20:02:01 EST 2000
+	expect = `1   Commit:  /ipfs/QmbZbGWMoc8oNgy9r718eH1nJJZjXCRHKHgF1J58F3cEQg
+    Date:    Sun Dec 31 20:05:01 EST 2000
     Storage: local
     Size:    137 B
 
@@ -84,8 +55,8 @@ func TestLogAndDeletes(t *testing.T) {
     	added row 2
     	added row 3
 
-2   Commit:  /ipfs/QmeDCtiNtcomDT6tm1kBCFD16pyHsZW5dRZGSo7Uwk4QKg
-    Date:    Sun Dec 31 20:01:01 EST 2000
+2   Commit:  /ipfs/QmUZ5CjiQ7hgAk9oRRQmwsUXrpm71Xg2DXpZNVTcpWxf9E
+    Date:    Sun Dec 31 20:02:01 EST 2000
     Storage: local
     Size:    79 B
 
@@ -108,8 +79,8 @@ func TestLogAndDeletes(t *testing.T) {
 		t.Fatal(err)
 	}
 	output = run.GetCommandOutput()
-	expect = `1   Commit:  /ipfs/QmeDCtiNtcomDT6tm1kBCFD16pyHsZW5dRZGSo7Uwk4QKg
-    Date:    Sun Dec 31 20:01:01 EST 2000
+	expect = `1   Commit:  /ipfs/QmUZ5CjiQ7hgAk9oRRQmwsUXrpm71Xg2DXpZNVTcpWxf9E
+    Date:    Sun Dec 31 20:02:01 EST 2000
     Storage: local
     Size:    79 B
 
@@ -142,8 +113,8 @@ func TestLogAndDeletes(t *testing.T) {
 		t.Fatal(err)
 	}
 	output = run.GetCommandOutput()
-	expect = `1   Commit:  /ipfs/QmXcjQ9CaF9RmQgHE7jdBCLsiNRfUniWUJurkn4Cv54Kwc
-    Date:    Sun Dec 31 20:03:01 EST 2000
+	expect = `1   Commit:  /ipfs/QmdV1msRdqijFjSTd47XKyykj6q28cghVq98KA7SZtJwww
+    Date:    Sun Dec 31 20:07:01 EST 2000
     Storage: local
     Size:    224 B
 

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -7,23 +7,18 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/qri-io/dataset"
-	"github.com/qri-io/ioes"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/localfs"
-	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dscache"
 	"github.com/qri-io/qri/errors"
-	"github.com/qri-io/qri/logbook"
-	"github.com/qri-io/qri/startf"
 )
 
 func TestSaveComplete(t *testing.T) {
-	streams, in, out, errs := ioes.NewTestIOStreams()
-	setNoColor(true)
+	run := NewTestRunner(t, "test_peer", "qri_test_save_complete")
+	defer run.Delete()
 
 	f, err := NewTestFactory()
 	if err != nil {
@@ -43,29 +38,29 @@ func TestSaveComplete(t *testing.T) {
 
 	for i, c := range cases {
 		opt := &SaveOptions{
-			IOStreams: streams,
+			IOStreams: run.Streams,
 		}
 
 		opt.Complete(f, c.args)
 
-		if c.err != errs.String() {
-			t.Errorf("case %d, error mismatch. Expected: '%s', Got: '%s'", i, c.err, errs.String())
-			ioReset(in, out, errs)
+		if c.err != run.ErrStream.String() {
+			t.Errorf("case %d, error mismatch. Expected: '%s', Got: '%s'", i, c.err, run.ErrStream.String())
+			run.IOReset()
 			continue
 		}
 
 		if c.expect != opt.Refs.Ref() {
 			t.Errorf("case %d, opt.Ref not set correctly. Expected: '%s', Got: '%s'", i, c.expect, opt.Refs.Ref())
-			ioReset(in, out, errs)
+			run.IOReset()
 			continue
 		}
 
 		if opt.DatasetRequests == nil {
 			t.Errorf("case %d, opt.DatasetRequests not set.", i)
-			ioReset(in, out, errs)
+			run.IOReset()
 			continue
 		}
-		ioReset(in, out, errs)
+		run.IOReset()
 	}
 }
 
@@ -107,21 +102,8 @@ func TestSaveValidate(t *testing.T) {
 }
 
 func TestSaveRun(t *testing.T) {
-	streams, in, out, errs := ioes.NewTestIOStreams()
-	setNoColor(true)
-	setNoPrompt(true)
-
-	prevXformVer := startf.Version
-	startf.Version = "test_version"
-	defer func() {
-		startf.Version = prevXformVer
-	}()
-
-	// to keep hashes consistent, artificially specify the timestamp by overriding
-	// the dsfs.Timestamp func
-	prev := dsfs.Timestamp
-	defer func() { dsfs.Timestamp = prev }()
-	dsfs.Timestamp = func() time.Time { return time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC) }
+	run := NewTestRunner(t, "peer_name", "qri_test_save_run")
+	defer run.Delete()
 
 	f, err := NewTestFactory()
 	if err != nil {
@@ -146,16 +128,16 @@ func TestSaveRun(t *testing.T) {
 		{"no data", "me/bad_dataset", "", "", "", "", false, false, true, "", "no changes to save", ""},
 		{"bad dataset file", "me/cities", "bad/filpath.json", "", "", "", false, false, true, "", "open bad/filpath.json: no such file or directory", ""},
 		{"bad body file", "me/cities", "", "bad/bodypath.csv", "", "", false, false, true, "", "opening dataset.bodyPath 'bad/bodypath.csv': path not found", ""},
-		{"good inputs, dryrun", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_ten.csv", "", "", false, true, true, "dataset saved: peer/movies@/map/QmYPf7XVDXPB3hQy8ptetyXAhGJsFdJmKfBrN9vWWvG3eQ\nthis dataset has 1 validation errors\n", "", ""},
-		{"good inputs", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_ten.csv", "", "", true, false, true, "dataset saved: peer/movies@/map/QmYPf7XVDXPB3hQy8ptetyXAhGJsFdJmKfBrN9vWWvG3eQ\nthis dataset has 1 validation errors\n", "", ""},
-		{"add rows, dry run", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "Added 10 more rows", "Adding to the number of rows in dataset", false, true, true, "dataset saved: peer/movies@/map/Qmf516nREprnwE3YnBpZd1y9DkS6e2ktKYDLMtz4L4MgMX\nthis dataset has 1 validation errors\n", "", ""},
-		{"add rows, save", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "Added 10 more rows", "Adding to the number of rows in dataset", true, false, true, "dataset saved: peer/movies@/map/Qmf516nREprnwE3YnBpZd1y9DkS6e2ktKYDLMtz4L4MgMX\nthis dataset has 1 validation errors\n", "", ""},
+		{"good inputs, dryrun", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_ten.csv", "", "", false, true, true, "dataset saved: peer/movies@/map/QmWehMxKs9dFqAxjh69FKyUmXVNQRnCZ4t6quvaZ8cA8s3\nthis dataset has 1 validation errors\n", "", ""},
+		{"good inputs", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_ten.csv", "", "", true, false, true, "dataset saved: peer/movies@/map/QmRgRuwLP3aZqktWv9Cv6tGwatyRjKDzqV1dDBFupJNiqj\nthis dataset has 1 validation errors\n", "", ""},
+		{"add rows, dry run", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "Added 10 more rows", "Adding to the number of rows in dataset", false, true, true, "dataset saved: peer/movies@/map/QmUPXbE9rg8K7Hw71eFxYe5ky6cSaXjEraZta1YywvePBe\nthis dataset has 1 validation errors\n", "", ""},
+		{"add rows, save", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "Added 10 more rows", "Adding to the number of rows in dataset", true, false, true, "dataset saved: peer/movies@/map/QmYvRp667oRMnWVGwnUD5GwceVYz2woYH9s2NkiZY2CX1f\nthis dataset has 1 validation errors\n", "", ""},
 		{"no changes", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "trying to add again", "hopefully this errors", false, false, true, "", "error saving: no changes", ""},
-		{"add viz", "me/movies", "testdata/movies/dataset_with_viz.json", "", "", "", false, false, false, "dataset saved: peer/movies@/map/QmXDKr4ryBuzXFhpKPUAe6GmqEacCjgPkG76NyVLpmPDSt\nthis dataset has 1 validation errors\n", "", ""},
+		{"add viz", "me/movies", "testdata/movies/dataset_with_viz.json", "", "", "", false, false, false, "dataset saved: peer/movies@/map/QmVtFptuccDEKX6oY9rZsyvxTcPy1x2grwnvVfXmV8GFHA\nthis dataset has 1 validation errors\n", "", ""},
 	}
 
 	for _, c := range cases {
-		ioReset(in, out, errs)
+		run.IOReset()
 		dsr, err := f.DatasetRequests()
 		if err != nil {
 			t.Errorf("case \"%s\", error creating dataset request: %s", c.description, err)
@@ -168,7 +150,7 @@ func TestSaveRun(t *testing.T) {
 		}
 
 		opt := &SaveOptions{
-			IOStreams:       streams,
+			IOStreams:       run.Streams,
 			Refs:            NewExplicitRefSelect(c.ref),
 			FilePaths:       pathList,
 			BodyPath:        c.bodypath,
@@ -196,8 +178,8 @@ func TestSaveRun(t *testing.T) {
 			continue
 		}
 
-		if c.expect != errs.String() {
-			t.Errorf("case '%s', err output mismatch. Expected: '%s', Got: '%s'", c.description, c.expect, errs.String())
+		if c.expect != run.ErrStream.String() {
+			t.Errorf("case '%s', err output mismatch. Expected: '%s', Got: '%s'", c.description, c.expect, run.ErrStream.String())
 
 			continue
 		}
@@ -232,32 +214,32 @@ func TestSaveBasicCommands(t *testing.T) {
 		{
 			"dataset file infer name",
 			"qri save --file dataset.yaml",
-			"dataset saved: test_peer/ten_movies@/ipfs/QmU935SkFafE786u7jQPknB858PDrJRFUJboxbS4vKkAe7\nthis dataset has 1 validation errors\n",
+			"dataset saved: test_peer/ten_movies@/ipfs/QmdYaCFsHcGiGcTG3vy2TRrDAoJ2iXyskq4gqmcfipQp9d\nthis dataset has 1 validation errors\n",
 		},
 		{
 			"dataset file me ref",
 			"qri save --file dataset.yaml me/my_dataset",
-			"dataset saved: test_peer/my_dataset@/ipfs/QmSSTAcuehjFFiHNBFicTXJv2uhbKg4hjGgCL8W46D3jGG\nthis dataset has 1 validation errors\n",
+			"dataset saved: test_peer/my_dataset@/ipfs/Qmf8BV8oXo9rPmZHeo6j1BSjHFb77DEc6mNzkyXQ8wnuAK\nthis dataset has 1 validation errors\n",
 		},
 		{
 			"dataset file explicit ref",
 			"qri save --file dataset.yaml test_peer/my_dataset",
-			"dataset saved: test_peer/my_dataset@/ipfs/QmeW1M8W9yj69pxE3uJZbYVBCaEARYkrkje3NHY1s6tHtP\nthis dataset has 1 validation errors\n",
+			"dataset saved: test_peer/my_dataset@/ipfs/QmeoNwgqDN133m5MZeTDt8b3W4sQQLZgDx2EkPiyxB62jY\nthis dataset has 1 validation errors\n",
 		},
 		{
 			"body file infer name",
 			"qri save --body body_ten.csv",
-			"dataset saved: test_peer/body_tencsv@/ipfs/QmWaS8ndeAhAWWSUmwJ6HiXKMNWnsL1LYhzrWJyzCgR9pd\nthis dataset has 1 validation errors\n",
+			"dataset saved: test_peer/body_tencsv@/ipfs/QmPA1xnbpqGzYoZNz26PcyVCgvBgWsi7hPFNvwcbamriBm\nthis dataset has 1 validation errors\n",
 		},
 		{
 			"body file me ref",
 			"qri save --body body_ten.csv me/my_dataset",
-			"dataset saved: test_peer/my_dataset@/ipfs/QmeyznW4FBaLY8rk5xpZyFHXixrq8qFJrFf8v1REZzmLLg\nthis dataset has 1 validation errors\n",
+			"dataset saved: test_peer/my_dataset@/ipfs/QmTNy5ZpjdaLLqWBuuX9GhjdoxgHdGksyhV4VFQNtXTcHu\nthis dataset has 1 validation errors\n",
 		},
 		{
 			"body file explicit ref",
 			"qri save --body body_ten.csv test_peer/my_dataset",
-			"dataset saved: test_peer/my_dataset@/ipfs/QmP9yay2KwPnyDLLhGXZsLdKG31qMAR3CSBAmscz3znC9C\nthis dataset has 1 validation errors\n",
+			"dataset saved: test_peer/my_dataset@/ipfs/Qmc1JR3G3hbRdgLdPzcV7991L7LVFDH5rgaPFY9RGtoqTs\nthis dataset has 1 validation errors\n",
 		},
 		// TODO(dustmop): It's intended that a user can save a dataset with a structure but no
 		// body. At some point that functionality broke, because there was no test for it. Fix that
@@ -279,7 +261,7 @@ func TestSaveBasicCommands(t *testing.T) {
 			run := NewTestRunner(t, "test_peer", "qri_test_save_basic")
 			defer run.Delete()
 
-			err := run.ExecCommand(c.command)
+			err := run.ExecCommandCombinedOutErr(c.command)
 			if err != nil {
 				t.Errorf("error %s\n", err)
 				return
@@ -335,9 +317,9 @@ func TestSaveInferName(t *testing.T) {
 	defer run.Delete()
 
 	// Save a dataset with an inferred name.
-	output := run.MustExec(t, "qri save --body testdata/movies/body_four.json")
+	output := run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/body_four.json")
 	actual := parseDatasetRefFromOutput(output)
-	expect := "dataset saved: test_peer/body_fourjson@/ipfs/QmcHttiUsLCcjEdhuSyA1YXFPymx3k7srjUjrsJdRCPSKn\n"
+	expect := "dataset saved: test_peer/body_fourjson@/ipfs/QmWS1sZzkpdUiuX17b6FZEqJQGLtuxbiHg3QKtymH4dpxL\n"
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)
 	}
@@ -353,33 +335,33 @@ func TestSaveInferName(t *testing.T) {
 	}
 
 	// Save but ensure a new dataset is created.
-	output = run.MustExec(t, "qri save --body testdata/movies/body_four.json --new")
+	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/body_four.json --new")
 	actual = parseDatasetRefFromOutput(output)
-	expect = "dataset saved: test_peer/body_fourjson_1@/ipfs/QmXzwvaxmHUbjkAmirgKEzQyQAvaDRXEcNizodaJ5LqbjE\n"
+	expect = "dataset saved: test_peer/body_fourjson_1@/ipfs/QmUVzyXdUzaDa43UNXNoA4bnV1UmvmF8TQkrYUL57uRVUt\n"
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)
 	}
 
 	// Save once again.
-	output = run.MustExec(t, "qri save --body testdata/movies/body_four.json --new")
+	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/body_four.json --new")
 	actual = parseDatasetRefFromOutput(output)
-	expect = "dataset saved: test_peer/body_fourjson_2@/ipfs/QmbURFB5RLWN3LdtKe9yX3emiyvNtvtocsoaK8eFFVTXFL\n"
+	expect = "dataset saved: test_peer/body_fourjson_2@/ipfs/QmagSArPqsugSno5nZAz14ndeamU8CjT97rukPCYjsuTZ8\n"
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)
 	}
 
 	// Save a dataset whose body filename starts with a number
-	output = run.MustExec(t, "qri save --body testdata/movies/2018_winners.csv")
+	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/2018_winners.csv")
 	actual = parseDatasetRefFromOutput(output)
-	expect = "dataset saved: test_peer/winnerscsv@/ipfs/Qmbis26hHj7o4XiYnYoKqTLYkvtxhWyyifR1PUz2rrnAcn\n"
+	expect = "dataset saved: test_peer/winnerscsv@/ipfs/Qmf9yTULephFi5j8eejVLokG3c5icaY2BNJKoZiX4LRPyY\n"
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)
 	}
 
 	// Save a dataset whose body filename is non-alphabetic
-	output = run.MustExec(t, "qri save --body testdata/2015-09-16--2016-09-30.csv")
+	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/2015-09-16--2016-09-30.csv")
 	actual = parseDatasetRefFromOutput(output)
-	expect = "dataset saved: test_peer/dataset_09_16_2016_09_30csv@/ipfs/Qmcg4Bm7fghMWZUb7Szi8eeAjZtwSQTVMpc2XZy5GhJ3WH\n"
+	expect = "dataset saved: test_peer/dataset_09_16_2016_09_30csv@/ipfs/QmTbL4rDZMSC5TNoYsbwoAUihPy9RRPTWE4zGjRepUgiGZ\n"
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)
 	}
@@ -388,14 +370,6 @@ func TestSaveInferName(t *testing.T) {
 func TestSaveDscacheFirstCommit(t *testing.T) {
 	run := NewTestRunner(t, "test_peer", "qri_test_dscache_first")
 	defer run.Delete()
-
-	prevTimestampFunc := logbook.NewTimestamp
-	logbook.NewTimestamp = func() int64 {
-		return 1000
-	}
-	defer func() {
-		logbook.NewTimestamp = prevTimestampFunc
-	}()
 
 	// Save a dataset with one version.
 	run.MustExec(t, "qri save --body testdata/movies/body_two.json me/movie_ds --use-dscache")
@@ -414,15 +388,15 @@ func TestSaveDscacheFirstCommit(t *testing.T) {
  Dscache.Users:
   0) user=test_peer profileID=QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
  Dscache.Refs:
-  0) initID        = gdulisqthishkm3rrrk4sals4hnnljkgurxteqwnlq5kssxqpp3q
+  0) initID        = vkys37xzcxpmw5zexzhyhpok3whl2vfeep2tyeegwnm2cxrr3umq
      profileID     = QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
      topIndex      = 1
      cursorIndex   = 1
      prettyName    = movie_ds
      bodySize      = 79
      bodyRows      = 2
-     commitTime    = 978310861
-     headRef       = /ipfs/QmYFApC68tU71We4rJ3Rp4k2tJhFuknfS8MvcJJfaLPAEi
+     commitTime    = 978310921
+     headRef       = /ipfs/QmdCjShoT9bKFjAMJ7dvdrHY476qPTouBmDs94RxMKyjms
 `
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)
@@ -447,24 +421,24 @@ func TestSaveDscacheFirstCommit(t *testing.T) {
  Dscache.Users:
   0) user=test_peer profileID=QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
  Dscache.Refs:
-  0) initID        = mji5zbbkphzl7unnngzzgel3yqnlzoa2x5w4segq2x2o3pv6o6da
+  0) initID        = zasmtvpvvddt536qmjtf4qdxszlpfcc6bqvmiemsmocaj4e74eiq
      profileID     = QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
      topIndex      = 1
      cursorIndex   = 1
      prettyName    = another_ds
      bodySize      = 137
      bodyRows      = 4
-     commitTime    = 978310921
-     headRef       = /ipfs/QmVjFS46hBiyuCjg7zYUijmCCZz1GG53ZSgNFKw4hbjWnY
-  1) initID        = gdulisqthishkm3rrrk4sals4hnnljkgurxteqwnlq5kssxqpp3q
+     commitTime    = 978311161
+     headRef       = /ipfs/QmSHzQVuWnBpapv4LVvfYqfQhJT8VTQ4dzPaxJvPGoUrwx
+  1) initID        = vkys37xzcxpmw5zexzhyhpok3whl2vfeep2tyeegwnm2cxrr3umq
      profileID     = QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
      topIndex      = 1
      cursorIndex   = 1
      prettyName    = movie_ds
      bodySize      = 79
      bodyRows      = 2
-     commitTime    = 978310861
-     headRef       = /ipfs/QmYFApC68tU71We4rJ3Rp4k2tJhFuknfS8MvcJJfaLPAEi
+     commitTime    = 978310921
+     headRef       = /ipfs/QmdCjShoT9bKFjAMJ7dvdrHY476qPTouBmDs94RxMKyjms
 `
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)
@@ -474,14 +448,6 @@ func TestSaveDscacheFirstCommit(t *testing.T) {
 func TestSaveDscacheExistingDataset(t *testing.T) {
 	run := NewTestRunner(t, "test_peer", "qri_test_save_dscache")
 	defer run.Delete()
-
-	prevTimestampFunc := logbook.NewTimestamp
-	logbook.NewTimestamp = func() int64 {
-		return 1000
-	}
-	defer func() {
-		logbook.NewTimestamp = prevTimestampFunc
-	}()
 
 	// Save a dataset with one version.
 	run.MustExec(t, "qri save --body testdata/movies/body_two.json me/movie_ds")
@@ -503,15 +469,15 @@ func TestSaveDscacheExistingDataset(t *testing.T) {
  Dscache.Users:
   0) user=test_peer profileID=QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
  Dscache.Refs:
-  0) initID        = gdulisqthishkm3rrrk4sals4hnnljkgurxteqwnlq5kssxqpp3q
+  0) initID        = vkys37xzcxpmw5zexzhyhpok3whl2vfeep2tyeegwnm2cxrr3umq
      profileID     = QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
      topIndex      = 1
      cursorIndex   = 1
      prettyName    = movie_ds
      bodySize      = 79
      bodyRows      = 2
-     commitTime    = 978310861
-     headRef       = /ipfs/QmYFApC68tU71We4rJ3Rp4k2tJhFuknfS8MvcJJfaLPAEi
+     commitTime    = 978310921
+     headRef       = /ipfs/QmdCjShoT9bKFjAMJ7dvdrHY476qPTouBmDs94RxMKyjms
 `
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)
@@ -535,15 +501,15 @@ func TestSaveDscacheExistingDataset(t *testing.T) {
  Dscache.Users:
   0) user=test_peer profileID=QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
  Dscache.Refs:
-  0) initID        = gdulisqthishkm3rrrk4sals4hnnljkgurxteqwnlq5kssxqpp3q
+  0) initID        = vkys37xzcxpmw5zexzhyhpok3whl2vfeep2tyeegwnm2cxrr3umq
      profileID     = QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
      topIndex      = 2
      cursorIndex   = 2
      prettyName    = movie_ds
      bodySize      = 137
      bodyRows      = 4
-     commitTime    = 978310921
-     headRef       = /ipfs/QmQ7BtW8wyYqHYMyFy8bUfSgJjfREXwF9B7uJA6MBeaZm1
+     commitTime    = 978311161
+     headRef       = /ipfs/QmZa3VTH759etCwCgWymbgtbmoSnpRb955iWwv7uwWwCyJ
 `
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)
@@ -553,14 +519,6 @@ func TestSaveDscacheExistingDataset(t *testing.T) {
 func TestSaveBadCaseCantBeUsedForNewDatasets(t *testing.T) {
 	run := NewTestRunner(t, "test_peer", "qri_save_bad_case")
 	defer run.Delete()
-
-	prevTimestampFunc := logbook.NewTimestamp
-	logbook.NewTimestamp = func() int64 {
-		return 1000
-	}
-	defer func() {
-		logbook.NewTimestamp = prevTimestampFunc
-	}()
 
 	// Try to save a new dataset, but its name has upper-case characters.
 	err := run.ExecCommand("qri save --body testdata/movies/body_two.json test_peer/a_New_Dataset")

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -4,12 +4,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/qri-io/ioes"
 )
 
 func TestSetupComplete(t *testing.T) {
-	streams, _, _, _ := ioes.NewTestIOStreams()
-	setNoColor(true)
+	run := NewTestRunner(t, "test_peer", "qri_test_setup_complete")
+	defer run.Delete()
 
 	f, err := NewTestFactory()
 	if err != nil {
@@ -18,14 +17,15 @@ func TestSetupComplete(t *testing.T) {
 	}
 
 	opt := &SetupOptions{
-		IOStreams: streams,
+		IOStreams: run.Streams,
 	}
 
 	opt.Complete(f, nil)
 }
 
 func TestSetupGimmeDoggo(t *testing.T) {
-	run := NewTestRunner(t, "test_peer", "")
+	run := NewTestRunner(t, "test_peer", "qri_test_gimme_doggo")
+	defer run.Delete()
 
 	actual := run.MustExec(t, "qri setup --gimme-doggo")
 	expect := "testnick\n"

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"testing"
-
-	"github.com/qri-io/ioes"
 )
 
 func TestStatsComplete(t *testing.T) {
-	streams, in, out, errs := ioes.NewTestIOStreams()
-	setNoColor(true)
+	run := NewTestRunner(t, "test_peer", "qri_test_stats_complete")
+	defer run.Delete()
 
 	f, err := NewTestFactory()
 	if err != nil {
@@ -26,18 +24,18 @@ func TestStatsComplete(t *testing.T) {
 
 	for i, c := range badCases {
 		opt := &StatsOptions{
-			IOStreams: streams,
+			IOStreams: run.Streams,
 		}
 
 		err := opt.Complete(f, c.args)
 
 		if c.err != err.Error() {
 			t.Errorf("%d. case %s, error mismatch. Expected: '%s', Got: '%s'", i, c.description, c.err, err.Error())
-			ioReset(in, out, errs)
+			run.IOReset()
 			continue
 		}
 
-		ioReset(in, out, errs)
+		run.IOReset()
 	}
 
 	goodCases := []struct {
@@ -51,7 +49,7 @@ func TestStatsComplete(t *testing.T) {
 
 	for i, c := range goodCases {
 		opt := &StatsOptions{
-			IOStreams: streams,
+			IOStreams: run.Streams,
 		}
 
 		if err := opt.Complete(f, c.args); err != nil {
@@ -60,23 +58,22 @@ func TestStatsComplete(t *testing.T) {
 
 		if c.expectedRef != opt.Refs.Ref() {
 			t.Errorf("%d. case %s, incorrect ref. Expected: '%s', Got: '%s'", i, c.description, c.expectedRef, opt.Refs.Ref())
-			ioReset(in, out, errs)
+			run.IOReset()
 			continue
 		}
 
 		if opt.DatasetRequests == nil {
 			t.Errorf("%d. case %s, opt.DatasetRequests not set.", i, c.description)
-			ioReset(in, out, errs)
+			run.IOReset()
 			continue
 		}
-		ioReset(in, out, errs)
+		run.IOReset()
 	}
 }
 
 func TestStatsRun(t *testing.T) {
-	streams, in, out, errs := ioes.NewTestIOStreams()
-	setNoColor(true)
-	setNoPrompt(true)
+	run := NewTestRunner(t, "test_peer", "qri_test_stats_run")
+	defer run.Delete()
 
 	f, err := NewTestFactory()
 	if err != nil {
@@ -97,10 +94,10 @@ func TestStatsRun(t *testing.T) {
 	}
 
 	for i, c := range badCases {
-		ioReset(in, out, errs)
+		run.IOReset()
 
 		opt := &StatsOptions{
-			IOStreams:       streams,
+			IOStreams:       run.Streams,
 			Refs:            NewExplicitRefSelect(c.ref),
 			DatasetRequests: dsr,
 		}
@@ -124,10 +121,10 @@ func TestStatsRun(t *testing.T) {
 	}
 
 	for i, c := range goodCases {
-		ioReset(in, out, errs)
+		run.IOReset()
 
 		opt := &StatsOptions{
-			IOStreams:       streams,
+			IOStreams:       run.Streams,
 			Refs:            NewExplicitRefSelect(c.ref),
 			DatasetRequests: dsr,
 		}

--- a/repo/test/temp_repo.go
+++ b/repo/test/temp_repo.go
@@ -1,14 +1,12 @@
 package test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	"github.com/qri-io/ioes"
 	ipfs_filestore "github.com/qri-io/qfs/cafs/ipfs"
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/config"
@@ -24,7 +22,6 @@ type TempRepo struct {
 	IPFSPath            string
 	QriPath             string
 	TestCrypto          gen.CryptoGenerator
-	Streams             ioes.IOStreams
 	cfg                 *config.Config
 	repo                repo.Repo
 	UseMockRemoteClient bool
@@ -110,24 +107,6 @@ func (r *TempRepo) WriteConfigFile() error {
 // GetConfig returns the configuration for the test repo.
 func (r *TempRepo) GetConfig() *config.Config {
 	return r.cfg
-}
-
-// GetOutput returns the output from the previously executed command.
-func (r *TempRepo) GetOutput() string {
-	buffer, ok := r.Streams.Out.(*bytes.Buffer)
-	if ok {
-		return buffer.String()
-	}
-	return ""
-}
-
-// GetErrOutput returns the "stderr" output from the previously executed command
-func (r *TempRepo) GetErrOutput() string {
-	buffer, ok := r.Streams.ErrOut.(*bytes.Buffer)
-	if ok {
-		return buffer.String()
-	}
-	return ""
 }
 
 // GetPathForDataset returns the path to where the index'th dataset is stored on CAFS.


### PR DESCRIPTION
Lots of test cleanups:

Many tests were hooking timestamp and stringer functions. Move those into the cmd TestRunner. Also, add TmpDir creation, which update and use were both doing. Cleanup the story about stdout and stderr capture with commands. Construct IOEStreams for each TestRunner, since a lot of tests were making their own. Use those streams for running commands. Be explicit about which
tests were checking the result of combined (intertwined) stdout and stderr, which wasn't happening before. Remove some one-off testRunners that were unnecessary.

closes #1233 