### PR TITLE
refactor(test): test requires stable output

### DIFF
--- a/cmd/fsi_integration_test.go
+++ b/cmd/fsi_integration_test.go
@@ -758,19 +758,19 @@ func TestGetPreviousVersionExplicitPath(t *testing.T) {
 	defer run.Delete()
 
 	// First version has only a body
-	output := run.MustExec(t, "qri save --body=testdata/movies/body_two.json me/get_ver")
+	output := run.MustExecCombinedOutErr(t, "qri save --body=testdata/movies/body_two.json me/get_ver")
 	ref1 := parseRefFromSave(output)
 
 	// Add a meta
-	output = run.MustExec(t, "qri save --file=testdata/movies/meta_override.yaml me/get_ver")
+	output = run.MustExecCombinedOutErr(t, "qri save --file=testdata/movies/meta_override.yaml me/get_ver")
 	_ = parseRefFromSave(output)
 
 	// Modify the body
-	output = run.MustExec(t, "qri save --body=testdata/movies/body_four.json me/get_ver")
+	output = run.MustExecCombinedOutErr(t, "qri save --body=testdata/movies/body_four.json me/get_ver")
 	ref3 := parseRefFromSave(output)
 
 	// Change the meta
-	output = run.MustExec(t, "qri save --file=testdata/movies/meta_another.yaml me/get_ver")
+	output = run.MustExecCombinedOutErr(t, "qri save --file=testdata/movies/meta_another.yaml me/get_ver")
 	_ = parseRefFromSave(output)
 
 	run.ChdirToRoot()


### PR DESCRIPTION
This addresses these:
```
--- FAIL: TestGetPreviousVersionExplicitPath (0.33s)
panic: expected output to start with "saved:", got "" [recovered]
        panic: expected output to start with "saved:", got ""

goroutine 5175 [running]:
testing.tRunner.func1.1(0x542e2a0, 0xc0513bbef0)
        /usr/local/Cellar/go/1.14/libexec/src/testing/testing.go:941 +0x3d0
testing.tRunner.func1(0xc050648900)
        /usr/local/Cellar/go/1.14/libexec/src/testing/testing.go:944 +0x3f9
panic(0x542e2a0, 0xc0513bbef0)
        /usr/local/Cellar/go/1.14/libexec/src/runtime/panic.go:967 +0x15d
github.com/qri-io/qri/cmd.parseRefFromSave(0x0, 0x0, 0x5704723, 0x3d)
        /Users/arqu/dev/qri/qri/cmd/fsi_integration_test.go:1656 +0x142
github.com/qri-io/qri/cmd.TestGetPreviousVersionExplicitPath(0xc050648900)
        /Users/arqu/dev/qri/qri/cmd/fsi_integration_test.go:766 +0x12c
testing.tRunner(0xc050648900, 0x586d840)
        /usr/local/Cellar/go/1.14/libexec/src/testing/testing.go:992 +0xdc
created by testing.(*T).Run
        /usr/local/Cellar/go/1.14/libexec/src/testing/testing.go:1043 +0x357
```