### PR TITLE
refactor(cmd): updating search and list to support --format simple

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -59,6 +59,7 @@ must have ` + "`qri connect`" + ` running in a separate terminal window.`,
 	cmd.Flags().StringVar(&o.Peername, "peer", "", "peer whose datasets to list")
 	cmd.Flags().BoolVarP(&o.Raw, "raw", "r", false, "to show raw references")
 	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "build and use dscache to list")
+	cmd.Flags().BoolVarP(&o.Simple, "simple", "", false, "only list dataset names")
 
 	return cmd
 }
@@ -76,6 +77,7 @@ type ListOptions struct {
 	ShowNumVersions bool
 	Raw             bool
 	UseDscache      bool
+	Simple          bool
 
 	DatasetRequests *lib.DatasetRequests
 }
@@ -140,6 +142,14 @@ func (o *ListOptions) Run() (err error) {
 		return
 	}
 
+	if o.Simple {
+		items := make([]string, len(infos))
+		for i, r := range infos {
+			items[i] = r.SimpleRef().Alias()
+		}
+		printlnStringItems(o.Out, items)
+		return nil
+	}
 	switch o.Format {
 	case "":
 		items := make([]fmt.Stringer, len(infos))

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -51,7 +51,7 @@ must have ` + "`qri connect`" + ` running in a separate terminal window.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.Format, "format", "f", "", "set output format [json]")
+	cmd.Flags().StringVarP(&o.Format, "format", "f", "", "set output format [json|simple]")
 	cmd.Flags().IntVar(&o.PageSize, "page-size", 25, "page size of results, default 25")
 	cmd.Flags().IntVar(&o.Page, "page", 1, "page number results, default 1")
 	cmd.Flags().BoolVarP(&o.Published, "published", "p", false, "list only published datasets")
@@ -59,7 +59,6 @@ must have ` + "`qri connect`" + ` running in a separate terminal window.`,
 	cmd.Flags().StringVar(&o.Peername, "peer", "", "peer whose datasets to list")
 	cmd.Flags().BoolVarP(&o.Raw, "raw", "r", false, "to show raw references")
 	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "build and use dscache to list")
-	cmd.Flags().BoolVarP(&o.Simple, "simple", "", false, "only list dataset names")
 
 	return cmd
 }
@@ -77,7 +76,6 @@ type ListOptions struct {
 	ShowNumVersions bool
 	Raw             bool
 	UseDscache      bool
-	Simple          bool
 
 	DatasetRequests *lib.DatasetRequests
 }
@@ -142,14 +140,6 @@ func (o *ListOptions) Run() (err error) {
 		return
 	}
 
-	if o.Simple {
-		items := make([]string, len(infos))
-		for i, r := range infos {
-			items[i] = r.SimpleRef().Alias()
-		}
-		printlnStringItems(o.Out, items)
-		return nil
-	}
 	switch o.Format {
 	case "":
 		items := make([]fmt.Stringer, len(infos))
@@ -157,6 +147,13 @@ func (o *ListOptions) Run() (err error) {
 			items[i] = versionInfoStringer(r)
 		}
 		printItems(o.Out, items, page.Offset())
+		return nil
+	case "simple":
+		items := make([]string, len(infos))
+		for i, r := range infos {
+			items[i] = r.SimpleRef().Alias()
+		}
+		printlnStringItems(o.Out, items)
 		return nil
 	case dataset.JSONDataFormat.String():
 		// TODO(dlong): This is broken, and has no tests, otherwise this regression would have

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -67,6 +67,16 @@ func printItems(w io.Writer, items []fmt.Stringer, offset int) (err error) {
 	return printToPager(w, buf)
 }
 
+// print a slice of stringer items to io.Writer as an indented & numbered list
+// offset specifies the number of items that have been skipped, index is 1-based
+func printlnStringItems(w io.Writer, items []string) (err error) {
+	buf := &bytes.Buffer{}
+	for _, item := range items {
+		buf.WriteString(item + "\n")
+	}
+	return printToPager(w, buf)
+}
+
 func printToPager(w io.Writer, buf *bytes.Buffer) (err error) {
 	// TODO (ramfox): This is POSIX specific, need to expand!
 	envPager := os.Getenv("PAGER")

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -39,10 +39,9 @@ Any dataset that has been published to the registry is available for search.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.Format, "format", "f", "", "set output format [json]")
+	cmd.Flags().StringVarP(&o.Format, "format", "f", "", "set output format [json|simple]")
 	cmd.Flags().IntVar(&o.PageSize, "page-size", 25, "page size of results, default 25")
 	cmd.Flags().IntVar(&o.Page, "page", 1, "page number of results, default 1")
-	cmd.Flags().BoolVarP(&o.Simple, "simple", "", false, "only list dataset names")
 
 	return cmd
 }
@@ -55,7 +54,6 @@ type SearchOptions struct {
 	Format   string
 	PageSize int
 	Page     int
-	Simple   bool
 	// Reindex bool
 
 	SearchMethods *lib.SearchMethods
@@ -101,14 +99,6 @@ func (o *SearchOptions) Run() (err error) {
 	}
 
 	// o.StopSpinner()
-	if o.Simple {
-		items := make([]string, len(results))
-		for i, r := range results {
-			items[i] = fmt.Sprintf("%s/%s", r.Value.Peername, r.Value.Name)
-		}
-		printlnStringItems(o.Out, items)
-		return nil
-	}
 	switch o.Format {
 	case "":
 		fmt.Fprintf(o.Out, "showing %d results for '%s'\n", len(results), o.Query)
@@ -119,7 +109,13 @@ func (o *SearchOptions) Run() (err error) {
 		o.StopSpinner()
 		printItems(o.Out, items, page.Offset())
 		return nil
-
+	case "simple":
+		items := make([]string, len(results))
+		for i, r := range results {
+			items[i] = fmt.Sprintf("%s/%s", r.Value.Peername, r.Value.Name)
+		}
+		printlnStringItems(o.Out, items)
+		return nil
 	case dataset.JSONDataFormat.String():
 		data, err := json.MarshalIndent(results, "", "  ")
 		if err != nil {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -42,6 +42,7 @@ Any dataset that has been published to the registry is available for search.`,
 	cmd.Flags().StringVarP(&o.Format, "format", "f", "", "set output format [json]")
 	cmd.Flags().IntVar(&o.PageSize, "page-size", 25, "page size of results, default 25")
 	cmd.Flags().IntVar(&o.Page, "page", 1, "page number of results, default 1")
+	cmd.Flags().BoolVarP(&o.Simple, "simple", "", false, "only list dataset names")
 
 	return cmd
 }
@@ -54,6 +55,7 @@ type SearchOptions struct {
 	Format   string
 	PageSize int
 	Page     int
+	Simple   bool
 	// Reindex bool
 
 	SearchMethods *lib.SearchMethods
@@ -99,6 +101,14 @@ func (o *SearchOptions) Run() (err error) {
 	}
 
 	// o.StopSpinner()
+	if o.Simple {
+		items := make([]string, len(results))
+		for i, r := range results {
+			items[i] = fmt.Sprintf("%s/%s", r.Value.Peername, r.Value.Name)
+		}
+		printlnStringItems(o.Out, items)
+		return nil
+	}
 	switch o.Format {
 	case "":
 		fmt.Fprintf(o.Out, "showing %d results for '%s'\n", len(results), o.Query)


### PR DESCRIPTION
Simplified output formats for easy piping into other scripts. Is a prerequisite for dataset name resolution on most `qri` commands for the autocomplete feature https://github.com/qri-io/qri/pull/1240 https://github.com/qri-io/qri/issues/1236