### PR TITLE
Fix #1245: Render error details when schema file can not be read

### DIFF
--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -1067,7 +1067,7 @@ func (r *DatasetRequests) Validate(p *ValidateDatasetParams, valerrs *[]jsonsche
 	} else {
 		data, err := ioutil.ReadFile(schemaFilename)
 		if err != nil {
-			return fmt.Errorf("error opening %s file: %s, error was: %s", schemaFlagType, schemaFilename, err)
+			return fmt.Errorf("error opening %s file: %s", schemaFlagType, schemaFilename)
 		}
 		var fileContent map[string]interface{}
 		err = json.Unmarshal(data, &fileContent)

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -1067,7 +1067,7 @@ func (r *DatasetRequests) Validate(p *ValidateDatasetParams, valerrs *[]jsonsche
 	} else {
 		data, err := ioutil.ReadFile(schemaFilename)
 		if err != nil {
-			return fmt.Errorf("error opening schema file: %s", p.SchemaFilename)
+			return fmt.Errorf("error opening %s file: %s, error was: %s", schemaFlagType, schemaFilename, err)
 		}
 		var fileContent map[string]interface{}
 		err = json.Unmarshal(data, &fileContent)


### PR DESCRIPTION
Fixes missing file name if structure file is provided instead of schema file and adds message of root cause error.