### PR TITLE
feat(dscache): Dscache can be used for get command

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -282,7 +282,7 @@ func (h *DatasetHandlers) listHandler(w http.ResponseWriter, r *http.Request) {
 // otherwise, resolve the peername and proceed as normal
 func (h *DatasetHandlers) getHandler(w http.ResponseWriter, r *http.Request) {
 	p := lib.GetParams{
-		Ref: HTTPPathToQriPath(r.URL.Path),
+		Refstr: HTTPPathToQriPath(r.URL.Path),
 	}
 	res := lib.GetResult{}
 	err := h.Get(&p, &res)
@@ -306,8 +306,8 @@ func (h *DatasetHandlers) getHandler(w http.ResponseWriter, r *http.Request) {
 		ProfileID: profile.IDB58DecodeOrEmpty(res.Dataset.ProfileID),
 		Name:      res.Dataset.Name,
 		Path:      res.Dataset.Path,
-		FSIPath:   res.Ref.FSIPath,
-		Published: res.Ref.Published,
+		FSIPath:   res.FSIPath,
+		Published: res.Published,
 		Dataset:   res.Dataset,
 	}
 	util.WriteResponse(w, ref)
@@ -582,7 +582,7 @@ func getParamsFromRequest(r *http.Request, readOnly bool, path string) (*lib.Get
 	}
 
 	p := &lib.GetParams{
-		Ref:      path,
+		Refstr:   path,
 		Format:   format,
 		Selector: "body",
 		Limit:    listParams.Limit,
@@ -659,7 +659,7 @@ func (h DatasetHandlers) bodyHandler(w http.ResponseWriter, r *http.Request) {
 
 func (h DatasetHandlers) statsHandler(w http.ResponseWriter, r *http.Request) {
 	p := lib.GetParams{
-		Ref:      HTTPPathToQriPath(r.URL.Path[len("/stats/"):]),
+		Refstr:   HTTPPathToQriPath(r.URL.Path[len("/stats/"):]),
 		Selector: "stats",
 	}
 	res := lib.GetResult{}

--- a/api/fsi.go
+++ b/api/fsi.go
@@ -165,7 +165,7 @@ func (h *FSIHandlers) initHandler(routePrefix string) http.HandlerFunc {
 		// Get code taken
 		// taken from ./root.go
 		gp := lib.GetParams{
-			Ref: name,
+			Refstr: name,
 		}
 		res := lib.GetResult{}
 		err := h.dsm.Get(&gp, &res)
@@ -188,8 +188,8 @@ func (h *FSIHandlers) initHandler(routePrefix string) http.HandlerFunc {
 			ProfileID: profile.IDB58DecodeOrEmpty(res.Dataset.ProfileID),
 			Name:      res.Dataset.Name,
 			Path:      res.Dataset.Path,
-			FSIPath:   res.Ref.FSIPath,
-			Published: res.Ref.Published,
+			FSIPath:   res.FSIPath,
+			Published: res.Published,
 			Dataset:   res.Dataset,
 		}
 

--- a/api/root.go
+++ b/api/root.go
@@ -53,7 +53,7 @@ func (mh *RootHandler) Handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p := lib.GetParams{
-		Ref: ref.String(),
+		Refstr: ref.String(),
 	}
 	res := lib.GetResult{}
 	err := mh.dsh.Get(&p, &res)
@@ -86,8 +86,8 @@ func (mh *RootHandler) Handler(w http.ResponseWriter, r *http.Request) {
 		ProfileID: profile.IDB58DecodeOrEmpty(res.Dataset.ProfileID),
 		Name:      res.Dataset.Name,
 		Path:      res.Dataset.Path,
-		FSIPath:   res.Ref.FSIPath,
-		Published: res.Ref.Published,
+		FSIPath:   res.FSIPath,
+		Published: res.Published,
 		Dataset:   res.Dataset,
 	}
 

--- a/base/dataset_prepare.go
+++ b/base/dataset_prepare.go
@@ -35,6 +35,16 @@ func PrepareDatasetSave(ctx context.Context, r repo.Repo, peername, name string)
 		return nil, nil, "", fmt.Errorf("peername required to prepare dataset")
 	}
 
+	// TODO(dustmop): We should not be calling CanonicalizeDatasetRef here. It's already been
+	// called up in lib, which means that we've thrown information away. Furthermore, we
+	// should be relying on stable identifiers this low down the stack. Instead, pass the initID
+	// down to this function. Also pass down a Resolver interface, and use that to look up the
+	// previous version.
+	// If we're using a dscache, we can use the future codepath:
+	//   rsolv.GetInfo(initID)
+	// otherwise, use the old technique of resolving a dataset ref:
+	//   rsolv.GetInfoByDsref(ref)
+
 	// Determine if the save is creating a new dataset or updating an existing dataset by
 	// seeing if the name can canonicalize to a repo that we know about
 	lookup := &reporef.DatasetRef{Name: name, Peername: peername}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -704,3 +704,30 @@ func TestRenameAfterRegistration(t *testing.T) {
 	}
 
 }
+
+// Test that list can format output as json
+func TestListFormatJson(t *testing.T) {
+	run := NewTestRunner(t, "test_peer", "list_format_json")
+	defer run.Delete()
+
+	run.MustExec(t, "qri save --body=testdata/movies/body_ten.csv me/my_ds")
+
+	// Verify the references in json format
+	output := run.MustExec(t, "qri list --format json")
+	expect := `[
+  {
+    "username": "test_peer",
+    "profileID": "QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B",
+    "name": "my_ds",
+    "path": "/ipfs/QmQwrGtU5ct8N6pLFPvHkvziybahRGfiCHw6kpBB1owg4R",
+    "bodySize": 224,
+    "bodyRows": 8,
+    "bodyFromat": "csv",
+    "numErrors": 1,
+    "commitTime": "2001-01-01T01:02:01.000000001Z"
+  }
+]`
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+}

--- a/cmd/fsi_integration_test.go
+++ b/cmd/fsi_integration_test.go
@@ -1653,9 +1653,13 @@ func TestUnlinkDirectoryButRefNotFound(t *testing.T) {
 func parseRefFromSave(output string) string {
 	pos := strings.Index(output, "saved: ")
 	if pos == -1 {
-		panic(fmt.Errorf("expected output to start with \"saved:\", got %q", output))
+		panic(fmt.Errorf("expected output to contain \"saved:\", got %q", output))
 	}
 	ref := output[pos+7:]
+	endPos := strings.Index(ref, "\n")
+	if endPos > -1 {
+		ref = ref[:endPos]
+	}
 	return strings.TrimSpace(ref)
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -131,7 +131,7 @@ func (o *GetOptions) Run() (err error) {
 	// convert Page and PageSize to Limit and Offset
 	page := util.NewPage(o.Page, o.PageSize)
 	p := lib.GetParams{
-		Ref:          o.Refs.Ref(),
+		Refstr:       o.Refs.Ref(),
 		Selector:     o.Selector,
 		Format:       o.Format,
 		FormatConfig: fc,

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGetComplete(t *testing.T) {
@@ -65,3 +68,309 @@ func TestGetComplete(t *testing.T) {
 		run.IOReset()
 	}
 }
+
+const (
+	currHeadRepo = `bodyPath: /ipfs/QmeLmPMNSCxVxCdDmdunBCfiN1crb3C2eUnZex6QgHpFiB
+commit:
+  author:
+    id: QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
+  message: "body:\n\tchanged by 54%"
+  path: /ipfs/QmX8i1pFR4uZqav7PU3DrHj2PgbTSrmtqrjfVpjz34gi77
+  qri: cm:0
+  signature: K/01QGH9pPdWigsVON/0INfeWWpoeN6ad97bBSpuRC050dyOP/086eHz19lWX6wZ0T0lFvViCEsq3XsOGrQ4a+BFxS5ut661uQxuuIE+40VsJ42XOGj1j1Y0XKl2bACGXV5MT0cpMYgrHBV2kgr/aliAi0SgW5ZbFukAR2Vnvjn37zTwLtVarTq1zFOOKuaLD3maJ4+5rgVEFErJCORxrCmQhiJt3hqwVzf0+kG65Y81iY6qnqiYjf94LgKFH8Nmq0Y7bdG02stxHtVtLMvea3nO8B/tNITgS1NolflAgIaJc6ylU4TNb1Z2Q3L63P6fRUf39E8cLD8631o6jWkWew==
+  timestamp: "2001-01-01T01:05:01.000000001Z"
+  title: body changed by 54%
+name: my_ds
+path: /ipfs/Qmbyggdcy4N55FFcmBu4HpDXeJQksktonP6he9wUfShmc6
+peername: test_peer
+previousPath: /ipfs/QmQwrGtU5ct8N6pLFPvHkvziybahRGfiCHw6kpBB1owg4R
+qri: ds:0
+structure:
+  checksum: QmSa4i985cF3dxNHxD5mSN7c6q1eYa83uNo1pLRmPZgTsa
+  depth: 2
+  entries: 18
+  errCount: 1
+  format: csv
+  formatConfig:
+    headerRow: true
+    lazyQuotes: true
+  length: 532
+  qri: st:0
+  schema:
+    items:
+      items:
+      - title: movie_title
+        type: string
+      - title: duration
+        type: integer
+      type: array
+    type: array
+viz:
+  format: html
+  qri: vz:0
+  renderedPath: /ipfs/QmYonnXgeckkXMvL47hvKJLAbwozYqELpZdoj5RaasL3QQ
+  scriptPath: /ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor
+
+`
+	prevHeadRepo = `bodyPath: /ipfs/QmXhsUK6vGZrqarhw9Z8RCXqhmEpvtVByKtaYVarbDZ5zn
+commit:
+  author:
+    id: QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
+  message: created dataset
+  path: /ipfs/QmNodcAnA9NXfU32NxRWRY1yUXeyNem4R9FMcchtgBtob1
+  qri: cm:0
+  signature: njCFxpGqq0xJSrjgxC289KncjflqA0e00txweEqIyUTvEKSUBKHcfQmx4OQIJzJqQJdcjIEzFrwP9cdquozRgsnrpsSfKb+wBWdtbnrg8zfat0X/Dqjro6JD7afJf0gU9s5SDi/s8g/qZOLwWh1nuoH4UAeUX+l3DH0ocFjeD6r/YkMJ0KXaWaFloKP8UPasfqoei9PxxmYQuAnFMqpXFisB7mKFAbgbpF3eL80UcbQPTih7WF11SBym/AzJhGNvOivOjmRxKGEuqEH9g3NPTEQr+LnP415X4qiaZA6MVmOO66vC0diUN4vJUMvhTsWnVEBtgqjTRYlSaYwabHv/gA==
+  timestamp: "2001-01-01T01:02:01.000000001Z"
+  title: created dataset
+name: my_ds
+path: /ipfs/QmQwrGtU5ct8N6pLFPvHkvziybahRGfiCHw6kpBB1owg4R
+peername: test_peer
+qri: ds:0
+structure:
+  checksum: QmcXDEGeWdyzfFRYyPsQVab5qszZfKqxTMEoXRDSZMyrhf
+  depth: 2
+  entries: 8
+  errCount: 1
+  format: csv
+  formatConfig:
+    headerRow: true
+    lazyQuotes: true
+  length: 224
+  qri: st:0
+  schema:
+    items:
+      items:
+      - title: movie_title
+        type: string
+      - title: duration
+        type: integer
+      type: array
+    type: array
+viz:
+  format: html
+  qri: vz:0
+  renderedPath: /ipfs/QmYonnXgeckkXMvL47hvKJLAbwozYqELpZdoj5RaasL3QQ
+  scriptPath: /ipfs/QmVM37PFzBcZn3qqKvyQ9rJ1jC8NkS8kYZNJke1Wje1jor
+
+`
+	currBodyRepo = `movie_title,duration
+Avatar ,178
+Pirates of the Caribbean: At World's End ,169
+Spectre ,148
+The Dark Knight Rises ,164
+Star Wars: Episode VII - The Force Awakens             ,
+John Carter ,132
+Spider-Man 3 ,156
+Tangled ,100
+Avengers: Age of Ultron ,141
+Harry Potter and the Half-Blood Prince ,153
+Batman v Superman: Dawn of Justice ,183
+Superman Returns ,169
+Quantum of Solace ,106
+Pirates of the Caribbean: Dead Man's Chest ,151
+The Lone Ranger ,150
+Man of Steel ,143
+The Chronicles of Narnia: Prince Caspian ,150
+The Avengers ,173
+
+`
+	prevBodyRepo = `movie_title,duration
+Avatar ,178
+Pirates of the Caribbean: At World's End ,169
+Spectre ,148
+The Dark Knight Rises ,164
+Star Wars: Episode VII - The Force Awakens             ,
+John Carter ,132
+Spider-Man 3 ,156
+Tangled ,100
+
+`
+	currHeadFSI = `bodyPath: /tmp/my_ds/my_ds/body.csv
+name: my_ds
+peername: test_peer
+qri: ds:0
+structure:
+  format: csv
+  formatConfig:
+    headerRow: true
+    lazyQuotes: true
+  qri: st:0
+  schema:
+    items:
+      items:
+      - title: movie_title
+        type: string
+      - title: duration
+        type: integer
+      type: array
+    type: array
+
+`
+	currBodyFSI = currBodyRepo
+)
+
+func TestGetDatasetFromRepo(t *testing.T) {
+	run := NewTestRunner(t, "test_peer", "get_dataset_head")
+	defer run.Delete()
+
+	// Save two versions.
+	got := run.MustExecCombinedOutErr(t, "qri save --body=testdata/movies/body_ten.csv me/my_ds")
+	ref := parseRefFromSave(got)
+	run.MustExec(t, "qri save --body=testdata/movies/body_twenty.csv me/my_ds")
+
+	// Get head.
+	output := run.MustExec(t, "qri get me/my_ds")
+	expect := currHeadRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get one version ago.
+	output = run.MustExec(t, fmt.Sprintf("qri get %s", ref))
+	expect = prevHeadRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get body from current commit.
+	output = run.MustExec(t, "qri get body me/my_ds")
+	expect = currBodyRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get body from one version ago.
+	output = run.MustExec(t, fmt.Sprintf("qri get body %s", ref))
+	expect = prevBodyRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetDatasetCheckedOut(t *testing.T) {
+	run := NewFSITestRunner(t, "get_dataset_checked_out")
+	defer run.Delete()
+
+	// Save two versions.
+	got := run.MustExecCombinedOutErr(t, "qri save --body=testdata/movies/body_ten.csv me/my_ds")
+	ref := parseRefFromSave(got)
+	run.MustExec(t, "qri save --body=testdata/movies/body_twenty.csv me/my_ds")
+
+	// Checkout to a working directory.
+	run.CreateAndChdirToWorkDir("my_ds")
+	run.MustExec(t, "qri checkout me/my_ds")
+
+	// Get head.
+	output := run.MustExec(t, "qri get me/my_ds")
+	expect := currHeadFSI
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get one version ago.
+	output = run.MustExec(t, fmt.Sprintf("qri get %s", ref))
+	expect = prevHeadRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get body from current commit.
+	output = run.MustExec(t, "qri get body me/my_ds")
+	expect = currBodyFSI
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get body from one version ago.
+	output = run.MustExec(t, fmt.Sprintf("qri get body %s", ref))
+	expect = prevBodyRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetDatasetUsingDscache(t *testing.T) {
+	run := NewTestRunner(t, "test_peer", "get_dataset_head")
+	defer run.Delete()
+
+	// Save two versions, using dscache.
+	got := run.MustExecCombinedOutErr(t, "qri save --use-dscache --body=testdata/movies/body_ten.csv me/my_ds")
+	ref := parseRefFromSave(got)
+	run.MustExec(t, "qri save --use-dscache --body=testdata/movies/body_twenty.csv me/my_ds")
+
+	// Get head.
+	output := run.MustExec(t, "qri get me/my_ds")
+	expect := currHeadRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get one version ago.
+	output = run.MustExec(t, fmt.Sprintf("qri get %s", ref))
+	expect = prevHeadRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get body from current commit.
+	output = run.MustExec(t, "qri get body me/my_ds")
+	expect = currBodyRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get body from one version ago.
+	output = run.MustExec(t, fmt.Sprintf("qri get body %s", ref))
+	expect = prevBodyRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetDatasetCheckedOutUsingDscache(t *testing.T) {
+	run := NewFSITestRunner(t, "get_dataset_checked_out")
+	defer run.Delete()
+
+	// Save two versions.
+	got := run.MustExecCombinedOutErr(t, "qri save --body=testdata/movies/body_ten.csv me/my_ds")
+	ref := parseRefFromSave(got)
+	run.MustExec(t, "qri save --body=testdata/movies/body_twenty.csv me/my_ds")
+
+	// Checkout to a working directory.
+	run.CreateAndChdirToWorkDir("my_ds")
+	run.MustExec(t, "qri checkout me/my_ds")
+
+	// Build the dscache
+	// TODO(dustmop): Can't immitate the other tests, because checkout doesn't know about dscache
+	// yet, it doesn't set the FSIPath. Instead, build the dscache here, so that the FSIPath exists.
+	run.MustExec(t, "qri list --use-dscache")
+
+	// Get head.
+	output := run.MustExec(t, "qri get me/my_ds")
+	expect := currHeadFSI
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get one version ago.
+	output = run.MustExec(t, fmt.Sprintf("qri get %s", ref))
+	expect = prevHeadRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get body from current commit.
+	output = run.MustExec(t, "qri get body me/my_ds")
+	expect = currBodyFSI
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+
+	// Get body from one version ago.
+	output = run.MustExec(t, fmt.Sprintf("qri get body %s", ref))
+	expect = prevBodyRepo
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
+	}
+}
+

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -58,7 +58,7 @@ must have ` + "`qri connect`" + ` running in a separate terminal window.`,
 	cmd.Flags().BoolVarP(&o.ShowNumVersions, "num-versions", "n", false, "show number of versions")
 	cmd.Flags().StringVar(&o.Peername, "peer", "", "peer whose datasets to list")
 	cmd.Flags().BoolVarP(&o.Raw, "raw", "r", false, "to show raw references")
-	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "build and use dscache to list")
+	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "experimental: build and use dscache to list")
 
 	return cmd
 }
@@ -156,8 +156,6 @@ func (o *ListOptions) Run() (err error) {
 		printlnStringItems(o.Out, items)
 		return nil
 	case dataset.JSONDataFormat.String():
-		// TODO(dlong): This is broken, and has no tests, otherwise this regression would have
-		// been caught.
 		data, err := json.MarshalIndent(infos, "", "  ")
 		if err != nil {
 			return err

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -74,7 +74,7 @@ commit message and title to the save.`,
 	// TODO(dlong): --no-render is deprecated, viz are being phased out, in favor of readme.
 	cmd.Flags().BoolVar(&o.NoRender, "no-render", false, "don't store a rendered version of the the vizualization ")
 	cmd.Flags().BoolVarP(&o.NewName, "new", "n", false, "save a new dataset only, using an available name")
-	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "build and use dscache if none exists")
+	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "experimental: build and use dscache if none exists")
 
 	return cmd
 }

--- a/dscache/dscache.go
+++ b/dscache/dscache.go
@@ -11,7 +11,7 @@ import (
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qfs"
-	dscachefb "github.com/qri-io/qri/dscache/dscachefb"
+	"github.com/qri-io/qri/dscache/dscachefb"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/repo/profile"
@@ -31,6 +31,7 @@ type Dscache struct {
 	Buffer              []byte
 	CreateNewEnabled    bool
 	ProfileIDToUsername map[string]string
+	DefaultUsername     string
 }
 
 // NewDscache will construct a dscache from the given filename, or will construct an empty dscache
@@ -51,6 +52,7 @@ func NewDscache(ctx context.Context, fsys qfs.Filesystem, book *logbook.Book, fi
 	}
 	if book != nil {
 		book.Observe(cache.update)
+		cache.DefaultUsername = book.AuthorName()
 	}
 	return &cache
 }
@@ -272,6 +274,7 @@ func (d *Dscache) updateMoveCursor(act *logbook.Action) error {
 	return d.save()
 }
 
+// copied to dscache/loader/loader.go
 func convertEntryToVersionInfo(r *dscachefb.RefEntryInfo) dsref.VersionInfo {
 	return dsref.VersionInfo{
 		InitID:      string(r.InitID()),

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -28,8 +28,8 @@ import (
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
-	"github.com/qri-io/qri/resolver/loader"
 	reporef "github.com/qri-io/qri/repo/ref"
+	"github.com/qri-io/qri/resolver/loader"
 )
 
 // DatasetRequests encapsulates business logic for working with Datasets on Qri

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -420,78 +420,78 @@ func TestDatasetRequestsGet(t *testing.T) {
 		expect      string
 	}{
 		{"invalid peer name",
-			&GetParams{Ref: "peer/ABC@abc"}, "'peer/ABC@abc' is not a valid dataset reference"},
+			&GetParams{Refstr: "peer/ABC@abc"}, "'peer/ABC@abc' is not a valid dataset reference"},
 
 		{"peername without path",
-			&GetParams{Ref: "peer/movies"},
+			&GetParams{Refstr: "peer/movies"},
 			componentToString(setDatasetName(moviesDs, "peer/movies"), "yaml")},
 
 		{"peername with path",
-			&GetParams{Ref: fmt.Sprintf("peer/movies@%s", ref.Path)},
+			&GetParams{Refstr: fmt.Sprintf("peer/movies@%s", ref.Path)},
 			componentToString(setDatasetName(moviesDs, "peer/movies"), "yaml")},
 
 		{"peername as json format",
-			&GetParams{Ref: "peer/movies", Format: "json"},
+			&GetParams{Refstr: "peer/movies", Format: "json"},
 			componentToString(setDatasetName(moviesDs, "peer/movies"), "json")},
 
 		{"commit component",
-			&GetParams{Ref: "peer/movies", Selector: "commit"},
+			&GetParams{Refstr: "peer/movies", Selector: "commit"},
 			componentToString(moviesDs.Commit, "yaml")},
 
 		{"commit component as json format",
-			&GetParams{Ref: "peer/movies", Selector: "commit", Format: "json"},
+			&GetParams{Refstr: "peer/movies", Selector: "commit", Format: "json"},
 			componentToString(moviesDs.Commit, "json")},
 
 		{"title field of commit component",
-			&GetParams{Ref: "peer/movies", Selector: "commit.title"}, "initial commit\n"},
+			&GetParams{Refstr: "peer/movies", Selector: "commit.title"}, "initial commit\n"},
 
 		{"title field of commit component as json",
-			&GetParams{Ref: "peer/movies", Selector: "commit.title", Format: "json"},
+			&GetParams{Refstr: "peer/movies", Selector: "commit.title", Format: "json"},
 			"\"initial commit\""},
 
 		{"title field of commit component as yaml",
-			&GetParams{Ref: "peer/movies", Selector: "commit.title", Format: "yaml"},
+			&GetParams{Refstr: "peer/movies", Selector: "commit.title", Format: "yaml"},
 			"initial commit\n"},
 
 		{"title field of commit component as mispelled format",
-			&GetParams{Ref: "peer/movies", Selector: "commit.title", Format: "jason"},
+			&GetParams{Refstr: "peer/movies", Selector: "commit.title", Format: "jason"},
 			"unknown format: \"jason\""},
 
 		{"body as json",
-			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json"}, "[]"},
+			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json"}, "[]"},
 
 		{"dataset empty",
-			&GetParams{Ref: "", Selector: "body", Format: "json"}, "repo: empty dataset reference"},
+			&GetParams{Refstr: "", Selector: "body", Format: "json"}, "repo: empty dataset reference"},
 
 		{"body as csv",
-			&GetParams{Ref: "peer/movies", Selector: "body", Format: "csv"}, "title,duration\n"},
+			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "csv"}, "title,duration\n"},
 
 		{"body with limit and offfset",
-			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
 				Limit: 5, Offset: 0, All: false}, bodyToString(moviesBody[:5])},
 
 		{"body with invalid limit and offset",
-			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
 				Limit: -5, Offset: -100, All: false}, "invalid limit / offset settings"},
 
 		{"body with all flag ignores invalid limit and offset",
-			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
 				Limit: -5, Offset: -100, All: true}, bodyToString(moviesBody)},
 
 		{"body with all flag",
-			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
 				Limit: 0, Offset: 0, All: true}, bodyToString(moviesBody)},
 
 		{"body with limit and non-zero offset",
-			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
 				Limit: 2, Offset: 10, All: false}, bodyToString(moviesBody[10:12])},
 
 		{"head non-pretty json",
-			&GetParams{Ref: "peer/movies", Format: "json", FormatConfig: nonprettyJSONConfig},
+			&GetParams{Refstr: "peer/movies", Format: "json", FormatConfig: nonprettyJSONConfig},
 			componentToString(setDatasetName(moviesDs, "peer/movies"), "non-pretty json")},
 
 		{"body pretty json",
-			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
 				FormatConfig: prettyJSONConfig, Limit: 3, Offset: 0, All: false},
 			bodyToPrettyString(moviesBody[:3])},
 	}
@@ -598,7 +598,7 @@ func TestDatasetRequestsGetP2p(t *testing.T) {
 
 			dsr := NewDatasetRequests(node, nil)
 			got := &GetResult{}
-			err = dsr.Get(&GetParams{Ref: ref.String()}, got)
+			err = dsr.Get(&GetParams{Refstr: ref.String()}, got)
 			if err != nil {
 				t.Errorf("error listing dataset for %s: %s", ref.Name, err.Error())
 			}

--- a/resolver/loader/loader.go
+++ b/resolver/loader/loader.go
@@ -1,0 +1,144 @@
+package loader
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	golog "github.com/ipfs/go-log"
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qfs/cafs"
+	"github.com/qri-io/qri/base/dsfs"
+	"github.com/qri-io/qri/dscache"
+	"github.com/qri-io/qri/dscache/dscachefb"
+	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/fsi"
+	"github.com/qri-io/qri/resolver"
+)
+
+var (
+	log = golog.Logger("loader")
+)
+
+var _ resolver.Resolver = (*DatasetResolver)(nil)
+
+// DatasetResolver is a high-level component that can resolve dataset references
+type DatasetResolver struct {
+	Dscache *dscache.Dscache
+	Store   cafs.Filestore
+}
+
+// NewDatasetResolver returns a new DatasetResolver from dscache and a filestore
+func NewDatasetResolver(d *dscache.Dscache, store cafs.Filestore) *DatasetResolver {
+	return &DatasetResolver{Dscache: d, Store: store}
+}
+
+// GetInfo looks up a VersionInfo from an initID
+func (dr *DatasetResolver) GetInfo(initID string) *dsref.VersionInfo {
+	log.Errorf("TODO(dustmop): Implement me")
+	return nil
+}
+
+// GetInfoByDsref looks up a VersionInfo from a dataset ref
+func (dr *DatasetResolver) GetInfoByDsref(ref dsref.Ref) *dsref.VersionInfo {
+	log.Errorf("TODO(dustmop): Implement me")
+	return nil
+}
+
+// LoadDsref will parse a ref string, resolve it using dscache and fsi, and return the dataset
+// along with additional info.
+// TODO(dustmop): Remove the info return value after fixing callers that currently rely on it
+func (dr *DatasetResolver) LoadDsref(ctx context.Context, refstr string) (*dataset.Dataset, string, dsref.Ref, *dsref.VersionInfo, error) {
+	// Parse the refstr
+	ref, err := dsref.Parse(refstr)
+	if err == dsref.ErrBadCaseName {
+		log.Error(dsref.ErrBadCaseShouldRename)
+	} else if err != nil {
+		return nil, "", ref, nil, err
+	}
+
+	// Handle the "me" convenience shortcut
+	if ref.Username == "me" && dr.Dscache.DefaultUsername != "" {
+		ref.Username = dr.Dscache.DefaultUsername
+	}
+
+	// Resolve username to profileID, lookup dataset by profileID + prettyName
+	info, err := lookupByName(dr.Dscache, ref)
+	if err != nil {
+		return nil, "", ref, nil, err
+	}
+
+	// Found a versionInfo, fill in ref.
+	ref.Name = info.Name
+	defaultPath := false
+	if ref.Path == "" {
+		ref.Path = info.Path
+		defaultPath = true
+	}
+
+	// Load the dataset head.
+	var ds *dataset.Dataset
+	if defaultPath && info.FSIPath != "" {
+		// Has an FSI Path, load from working directory
+		if ds, err = fsi.ReadDir(info.FSIPath); err != nil {
+			return nil, "", ref, nil, err
+		}
+	} else {
+		// Load from dsfs
+		if ds, err = dsfs.LoadDataset(ctx, dr.Store, ref.Path); err != nil {
+			return nil, "", ref, nil, err
+		}
+	}
+	// Set transient info on the returned dataset
+	ds.Name = ref.Name
+	ds.Peername = ref.Username
+	return ds, info.InitID, ref, info, err
+}
+
+func lookupByName(dc *dscache.Dscache, ref dsref.Ref) (*dsref.VersionInfo, error) {
+	// Convert the username into a profileID
+	for i := 0; i < dc.Root.UsersLength(); i++ {
+		userAssoc := dscachefb.UserAssoc{}
+		dc.Root.Users(&userAssoc, i)
+		username := userAssoc.Username()
+		profileID := userAssoc.ProfileID()
+		if ref.Username == string(username) {
+			ref.ProfileID = string(profileID)
+			break
+		}
+	}
+	if ref.ProfileID == "" {
+		return nil, fmt.Errorf("unknown username %q", ref.Username)
+	}
+	// Lookup the info, given the profileID/dsname
+	for i := 0; i < dc.Root.RefsLength(); i++ {
+		r := dscachefb.RefEntryInfo{}
+		dc.Root.Refs(&r, i)
+		if string(r.ProfileID()) == ref.ProfileID && string(r.PrettyName()) == ref.Name {
+			info := convertEntryToVersionInfo(&r)
+			return &info, nil
+		}
+	}
+	return nil, fmt.Errorf("dataset ref not found %s/%s", ref.Username, ref.Name)
+}
+
+// copied from dscache/dscache.go
+func convertEntryToVersionInfo(r *dscachefb.RefEntryInfo) dsref.VersionInfo {
+	return dsref.VersionInfo{
+		InitID:        string(r.InitID()),
+		ProfileID:     string(r.ProfileID()),
+		Name:          string(r.PrettyName()),
+		Path:          string(r.HeadRef()),
+		Published:     r.Published(),
+		Foreign:       r.Foreign(),
+		MetaTitle:     string(r.MetaTitle()),
+		ThemeList:     string(r.ThemeList()),
+		BodySize:      int(r.BodySize()),
+		BodyRows:      int(r.BodyRows()),
+		BodyFormat:    string(r.BodyFormat()),
+		NumErrors:     int(r.NumErrors()),
+		CommitTime:    time.Unix(r.CommitTime(), 0),
+		NumVersions:   int(r.NumVersions()),
+		FSIPath:       string(r.FsiPath()),
+	}
+}

--- a/resolver/mem_resolver.go
+++ b/resolver/mem_resolver.go
@@ -1,0 +1,46 @@
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/qri-io/qri/dsref"
+)
+
+// MemResolver holds maps that can do a cheap version of dataset resolution, for tests
+type MemResolver struct {
+	RefMap map[string]string
+	IDMap  map[string]dsref.VersionInfo
+}
+
+// NewMemResolver returns a new MemResolver
+func NewMemResolver() *MemResolver {
+	return &MemResolver{
+		RefMap: make(map[string]string),
+		IDMap:  make(map[string]dsref.VersionInfo),
+	}
+}
+
+// Put adds a VersionInfo to the resolver
+func (m *MemResolver) Put(info dsref.VersionInfo) {
+	refStr := fmt.Sprintf("%s/%s", info.Username, info.Name)
+	initID := info.InitID
+	m.RefMap[refStr] = initID
+	m.IDMap[initID] = info
+}
+
+// GetInfo returns a VersionInfo by initID, or nil if not found
+func (m *MemResolver) GetInfo(initID string) *dsref.VersionInfo {
+	if info, ok := m.IDMap[initID]; ok {
+		return &info
+	}
+	return nil
+}
+
+// GetInfoByDsref returns a VersionInfo by dsref, or nil if not found
+func (m *MemResolver) GetInfoByDsref(dr dsref.Ref) *dsref.VersionInfo {
+	refStr := fmt.Sprintf("%s/%s", dr.Username, dr.Name)
+	if initID, ok := m.RefMap[refStr]; ok {
+		return m.GetInfo(initID)
+	}
+	return nil
+}

--- a/resolver/mem_resolver.go
+++ b/resolver/mem_resolver.go
@@ -6,6 +6,8 @@ import (
 	"github.com/qri-io/qri/dsref"
 )
 
+var _ Resolver = (*MemResolver)(nil)
+
 // MemResolver holds maps that can do a cheap version of dataset resolution, for tests
 type MemResolver struct {
 	RefMap map[string]string

--- a/resolver/mem_resolver_test.go
+++ b/resolver/mem_resolver_test.go
@@ -9,10 +9,10 @@ import (
 func TestMemResolver(t *testing.T) {
 	m := NewMemResolver()
 	m.Put(dsref.VersionInfo{
-		InitID: "myInitID",
+		InitID:   "myInitID",
 		Username: "test_peer",
-		Name: "my_ds",
-		Path: "/ipfs/QmeXaMpLe",
+		Name:     "my_ds",
+		Path:     "/ipfs/QmeXaMpLe",
 	})
 	expectPath := "/ipfs/QmeXaMpLe"
 

--- a/resolver/mem_resolver_test.go
+++ b/resolver/mem_resolver_test.go
@@ -1,0 +1,44 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/qri-io/qri/dsref"
+)
+
+func TestMemResolver(t *testing.T) {
+	m := NewMemResolver()
+	m.Put(dsref.VersionInfo{
+		InitID: "myInitID",
+		Username: "test_peer",
+		Name: "my_ds",
+		Path: "/ipfs/QmeXaMpLe",
+	})
+	expectPath := "/ipfs/QmeXaMpLe"
+
+	info := m.GetInfo("invalid")
+	if info != nil {
+		t.Errorf("expected info to be nil")
+	}
+
+	info = m.GetInfo("myInitID")
+	if info == nil {
+		t.Fatal("unexpected nil info")
+	}
+	if info.Path != expectPath {
+		t.Errorf("path mismatch: expect %q, got %q", expectPath, info.Path)
+	}
+
+	info = m.GetInfoByDsref(dsref.Ref{Username: "test_peer", Name: "not_found"})
+	if info != nil {
+		t.Errorf("expected info to be nil")
+	}
+
+	info = m.GetInfoByDsref(dsref.Ref{Username: "test_peer", Name: "my_ds"})
+	if info == nil {
+		t.Fatal("unexpected nil info")
+	}
+	if info.Path != expectPath {
+		t.Errorf("path mismatch: expect %q, got %q", expectPath, info.Path)
+	}
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,11 +1,22 @@
+// Package resolver centralizes logic for resolving dataset names. It provides a low-dependency
+// interface that can be used throughout the stack, and also an implementation that ties together
+// multiple subsystems to be used as a high-level mechanism for name resolution.
 package resolver
 
 import (
+	"fmt"
+
 	"github.com/qri-io/qri/dsref"
 )
 
 // Resolver resolves identifiers into info about datasets
 type Resolver interface {
+	// GetInfo takes an initID for a dataset and returns the most recent VersionInfo
 	GetInfo(initID string) *dsref.VersionInfo
+	// GetInfoByDsref takes a dsref and returns the most recent VersionInfo. GetInfo should be
+	// used instead when possible.
 	GetInfoByDsref(dr dsref.Ref) *dsref.VersionInfo
 }
+
+// ErrCannotResolveName is an error representing common name resolution problems
+var ErrCannotResolveName = fmt.Errorf("cannot resolve name")

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,0 +1,11 @@
+package resolver
+
+import (
+	"github.com/qri-io/qri/dsref"
+)
+
+// Resolver resolves identifiers into info about datasets
+type Resolver interface {
+	GetInfo(initID string) *dsref.VersionInfo
+	GetInfoByDsref(dr dsref.Ref) *dsref.VersionInfo
+}


### PR DESCRIPTION
New resolver interface looks up VersionInfo or dataset from references or initIDs. A high-level implementation called DatasetResolver ties together fsi and dscache and dsfs to be used from lib.

Add a flag for experimenting with using dscache for get. Add some comments that describe where the resolver interface will be used next, and talking about how the save path should change in the future. Fix some small TODOs by adding missing tests.