### PR TITLE
fix(cmd): tty should auto disable color

### DIFF
--- a/config/test_config.go
+++ b/config/test_config.go
@@ -13,6 +13,7 @@ func DefaultConfigForTesting() *Config {
 	cfg.Profile.Peername = "default_profile_for_testing"
 	cfg.Profile.PrivKey = info.EncodedPrivKey
 	cfg.Profile.ID = info.EncodedPeerID
+	cfg.CLI.ColorizeOutput = false
 	return cfg
 }
 


### PR DESCRIPTION
Sprint board didn't update so I got started on https://github.com/qri-io/qri/issues/955
Wound up on the https://github.com/qri-io/ioes/commit/28794e5a4c834251ed7e0fde143fd3c99bb58db3 commit.
Once we cut the release on `ioes` I'll update the deps here and we can merge.