### PR TITLE
fix(setup): Don't crash when running `qri setup`

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -210,7 +210,7 @@ func (o *SetupOptions) DoSetup(f Factory) (err error) {
 		}
 		break
 	}
-	return f.Init()
+	return nil
 }
 
 // CreateAndDisplayDoggo creates and display a doggo name


### PR DESCRIPTION
Initialization and error handling is pretty messy right now. Init can only be run once, but if it encounters an error, that error can very easily be swallowed. Instead, save the err and return it each time Init is called in the future. This allows both accessing the instance early (to assign colors) and also will properly display an error for commands run before setup, instead of having those commands segfault.

In NewQriCommand.PersistentPreRun, check the instance is non-nil before accessing the config.

Remove the call to `f.Init` at the end of Setup, because at that point, Init has already been run and the sync.Once will make calling it again a no-op.