### PR TITLE
chore(dag): Bump dag version again to fix flaky tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/multiformats/go-multihash v0.0.8
 	github.com/pkg/errors v0.8.1
 	github.com/qri-io/apiutil v0.1.0
-	github.com/qri-io/dag v0.2.1-0.20191025201336-254aa177fbd7
+	github.com/qri-io/dag v0.2.1-0.20200317231253-5cd938b03caf
 	github.com/qri-io/dataset v0.1.5-0.20200324184139-108a69072ede
 	github.com/qri-io/deepdiff v0.1.1-0.20200305020550-8173efebcaa1
 	github.com/qri-io/doggos v0.1.0


### PR DESCRIPTION
Originally bumped by f08363dbeec4ce904b1935bdd0179bc0e8b2ae76, reverted by 7a6d8aee0fd0c1c090226093cef0d86b7deeb24d. Will fix the flaky test TestDatasetPullPushDeleteFeedsPreviewHTTP, issue https://github.com/qri-io/qri/issues/1172.