### PR TITLE
fix(export): handle ok-case of bad viz while connected

### DIFF
--- a/base/archive/zip.go
+++ b/base/archive/zip.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -95,7 +96,11 @@ func WriteZip(ctx context.Context, store cafs.Filestore, ds *dataset.Dataset, fo
 
 		if ds.Viz.RenderedPath != "" {
 			if err = maybeWriteRenderedViz(ctx, store, zw, ds.Viz.RenderedPath); err != nil {
-				return err
+				if errors.Is(err, context.DeadlineExceeded) {
+					err = nil
+				} else {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
this was an incomplete fix to https://github.com/qri-io/qri/issues/1161

while running qri connect we need to properly handle the context deadline for a missing viz by ignoring the error.

This is causing major issues for our users, so I've dropped to smoke-testing, and can confirm this change fixes export in qri desktop, particularly for the turnstile dataset @chriswhong's been publishing.