### PR TITLE
fix(repo): Construct temp repo using correct path

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/qri/config"
-	"github.com/qri-io/qri/startf"
 )
 
 func init() {
@@ -313,13 +312,6 @@ func TestSaveThenOverrideTransform(t *testing.T) {
 	run := NewTestRunner(t, "test_peer", "qri_test_save_file_transform")
 	defer run.Delete()
 
-	// TODO(dlong): Move into TestRunner, use this everywhere.
-	prevXformVer := startf.Version
-	startf.Version = "test_version"
-	defer func() {
-		startf.Version = prevXformVer
-	}()
-
 	// Save a version, then save another with a transform
 	run.MustExec(t, "qri save --file=testdata/movies/ds_ten.yaml me/test_ds")
 	run.MustExec(t, "qri save --file=testdata/movies/tf.star me/test_ds")
@@ -367,13 +359,6 @@ func TestSaveThenOverrideMetaAndTransformAndViz(t *testing.T) {
 
 	run := NewTestRunner(t, "test_peer", "qri_test_save_file_transform")
 	defer run.Delete()
-
-	// TODO(dlong): Move into TestRunner, use this everywhere.
-	prevXformVer := startf.Version
-	startf.Version = "test_version"
-	defer func() {
-		startf.Version = prevXformVer
-	}()
 
 	// Save a version, then save another with three components at once
 	run.MustExec(t, "qri save --file=testdata/movies/ds_ten.yaml me/test_ds")

--- a/cmd/fsi_integration_test.go
+++ b/cmd/fsi_integration_test.go
@@ -1423,7 +1423,7 @@ func TestUnlinkBasic(t *testing.T) {
 	}
 
 	// Verify that reference in refstore does not have FSIPath
-	vinfo := run.LookupVersionInfo("me/unlink_me")
+	vinfo := run.LookupVersionInfo(t, "me/unlink_me")
 	if vinfo == nil {
 		t.Fatal("not found: me/unlink_me")
 	}
@@ -1462,7 +1462,7 @@ func TestUnlinkMissingLinkFile(t *testing.T) {
 	}
 
 	// Verify that reference in refstore does not have FSIPath
-	vinfo := run.LookupVersionInfo("me/unlink_me")
+	vinfo := run.LookupVersionInfo(t, "me/unlink_me")
 	if vinfo == nil {
 		t.Fatal("not found: me/unlink_me")
 	}
@@ -1493,7 +1493,7 @@ func TestUnlinkNoHistory(t *testing.T) {
 	}
 
 	// Verify that reference hsa been removed from refstore
-	vinfo := run.LookupVersionInfo("me/unlink_me")
+	vinfo := run.LookupVersionInfo(t, "me/unlink_me")
 	if vinfo != nil {
 		t.Errorf("dataset should have been removed from refstore")
 	}
@@ -1528,7 +1528,7 @@ unlinked: test_peer/unlink_me
 	}
 
 	// Verify that reference in refstore does not have FSIPath
-	vinfo := run.LookupVersionInfo("me/unlink_me")
+	vinfo := run.LookupVersionInfo(t, "me/unlink_me")
 	if vinfo == nil {
 		t.Fatal("not found: me/unlink_me")
 	}
@@ -1566,7 +1566,7 @@ func TestUnlinkLinkFileButNoFSIPath(t *testing.T) {
 	}
 
 	// Verify that reference in refstore does not have FSIPath
-	vinfo := run.LookupVersionInfo("me/unlink_me")
+	vinfo := run.LookupVersionInfo(t, "me/unlink_me")
 	if vinfo == nil {
 		t.Fatal("not found: me/unlink_me")
 	}
@@ -1607,7 +1607,7 @@ unlinked: test_peer/unlink_me
 	}
 
 	// Verify that reference in refstore does not have FSIPath
-	vinfo := run.LookupVersionInfo("me/unlink_me")
+	vinfo := run.LookupVersionInfo(t, "me/unlink_me")
 	if vinfo == nil {
 		t.Fatal("not found: me/unlink_me")
 	}
@@ -1642,7 +1642,7 @@ func TestUnlinkDirectoryButRefNotFound(t *testing.T) {
 	}
 
 	// Verify that reference in refstore still has FSIPath
-	vinfo := run.LookupVersionInfo("me/unlink_me")
+	vinfo := run.LookupVersionInfo(t, "me/unlink_me")
 	if vinfo == nil {
 		t.Fatal("not found: me/unlink_me")
 	}

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -476,15 +476,15 @@ func TestSaveDscacheFirstCommit(t *testing.T) {
  Dscache.Users:
   0) user=test_peer profileID=QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
  Dscache.Refs:
-  0) initID        = zasmtvpvvddt536qmjtf4qdxszlpfcc6bqvmiemsmocaj4e74eiq
+  0) initID        = wkr66hbcqitgufnn7sp4iablkvogdwiqcin3pzugdb2fnngmct4q
      profileID     = QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
      topIndex      = 1
      cursorIndex   = 1
      prettyName    = another_ds
      bodySize      = 137
      bodyRows      = 4
-     commitTime    = 978311161
-     headRef       = /ipfs/QmUNS2ef3x6gQHG9LYgWN5F77V1uLvgcooYVSg6sUSokoT
+     commitTime    = 978311101
+     headRef       = /ipfs/QmdsFMZ7brMdEEfzpWzQSLYWyCLHDgNm722TPAPWEW5KnJ
   1) initID        = vkys37xzcxpmw5zexzhyhpok3whl2vfeep2tyeegwnm2cxrr3umq
      profileID     = QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
      topIndex      = 1
@@ -551,7 +551,6 @@ func TestSaveDscacheExistingDataset(t *testing.T) {
 
 	// Dscache should now have one reference. Now topIndex is 2 because there is another "commit".
 	actual = cache.VerboseString(false)
-	// TODO(dlong): bodySize, bodyRows, commitTime should all be filled in
 	expect = `Dscache:
  Dscache.Users:
   0) user=test_peer profileID=QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B
@@ -563,8 +562,8 @@ func TestSaveDscacheExistingDataset(t *testing.T) {
      prettyName    = movie_ds
      bodySize      = 137
      bodyRows      = 4
-     commitTime    = 978311161
-     headRef       = /ipfs/QmX2mvSMqK1g8dCXJBZ44CrMUWysXwzjinCSFaPPp4MbfF
+     commitTime    = 978311101
+     headRef       = /ipfs/QmQJX35zUadkoXjTW3uBksyWgiNKvziVpUsVmxi5nJjDqk
 `
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("result mismatch (-want +got):%s\n", diff)

--- a/repo/buildrepo/build.go
+++ b/repo/buildrepo/build.go
@@ -156,7 +156,7 @@ func newLogbook(fs qfs.Filesystem, pro *profile.Profile, repoPath string) (book 
 func newDscache(ctx context.Context, fs qfs.Filesystem, book *logbook.Book, repoPath string) (*dscache.Dscache, error) {
 	// This seems to be a bug, the repoPath does not end in "qri" in some tests.
 	if !strings.HasSuffix(repoPath, "qri") {
-		repoPath = repoPath + "/qri"
+		return nil, fmt.Errorf("invalid repo path")
 	}
 	dscachePath := filepath.Join(repoPath, "dscache.qfb")
 	return dscache.NewDscache(ctx, fs, book, dscachePath), nil

--- a/repo/test/temp_repo.go
+++ b/repo/test/temp_repo.go
@@ -87,7 +87,7 @@ func newTempRepo(peername, prefix string, g gen.CryptoGenerator) (r TempRepo, er
 func (r *TempRepo) Repo() (repo.Repo, error) {
 	if r.repo == nil {
 		var err error
-		if r.repo, err = buildrepo.New(context.TODO(), r.RootPath, r.cfg); err != nil {
+		if r.repo, err = buildrepo.New(context.TODO(), r.QriPath, r.cfg); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
The TestRunner uses a TempRepo, which should pass the correct qri path, instead of the root path, when building the repo. This prevents two separate repos from being constructed in tests, cleaning up a bunch of subtle bugs that we were working around. Some test timestamps change because now some things that were constructed twice are now only constructed once.