### PR TITLE
feat(save): add --drop flag to remove dataset components when saving

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -455,6 +455,8 @@ func (h *DatasetHandlers) saveHandler(w http.ResponseWriter, r *http.Request) {
 		ShouldRender: !(r.FormValue("no_render") == "true"),
 		NewName:      r.FormValue("new") == "true",
 		BodyPath:     r.FormValue("bodypath"),
+		Recall:       r.FormValue("recall"),
+		Drop:         r.FormValue("drop"),
 
 		ConvertFormatToPrev: true,
 		ScriptOutput:        scriptOutput,

--- a/base/dsfs/dataset.go
+++ b/base/dsfs/dataset.go
@@ -239,6 +239,8 @@ type SaveSwitches struct {
 	NewName bool
 	// FileHint is a hint for what file is used for creating this dataset
 	FileHint string
+	// Drop is a string of components to remove before saving
+	Drop string
 }
 
 // CreateDataset places a dataset into the store.

--- a/base/revisions.go
+++ b/base/revisions.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/base/dsfs"
@@ -120,4 +121,40 @@ func sel(r *dsref.Rev, ds, res *dataset.Dataset) bool {
 	}
 
 	return r.Gen == 0
+}
+
+// Drop sets named components to nil from a revision string
+func Drop(ds *dataset.Dataset, revStr string) error {
+	if revStr == "" {
+		return nil
+	}
+
+	revs, err := dsref.ParseRevs(revStr)
+	if err != nil {
+		return err
+	}
+
+	for _, rev := range revs {
+		if rev.Gen != 1 {
+			return fmt.Errorf("cannot drop specific generations")
+		}
+		switch rev.Field {
+		case "md":
+			ds.Meta = nil
+		case "vz":
+			ds.Viz = nil
+		case "tf":
+			ds.Transform = nil
+		case "st":
+			ds.Structure = nil
+		case "bd":
+			ds.Body = nil
+		case "rm":
+			ds.Readme = nil
+		default:
+			return fmt.Errorf("cannot drop component: %q", rev.Field)
+		}
+	}
+
+	return nil
 }

--- a/base/save.go
+++ b/base/save.go
@@ -10,7 +10,6 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/base/dsfs"
-	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/profile"
@@ -245,44 +244,4 @@ func GenerateAvailableName(r repo.Repo, peername, prefix string) string {
 			return tryName
 		}
 	}
-}
-
-// Drop sets named components to nil
-func Drop(ds *dataset.Dataset, revStr string) error {
-	if revStr == "" {
-		return nil
-	}
-
-	revs, err := dsref.ParseRevs(revStr)
-	if err != nil {
-		return err
-	}
-
-	for _, rev := range revs {
-		if rev.Gen != 1 {
-			return fmt.Errorf("cannot drop specific generations")
-		}
-		switch rev.Field {
-		case "md":
-			ds.Meta = nil
-		case "vz":
-			ds.Viz = nil
-		case "tf":
-			ds.Transform = nil
-		case "st":
-			ds.Structure = nil
-		case "bd":
-			ds.Body = nil
-		case "rd":
-			if ds.Viz != nil {
-				ds.Viz.RenderedPath = ""
-			}
-		case "rm":
-			ds.Readme = nil
-		default:
-			return fmt.Errorf("cannot drop component: %q", rev.Field)
-		}
-	}
-
-	return nil
 }

--- a/cmd/fsi_integration_test.go
+++ b/cmd/fsi_integration_test.go
@@ -625,6 +625,21 @@ fix these problems before saving this dataset
 	}
 }
 
+func TestFSISaveDeniesDrop(t *testing.T) {
+	run := NewFSITestRunner(t, "qri_test_fsi_save_denies_drop_flag")
+	defer run.Delete()
+
+	run.MustExec(t, "qri save --body=testdata/movies/body_ten.csv me/ten_movies")
+	run.ChdirToRoot()
+	run.MustExec(t, "qri checkout me/ten_movies")
+	run.ChdirToWorkDir("ten_movies")
+	got := run.ExecCommandCombinedOutErr("qri save --drop md")
+	expect := "cannot drop while FSI-linked"
+	if diff := cmp.Diff(expect, got.Error()); diff != "" {
+		t.Errorf("response mismatch. (-want +got):\n%s", diff)
+	}
+}
+
 // Test what changed command
 func TestWhatChanged(t *testing.T) {
 	run := NewFSITestRunner(t, "qri_test_status_at_version")

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -75,6 +75,7 @@ commit message and title to the save.`,
 	cmd.Flags().BoolVar(&o.NoRender, "no-render", false, "don't store a rendered version of the the vizualization ")
 	cmd.Flags().BoolVarP(&o.NewName, "new", "n", false, "save a new dataset only, using an available name")
 	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "experimental: build and use dscache if none exists")
+	cmd.Flags().StringVar(&o.Drop, "drop", "", "comma-separated list of components to remove")
 
 	return cmd
 }
@@ -87,6 +88,7 @@ type SaveOptions struct {
 	FilePaths []string
 	BodyPath  string
 	Recall    string
+	Drop      string
 
 	Title   string
 	Message string
@@ -159,6 +161,7 @@ func (o *SaveOptions) Run() (err error) {
 		Publish:             o.Publish,
 		DryRun:              o.DryRun,
 		Recall:              o.Recall,
+		Drop:                o.Drop,
 		ConvertFormatToPrev: o.KeepFormat,
 		Force:               o.Force,
 		ReturnBody:          o.DryRun,

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -422,6 +422,15 @@ func TestSaveFilenameUsedForCommitMessage(t *testing.T) {
 	}
 }
 
+func TestSaveDrop(t *testing.T) {
+	run := NewTestRunner(t, "test_peer", "qri_test_save_drop")
+	defer run.Delete()
+
+	run.MustExec(t, "qri save --body testdata/movies/body_two.json me/drop_stuff")
+	run.MustExec(t, "qri save --file testdata/movies/tf_123.star me/drop_stuff")
+	run.MustExec(t, "qri save --drop tf me/drop_stuff")
+}
+
 func TestSaveDscacheFirstCommit(t *testing.T) {
 	run := NewTestRunner(t, "test_peer", "qri_test_dscache_first")
 	defer run.Delete()

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -430,6 +430,8 @@ type SaveParams struct {
 	ConvertFormatToPrev bool
 	// string of references to recall before saving
 	Recall string
+	// string of references to delete before saving
+	Drop string
 	// force a new commit, even if no changes are detected
 	Force bool
 	// save a rendered version of the template along with the dataset
@@ -583,7 +585,7 @@ func (r *DatasetRequests) Save(p *SaveParams, res *reporef.DatasetRef) (err erro
 	if p.BodyPath == "" && ds.Name == "" {
 		return fmt.Errorf("name or bodypath is required")
 	}
-	if !p.Force &&
+	if !p.Force && p.Drop == "" &&
 		ds.BodyPath == "" &&
 		ds.Body == nil &&
 		ds.BodyBytes == nil &&
@@ -623,6 +625,7 @@ func (r *DatasetRequests) Save(p *SaveParams, res *reporef.DatasetRef) (err erro
 		ForceIfNoChanges:    p.Force,
 		ShouldRender:        p.ShouldRender,
 		NewName:             p.NewName,
+		Drop:                p.Drop,
 	}
 	datasetRef, err = base.SaveDataset(ctx, r.node.Repo, r.node.LocalStreams, ds, p.Secrets, p.ScriptOutput, switches)
 	if err != nil {

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -430,7 +430,7 @@ type SaveParams struct {
 	ConvertFormatToPrev bool
 	// string of references to recall before saving
 	Recall string
-	// string of references to delete before saving
+	// comma separated list of component names to delete before saving
 	Drop string
 	// force a new commit, even if no changes are detected
 	Force bool
@@ -610,6 +610,10 @@ func (r *DatasetRequests) Save(p *SaveParams, res *reporef.DatasetRef) (err erro
 
 	// TODO (b5) - this should be integrated into base.SaveDataset
 	fsiPath := datasetRef.FSIPath
+
+	if fsiPath != "" && p.Drop != "" {
+		return errors.New(fmt.Errorf("cannot drop while FSI-linked"), "can't drop component from a working-directory, delete files instead.")
+	}
 
 	fileHint := p.BodyPath
 	if len(p.FilePaths) > 0 {

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -166,7 +166,7 @@ func TestDatasetRequestsForceSave(t *testing.T) {
 	}
 }
 
-func TestDatasetRequestsSaveRecall(t *testing.T) {
+func TestDatasetRequestsSaveRecallDrop(t *testing.T) {
 	node := newTestQriNode(t)
 	ref := addNowTransformDataset(t, node)
 	r := NewDatasetRequests(node, nil)
@@ -204,6 +204,25 @@ func TestDatasetRequestsSaveRecall(t *testing.T) {
 	}
 	if res.Dataset.Transform == nil {
 		t.Error("expected transform to exist on recalled save")
+	}
+
+	err = r.Save(&SaveParams{
+		Ref:  ref.AliasString(),
+		Drop: "wut",
+	}, res)
+	if err == nil {
+		t.Fatal("expected bad recall to error")
+	}
+
+	err = r.Save(&SaveParams{
+		Ref:  ref.AliasString(),
+		Drop: "tf",
+	}, res)
+	if err != nil {
+		t.Fatal("expected bad recall to error")
+	}
+	if res.Dataset.Transform != nil {
+		t.Error("expected transform be nil")
 	}
 }
 


### PR DESCRIPTION
I'm not sure this should be merged as-is (which is why I've skipped tests for the moment).

We're in a situation where a few versions of qri have been creating bad DAG structures, referencing blocks not stored within the created DAG. Thanks to save being a patch operation, and FSI-linked save not recognizing the viz component, qri presents no way to remove a bad viz component. This --drop flag at least lets us drop entire component for now upon save.

Example uses:
```
# drop viz
$ qri save --drop viz

# add stuff, and drop readme
$ qri save --file body.csv --drop rm
```