### PR TITLE
fix(init): Multiple fixes to init, save, dscache

### DIFF
--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -1,45 +1,42 @@
 package cmd
 
 import (
-	"context"
+	"fmt"
+	"regexp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestLogbookCommand(t *testing.T) {
 	r := NewTestRunner(t, "test_peer", "qri_test_logbook")
 	defer r.Delete()
 
-	ctx, done := context.WithCancel(context.Background())
-	defer done()
+	r.MustExec(t, "qri save --body=testdata/movies/body_ten.csv me/test_movies")
 
-	cmdR := r.CreateCommandRunner(ctx)
-	err := executeCommand(cmdR, "qri save --body=testdata/movies/body_ten.csv me/test_movies")
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	r.MustExec(t, "qri save --body=testdata/movies/body_thirty.csv me/test_movies")
 
-	cmdR = r.CreateCommandRunner(ctx)
-	if err = executeCommand(cmdR, "qri save --body=testdata/movies/body_thirty.csv me/test_movies"); err != nil {
-		t.Fatal(err)
-	}
-
-	cmdR = r.CreateCommandRunner(ctx)
-	if err = executeCommand(cmdR, "qri logbook me/test_movies --raw"); err == nil {
+	// Cannot provide dataset reference with the --raw flag
+	if err := r.ExecCommand("qri logbook me/test_movies --raw"); err == nil {
 		t.Error("expected using a ref and the raw flag to error")
 	}
 
-	cmdR = r.CreateCommandRunner(ctx)
-	if err = executeCommand(cmdR, "qri logbook --raw"); err != nil {
-		t.Fatal(err)
-	}
+	// ProfileID of the test user
+	profileID := "QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"
+	// AuthorID is the hash ID of the initialization block for the author
+	authorID := "dis3dq3ta5donb2xoviyyfibihpsjaiqg7l6ktbuipuflxa72qqq"
+	// Logbook formatted as raw json
+	template := `[{"ops":[{"type":"init","model":"user","name":"test_peer","authorID":"%s","timestamp":"timeStampHere"}],"logs":[{"ops":[{"type":"init","model":"dataset","name":"test_movies","authorID":"%s","timestamp":"timeStampHere"}],"logs":[{"ops":[{"type":"init","model":"branch","name":"main","authorID":"%s","timestamp":"timeStampHere"},{"type":"init","model":"commit","ref":"/ipfs/QmXte9h1Ztm1nyd4G1CUjWnkL82T2eY7qomMfY4LUXsn3Z","timestamp":"timeStampHere","size":224,"note":"created dataset from body_ten.csv"},{"type":"init","model":"commit","ref":"/ipfs/Qmde2e5etUdVtBzHdvnsPXU4mFmy3yepw72rWz3CQ8JQ3v","prev":"/ipfs/QmXte9h1Ztm1nyd4G1CUjWnkL82T2eY7qomMfY4LUXsn3Z","timestamp":"timeStampHere","size":720,"note":"body changed by 70%%"}]}]}]}]`
 
-	// TODO (b5) - once we have consistent timestamps from the logbook package
-	// for testing, enable this & compare output
-	// res := r.GetOutput()
-	// t.Log(res)
+	// Regex that replaces the timestamp with just static text
+	fixTs := regexp.MustCompile(`"(timestamp|commitTime)":\s?"[0-9TZ.:+-]*?"`)
 
-	cmdR = r.CreateCommandRunner(ctx)
-	if err = executeCommand(cmdR, "qri logbook me/test_movies"); err != nil {
-		t.Fatal(err)
+	// Verify the raw output of the logbook
+	actual := r.MustExec(t, "qri logbook --raw")
+	// TODO(dustmop): Make logbook's timestamp stringifier be hot-swappable to avoid this hack.
+	actual = string(fixTs.ReplaceAll([]byte(actual), []byte(`"timestamp":"timeStampHere"`)))
+	expect := fmt.Sprintf(template, profileID, authorID, authorID)
+	if diff := cmp.Diff(expect, actual); diff != "" {
+		t.Errorf("unexpected (-want +got):\n%s", diff)
 	}
 }

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -157,13 +157,13 @@ func TestStatsFSI(t *testing.T) {
 
 `
 
-    if diff := cmp.Diff(expect, output); diff != "" {
-        t.Errorf("output mismatch (-want +got):\n%s", diff)
-    }
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
 
-    output = run.MustExecCombinedOutErr(t, "qri stats --pretty")
+	output = run.MustExecCombinedOutErr(t, "qri stats --pretty")
 
-    expect = `for linked dataset [test_peer/move_dir]
+	expect = `for linked dataset [test_peer/move_dir]
 
 [
   {
@@ -218,7 +218,7 @@ func TestStatsFSI(t *testing.T) {
 ]
 `
 
-    if diff := cmp.Diff(expect, output); diff != "" {
-        t.Errorf("output mismatch (-want +got):\n%s", diff)
-    }
+	if diff := cmp.Diff(expect, output); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
 }

--- a/cmd/testdata/detect/meta.json
+++ b/cmd/testdata/detect/meta.json
@@ -1,0 +1,3 @@
+{
+  "title": "This is dataset title"
+}

--- a/dscache/builder.go
+++ b/dscache/builder.go
@@ -31,7 +31,7 @@ func (b *Builder) AddUser(username, profileID string) {
 
 // AddDsVersionInfo adds a versionInfo to the dscache
 func (b *Builder) AddDsVersionInfo(ver dsref.VersionInfo) {
-	b.AddDsVersionInfoWithIndexes(ver, -1, -1)
+	b.AddDsVersionInfoWithIndexes(ver, 0, 0)
 }
 
 // AddDsVersionInfoWithIndexes adds a versionInfo with indexes to the dscache

--- a/lib/file_test.go
+++ b/lib/file_test.go
@@ -35,6 +35,17 @@ func TestReadDatasetFiles(t *testing.T) {
 			},
 		},
 
+		{"meta.json has no component key",
+			[]string{
+				"testdata/detect/meta.json",
+			},
+			&dataset.Dataset{
+				Meta: &dataset.Meta{
+					Title: "This is dataset title",
+				},
+			},
+		},
+
 		{"structure.json, meta.json component files",
 			[]string{
 				"testdata/component_files/structure.json",

--- a/lib/testdata/detect/meta.json
+++ b/lib/testdata/detect/meta.json
@@ -1,0 +1,3 @@
+{
+  "title": "This is dataset title"
+}


### PR DESCRIPTION
* Init works while running `qri connect`, by taking Abspath of source-body-path
* Init checks if the working directory has conflicting files before prompting for user input
* Init can use source-body-path with the value "body.csv", instead of failing
* Init will create an entry in dscache if run with --use-dscache
* Fix the error message when structure.json already exists when init'ing
* Can save using known component filenames instead of keys
* Improve the log test to inspect logbook's state

Fixes https://github.com/qri-io/qri/issues/1298, and https://github.com/qri-io/qri/issues/1297, and https://github.com/qri-io/qri/issues/1206.