### PR TITLE
fix(init): Derive dataset name from directory base, not whole path

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -88,7 +88,9 @@ func (o *InitOptions) Run() (err error) {
 
 	// Suggestion for the dataset name defaults to directory it is being linked into
 	if o.Name == "" {
-		suggestedName := dsref.GenerateName(targetDir, "dataset_")
+		// TODO(dustmop): Currently all tests that call `init` use the --name flag. Add a test
+		// that receives stdin and checks what is written to stdout.
+		suggestedName := dsref.GenerateName(filepath.Base(targetDir), "dataset_")
 		o.Name = inputText(o.Out, o.In, "Name of new dataset", suggestedName)
 	}
 


### PR DESCRIPTION
Oops, I recently broke this because there are no tests for what stdout writes.