### PR TITLE
refactor(logbook): Most logbook methods take an initID, not ref

### DIFF
--- a/base/log_test.go
+++ b/base/log_test.go
@@ -79,14 +79,14 @@ func TestDatasetLogForeign(t *testing.T) {
 	theirRefStr := "them/foreign"
 	otherPeerInfo := testPeers.GetTestPeerInfo(1)
 	foreignBuilder := logbook.NewLogbookTempBuilder(t, otherPeerInfo.PrivKey, "them", fs, theirBookPath)
-	foreignBuilder.DatasetInit(ctx, t, theirRefStr)
 	ref, err := dsref.Parse(theirRefStr)
 	if err != nil {
 		t.Fatal(err)
 	}
+	initID := foreignBuilder.DatasetInit(ctx, t, ref.Name)
 	// NOTE: Need to assign ProfileID because nothing is resolving the username
 	ref.ProfileID = otherPeerInfo.EncodedPeerID
-	foreignBuilder.Commit(ctx, t, ref, "their commit", "QmExample")
+	foreignBuilder.Commit(ctx, t, initID, "their commit", "QmExample")
 	foreignBook := foreignBuilder.Logbook()
 	foreignLog, err := foreignBook.UserDatasetRef(ctx, ref)
 	if err != nil {

--- a/base/ref.go
+++ b/base/ref.go
@@ -142,11 +142,17 @@ func RenameDatasetRef(ctx context.Context, r repo.Repo, curr, next dsref.Ref) (*
 	nextRef.FSIPath = currRef.FSIPath
 
 	// Copy data back to the dsref after canonicalization.
-	// TODO(dlong): Once we fully convert to dsref this will be unnecessary
+	// TODO(dustmop): Once we fully convert to dsref this will be unnecessary
 	curr.Username = currRef.Peername
 	curr.ProfileID = currRef.ProfileID.String()
 
-	err = r.Logbook().WriteDatasetRename(ctx, curr, nextRef.Name)
+	// TODO(dustmop): When we switch to initIDs, use the initID passed to this function, retrieved
+	// from the top-level resolver.
+	initID, err := r.Logbook().RefToInitID(curr)
+	if err != nil && err != logbook.ErrNoLogbook {
+		return nil, err
+	}
+	err = r.Logbook().WriteDatasetRename(ctx, initID, nextRef.Name)
 	if err != nil && err != logbook.ErrNoLogbook {
 		return nil, err
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -120,11 +120,11 @@ func (o *InitOptions) Run() (err error) {
 		SourceBodyPath: o.SourceBodyPath,
 		UseDscache:     o.UseDscache,
 	}
-	var name string
-	if err = o.FSIMethods.InitDataset(p, &name); err != nil {
+	var refstr string
+	if err = o.FSIMethods.InitDataset(p, &refstr); err != nil {
 		return err
 	}
 
-	printSuccess(o.Out, "initialized working directory for new dataset %s", name)
+	printSuccess(o.Out, "initialized working directory for new dataset %s", refstr)
 	return nil
 }

--- a/dscache/convert_test.go
+++ b/dscache/convert_test.go
@@ -562,20 +562,20 @@ func makeFakeLogbook(ctx context.Context, t *testing.T, username string, privKey
 	builder := logbook.NewLogbookTempBuilder(t, privKey, username, fs, rootPath)
 
 	// A dataset with one commit, then a rename, then another commit
-	refA := builder.DatasetInit(ctx, t, "first_name")
-	refA = builder.Commit(ctx, t, refA, "initial commit", "QmHashOfVersion1")
-	refA = builder.DatasetRename(ctx, t, refA, "first_new_name")
-	refA = builder.Commit(ctx, t, refA, "another commit", "QmHashOfVersion2")
+	aid := builder.DatasetInit(ctx, t, "first_name")
+	builder.Commit(ctx, t, aid, "initial commit", "QmHashOfVersion1")
+	builder.DatasetRename(ctx, t, aid, "first_new_name")
+	builder.Commit(ctx, t, aid, "another commit", "QmHashOfVersion2")
 
 	// A dataset with five commits, two of which were deleted
-	refB := builder.DatasetInit(ctx, t, "second_name")
-	refB = builder.Commit(ctx, t, refB, "initial commit", "QmHashOfVersion3")
-	refB = builder.Commit(ctx, t, refB, "second commit", "QmHashOfVersion4")
-	refB = builder.Delete(ctx, t, refB, 1)
-	refB = builder.Commit(ctx, t, refB, "fix second", "QmHashOfVersion5")
-	refB = builder.Commit(ctx, t, refB, "third commit", "QmHashOfVersion6")
-	refB = builder.Commit(ctx, t, refB, "whoops", "QmHashOfVersion7")
-	refB = builder.Delete(ctx, t, refB, 1)
+	bid := builder.DatasetInit(ctx, t, "second_name")
+	builder.Commit(ctx, t, bid, "initial commit", "QmHashOfVersion3")
+	builder.Commit(ctx, t, bid, "second commit", "QmHashOfVersion4")
+	builder.Delete(ctx, t, bid, 1)
+	builder.Commit(ctx, t, bid, "fix second", "QmHashOfVersion5")
+	builder.Commit(ctx, t, bid, "third commit", "QmHashOfVersion6")
+	builder.Commit(ctx, t, bid, "whoops", "QmHashOfVersion7")
+	builder.Delete(ctx, t, bid, 1)
 
 	return builder.Logbook()
 }
@@ -590,16 +590,16 @@ func makeFakeLogbookNonAlphabetical(ctx context.Context, t *testing.T, username 
 	builder := logbook.NewLogbookTempBuilder(t, privKey, username, fs, rootPath)
 
 	// A dataset with one commit
-	refA := builder.DatasetInit(ctx, t, "some_dataset")
-	refA = builder.Commit(ctx, t, refA, "initial commit", "QmHashOfVersion1")
+	aid := builder.DatasetInit(ctx, t, "some_dataset")
+	builder.Commit(ctx, t, aid, "initial commit", "QmHashOfVersion1")
 
 	// Another dataset with one commit
-	refB := builder.DatasetInit(ctx, t, "another_dataset")
-	refB = builder.Commit(ctx, t, refB, "initial commit", "QmHashOfVersion2")
+	bid := builder.DatasetInit(ctx, t, "another_dataset")
+	builder.Commit(ctx, t, bid, "initial commit", "QmHashOfVersion2")
 
 	// Yet another dataset with one commit
-	refC := builder.DatasetInit(ctx, t, "yet_another")
-	refC = builder.Commit(ctx, t, refC, "initial commit", "QmHashOfVersion3")
+	cid := builder.DatasetInit(ctx, t, "yet_another")
+	builder.Commit(ctx, t, cid, "initial commit", "QmHashOfVersion3")
 
 	return builder.Logbook()
 }
@@ -614,22 +614,22 @@ func makeFakeLogbookWithNoHistoryAndDelete(ctx context.Context, t *testing.T, us
 	builder := logbook.NewLogbookTempBuilder(t, privKey, username, fs, rootPath)
 
 	// A dataset with one commit, pretty normal. Corresponding dsref has no FSIPath (no checkout)
-	refA := builder.DatasetInit(ctx, t, "first_ds")
-	refA = builder.Commit(ctx, t, refA, "initial commit", "QmHashOfVersion1001")
+	aid := builder.DatasetInit(ctx, t, "first_ds")
+	builder.Commit(ctx, t, aid, "initial commit", "QmHashOfVersion1001")
 
 	// A dataset with two commits that gets deleted
-	refB := builder.DatasetInit(ctx, t, "second_ds")
-	refB = builder.Commit(ctx, t, refB, "initial commit", "QmHashOfVersion1002")
-	refB = builder.Commit(ctx, t, refB, "another commit", "QmHashOfVersion1003")
-	builder.DatasetDelete(ctx, t, refB)
+	bid := builder.DatasetInit(ctx, t, "second_ds")
+	builder.Commit(ctx, t, bid, "initial commit", "QmHashOfVersion1002")
+	builder.Commit(ctx, t, bid, "another commit", "QmHashOfVersion1003")
+	builder.DatasetDelete(ctx, t, bid)
 
 	// A dataset with no commits, hits the "no history" codepath
-	_ = builder.DatasetInit(ctx, t, "third_ds")
+	builder.DatasetInit(ctx, t, "third_ds")
 
 	// A dataset with two commits, pretty normal
-	refD := builder.DatasetInit(ctx, t, "fourth_ds")
-	refD = builder.Commit(ctx, t, refD, "initial commit", "QmHashOfVersion1004")
-	refD = builder.Commit(ctx, t, refD, "another commit", "QmHashOfVersion1005")
+	did := builder.DatasetInit(ctx, t, "fourth_ds")
+	builder.Commit(ctx, t, did, "initial commit", "QmHashOfVersion1004")
+	builder.Commit(ctx, t, did, "another commit", "QmHashOfVersion1005")
 
 	return builder.Logbook()
 }

--- a/fsi/init.go
+++ b/fsi/init.go
@@ -197,7 +197,7 @@ func (fsi *FSI) InitDataset(p InitParams) (name string, err error) {
 		}
 	}
 
-	if err = fsi.repo.Logbook().WriteDatasetInit(context.TODO(), ref.Name); err != nil {
+	if _, err = fsi.repo.Logbook().WriteDatasetInit(context.TODO(), ref.Name); err != nil {
 		if err == logbook.ErrNoLogbook {
 			rollback = func() {}
 			return name, nil

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -348,13 +348,13 @@ func (m *FSIMethods) Restore(p *RestoreParams, out *string) (err error) {
 type InitFSIDatasetParams = fsi.InitParams
 
 // InitDataset creates a new dataset and FSI link
-func (m *FSIMethods) InitDataset(p *InitFSIDatasetParams, name *string) (err error) {
+func (m *FSIMethods) InitDataset(p *InitFSIDatasetParams, refstr *string) (err error) {
 	if err = qfs.AbsPath(&p.SourceBodyPath); err != nil {
 		return err
 	}
 
 	if m.inst.rpc != nil {
-		return checkRPCError(m.inst.rpc.Call("FSIMethods.InitDataset", p, name))
+		return checkRPCError(m.inst.rpc.Call("FSIMethods.InitDataset", p, refstr))
 	}
 
 	// If the dscache doesn't exist yet, it will only be created if the appropriate flag enables it.
@@ -363,7 +363,7 @@ func (m *FSIMethods) InitDataset(p *InitFSIDatasetParams, name *string) (err err
 		c.CreateNewEnabled = true
 	}
 
-	*name, err = m.inst.fsi.InitDataset(*p)
+	*refstr, err = m.inst.fsi.InitDataset(*p)
 	return err
 }
 

--- a/logbook/logsync/logsync_test.go
+++ b/logbook/logsync/logsync_test.go
@@ -415,7 +415,8 @@ func newTestbook(username string, pk crypto.PrivKey) (*logbook.Book, error) {
 
 func writeNasdaqLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, err error) {
 	name := "nasdaq"
-	if err = book.WriteDatasetInit(ctx, name); err != nil {
+	initID, err := book.WriteDatasetInit(ctx, name)
+	if err != nil {
 		return ref, err
 	}
 
@@ -430,14 +431,14 @@ func writeNasdaqLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, er
 		PreviousPath: "",
 	}
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
 		return ref, err
 	}
 
 	ds.Path = "v1"
 	ds.PreviousPath = "v0"
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
 		return ref, err
 	}
 
@@ -449,7 +450,8 @@ func writeNasdaqLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, er
 
 func writeWorldBankLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, err error) {
 	name := "world_bank_population"
-	if err = book.WriteDatasetInit(ctx, name); err != nil {
+	initID, err := book.WriteDatasetInit(ctx, name)
+	if err != nil {
 		return ref, err
 	}
 
@@ -464,21 +466,21 @@ func writeWorldBankLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref,
 		PreviousPath: "",
 	}
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
 		return ref, err
 	}
 
 	ds.Path = "v1"
 	ds.PreviousPath = "v0"
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
 		return ref, err
 	}
 
 	ds.Path = "v2"
 	ds.PreviousPath = "v1"
 
-	if err = book.WriteVersionSave(ctx, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
 		return ref, err
 	}
 

--- a/logbook/oplog/log.go
+++ b/logbook/oplog/log.go
@@ -75,19 +75,13 @@ type Logstore interface {
 	// use Logstore.Children or Logstore.Descendants to populate missing children
 	HeadRef(ctx context.Context, names ...string) (*Log, error)
 
-	// RetrieveRef returns the log that matches the username and dataset name
-	RetrieveRef(username, dsName string) (*Log, error)
-
-	// RetrieveByInitID returns the log that matches the initID
-	RetrieveByInitID(initID string) (*Log, error)
-
 	// get a log according to it's ID string
 	// Log must return ErrNotFound if the ID does not exist
 	//
 	// Log MAY return children of a log. If the returned log.Log value is
 	// populated, it MUST contain all children of the log.
 	// use Logstore.Children or Logstore.Descendants to populate missing children
-	Log(ctx context.Context, id string) (*Log, error)
+	Get(ctx context.Context, id string) (*Log, error)
 
 	// get the immediate descendants of a log, using the given log as an outparam.
 	// Children must only mutate Logs field of the passed-in log pointer
@@ -134,7 +128,7 @@ func (j *Journal) ID() string {
 
 // SetID assigns the book identifier
 func (j *Journal) SetID(ctx context.Context, id string) error {
-	if _, err := j.Log(ctx, id); err != nil {
+	if _, err := j.Get(ctx, id); err != nil {
 		return err
 	}
 
@@ -148,7 +142,7 @@ func (j *Journal) MergeLog(ctx context.Context, l *Log) error {
 		return fmt.Errorf("oplog: log ID cannot be empty")
 	}
 
-	found, err := j.Log(ctx, l.ID())
+	found, err := j.Get(ctx, l.ID())
 	if err != nil {
 		if err == ErrNotFound {
 			j.logs = append(j.logs, l)
@@ -197,8 +191,8 @@ func (j *Journal) RemoveLog(ctx context.Context, names ...string) error {
 	return ErrNotFound
 }
 
-// Log fetches a log for a given ID
-func (j *Journal) Log(_ context.Context, id string) (*Log, error) {
+// Get fetches a log for a given ID
+func (j *Journal) Get(_ context.Context, id string) (*Log, error) {
 	for _, lg := range j.logs {
 		if l, err := lg.Log(id); err == nil {
 			return l, nil
@@ -219,28 +213,6 @@ func (j *Journal) HeadRef(_ context.Context, names ...string) (*Log, error) {
 	for _, log := range j.logs {
 		if log.Name() == names[0] && !log.Removed() {
 			return log.HeadRef(names[1:]...)
-		}
-	}
-	return nil, ErrNotFound
-}
-
-// RetrieveRef takes a username and name and returns the log that matches
-func (j *Journal) RetrieveRef(username, dsName string) (*Log, error) {
-	for _, log := range j.logs {
-		if log.Name() == username && !log.Removed() {
-			return log.HeadRef(dsName)
-		}
-	}
-	return nil, ErrNotFound
-}
-
-// RetrieveByInitID finds the dataset level log which matches the initID
-func (j *Journal) RetrieveByInitID(initID string) (*Log, error) {
-	for _, userLog := range j.logs {
-		for _, datasetLog := range userLog.Logs {
-			if datasetLog.ID() == initID {
-				return datasetLog, nil
-			}
 		}
 	}
 	return nil, ErrNotFound
@@ -275,7 +247,7 @@ func (j *Journal) Children(ctx context.Context, l *Log) error {
 // Descendants gets all descentants of a log & assigns the results to the given
 // Log parameter, setting only the Logs field
 func (j *Journal) Descendants(ctx context.Context, l *Log) error {
-	got, err := j.Log(ctx, l.ID())
+	got, err := j.Get(ctx, l.ID())
 	if err != nil {
 		return err
 	}

--- a/logbook/oplog/log_test.go
+++ b/logbook/oplog/log_test.go
@@ -87,7 +87,7 @@ func TestJournalMerge(t *testing.T) {
 		t.Errorf("top level log length shouldn't change after merging a child log. expected: %d, got: %d", expectLen, gotLen)
 	}
 
-	got, err := tr.Journal.Log(ctx, a.ID())
+	got, err := tr.Journal.Get(ctx, a.ID())
 	if err != nil {
 		t.Error(err)
 	}
@@ -226,13 +226,13 @@ func TestLogGetID(t *testing.T) {
 	tr.AddAuthorLogTree(t)
 	ctx := tr.Ctx
 
-	got, err := tr.Journal.Log(ctx, "nonsense")
+	got, err := tr.Journal.Get(ctx, "nonsense")
 	if err != ErrNotFound {
 		t.Errorf("expected not-found error for missing ID. got: %s", err)
 	}
 
 	root := tr.Journal.logs[0]
-	got, err = tr.Journal.Log(ctx, root.ID())
+	got, err = tr.Journal.Get(ctx, root.ID())
 	if err != nil {
 		t.Errorf("unexpected error fetching root ID: %s", err)
 	} else if !got.Head().Equal(root.Head()) {
@@ -240,7 +240,7 @@ func TestLogGetID(t *testing.T) {
 	}
 
 	child := root.Logs[0]
-	got, err = tr.Journal.Log(ctx, child.ID())
+	got, err = tr.Journal.Get(ctx, child.ID())
 	if err != nil {
 		t.Errorf("unexpected error fetching child ID: %s", err)
 	}

--- a/logbook/types.go
+++ b/logbook/types.go
@@ -1,0 +1,85 @@
+package logbook
+
+import (
+	"github.com/qri-io/qri/logbook/oplog"
+)
+
+// AuthorLog is the top-level log representing the book author
+type AuthorLog struct {
+	l *oplog.Log
+}
+
+// TODO(dustmop): Consider changing the "Append" methods to type-safe methods that are specific
+// to each log level, which accept individual parameters instead of type-unsafe Op values.
+
+// Append adds an op to the AuthorLog
+func (alog *AuthorLog) Append(op oplog.Op) {
+	if op.Model != AuthorModel {
+		log.Errorf("cannot Append, incorrect model %d for AuthorLog", op.Model)
+		return
+	}
+	alog.l.Append(op)
+}
+
+// ProfileID returns the profileID for the author
+func (alog *AuthorLog) ProfileID() string {
+	return alog.l.Ops[0].AuthorID
+}
+
+// AddChild adds a child log
+// TODO(dustmop): Change this parameter to be a DatasetLog
+func (alog *AuthorLog) AddChild(l *oplog.Log) {
+	alog.l.AddChild(l)
+}
+
+// DatasetLog is the mid-level log representing a single dataset
+type DatasetLog struct {
+	l *oplog.Log
+}
+
+// Append adds an op to the DatasetLog
+func (dlog *DatasetLog) Append(op oplog.Op) {
+	if op.Model != DatasetModel {
+		log.Errorf("cannot Append, incorrect model %d for DatasetLog", op.Model)
+		return
+	}
+	dlog.l.Append(op)
+}
+
+// InitID returns the initID for the dataset
+func (dlog *DatasetLog) InitID() string {
+	return dlog.l.ID()
+}
+
+// BranchLog is the bottom-level log representing a branch of a dataset history
+type BranchLog struct {
+	l *oplog.Log
+}
+
+// Append adds an op to the BranchLog
+func (blog *BranchLog) Append(op oplog.Op) {
+	if op.Model != BranchModel && op.Model != CommitModel && op.Model != PublicationModel {
+		log.Errorf("cannot Append, incorrect model %d for BranchLog", op.Model)
+		return
+	}
+	blog.l.Append(op)
+}
+
+// Size returns the size of the branch
+func (blog *BranchLog) Size() int {
+	return len(blog.l.Ops)
+}
+
+// Ops returns the raw Op list
+func (blog *BranchLog) Ops() []oplog.Op {
+	return blog.l.Ops
+}
+
+func branchLogFromRawLog(l *oplog.Log) *BranchLog {
+	blog := BranchLog{l: l}
+	// BranchLog should never have logs underneath it, display error if any are found
+	if len(l.Logs) > 0 {
+		log.Errorf("invalid branchLog, has %d child Logs", len(l.Logs))
+	}
+	return &blog
+}

--- a/logbook/types.go
+++ b/logbook/types.go
@@ -4,31 +4,31 @@ import (
 	"github.com/qri-io/qri/logbook/oplog"
 )
 
-// AuthorLog is the top-level log representing the book author
-type AuthorLog struct {
+// UserLog is the top-level log representing users that make datasets
+type UserLog struct {
 	l *oplog.Log
 }
 
 // TODO(dustmop): Consider changing the "Append" methods to type-safe methods that are specific
 // to each log level, which accept individual parameters instead of type-unsafe Op values.
 
-// Append adds an op to the AuthorLog
-func (alog *AuthorLog) Append(op oplog.Op) {
+// Append adds an op to the UserLog
+func (alog *UserLog) Append(op oplog.Op) {
 	if op.Model != AuthorModel {
-		log.Errorf("cannot Append, incorrect model %d for AuthorLog", op.Model)
+		log.Errorf("cannot Append, incorrect model %d for UserLog", op.Model)
 		return
 	}
 	alog.l.Append(op)
 }
 
-// ProfileID returns the profileID for the author
-func (alog *AuthorLog) ProfileID() string {
+// ProfileID returns the profileID for the user
+func (alog *UserLog) ProfileID() string {
 	return alog.l.Ops[0].AuthorID
 }
 
 // AddChild adds a child log
 // TODO(dustmop): Change this parameter to be a DatasetLog
-func (alog *AuthorLog) AddChild(l *oplog.Log) {
+func (alog *UserLog) AddChild(l *oplog.Log) {
 	alog.l.AddChild(l)
 }
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -251,8 +251,6 @@ func (r *Remote) RemoveDataset(ctx context.Context, params map[string]string) er
 		}
 	}
 
-	// TODO(dlong): logbook is not being updated here
-
 	// remove all the versions of this dataset from the store
 	if _, err := base.RemoveNVersionsFromStore(ctx, r.node.Repo, reporef.ConvertToDsref(ref), -1); err != nil {
 		return err


### PR DESCRIPTION
Change most logbook methods, especially the ones that add operations to the logs, so that they accept initIDs instead. This will make it much easier to transition away from the old refstore.

Add a helper method that looks up the initID given a ref; this makes it possible to work with base before dscache is done.

Extract the initName helper out of mutations; callers should instead either have an initID or create one by using WriteDatasetInit.

Create strongly typed structs for each log level - AuthorLog, DatasetLog, BranchLog - to aid in understanding logbook code. They aren't used everywhere, but it's a start.

Remove CronJob Model now that update is gone.