### PR TITLE
refactor(log): `pull` flag skips local log search, & `remote=registry` is recognized

### DIFF
--- a/api/log.go
+++ b/api/log.go
@@ -60,14 +60,15 @@ func (h *LogHandlers) logHandler(w http.ResponseWriter, r *http.Request) {
 
 	local := r.FormValue("local") == "true"
 	remoteName := r.FormValue("remote")
+	pull := r.FormValue("pull") == "true"
 
-	if local && remoteName != "" {
-		util.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("cannot use the 'local' and 'remote' params at the same time"))
+	if local && (remoteName != "" || pull) {
+		util.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("cannot use the 'local' param with either the 'remote' or 'pull' params"))
 		return
 	}
 
 	res := []DatasetLogItem{}
-	if remoteName == "" {
+	if remoteName == "" && !pull {
 		params := &lib.LogParams{
 			Ref:        args.String(),
 			ListParams: lp,

--- a/api/log.go
+++ b/api/log.go
@@ -92,6 +92,13 @@ func (h *LogHandlers) logHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+
+	// TODO(ramfox): currently, at the lib level, the empty string indicates that we
+	// should be fetching from the registry by default.
+	if remoteName == "registry" {
+		remoteName = ""
+	}
+
 	p := &lib.FetchParams{
 		Ref:        args.String(),
 		RemoteName: remoteName,

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -57,7 +57,7 @@ on the network at a remote.
 	// cmd.Flags().StringVarP(&o.Format, "format", "f", "", "set output format [json]")
 	cmd.Flags().IntVar(&o.PageSize, "page-size", 25, "page size of results, default 25")
 	cmd.Flags().IntVar(&o.Page, "page", 1, "page number of results, default 1")
-	cmd.Flags().StringVarP(&o.RemoteName, "remote", "", "", "name of remote to fetch to")
+	cmd.Flags().StringVarP(&o.RemoteName, "remote", "", "", "name of remote to fetch from, disables local actions. `registry` will search the default qri registry")
 	cmd.Flags().BoolVarP(&o.Local, "local", "", false, "only fetch local logs, disables network actions")
 
 	return cmd
@@ -135,6 +135,12 @@ func (o *LogOptions) Run() error {
 			makeItemsAndPrint(refs, o.Out, page)
 			return nil
 		}
+	}
+
+	// TODO(ramfox): currently, at the lib level, the empty string indicates that we
+	// should be fetching from the registry by default.
+	if (o.RemoteName == "registry") {
+		o.RemoteName = ""
 	}
 
 	p := lib.FetchParams{


### PR DESCRIPTION
Using the `pull` flag lets the user pull the latest logs from the remote source. No `remote` flag and `remote=registry` both default to pulling from the registry. 

At the api and cmd levels, if the user has the `remote` flag set to "registry", skip searching locally and instead search the default registry. This does not make any changes to lib or lower, lib still expects an empty `remote` param to mean search the registry. Leaving it this way until we have a better understanding of what is expected in future commands.

closes #1328 