### PR TITLE
refactor(lib): rename RenderRequests -> RenderMethods, use an instance

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -228,7 +228,6 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 // NewServerRoutes returns a Muxer that has all API routes
 func NewServerRoutes(s Server) *http.ServeMux {
-	node := s.Node()
 	cfg := s.Config()
 
 	m := http.NewServeMux()
@@ -286,7 +285,7 @@ func NewServerRoutes(s Server) *http.ServeMux {
 	m.Handle("/restore/", s.middleware(fsih.RestoreHandler("/restore")))
 	m.Handle("/fsi/write/", s.middleware(fsih.WriteHandler("/fsi/write")))
 
-	renderh := NewRenderHandlers(node.Repo)
+	renderh := NewRenderHandlers(s.Instance)
 	m.Handle("/render", s.middleware(renderh.RenderHandler))
 	m.Handle("/render/", s.middleware(renderh.RenderHandler))
 

--- a/api/render.go
+++ b/api/render.go
@@ -7,19 +7,17 @@ import (
 	"github.com/qri-io/apiutil"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/lib"
-	"github.com/qri-io/qri/repo"
 )
 
 // RenderHandlers wraps a requests struct to interface with http.HandlerFunc
 type RenderHandlers struct {
-	lib.RenderRequests
-	repo repo.Repo
+	lib.RenderMethods
 }
 
 // NewRenderHandlers allocates a RenderHandlers pointer
-func NewRenderHandlers(r repo.Repo) *RenderHandlers {
-	req := lib.NewRenderRequests(r, nil)
-	h := RenderHandlers{*req, r}
+func NewRenderHandlers(inst *lib.Instance) *RenderHandlers {
+	req := lib.NewRenderMethods(inst)
+	h := RenderHandlers{*req}
 	return &h
 }
 

--- a/api/render_test.go
+++ b/api/render_test.go
@@ -9,15 +9,17 @@ import (
 )
 
 func TestRenderHandler(t *testing.T) {
-	r, teardown := newTestRepo(t)
+	node, teardown := newTestNode(t)
 	defer teardown()
+
+	inst := newTestInstanceWithProfileFromNode(node)
 
 	cases := []handlerTestCase{
 		{"OPTIONS", "/render", nil},
 		{"GET", "/render/me/movies?viz=true", nil},
 	}
 
-	h := NewRenderHandlers(r)
+	h := NewRenderHandlers(inst)
 	runHandlerTestCases(t, "render", h.RenderHandler, cases, false)
 }
 
@@ -26,7 +28,7 @@ func TestRenderReadmeHandler(t *testing.T) {
 	defer teardown()
 
 	inst := newTestInstanceWithProfileFromNode(node)
-	h := NewRenderHandlers(inst.Repo())
+	h := NewRenderHandlers(inst)
 	dsm := lib.NewDatasetMethods(inst)
 
 	// TODO(dlong): Copied from fsi_test, refactor into a common utility

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -36,10 +36,10 @@ type Factory interface {
 	SearchMethods() (*lib.SearchMethods, error)
 	SQLMethods() (*lib.SQLMethods, error)
 	FSIMethods() (*lib.FSIMethods, error)
+	RenderMethods() (*lib.RenderMethods, error)
 
 	// TODO (b5) - these should be deprecated:
 	ExportRequests() (*lib.ExportRequests, error)
-	RenderRequests() (*lib.RenderRequests, error)
 }
 
 // PathFactory is a function that returns paths to qri & ipfs repos

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -201,9 +201,9 @@ func (t TestFactory) SQLMethods() (*lib.SQLMethods, error) {
 	return lib.NewSQLMethods(t.inst), nil
 }
 
-// RenderRequests generates a lib.RenderRequests from internal state
-func (t TestFactory) RenderRequests() (*lib.RenderRequests, error) {
-	return lib.NewRenderRequests(t.repo, t.rpc), nil
+// RenderMethods generates a lib.RenderMethods from internal state
+func (t TestFactory) RenderMethods() (*lib.RenderMethods, error) {
+	return lib.NewRenderMethods(t.inst), nil
 }
 
 func TestEnvPathFactory(t *testing.T) {

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -267,12 +267,12 @@ func (o *QriOptions) SQLMethods() (*lib.SQLMethods, error) {
 	return lib.NewSQLMethods(o.inst), nil
 }
 
-// RenderRequests generates a lib.RenderRequests from internal state
-func (o *QriOptions) RenderRequests() (*lib.RenderRequests, error) {
+// RenderMethods generates a lib.RenderMethods from internal state
+func (o *QriOptions) RenderMethods() (*lib.RenderMethods, error) {
 	if err := o.Init(); err != nil {
 		return nil, err
 	}
-	return lib.NewRenderRequests(o.inst.Repo(), o.inst.RPC()), nil
+	return lib.NewRenderMethods(o.inst), nil
 }
 
 // ConfigMethods generates a lib.ConfigMethods from internal state

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -60,12 +60,12 @@ type RenderOptions struct {
 	UseViz   bool
 	Output   string
 
-	RenderRequests *lib.RenderRequests
+	RenderMethods *lib.RenderMethods
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *RenderOptions) Complete(f Factory, args []string) (err error) {
-	if o.RenderRequests, err = f.RenderRequests(); err != nil {
+	if o.RenderMethods, err = f.RenderMethods(); err != nil {
 		return err
 	}
 	if o.Refs, err = GetCurrentRefSelect(f, args, 1, nil); err != nil {
@@ -107,7 +107,7 @@ func (o *RenderOptions) RunVizRender() (err error) {
 	}
 
 	res := []byte{}
-	if err := o.RenderRequests.RenderViz(p, &res); err != nil {
+	if err := o.RenderMethods.RenderViz(p, &res); err != nil {
 		if err == repo.ErrEmptyRef {
 			return errors.New(err, "peername and dataset name needed in order to render, for example:\n   $ qri render me/dataset_name\nsee `qri render --help` from more info")
 		}
@@ -133,7 +133,7 @@ func (o *RenderOptions) RunReadmeRender() error {
 	}
 
 	var res string
-	if err := o.RenderRequests.RenderReadme(p, &res); err != nil {
+	if err := o.RenderMethods.RenderReadme(p, &res); err != nil {
 		return err
 	}
 

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -49,8 +49,8 @@ func TestRenderComplete(t *testing.T) {
 			continue
 		}
 
-		if opt.RenderRequests == nil {
-			t.Errorf("case %d, opt.RenderRequests not set.", i)
+		if opt.RenderMethods == nil {
+			t.Errorf("case %d, opt.RenderMethods not set.", i)
 			run.IOReset()
 			continue
 		}
@@ -121,19 +121,19 @@ func TestRenderRun(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		rr, err := f.RenderRequests()
+		rr, err := f.RenderMethods()
 		if err != nil {
 			t.Errorf("case %d, error creating dataset request: %s", i, err)
 			continue
 		}
 
 		opt := &RenderOptions{
-			IOStreams:      run.Streams,
-			Refs:           NewExplicitRefSelect(c.ref),
-			UseViz:         true,
-			Template:       c.template,
-			Output:         c.output,
-			RenderRequests: rr,
+			IOStreams:     run.Streams,
+			Refs:          NewExplicitRefSelect(c.ref),
+			UseViz:        true,
+			Template:      c.template,
+			Output:        c.output,
+			RenderMethods: rr,
 		}
 
 		err = opt.Run()

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -63,22 +63,21 @@ func init() {
 // Receivers returns a slice of CoreRequests that defines the full local
 // API of lib methods
 func Receivers(inst *Instance) []Methods {
-	node := inst.Node()
-	r := inst.Repo()
-
 	return []Methods{
 		NewDatasetMethods(inst),
 		NewRegistryClientMethods(inst),
 		NewRemoteMethods(inst),
 		NewLogMethods(inst),
-		NewExportRequests(node, nil),
 		NewPeerMethods(inst),
 		NewProfileMethods(inst),
 		NewConfigMethods(inst),
 		NewSearchMethods(inst),
 		NewSQLMethods(inst),
-		NewRenderRequests(r, nil),
+		NewRenderMethods(inst),
 		NewFSIMethods(inst),
+
+		// TODO (b5) - deprecate ExportRequests
+		NewExportRequests(inst.Node(), nil),
 	}
 }
 


### PR DESCRIPTION
our current plans have us keeping the `render` functionality around. This brings render up to pace.

Considering we'll remove `ExportRequests` with the PR that does the merging work, I think this PR closes #1235.