### PR TITLE
test(benchmark): added benchmarks for save/validate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/qri-io/apiutil v0.1.0
 	github.com/qri-io/dag v0.2.1-0.20200317231253-5cd938b03caf
-	github.com/qri-io/dataset v0.1.5-0.20200324184139-108a69072ede
+	github.com/qri-io/dataset v0.1.5-0.20200511122508-17e18c0944de // indirect
 	github.com/qri-io/deepdiff v0.1.1-0.20200305020550-8173efebcaa1
 	github.com/qri-io/doggos v0.1.0
 	github.com/qri-io/ioes v0.1.1


### PR DESCRIPTION
Benchmarks for the save code path with an added deep dive on the validation side.
Special note: this chokes on my machine for the 1G datasets without the optimizations that will follow on this.

Also will have to update the dependencies before merging, but want to get this up as a launch pad for the following PRs