### PR TITLE
feat(lib): subsystems can turn reference strings into datasets with a ParseLoadResolve function

### DIFF
--- a/base/dataset.go
+++ b/base/dataset.go
@@ -10,9 +10,35 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/base/dsfs"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/repo"
 	reporef "github.com/qri-io/qri/repo/ref"
 )
+
+// NewLocalDatasetLoader creates a dsfs.Loader that operates on a filestore
+func NewLocalDatasetLoader(r repo.Repo) dsref.Loader {
+	return loader{r}
+}
+
+type loader struct {
+	r repo.Repo
+}
+
+func (l loader) LoadDataset(ctx context.Context, ref dsref.Ref, source string) (*dataset.Dataset, error) {
+	// LoadDataset fetches, derefences and opens a dataset from a reference
+	// implements the dsfs.Loader interface
+	if source != "" {
+		return nil, fmt.Errorf("only local datasets can be loaded")
+	}
+
+	ds, err := dsfs.LoadDataset(ctx, l.r.Store(), ref.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = OpenDataset(ctx, l.r.Filesystem(), ds)
+	return ds, err
+}
 
 // OpenDataset prepares a dataset for use, checking each component
 // for populated Path or Byte suffixed fields, consuming those fields to

--- a/base/dataset.go
+++ b/base/dataset.go
@@ -24,9 +24,9 @@ type loader struct {
 	r repo.Repo
 }
 
+// LoadDataset fetches, derefernces and opens a dataset from a reference
+// implements the dsfs.Loader interface
 func (l loader) LoadDataset(ctx context.Context, ref dsref.Ref, source string) (*dataset.Dataset, error) {
-	// LoadDataset fetches, derefences and opens a dataset from a reference
-	// implements the dsfs.Loader interface
 	if source != "" {
 		return nil, fmt.Errorf("only local datasets can be loaded")
 	}

--- a/base/ref.go
+++ b/base/ref.go
@@ -73,7 +73,7 @@ func RenameDatasetRef(ctx context.Context, r repo.Repo, ref dsref.Ref, newName s
 	if _, newRefErr := r.ResolveRef(ctx, &next); newRefErr == nil {
 		// successful resolution on rename is an error
 		return nil, fmt.Errorf("dataset %q already exists", next.Human())
-	} else if errors.Is(newRefErr, dsref.ErrNotFound) {
+	} else if errors.Is(newRefErr, dsref.ErrRefNotFound) {
 		// this is a good thing.
 	} else {
 		log.Debug(newRefErr.Error())

--- a/base/transform_apply.go
+++ b/base/transform_apply.go
@@ -8,6 +8,7 @@ import (
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/base/dsfs"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/repo"
 	reporef "github.com/qri-io/qri/repo/ref"
 	"github.com/qri-io/qri/startf"
@@ -16,7 +17,15 @@ import (
 // TODO(dustmop): Tests. Especially once the `apply` command exists.
 
 // TransformApply applies the transform script to order to modify the changing dataset
-func TransformApply(ctx context.Context, ds *dataset.Dataset, r repo.Repo, str ioes.IOStreams, scriptOut io.Writer, secrets map[string]string) error {
+func TransformApply(
+	ctx context.Context,
+	ds *dataset.Dataset,
+	r repo.Repo,
+	loader dsref.ParseResolveLoad,
+	str ioes.IOStreams,
+	scriptOut io.Writer,
+	secrets map[string]string,
+) error {
 	pro, err := r.Profile()
 	if err != nil {
 		return err
@@ -62,6 +71,7 @@ func TransformApply(ctx context.Context, ds *dataset.Dataset, r repo.Repo, str i
 		startf.AddMutateFieldCheck(mutateCheck),
 		startf.SetErrWriter(scriptOut),
 		startf.SetSecrets(secrets),
+		startf.AddDatasetLoader(loader),
 	}
 
 	if err = startf.ExecScript(ctx, target, head, opts...); err != nil {

--- a/cmd/sql.go
+++ b/cmd/sql.go
@@ -56,6 +56,7 @@ PostgreSQL in a few ways:
 	}
 
 	cmd.Flags().StringVarP(&o.Format, "format", "f", "table", "set output format [table]")
+	cmd.Flags().BoolVar(&o.Offline, "offline", false, "prevent network access")
 
 	return cmd
 }
@@ -64,8 +65,9 @@ PostgreSQL in a few ways:
 type SQLOptions struct {
 	ioes.IOStreams
 
-	Query  string
-	Format string
+	Query   string
+	Format  string
+	Offline bool
 
 	SQLMethods *lib.SQLMethods
 }
@@ -82,9 +84,15 @@ func (o *SQLOptions) Complete(f Factory, args []string) (err error) {
 func (o *SQLOptions) Run() (err error) {
 	o.StartSpinner()
 
+	var rm string
+	if o.Offline {
+		rm = "local"
+	}
+
 	p := &lib.SQLQueryParams{
 		Query:        o.Query,
 		OutputFormat: o.Format,
+		ResolverMode: rm,
 	}
 
 	res := []byte{}

--- a/cmd/sql.go
+++ b/cmd/sql.go
@@ -84,15 +84,15 @@ func (o *SQLOptions) Complete(f Factory, args []string) (err error) {
 func (o *SQLOptions) Run() (err error) {
 	o.StartSpinner()
 
-	var rm string
+	var mode string
 	if o.Offline {
-		rm = "local"
+		mode = "local"
 	}
 
 	p := &lib.SQLQueryParams{
 		Query:        o.Query,
 		OutputFormat: o.Format,
-		ResolverMode: rm,
+		ResolverMode: mode,
 	}
 
 	res := []byte{}

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -487,8 +487,7 @@ func (run *TestRunner) AddDatasetToRefstore(ctx context.Context, t *testing.T, r
 	// No existing commit
 	emptyHeadRef := ""
 
-	_, err = base.SaveDataset(ctx, r, initID, emptyHeadRef, ds, base.SaveSwitches{})
-	if err != nil {
+	if _, err = base.SaveDataset(ctx, r, initID, emptyHeadRef, ds, base.SaveSwitches{}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/dscache/dscache.go
+++ b/dscache/dscache.go
@@ -182,12 +182,12 @@ func (d *Dscache) ListRefs() ([]reporef.DatasetRef, error) {
 func (d *Dscache) ResolveRef(ctx context.Context, ref *dsref.Ref) (string, error) {
 	// NOTE: isEmpty is nil-callable. important b/c ResolveRef must be nil-callable
 	if d.IsEmpty() {
-		return "", dsref.ErrNotFound
+		return "", dsref.ErrRefNotFound
 	}
 
 	vi, err := d.LookupByName(*ref)
 	if err != nil {
-		return "", dsref.ErrNotFound
+		return "", dsref.ErrRefNotFound
 	}
 
 	ref.InitID = vi.InitID

--- a/dsref/load.go
+++ b/dsref/load.go
@@ -2,10 +2,8 @@ package dsref
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/qri-io/dataset"
-	qerr "github.com/qri-io/qri/errors"
 )
 
 // Loader loads and opens a dataset. The only useful implementation of the
@@ -15,33 +13,7 @@ type Loader interface {
 	LoadDataset(ctx context.Context, ref Ref, source string) (*dataset.Dataset, error)
 }
 
-// ParseResolveLoad is the function type returned by NewParseResolveLoader
+// ParseResolveLoad is a function that combines dataset reference parsing,
+// reference resolution, and loading in one function, turning a reference string
+// into a dataset pointer
 type ParseResolveLoad func(ctx context.Context, refStr string) (*dataset.Dataset, error)
-
-// NewParseResolveLoadFunc composes a username, resolver, and loader into a
-// higher-order function that converts strings to full datasets
-// pass the empty string as a username to disable the "me" keyword in references
-func NewParseResolveLoadFunc(username string, resolver Resolver, loader Loader) ParseResolveLoad {
-	return func(ctx context.Context, refStr string) (*dataset.Dataset, error) {
-		ref, err := Parse(refStr)
-		if err != nil {
-			return nil, err
-		}
-
-		if username == "" && ref.Username == "me" {
-			msg := fmt.Sprintf(`Can't use the "me" keyword to refer to a dataset in this context.
-Replace "me" with your username for the reference:
-%s`, refStr)
-			return nil, qerr.New(fmt.Errorf("invalid contextual reference"), msg)
-		} else if username != "" && ref.Username == "me" {
-			ref.Username = username
-		}
-
-		source, err := resolver.ResolveRef(ctx, &ref)
-		if err != nil {
-			return nil, err
-		}
-
-		return loader.LoadDataset(ctx, ref, source)
-	}
-}

--- a/dsref/load.go
+++ b/dsref/load.go
@@ -1,0 +1,47 @@
+package dsref
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qri-io/dataset"
+	qerr "github.com/qri-io/qri/errors"
+)
+
+// Loader loads and opens a dataset. The only useful implementation of the
+// loader interface is in github.com/qri-io/qri/lib.
+// TODO(b5) - This interface is a work-in-progress
+type Loader interface {
+	LoadDataset(ctx context.Context, ref Ref, source string) (*dataset.Dataset, error)
+}
+
+// ParseResolveLoad is the function type returned by NewParseResolveLoader
+type ParseResolveLoad func(ctx context.Context, refStr string) (*dataset.Dataset, error)
+
+// NewParseResolveLoadFunc composes a username, resolver, and loader into a
+// higher-order function that converts strings to full datasets
+// pass the empty string as a username to disable the "me" keyword in references
+func NewParseResolveLoadFunc(username string, resolver Resolver, loader Loader) ParseResolveLoad {
+	return func(ctx context.Context, refStr string) (*dataset.Dataset, error) {
+		ref, err := Parse(refStr)
+		if err != nil {
+			return nil, err
+		}
+
+		if username == "" && ref.Username == "me" {
+			msg := fmt.Sprintf(`Can't use the "me" keyword to refer to a dataset in this context.
+Replace "me" with your username for the reference:
+%s`, refStr)
+			return nil, qerr.New(fmt.Errorf("invalid contextual reference"), msg)
+		} else if username != "" && ref.Username == "me" {
+			ref.Username = username
+		}
+
+		source, err := resolver.ResolveRef(ctx, &ref)
+		if err != nil {
+			return nil, err
+		}
+
+		return loader.LoadDataset(ctx, ref, source)
+	}
+}

--- a/dsref/mem_resolver.go
+++ b/dsref/mem_resolver.go
@@ -45,13 +45,13 @@ func (m *MemResolver) GetInfo(initID string) *VersionInfo {
 // implements resolve.NameResolver interface
 func (m *MemResolver) ResolveRef(ctx context.Context, ref *Ref) (string, error) {
 	if m == nil {
-		return "", ErrNotFound
+		return "", ErrRefNotFound
 	}
 
 	id := m.RefMap[ref.Alias()]
 	resolved, ok := m.IDMap[id]
 	if !ok {
-		return "", ErrNotFound
+		return "", ErrRefNotFound
 	}
 
 	ref.InitID = id

--- a/dsref/mem_resolver_test.go
+++ b/dsref/mem_resolver_test.go
@@ -14,8 +14,8 @@ func TestMemResolver(t *testing.T) {
 	ctx := context.Background()
 	m := dsref.NewMemResolver("test_peer")
 
-	if _, err := (*dsref.MemResolver)(nil).ResolveRef(ctx, nil); err != dsref.ErrNotFound {
-		t.Errorf("ResolveRef must be nil-callable. expected: %q, got %v", dsref.ErrNotFound, err)
+	if _, err := (*dsref.MemResolver)(nil).ResolveRef(ctx, nil); err != dsref.ErrRefNotFound {
+		t.Errorf("ResolveRef must be nil-callable. expected: %q, got %v", dsref.ErrRefNotFound, err)
 	}
 
 	dsrefspec.AssertResolverSpec(t, m, func(ref dsref.Ref, author identity.Author, log *oplog.Log) error {

--- a/dsref/resolve.go
+++ b/dsref/resolve.go
@@ -6,9 +6,9 @@ import (
 )
 
 var (
-	// ErrNotFound must be returned by a ref resolver that cannot resolve a given
-	// reference
-	ErrNotFound = errors.New("reference not found")
+	// ErrRefNotFound must be returned by a ref resolver that cannot resolve a
+	// given reference
+	ErrRefNotFound = errors.New("reference not found")
 	// ErrPathRequired should be returned by functions that require a reference
 	// have a path value, but got none.
 	// ErrPathRequired should *not* be returned by implentationf of the
@@ -44,7 +44,7 @@ func (rs parallelResolver) ResolveRef(ctx context.Context, ref *Ref) (string, er
 
 	run := func(ctx context.Context, r Resolver) {
 		if r == nil {
-			errs <- ErrNotFound
+			errs <- ErrRefNotFound
 			return
 		}
 
@@ -73,10 +73,10 @@ func (rs parallelResolver) ResolveRef(ctx context.Context, ref *Ref) (string, er
 			return res.Source, nil
 		case err := <-errs:
 			attempts--
-			if !errors.Is(err, ErrNotFound) {
+			if !errors.Is(err, ErrRefNotFound) {
 				return "", err
 			} else if attempts == 0 {
-				return "", ErrNotFound
+				return "", ErrRefNotFound
 			}
 		case <-ctx.Done():
 			return "", ctx.Err()
@@ -97,7 +97,7 @@ func (sr sequentialResolver) ResolveRef(ctx context.Context, ref *Ref) (string, 
 	for _, resolver := range sr {
 		resolvedSource, err := resolver.ResolveRef(ctx, ref)
 		if err != nil {
-			if errors.Is(err, ErrNotFound) {
+			if errors.Is(err, ErrRefNotFound) {
 				continue
 			} else {
 				return "", err
@@ -106,5 +106,5 @@ func (sr sequentialResolver) ResolveRef(ctx context.Context, ref *Ref) (string, 
 		return resolvedSource, nil
 	}
 
-	return "", ErrNotFound
+	return "", ErrRefNotFound
 }

--- a/dsref/resolve.go
+++ b/dsref/resolve.go
@@ -28,7 +28,7 @@ type Resolver interface {
 
 // ParallelResolver composes multiple resolvers into one resolver that runs
 // in parallel when called, using the first resolver that doesn't return
-// ErrorNotFound
+// ErrRefNotFound
 func ParallelResolver(resolvers ...Resolver) Resolver {
 	return parallelResolver(resolvers)
 }

--- a/dsref/resolve_test.go
+++ b/dsref/resolve_test.go
@@ -7,3 +7,7 @@ import (
 func TestParallelResolver(t *testing.T) {
 	t.Skip("TODO(b5)")
 }
+
+func TestSequentialResolver(t *testing.T) {
+	t.Skip("TODO(b5)")
+}

--- a/dsref/spec/load.go
+++ b/dsref/spec/load.go
@@ -13,7 +13,7 @@ import (
 
 // PutDatasetFunc adds a dataset to a system that stores datasets
 // PutDatasetFunc is required to run the LoaderSpec test. When called the
-// Resolver should retain the dataset for later loading by the spec test
+// Loader should retain the dataset for later loading by the spec test
 type PutDatasetFunc func(ds *dataset.Dataset) (path string, err error)
 
 // AssertLoaderSpec confirms the expected behaviour of a dsref.Loader

--- a/dsref/spec/load.go
+++ b/dsref/spec/load.go
@@ -1,0 +1,112 @@
+package spec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qfs"
+	"github.com/qri-io/qri/dsref"
+)
+
+// PutDatasetFunc adds a dataset to a system that stores datasets
+// PutDatasetFunc is required to run the LoaderSpec test. When called the
+// Resolver should retain the dataset for later loading by the spec test
+type PutDatasetFunc func(ds *dataset.Dataset) (path string, err error)
+
+// AssertLoaderSpec confirms the expected behaviour of a dsref.Loader
+// Interface implementation. In addition to this test passing, implementations
+// MUST be nil-callable. Please add a nil-callable test for each implementation
+//
+// TODO(b5) - loader spec is intentionally a little vague at the moment. I'm not
+// sure the interface belongs in this package, and this test isn't working
+// network sources. This test serves to confirm basic requirements of a local
+// loader function for the moment
+func AssertLoaderSpec(t *testing.T, r dsref.Loader, putFunc PutDatasetFunc) {
+	var (
+		ctx      = context.Background()
+		username = "example_user"
+		name     = "this_is_an_example"
+		path     = ""
+	)
+
+	ds, err := GenerateExampleDataset(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path, err = putFunc(ds)
+	if err != nil {
+		t.Fatalf("putting dataset: %s", err)
+	}
+
+	ref := dsref.Ref{}
+	_, err = r.LoadDataset(ctx, ref, "")
+	if err == nil {
+		t.Errorf("expected loading without a reference Path value to fail, got nil")
+	}
+
+	ref = dsref.Ref{
+		Username: username,
+		Name:     name,
+		Path:     path,
+	}
+	got, err := r.LoadDataset(ctx, ref, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.BodyFile() == nil {
+		t.Errorf("expected body file to be open & ready to read")
+	}
+
+	if username != got.Peername {
+		t.Errorf("load Dataset didn't set dataset.Peername field to given reference. want: %q got: %q", username, got.Peername)
+	}
+	if name != got.Name {
+		t.Errorf("load Dataset didn't set dataset.Name field to given reference. want: %q got: %q", name, got.Name)
+	}
+
+	ds.Peername = username
+	ds.Name = name
+	if diff := cmp.Diff(ds, got, cmpopts.IgnoreUnexported(dataset.Dataset{}, dataset.Meta{})); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// GenerateExampleDataset creates an example dataset document
+func GenerateExampleDataset(ctx context.Context) (*dataset.Dataset, error) {
+	ds := &dataset.Dataset{
+		Commit: &dataset.Commit{
+			Title: "initial commit",
+		},
+		Meta: &dataset.Meta{
+			Title:       "dataset loader spec test",
+			Description: "a dataset to check that",
+		},
+		Structure: &dataset.Structure{
+			Format: "json",
+			Schema: map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "array",
+					"items": []interface{}{
+						map[string]interface{}{"title": "a", "type": "string"},
+						map[string]interface{}{"title": "b", "type": "number"},
+						map[string]interface{}{"title": "c", "type": "boolean"},
+					},
+				},
+			},
+		},
+	}
+
+	ds.SetBodyFile(qfs.NewMemfileBytes("body.json", []byte(`[
+		["a",1,false],
+		["b",2,true],
+		["c",3,true]
+	]`)))
+
+	return ds, nil
+}

--- a/dsref/spec/resolve.go
+++ b/dsref/spec/resolve.go
@@ -18,16 +18,16 @@ import (
 	"github.com/qri-io/qri/logbook/oplog"
 )
 
-// PutFunc adds a reference to a system that retains references
-// PutFunc is required to run the ResolverSpec test, when called the Resolver
-// should retain the reference for later retrieval by the spec test. PutFunc
+// PutRefFunc adds a reference to a system that retains references
+// PutRefFunc is required to run the ResolverSpec test, when called the Resolver
+// should retain the reference for later retrieval by the spec test. PutRefFunc
 // also passes the author & oplog that back the reference
-type PutFunc func(ref dsref.Ref, author identity.Author, log *oplog.Log) error
+type PutRefFunc func(ref dsref.Ref, author identity.Author, log *oplog.Log) error
 
 // AssertResolverSpec confirms the expected behaviour of a dsref.Resolver
 // Interface implementation. In addition to this test passing, implementations
 // MUST be nil-callable. Please add a nil-callable test for each implementation
-func AssertResolverSpec(t *testing.T, r dsref.Resolver, putFunc PutFunc) {
+func AssertResolverSpec(t *testing.T, r dsref.Resolver, putFunc PutRefFunc) {
 	var (
 		ctx              = context.Background()
 		username, dsname = "resolve_spec_test_peer", "stored_ref_dataset"
@@ -55,8 +55,8 @@ func AssertResolverSpec(t *testing.T, r dsref.Resolver, putFunc PutFunc) {
 		_, err := r.ResolveRef(ctx, &dsref.Ref{Username: "username", Name: "does_not_exist"})
 		if err == nil {
 			t.Errorf("expected error resolving nonexistent reference, got none")
-		} else if !errors.Is(err, dsref.ErrNotFound) {
-			t.Errorf("expected standard error resolving nonexistent ref: %q, got: %q", dsref.ErrNotFound, err)
+		} else if !errors.Is(err, dsref.ErrRefNotFound) {
+			t.Errorf("expected standard error resolving nonexistent ref: %q, got: %q", dsref.ErrRefNotFound, err)
 		}
 
 		resolveMe := dsref.Ref{
@@ -145,8 +145,8 @@ func ConsistentResolvers(t *testing.T, ref dsref.Ref, resolvers ...dsref.Resolve
 	for i, r := range resolvers {
 		got := ref.Copy()
 		if _, resolveErr := r.ResolveRef(ctx, &got); resolveErr != nil {
-			// only legal error return value is dsref.ErrNotFound
-			if resolveErr != dsref.ErrNotFound {
+			// only legal error return value is dsref.ErrRefNotFound
+			if resolveErr != dsref.ErrRefNotFound {
 				return fmt.Errorf("unexpected error checking consistency with resolver %d (%v): %w", i, r, resolveErr)
 			}
 

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -756,7 +756,7 @@ func (m *DatasetMethods) Save(p *SaveParams, res *reporef.DatasetRef) error {
 func (m *DatasetMethods) nameIsInUse(ctx context.Context, ref dsref.Ref) bool {
 	res := ref.Copy()
 	_, err := m.inst.ResolveReference(ctx, &res, "local")
-	if errors.Is(err, dsref.ErrNotFound) {
+	if errors.Is(err, dsref.ErrRefNotFound) {
 		return false
 	} else if err != nil {
 		// TODO(b5): Unsure if this is correct. If `Get` hits some other error, we aren't

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -634,11 +634,11 @@ func (m *DatasetMethods) Save(p *SaveParams, res *reporef.DatasetRef) error {
 		}
 
 		// create a loader so transforms can call `load_dataset`
-		// TODO(b5) - add a ResolverMode save parameter and call m.inst.resolverMode
+		// TODO(b5) - add a ResolverMode save parameter and call m.inst.resolverForMode
 		// on the passed in mode string instead of just using the default resolver
 		// cmd can then define "remote" and "offline" flags, that set the ResolverMode
 		// string and control how transform functions
-		loader := dsref.NewParseResolveLoadFunc("", m.inst.defaultResolver(), m.inst)
+		loader := NewParseResolveLoadFunc("", m.inst.defaultResolver(), m.inst)
 
 		// apply the transform
 		err := base.TransformApply(ctx, ds, r, loader, str, scriptOut, secrets)

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -190,7 +190,7 @@ func (m *FSIMethods) Checkout(p *CheckoutParams, out *string) (err error) {
 	}
 
 	// Load dataset that is being checked out.
-	ds, err := m.inst.loadDataset(ctx, ref)
+	ds, err := m.inst.LoadDataset(ctx, ref, "")
 	if err != nil {
 		log.Debugf("Checkout, dsfs.LoadDataset failed, error: %s", err)
 		return err

--- a/lib/load.go
+++ b/lib/load.go
@@ -1,0 +1,74 @@
+package lib
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/base"
+	"github.com/qri-io/qri/base/dsfs"
+	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/fsi"
+	reporef "github.com/qri-io/qri/repo/ref"
+)
+
+// LoadDataset fetches, derefences and opens a dataset from a reference
+// implements the dsfs.Loader interface
+func (inst *Instance) LoadDataset(ctx context.Context, ref dsref.Ref, source string) (*dataset.Dataset, error) {
+	if source == "" {
+		return inst.loadLocalDataset(ctx, ref)
+	}
+
+	// TODO(b5) - for now we're assuming any non-local source must fetch from the registry
+	if inst.cfg.Registry == nil {
+		return nil, fmt.Errorf("can't fetch remote dataset %q without a configured registry", ref)
+	} else if inst.cfg.Registry.Location == "" {
+		return nil, fmt.Errorf("can't fetch remote dataset %q without a configured registry", ref)
+	}
+
+	source = inst.cfg.Registry.Location
+
+	msg := fmt.Sprintf("pulling dataset from registry: %s ...\n", ref)
+	inst.streams.Out.Write([]byte(msg))
+
+	if err := inst.remoteClient.CloneLogs(ctx, ref, source); err != nil {
+		return nil, err
+	}
+
+	rref := reporef.RefFromDsref(ref)
+	if err := inst.remoteClient.AddDataset(ctx, &rref, source); err != nil {
+		return nil, err
+	}
+
+	return inst.loadLocalDataset(ctx, ref)
+}
+
+func (inst *Instance) loadLocalDataset(ctx context.Context, ref dsref.Ref) (*dataset.Dataset, error) {
+	var (
+		ds  *dataset.Dataset
+		err error
+	)
+
+	if strings.HasPrefix(ref.Path, "/fsi") {
+		// Has an FSI Path, load from working directory
+		if ds, err = fsi.ReadDir(strings.TrimPrefix(ref.Path, "/fsi")); err != nil {
+			return nil, err
+		}
+	} else {
+		// Load from dsfs
+		if ds, err = dsfs.LoadDataset(ctx, inst.store, ref.Path); err != nil {
+			return nil, err
+		}
+	}
+	// Set transient info on the returned dataset
+	ds.Name = ref.Name
+	ds.Peername = ref.Username
+
+	if err = base.OpenDataset(ctx, inst.repo.Filesystem(), ds); err != nil {
+		log.Debugf("Get dataset, base.OpenDataset failed, error: %s", err)
+		return nil, err
+	}
+
+	return ds, nil
+}

--- a/lib/load.go
+++ b/lib/load.go
@@ -16,6 +16,9 @@ import (
 // LoadDataset fetches, derefences and opens a dataset from a reference
 // implements the dsfs.Loader interface
 func (inst *Instance) LoadDataset(ctx context.Context, ref dsref.Ref, source string) (*dataset.Dataset, error) {
+	if inst == nil {
+		return nil, fmt.Errorf("no instance")
+	}
 	if source == "" {
 		return inst.loadLocalDataset(ctx, ref)
 	}

--- a/lib/load_test.go
+++ b/lib/load_test.go
@@ -1,0 +1,30 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/base/dsfs"
+	"github.com/qri-io/qri/dsref"
+	dsrefspec "github.com/qri-io/qri/dsref/spec"
+)
+
+func TestLoadDataset(t *testing.T) {
+	tr := newTestRunner(t)
+	defer tr.Delete()
+
+	if _, err := (*Instance)(nil).LoadDataset(tr.Ctx, dsref.Ref{}, ""); err == nil {
+		t.Errorf("expected loadDataset on a nil instance to fail without panicing")
+	}
+
+	dsrefspec.AssertLoaderSpec(t, tr.Instance, func(ds *dataset.Dataset) (string, error) {
+		return dsfs.CreateDataset(
+			tr.Ctx,
+			tr.Instance.Repo().Store(),
+			ds,
+			nil,
+			tr.Instance.repo.PrivateKey(),
+			dsfs.SaveSwitches{},
+		)
+	})
+}

--- a/lib/render.go
+++ b/lib/render.go
@@ -95,12 +95,12 @@ func (m *RenderMethods) RenderReadme(p *RenderParams, res *string) (err error) {
 	if p.Dataset != nil {
 		ds = p.Dataset
 	} else {
-		ref, _, err := m.inst.ParseAndResolveRefWithWorkingDir(ctx, p.Ref, "local")
+		ref, source, err := m.inst.ParseAndResolveRefWithWorkingDir(ctx, p.Ref, "local")
 		if err != nil {
 			return err
 		}
 
-		ds, err = m.inst.loadDataset(ctx, ref)
+		ds, err = m.inst.LoadDataset(ctx, ref, source)
 		if err != nil {
 			return fmt.Errorf("loading dataset: %w", err)
 		}

--- a/lib/resolve.go
+++ b/lib/resolve.go
@@ -57,7 +57,7 @@ func (inst *Instance) ResolveReference(ctx context.Context, ref *dsref.Ref, mode
 		ref.Username = inst.cfg.Profile.Peername
 	}
 
-	resolver, err := inst.resolverMode(mode)
+	resolver, err := inst.resolverForMode(mode)
 	if err != nil {
 		return "", err
 	}
@@ -65,7 +65,7 @@ func (inst *Instance) ResolveReference(ctx context.Context, ref *dsref.Ref, mode
 	return resolver.ResolveRef(ctx, ref)
 }
 
-func (inst *Instance) resolverMode(mode string) (dsref.Resolver, error) {
+func (inst *Instance) resolverForMode(mode string) (dsref.Resolver, error) {
 	switch mode {
 	case "":
 		return inst.defaultResolver(), nil

--- a/lib/resolve.go
+++ b/lib/resolve.go
@@ -2,13 +2,8 @@ package lib
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
 
-	"github.com/qri-io/dataset"
-	"github.com/qri-io/qri/base"
-	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/fsi"
 	"github.com/qri-io/qri/remote"
@@ -51,8 +46,8 @@ func (inst *Instance) ParseAndResolveRefWithWorkingDir(ctx context.Context, refS
 }
 
 // ResolveReference finds the identifier & HEAD path for a dataset reference.
-// the source parameter determines which subsystems of Qri to use when
-func (inst *Instance) ResolveReference(ctx context.Context, ref *dsref.Ref, source string) (string, error) {
+// the mode parameter determines which subsystems of Qri to use when resolving
+func (inst *Instance) ResolveReference(ctx context.Context, ref *dsref.Ref, mode string) (string, error) {
 	if inst == nil {
 		return "", dsref.ErrNotFound
 	}
@@ -62,96 +57,51 @@ func (inst *Instance) ResolveReference(ctx context.Context, ref *dsref.Ref, sour
 		ref.Username = inst.cfg.Profile.Peername
 	}
 
-	resolvers, err := inst.resolveSources(source)
+	resolver, err := inst.resolverMode(mode)
 	if err != nil {
 		return "", err
 	}
 
-	for _, resolver := range resolvers {
-		resolvedSource, err := resolver.ResolveRef(ctx, ref)
-		if err != nil {
-			if errors.Is(err, dsref.ErrNotFound) {
-				continue
-			} else {
-				return "", err
-			}
-		}
-
-		return resolvedSource, nil
-	}
-
-	return "", dsref.ErrNotFound
+	return resolver.ResolveRef(ctx, ref)
 }
 
-func (inst *Instance) resolveSources(source string) ([]dsref.Resolver, error) {
-	switch source {
+func (inst *Instance) resolverMode(mode string) (dsref.Resolver, error) {
+	switch mode {
 	case "":
-		return []dsref.Resolver{
+		return inst.defaultResolver(), nil
+	case "local":
+		return dsref.SequentialResolver(
 			inst.dscache,
 			inst.repo,
-			dsref.ParallelResolver(
-				inst.registry,
-				// inst.node,
-			),
-		}, nil
-	case "local":
-		return []dsref.Resolver{inst.dscache, inst.repo}, nil
+		), nil
 	case "network":
-		return []dsref.Resolver{
-			dsref.ParallelResolver(
-				inst.registry,
-				// inst.node,
-			),
-		}, nil
+		// TODO(b5) - one day use registry & p2p in paralle here
+		return inst.registry, nil
 	case "registry":
-		return []dsref.Resolver{inst.registry}, nil
+		return inst.registry, nil
 	case "p2p":
 		return nil, fmt.Errorf("p2p network cannot be used to resolve references")
 	}
 
-	// TODO (b5) - sources could be one of:
+	// TODO (b5) - mode could be one of:
 	// * configured remote name
 	// * peername
 	// * peer multiaddress
 	// add support for peername & multiaddress resolution
-	addr, err := remote.Address(inst.Config(), source)
+	addr, err := remote.Address(inst.Config(), mode)
 	if err != nil {
 		return nil, err
 	}
-	return []dsref.Resolver{inst.remoteClient.NewRemoteRefResolver(addr)}, nil
+	return inst.remoteClient.NewRemoteRefResolver(addr), nil
 }
 
-// loadDataset fetches, derefences and opens a dataset from a reference
-// TODO (b5) - this needs to move down into base, replacing base.LoadDataset with
-// a version that can load paths with a /fsi prefix, but before that can happen
-// base needs to be able to import FSI. Currently FSI imports base, and doesn't
-// really need to. Most of the base package functions used by FSI should be in
-// FSI, as they deal with filesystem interaction.
-func (inst *Instance) loadDataset(ctx context.Context, ref dsref.Ref) (*dataset.Dataset, error) {
-	var (
-		ds  *dataset.Dataset
-		err error
+func (inst *Instance) defaultResolver() dsref.Resolver {
+	return dsref.SequentialResolver(
+		inst.dscache,
+		inst.repo,
+		dsref.ParallelResolver(
+			inst.registry,
+			// inst.node,
+		),
 	)
-
-	if strings.HasPrefix(ref.Path, "/fsi") {
-		// Has an FSI Path, load from working directory
-		if ds, err = fsi.ReadDir(strings.TrimPrefix(ref.Path, "/fsi")); err != nil {
-			return nil, err
-		}
-	} else {
-		// Load from dsfs
-		if ds, err = dsfs.LoadDataset(ctx, inst.store, ref.Path); err != nil {
-			return nil, err
-		}
-	}
-	// Set transient info on the returned dataset
-	ds.Name = ref.Name
-	ds.Peername = ref.Username
-
-	if err = base.OpenDataset(ctx, inst.repo.Filesystem(), ds); err != nil {
-		log.Debugf("Get dataset, base.OpenDataset failed, error: %s", err)
-		return nil, err
-	}
-
-	return ds, nil
 }

--- a/lib/resolve.go
+++ b/lib/resolve.go
@@ -49,7 +49,7 @@ func (inst *Instance) ParseAndResolveRefWithWorkingDir(ctx context.Context, refS
 // the mode parameter determines which subsystems of Qri to use when resolving
 func (inst *Instance) ResolveReference(ctx context.Context, ref *dsref.Ref, mode string) (string, error) {
 	if inst == nil {
-		return "", dsref.ErrNotFound
+		return "", dsref.ErrRefNotFound
 	}
 
 	// Handle the "me" convenience shortcut

--- a/lib/sql.go
+++ b/lib/sql.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/sql"
 )
 
@@ -41,13 +40,13 @@ func (m *SQLMethods) Exec(p *SQLQueryParams, results *[]byte) error {
 	}
 	ctx := context.TODO()
 
-	resolver, err := m.inst.resolverMode(p.ResolverMode)
+	resolver, err := m.inst.resolverForMode(p.ResolverMode)
 	if err != nil {
 		return err
 	}
 	// create a loader sql will use to load & fetch datasets
 	// pass in the configured peername, allowing the "me" alias in reference strings
-	loadDataset := dsref.NewParseResolveLoadFunc(m.inst.cfg.Profile.Peername, resolver, m.inst)
+	loadDataset := NewParseResolveLoadFunc(m.inst.cfg.Profile.Peername, resolver, m.inst)
 	svc := sql.New(m.inst.repo, loadDataset)
 
 	buf := &bytes.Buffer{}

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -644,12 +644,12 @@ func (book Book) Log(ctx context.Context, id string) (*oplog.Log, error) {
 // implements resolve.NameResolver interface
 func (book *Book) ResolveRef(ctx context.Context, ref *dsref.Ref) (string, error) {
 	if book == nil {
-		return "", dsref.ErrNotFound
+		return "", dsref.ErrRefNotFound
 	}
 
 	initID, err := book.RefToInitID(*ref)
 	if err != nil {
-		return "", dsref.ErrNotFound
+		return "", dsref.ErrRefNotFound
 	}
 	ref.InitID = initID
 

--- a/logbook/logbook_test.go
+++ b/logbook/logbook_test.go
@@ -231,8 +231,8 @@ func TestNilCallable(t *testing.T) {
 	if err = book.WriteVersionSave(ctx, initID, nil); err != logbook.ErrNoLogbook {
 		t.Errorf("expected '%s', got: %v", logbook.ErrNoLogbook, err)
 	}
-	if _, err = book.ResolveRef(ctx, nil); err != dsref.ErrNotFound {
-		t.Errorf("expected '%s', got: %v", dsref.ErrNotFound, err)
+	if _, err = book.ResolveRef(ctx, nil); err != dsref.ErrRefNotFound {
+		t.Errorf("expected '%s', got: %v", dsref.ErrRefNotFound, err)
 	}
 }
 
@@ -240,8 +240,8 @@ func TestResolveRef(t *testing.T) {
 	tr, cleanup := newTestRunner(t)
 	defer cleanup()
 
-	if _, err := (*logbook.Book)(nil).ResolveRef(tr.Ctx, nil); err != dsref.ErrNotFound {
-		t.Errorf("book ResolveRef must be nil-callable. expected: %q, got %v", dsref.ErrNotFound, err)
+	if _, err := (*logbook.Book)(nil).ResolveRef(tr.Ctx, nil); err != dsref.ErrRefNotFound {
+		t.Errorf("book ResolveRef must be nil-callable. expected: %q, got %v", dsref.ErrRefNotFound, err)
 	}
 
 	book := tr.Book

--- a/registry/regclient/client.go
+++ b/registry/regclient/client.go
@@ -53,7 +53,7 @@ var _ dsref.Resolver = (*Client)(nil)
 // implements dsref.Resolver interface
 func (c *Client) ResolveRef(ctx context.Context, ref *dsref.Ref) (string, error) {
 	if c == nil {
-		return "", dsref.ErrNotFound
+		return "", dsref.ErrRefNotFound
 	}
 
 	// TODO (b5) - for now we're just using "registry" as the returned source value
@@ -84,7 +84,7 @@ func (c *Client) ResolveRef(ctx context.Context, ref *dsref.Ref) (string, error)
 	}
 
 	if res.StatusCode == http.StatusNotFound {
-		return "", dsref.ErrNotFound
+		return "", dsref.ErrRefNotFound
 	} else if res.StatusCode != http.StatusOK {
 		errMsg, _ := ioutil.ReadAll(res.Body)
 		return addr, fmt.Errorf("resolving dataset ref from registry failed: %s", string(errMsg))

--- a/registry/regclient/client_test.go
+++ b/registry/regclient/client_test.go
@@ -25,7 +25,7 @@ func TestResolveRef(t *testing.T) {
 
 	ctx := context.Background()
 
-	if _, err := (*Client)(nil).ResolveRef(ctx, nil); err != dsref.ErrNotFound {
+	if _, err := (*Client)(nil).ResolveRef(ctx, nil); err != dsref.ErrRefNotFound {
 		t.Errorf("expected client to be nil-callable")
 	}
 

--- a/remote/peer_sync_client.go
+++ b/remote/peer_sync_client.go
@@ -258,7 +258,7 @@ type remoteRefResolver struct {
 // TODO (b5) - implementation isn't complete, remotes don't complete InitID
 func (rr *remoteRefResolver) ResolveRef(ctx context.Context, ref *dsref.Ref) (string, error) {
 	if rr == nil || rr.cli == nil {
-		return rr.remoteAddr, dsref.ErrNotFound
+		return rr.remoteAddr, dsref.ErrRefNotFound
 	}
 
 	repoRef := reporef.RefFromDsref(*ref)

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -82,7 +82,7 @@ func NewRepo(store cafs.Filestore, fsys qfs.Filesystem, book *logbook.Book, cach
 // ResolveRef implements the dsref.RefResolver interface
 func (r *Repo) ResolveRef(ctx context.Context, ref *dsref.Ref) (string, error) {
 	if r == nil {
-		return "", dsref.ErrNotFound
+		return "", dsref.ErrRefNotFound
 	}
 
 	// TODO (b5) - not totally sure why, but memRepo doesn't seem to be wiring up

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -58,7 +58,7 @@ func NewMemRepo(p *profile.Profile, store cafs.Filestore, fsys qfs.Filesystem, p
 // ResolveRef implements the dsref.Resolver interface
 func (r *MemRepo) ResolveRef(ctx context.Context, ref *dsref.Ref) (string, error) {
 	if r == nil {
-		return "", dsref.ErrNotFound
+		return "", dsref.ErrRefNotFound
 	}
 
 	// TODO (b5) - not totally sure why, but memRepo doesn't seem to be wiring up

--- a/repo/test/temp_repo.go
+++ b/repo/test/temp_repo.go
@@ -188,3 +188,10 @@ func (r *TempRepo) LoadDataset(ref string) (*dataset.Dataset, error) {
 	}
 	return ds, nil
 }
+
+// WriteRootFile writes a file string to the root directory of the temp repo
+func (r *TempRepo) WriteRootFile(filename, data string) (path string, err error) {
+	path = filepath.Join(r.RootPath, filename)
+	err = ioutil.WriteFile(path, []byte(data), 0667)
+	return path, err
+}

--- a/sql/qds/datasource_test.go
+++ b/sql/qds/datasource_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/cube2222/octosql/parser/sqlparser"
 	"github.com/cube2222/octosql/physical"
 	"github.com/google/go-cmp/cmp"
+	"github.com/qri-io/qri/base"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/repo"
 	repotest "github.com/qri-io/qri/repo/test"
 )
@@ -63,7 +65,7 @@ func newTestRunner(t *testing.T) (*testRunner, func()) {
 }
 
 func (tr *testRunner) MustRun(t *testing.T, query string, cfg *octocfg.Config) string {
-	fac := NewDataSourceBuilderFactory(tr.repo)
+	fac := NewDataSourceBuilderFactory(tr.repo, tr.loadDatasetFunc())
 	ff := func(dbConfig map[string]interface{}) (physical.DataSourceBuilderFactory, error) {
 		return fac, nil
 	}
@@ -101,4 +103,10 @@ func (tr *testRunner) MustRun(t *testing.T, query string, cfg *octocfg.Config) s
 	// Run query
 	app.RunPlan(tr.ctx, plan)
 	return out.String()
+}
+
+func (tr *testRunner) loadDatasetFunc() dsref.ParseResolveLoad {
+	pro, _ := tr.repo.Profile()
+	loader := base.NewLocalDatasetLoader(tr.repo)
+	return dsref.NewParseResolveLoadFunc(pro.Peername, tr.repo, loader)
 }

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cube2222/octosql/physical"
 	golog "github.com/ipfs/go-log"
 	"github.com/pkg/errors"
+	"github.com/qri-io/qri/dsref"
 	qrierr "github.com/qri-io/qri/errors"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/sql/preprocess"
@@ -27,13 +28,15 @@ var log = golog.Logger("sql")
 
 // Service executes SQL queries against qri datasets
 type Service struct {
-	r repo.Repo
+	r           repo.Repo
+	loadDataset dsref.ParseResolveLoad
 }
 
 // New creates an SQL service
-func New(r repo.Repo) *Service {
+func New(r repo.Repo, loadDataset dsref.ParseResolveLoad) *Service {
 	return &Service{
-		r: r,
+		r:           r,
+		loadDataset: loadDataset,
 	}
 }
 
@@ -58,7 +61,7 @@ func (svc *Service) Exec(ctx context.Context, w io.Writer, outFormat, query stri
 	}
 
 	ff := func(dbConfig map[string]interface{}) (physical.DataSourceBuilderFactory, error) {
-		return qds.NewDataSourceBuilderFactory(svc.r), nil
+		return qds.NewDataSourceBuilderFactory(svc.r, svc.loadDataset), nil
 	}
 
 	dataSourceRespository, err := physical.CreateDataSourceRepositoryFromConfig(

--- a/startf/transform_test.go
+++ b/startf/transform_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
 	"github.com/qri-io/qfs"
+	"github.com/qri-io/qri/base/dsfs"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/repo"
 	repoTest "github.com/qri-io/qri/repo/test"
 	"github.com/qri-io/starlib"
@@ -136,7 +138,7 @@ def transform(ds, ctx):
 
 func TestLoadDataset(t *testing.T) {
 	ctx := context.Background()
-	repo := testRepo(t)
+	r := testRepo(t)
 
 	ds := &dataset.Dataset{
 		Transform: &dataset.Transform{},
@@ -144,12 +146,41 @@ func TestLoadDataset(t *testing.T) {
 	ds.Transform.SetScriptFile(scriptFile(t, "testdata/load_ds.star"))
 
 	err := ExecScript(ctx, ds, nil, func(o *ExecOpts) {
-		o.Repo = repo
+		o.Repo = r
 		o.ModuleLoader = testModuleLoader(t)
+		o.DatasetLoader = dsref.NewParseResolveLoadFunc("", r, repoLoader{r})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TODO(b5) - we should think about moving this somewhere more general
+type repoLoader struct {
+	r repo.Repo
+}
+
+func (rl repoLoader) LoadDataset(ctx context.Context, ref dsref.Ref, source string) (*dataset.Dataset, error) {
+	var (
+		ds  *dataset.Dataset
+		err error
+	)
+
+	if ds, err = dsfs.LoadDataset(ctx, rl.r.Store(), ref.Path); err != nil {
+		return nil, err
+	}
+	// Set transient info on the returned dataset
+	ds.Name = ref.Name
+	ds.Peername = ref.Username
+
+	// TODO (b5) - this should be a call to base.OpenDatasets
+	if ds.BodyFile() == nil {
+		if err = ds.OpenBodyFile(ctx, rl.r.Filesystem()); err != nil {
+			return nil, err
+		}
+	}
+
+	return ds, nil
 }
 
 func TestGetMetaNilPrev(t *testing.T) {


### PR DESCRIPTION
builds on #1359

introduce a new interface: `dsfs.Loader` for loading datasets from a passed-in "source" parameter.

a high level `dsfs.ParseLoadResolve` function encomposes the common stack of parsing a reference, resolving, then loading (with a potential network pull for resolution and loading) makes a useful inversion of control flow for subsystems that need this highest-order functionality, while still providing configurability at the instance level.