### PR TITLE
refactor(config): expose filesystem config

### DIFF
--- a/config/api.go
+++ b/config/api.go
@@ -35,11 +35,23 @@ type API struct {
 	WebsocketAddress string `json:"websocketaddress"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (a *API) SetArbitrary(key string, val interface{}) error {
-	return nil
+// Ignore implements the ignorer interface from base/fill/struct in order to safely
+// consume config files that have definitions beyond those specified in the struct
+// and are either deprecaated or no longer supported.
+// This simply ignores all defined ignore fields at read time.
+func (a *API) Ignore(key string) error {
+	ignoredPaths := map[string]bool{
+		"remotemode":            true,
+		"remoteacceptsizemax":   true,
+		"remoteaccepttimeoutms": true,
+		"urlroot":               true,
+		"tls":                   true,
+		"proxyforcehttps":       true,
+	}
+	if ignoredPaths[key] {
+		return nil
+	}
+	return fmt.Errorf("key '%s' not found", key)
 }
 
 // Validate validates all fields of api returning all errors found.

--- a/config/api.go
+++ b/config/api.go
@@ -35,23 +35,18 @@ type API struct {
 	WebsocketAddress string `json:"websocketaddress"`
 }
 
-// Ignore implements the ignorer interface from base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct
-// and are either deprecaated or no longer supported.
-// This simply ignores all defined ignore fields at read time.
-func (a *API) Ignore(key string) error {
-	ignoredPaths := map[string]bool{
+// IgnoreFillField implements the FieldIgnorer interface from base/fill/struct
+// in order to safely consume config files that have definitions beyond those
+// specified in the struct and are either deorecated or no longer supported
+func (a *API) IgnoreFillField(key string) bool {
+	return map[string]bool{
 		"remotemode":            true,
 		"remoteacceptsizemax":   true,
 		"remoteaccepttimeoutms": true,
 		"urlroot":               true,
 		"tls":                   true,
 		"proxyforcehttps":       true,
-	}
-	if ignoredPaths[key] {
-		return nil
-	}
-	return fmt.Errorf("key '%s' not found", key)
+	}[key]
 }
 
 // Validate validates all fields of api returning all errors found.

--- a/config/cli.go
+++ b/config/cli.go
@@ -7,13 +7,6 @@ type CLI struct {
 	ColorizeOutput bool `json:"colorizeoutput"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (c *CLI) SetArbitrary(key string, val interface{}) error {
-	return nil
-}
-
 // DefaultCLI returns a new default CLI configuration
 func DefaultCLI() *CLI {
 	return &CLI{

--- a/config/config.go
+++ b/config/config.go
@@ -40,20 +40,15 @@ type Config struct {
 	Logging *Logging
 }
 
-// Ignore implements the ignorer interface from base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct
-// and are either deprecaated or no longer supported.
-// This simply ignores all defined ignore fields at read time.
-func (cfg *Config) Ignore(key string) error {
-	ignoredPaths := map[string]bool{
-		"update": true,
-		"webapp": true,
-		"render": true,
-	}
-	if ignoredPaths[key] {
-		return nil
-	}
-	return fmt.Errorf("key '%s' not found", key)
+// IgnoreFillField implements the FieldIgnorer interface from base/fill/struct
+// in order to safely consume config files that have definitions beyond those
+// specified in the struct and are either deorecated or no longer supported
+func (cfg *Config) IgnoreFillField(key string) bool {
+	return map[string]bool{
+		"Update": true,
+		"Webapp": true,
+		"Render": true,
+	}[key]
 }
 
 // NOTE: The configuration returned by DefaultConfig is insufficient, as is, to run a functional

--- a/config/config.go
+++ b/config/config.go
@@ -22,12 +22,13 @@ const CurrentConfigRevision = 2
 type Config struct {
 	path string
 
-	Revision int
-	Profile  *ProfilePod
-	Repo     *Repo
-	Store    *Store
-	P2P      *P2P
-	Stats    *Stats
+	Revision    int
+	Profile     *ProfilePod
+	Repo        *Repo
+	Store       *Store
+	P2P         *P2P
+	Stats       *Stats
+	Filesystems *Filesystems
 
 	Registry *Registry
 	Remotes  *Remotes
@@ -57,20 +58,18 @@ func (cfg *Config) SetArbitrary(key string, val interface{}) error {
 // DefaultConfig gives a new configuration with simple, default settings
 func DefaultConfig() *Config {
 	return &Config{
-		Revision: CurrentConfigRevision,
-		Profile:  DefaultProfile(),
-		Repo:     DefaultRepo(),
-		Store:    DefaultStore(),
-		P2P:      DefaultP2P(),
-		Stats:    DefaultStats(),
-
-		Registry: DefaultRegistry(),
-		// default to no configured remotes
-
-		CLI:     DefaultCLI(),
-		API:     DefaultAPI(),
-		RPC:     DefaultRPC(),
-		Logging: DefaultLogging(),
+		Revision:    CurrentConfigRevision,
+		Profile:     DefaultProfile(),
+		Repo:        DefaultRepo(),
+		Store:       DefaultStore(),
+		P2P:         DefaultP2P(),
+		Stats:       DefaultStats(),
+		Registry:    DefaultRegistry(),
+		CLI:         DefaultCLI(),
+		API:         DefaultAPI(),
+		RPC:         DefaultRPC(),
+		Logging:     DefaultLogging(),
+		Filesystems: DefaultFilesystems(),
 	}
 }
 
@@ -196,7 +195,7 @@ func (cfg Config) Validate() error {
     "title": "config",
     "description": "qri configuration",
     "type": "object",
-    "required": ["Profile", "Repo", "Store", "P2P", "CLI", "API", "RPC"],
+    "required": ["Profile", "Repo", "Store", "P2P", "CLI", "API", "RPC", "Filesystems"],
     "properties" : {
 			"Profile" : { "type":"object" },
 			"Repo" : { "type":"object" },
@@ -204,7 +203,8 @@ func (cfg Config) Validate() error {
 			"P2P" : { "type":"object" },
 			"CLI" : { "type":"object" },
 			"API" : { "type":"object" },
-			"RPC" : { "type":"object" }
+			"RPC" : { "type":"object" },
+			"Filesystems" : { "type":"array", "items": { "type": "object"} }
     }
   }`)
 	if err := validate(schema, &cfg); err != nil {
@@ -220,6 +220,7 @@ func (cfg Config) Validate() error {
 		cfg.API,
 		cfg.RPC,
 		cfg.Logging,
+		cfg.Filesystems,
 	}
 	for _, val := range validators {
 		// we need to check here because we're potentially calling methods on nil
@@ -280,6 +281,9 @@ func (cfg *Config) Copy() *Config {
 	}
 	if cfg.Stats != nil {
 		res.Stats = cfg.Stats.Copy()
+	}
+	if cfg.Filesystems != nil {
+		res.Filesystems = cfg.Filesystems.Copy()
 	}
 
 	return res

--- a/config/config.go
+++ b/config/config.go
@@ -40,11 +40,20 @@ type Config struct {
 	Logging *Logging
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (cfg *Config) SetArbitrary(key string, val interface{}) error {
-	return nil
+// Ignore implements the ignorer interface from base/fill/struct in order to safely
+// consume config files that have definitions beyond those specified in the struct
+// and are either deprecaated or no longer supported.
+// This simply ignores all defined ignore fields at read time.
+func (cfg *Config) Ignore(key string) error {
+	ignoredPaths := map[string]bool{
+		"update": true,
+		"webapp": true,
+		"render": true,
+	}
+	if ignoredPaths[key] {
+		return nil
+	}
+	return fmt.Errorf("key '%s' not found", key)
 }
 
 // NOTE: The configuration returned by DefaultConfig is insufficient, as is, to run a functional

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -224,3 +224,15 @@ func TestConfigCopy(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigIgnoreFields(t *testing.T) {
+	if _, err := ReadFromFile("testdata/deprecated.yaml"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestConfigInvalidFields(t *testing.T) {
+	if _, err := ReadFromFile("testdata/invalid.yaml"); err == nil {
+		t.Errorf("expected error, got none")
+	}
+}

--- a/config/filesystem.go
+++ b/config/filesystem.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"reflect"
+
+	"github.com/qri-io/jsonschema"
+)
+
+// Filesystem configures the filesystem for qri content
+type Filesystem struct {
+	Type   string                 `json:"type"`
+	Config map[string]interface{} `json:"config,omitempty"`
+	Source string                 `json:"source,omitempty"`
+}
+
+// SetArbitrary is an interface implementation of base/fill/struct in order to safely
+// consume config files that have definitions beyond those specified in the struct.
+// This simply ignores all additional fields at read time.
+func (cfg *Filesystem) SetArbitrary(key string, val interface{}) error {
+	return nil
+}
+
+// DefaultFilesystemIPFS returns a new default ipfs filesystem configuration
+func DefaultFilesystemIPFS() *Filesystem {
+	return &Filesystem{
+		Type: "ipfs",
+		Config: map[string]interface{}{
+			"path":   "./ipfs",
+			"api":    true,
+			"pubsub": false,
+		},
+		Source: "",
+	}
+}
+
+// DefaultFilesystemHTTP returns a new default ipfs filesystem configuration
+func DefaultFilesystemHTTP() *Filesystem {
+	return &Filesystem{
+		Type: "http",
+	}
+}
+
+// DefaultFilesystemLocal returns a new default ipfs filesystem configuration
+func DefaultFilesystemLocal() *Filesystem {
+	return &Filesystem{
+		Type: "local",
+	}
+}
+
+// Validate validates all fields of filesystem returning all errors found.
+func (cfg Filesystem) Validate() error {
+	schema := jsonschema.Must(`{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Filesystem",
+    "description": "Config for the qri content filesystem",
+    "type": "object",
+    "required": ["type"],
+    "properties": {
+    	"type": {
+        "description": "Type of filesystem",
+        "type": "string",
+        "enum": [
+			"http",
+			"ipfs",
+			"local",
+			"map",
+			"mem"
+        ]
+      }
+    }
+  }`)
+	return validate(schema, &cfg)
+}
+
+// Copy returns a deep copy of the Filesystem struct
+func (cfg *Filesystem) Copy() *Filesystem {
+	res := &Filesystem{
+		Type:   cfg.Type,
+		Config: cfg.Config,
+		Source: cfg.Source,
+	}
+
+	return res
+}
+
+// Filesystems is a type alias to wrap around an array of Filesystem structs
+type Filesystems []*Filesystem
+
+// SetArbitrary is an interface implementation of base/fill/struct in order to safely
+// consume config files that have definitions beyond those specified in the struct.
+// This simply ignores all additional fields at read time.
+func (cfg *Filesystems) SetArbitrary(key string, val interface{}) error {
+	return nil
+}
+
+// DefaultFilesystems returns a new default filesystems configuration
+func DefaultFilesystems() *Filesystems {
+	return &Filesystems{
+		DefaultFilesystemIPFS(),
+		DefaultFilesystemHTTP(),
+		DefaultFilesystemLocal(),
+	}
+}
+
+// Validate validates all fields of filesystem returning all errors found.
+func (cfg Filesystems) Validate() error {
+	for _, filesystem := range cfg {
+		if !reflect.ValueOf(filesystem).IsNil() {
+			if err := filesystem.Validate(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Copy returns a deep copy of the Filesystem struct
+func (cfg *Filesystems) Copy() *Filesystems {
+	res := &Filesystems{}
+	for _, f := range *cfg {
+		*res = append(*res, f.Copy())
+	}
+	return res
+}

--- a/config/filesystem.go
+++ b/config/filesystem.go
@@ -13,13 +13,6 @@ type Filesystem struct {
 	Source string                 `json:"source,omitempty"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (cfg *Filesystem) SetArbitrary(key string, val interface{}) error {
-	return nil
-}
-
 // DefaultFilesystemIPFS returns a new default ipfs filesystem configuration
 func DefaultFilesystemIPFS() *Filesystem {
 	return &Filesystem{

--- a/config/filesystem_test.go
+++ b/config/filesystem_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilesystemValidate(t *testing.T) {
+	err := DefaultFilesystemLocal().Validate()
+	if err != nil {
+		t.Errorf("error validating default store: %s", err)
+	}
+}
+
+func TestFilesystemCopy(t *testing.T) {
+	cases := []struct {
+		filesystem *Filesystem
+	}{
+		{DefaultFilesystemLocal()},
+	}
+	for i, c := range cases {
+		cpy := c.filesystem.Copy()
+		if !reflect.DeepEqual(cpy, c.filesystem) {
+			t.Errorf("Filesystem Copy test case %v, filesystem structs are not equal: \ncopy: %v, \noriginal: %v", i, cpy, c.filesystem)
+			continue
+		}
+		cpy.Type = "test"
+		if reflect.DeepEqual(cpy, c.filesystem) {
+			t.Errorf("Filesystem Copy test case %v, editing one filesystem struct should not affect the other: \ncopy: %v, \noriginal: %v", i, cpy, c.filesystem)
+			continue
+		}
+	}
+}

--- a/config/logging.go
+++ b/config/logging.go
@@ -8,13 +8,6 @@ type Logging struct {
 	Levels map[string]string `json:"levels"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (l *Logging) SetArbitrary(key string, val interface{}) error {
-	return nil
-}
-
 // DefaultLogging produces a new default logging configuration
 func DefaultLogging() *Logging {
 	return &Logging{

--- a/config/migrate/migrate.go
+++ b/config/migrate/migrate.go
@@ -14,7 +14,7 @@ import (
 // RunMigrations checks to see if any migrations runs them
 func RunMigrations(streams ioes.IOStreams, cfg *config.Config) (err error) {
 	if cfg.Revision != config.CurrentConfigRevision {
-		streams.PrintErr("migrating configuration...")
+		streams.PrintErr("migrating configuration...\n")
 		if cfg.Revision == 0 {
 			if err := ZeroToOne(cfg); err != nil {
 				return err

--- a/config/migrate/migrate.go
+++ b/config/migrate/migrate.go
@@ -114,6 +114,10 @@ func oneToTwoConfig(cfg *config.Config) error {
 		return qerr.New(fmt.Errorf("invalid config"), "config does not contain RPC configuration")
 	}
 
+	if cfg.Filesystems == nil {
+		cfg.Filesystems = config.DefaultFilesystems()
+	}
+
 	return nil
 }
 

--- a/config/p2p.go
+++ b/config/p2p.go
@@ -40,20 +40,15 @@ type P2P struct {
 	AutoNAT bool `json:"autoNAT"`
 }
 
-// Ignore implements the ignorer interface from base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct
-// and are either deprecaated or no longer supported.
-// This simply ignores all defined ignore fields at read time.
-func (cfg *P2P) Ignore(key string) error {
-	ignoredPaths := map[string]bool{
+// IgnoreFillField implements the FieldIgnorer interface from base/fill/struct
+// in order to safely consume config files that have definitions beyond those
+// specified in the struct and are either deorecated or no longer supported
+func (cfg *P2P) IgnoreFillField(key string) bool {
+	return map[string]bool{
 		"pubkey":             true,
 		"httpgatewayaddr":    true,
 		"profilereplication": true,
-	}
-	if ignoredPaths[key] {
-		return nil
-	}
-	return fmt.Errorf("key '%s' not found", key)
+	}[key]
 }
 
 // DefaultP2P generates a p2p struct with only bootstrap addresses set

--- a/config/p2p.go
+++ b/config/p2p.go
@@ -40,11 +40,20 @@ type P2P struct {
 	AutoNAT bool `json:"autoNAT"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (cfg *P2P) SetArbitrary(key string, val interface{}) error {
-	return nil
+// Ignore implements the ignorer interface from base/fill/struct in order to safely
+// consume config files that have definitions beyond those specified in the struct
+// and are either deprecaated or no longer supported.
+// This simply ignores all defined ignore fields at read time.
+func (cfg *P2P) Ignore(key string) error {
+	ignoredPaths := map[string]bool{
+		"pubkey":             true,
+		"httpgatewayaddr":    true,
+		"profilereplication": true,
+	}
+	if ignoredPaths[key] {
+		return nil
+	}
+	return fmt.Errorf("key '%s' not found", key)
 }
 
 // DefaultP2P generates a p2p struct with only bootstrap addresses set

--- a/config/profile.go
+++ b/config/profile.go
@@ -50,13 +50,6 @@ type ProfilePod struct {
 	NetworkAddrs []string `json:"networkAddrs,omitempty"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (p *ProfilePod) SetArbitrary(key string, val interface{}) error {
-	return nil
-}
-
 // DefaultProfile gives a new default profile configuration
 func DefaultProfile() *ProfilePod {
 	now := time.Now()

--- a/config/registry.go
+++ b/config/registry.go
@@ -9,13 +9,6 @@ type Registry struct {
 	Location string `json:"location"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (cfg *Registry) SetArbitrary(key string, val interface{}) error {
-	return nil
-}
-
 // DefaultRegistry generates a new default registry instance
 func DefaultRegistry() *Registry {
 	r := &Registry{

--- a/config/remote.go
+++ b/config/remote.go
@@ -21,13 +21,6 @@ type Remote struct {
 	AllowRemoves bool `json:"allowremoves"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (cfg *Remote) SetArbitrary(key string, val interface{}) error {
-	return nil
-}
-
 // Validate validates all fields of render returning all errors found.
 func (cfg Remote) Validate() error {
 	schema := jsonschema.Must(`{

--- a/config/repo.go
+++ b/config/repo.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/qri-io/jsonschema"
 )
 
@@ -12,18 +10,13 @@ type Repo struct {
 	Path string `json:"path,omitempty"`
 }
 
-// Ignore implements the ignorer interface from base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct
-// and are either deprecaated or no longer supported.
-// This simply ignores all defined ignore fields at read time.
-func (cfg *Repo) Ignore(key string) error {
-	ignoredPaths := map[string]bool{
+// IgnoreFillField implements the FieldIgnorer interface from base/fill/struct
+// in order to safely consume config files that have definitions beyond those
+// specified in the struct and are either deorecated or no longer supported
+func (cfg *Repo) IgnoreFillField(key string) bool {
+	return map[string]bool{
 		"middleware": true,
-	}
-	if ignoredPaths[key] {
-		return nil
-	}
-	return fmt.Errorf("key '%s' not found", key)
+	}[key]
 }
 
 // DefaultRepo creates & returns a new default repo configuration

--- a/config/repo.go
+++ b/config/repo.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/qri-io/jsonschema"
 )
 
@@ -10,11 +12,18 @@ type Repo struct {
 	Path string `json:"path,omitempty"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (cfg *Repo) SetArbitrary(key string, val interface{}) error {
-	return nil
+// Ignore implements the ignorer interface from base/fill/struct in order to safely
+// consume config files that have definitions beyond those specified in the struct
+// and are either deprecaated or no longer supported.
+// This simply ignores all defined ignore fields at read time.
+func (cfg *Repo) Ignore(key string) error {
+	ignoredPaths := map[string]bool{
+		"middleware": true,
+	}
+	if ignoredPaths[key] {
+		return nil
+	}
+	return fmt.Errorf("key '%s' not found", key)
 }
 
 // DefaultRepo creates & returns a new default repo configuration

--- a/config/rpc.go
+++ b/config/rpc.go
@@ -8,13 +8,6 @@ type RPC struct {
 	Address string `json:"address"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (cfg *RPC) SetArbitrary(key string, val interface{}) error {
-	return nil
-}
-
 // DefaultRPCAddress is the address RPC serves on by default
 var DefaultRPCAddress = "/ip4/127.0.0.1/tcp/2504"
 

--- a/config/stats.go
+++ b/config/stats.go
@@ -11,13 +11,6 @@ type Stats struct {
 	// StopFreqCountThreshold int
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (cfg *Stats) SetArbitrary(key string, val interface{}) error {
-	return nil
-}
-
 // cache configures the cached storage of stats
 type cache struct {
 	Type    string `json:"type"`

--- a/config/store.go
+++ b/config/store.go
@@ -9,13 +9,6 @@ type Store struct {
 	Path    string                 `json:"path,omitempty"`
 }
 
-// SetArbitrary is an interface implementation of base/fill/struct in order to safely
-// consume config files that have definitions beyond those specified in the struct.
-// This simply ignores all additional fields at read time.
-func (cfg *Store) SetArbitrary(key string, val interface{}) error {
-	return nil
-}
-
 // DefaultStore returns a new default Store configuration
 func DefaultStore() *Store {
 	return &Store{

--- a/config/store.go
+++ b/config/store.go
@@ -54,6 +54,7 @@ func (cfg *Store) Copy() *Store {
 	res := &Store{
 		Type:    cfg.Type,
 		Options: cfg.Options,
+		Path:    cfg.Path,
 	}
 
 	return res

--- a/config/testdata/default.yaml
+++ b/config/testdata/default.yaml
@@ -5,6 +5,14 @@ repo:
   type: fs
 store:
   type: ipfs
+filesystems:
+  - type: ipfs
+    config:
+      path: ./ipfs
+      api: true
+      pubsub: false
+  - type: local
+  - type: http
 cli:
   colorizeoutput: true
 api:

--- a/config/testdata/deprecated.yaml
+++ b/config/testdata/deprecated.yaml
@@ -1,0 +1,103 @@
+# yaml file that contains old fields qri must safely ignore
+API:
+  address: /ip4/127.0.0.1/tcp/2503
+  allowedorigins:
+  - electron://local.qri.io
+  - http://localhost:2505
+  - http://localhost:6006
+  - http://app.qri.io
+  - https://app.qri.io
+  enabled: true
+  proxyforcehttps: false
+  readonly: false
+  remoteacceptsizemax: 0
+  remoteaccepttimeoutms: 0
+  remotemode: false
+  serveremotetraffic: true
+  tls: false
+  urlroot: ""
+  websocketaddress: /ip4/127.0.0.1/tcp/2506
+CLI:
+  colorizeoutput: true
+Logging:
+  levels:
+    actions: info
+    base: info
+    core: debug
+    cron: debug
+    dsfs: info
+    lib: info
+    logbook: info
+    qriapi: info
+    qricore: info
+    qrip2p: info
+P2P:
+  addrs: null
+  autoNAT: false
+  bootstrapaddrs: []
+  enabled: true
+  httpgatewayaddr: ""
+  peerid: QmdJQpcmGMkNtKYv5bviZ7z9kPh7uLKSMzqdSbemYs3XpH
+  port: 0
+  privkey: ""
+  profilereplication: full
+  pubkey: ""
+  qribootstrapaddrs:
+  - /ip4/35.193.162.149/tcp/4001/ipfs/QmTZxETL4YCCzB1yFx4GT1te68henVHD1XPQMkHZ1N22mm
+  - /ip4/35.239.80.82/tcp/4001/ipfs/QmdpGkbqDYRPCcwLYnEm8oYGz2G9aUZn9WwPjqvqw3XUAc
+  - /ip4/35.225.152.38/tcp/4001/ipfs/QmTRqTLbKndFC2rp6VzpyApxHCLrFV35setF1DQZaRWPVf
+  - /ip4/35.202.155.225/tcp/4001/ipfs/QmegNYmwHUQFc3v3eemsYUVf3WiSg4RcMrh3hovA5LncJ2
+  - /ip4/35.238.10.180/tcp/4001/ipfs/QmessbA6uGLJ7HTwbUJ2niE49WbdPfzi27tdYXdAaGRB4G
+  - /ip4/35.238.105.35/tcp/4001/ipfs/Qmc353gHY5Wx5iHKHPYj3QDqHP4hVA1MpoSsT6hwSyVx3r
+  - /ip4/35.239.138.186/tcp/4001/ipfs/QmT9YHJF2YkysLqWhhiVTL5526VFtavic3bVueF9rCsjVi
+  - /ip4/35.226.44.58/tcp/4001/ipfs/QmQS2ryqZrjJtPKDy9VTkdPwdUSpTi1TdpGUaqAVwfxcNh
+Profile:
+  color: ""
+  created: "2020-06-01T09:39:36-04:00"
+  description: ""
+  email: deprecated@qri.io
+  homeurl: ""
+  id: QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W
+  name: ""
+  peername: deprecated
+  photo: https://qri-user-images.storage.googleapis.com/1570029792579.png
+  poster: /ipfs/QmSN2yHp4qFy1xLCRVQNJKAjgbwHYPAho9fT7C3vAM426c
+  thumb: ""
+  twitter: ""
+  type: peer
+  updated: "2018-04-19T18:10:46.627471799-04:00"
+RPC:
+  address: /ip4/127.0.0.1/tcp/2504
+  enabled: true
+Registry:
+  location: http://localhost:3002
+Remote:
+  acceptsizemax: 0
+  accepttimeoutms: 0
+  allowremoves: false
+  enabled: false
+  requireallblocks: false
+Remotes: null
+Render:
+  defaultTemplateHash: /ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw
+  templateUpdateAddress: /ipns/defaulttmpl.qri.io
+Repo:
+  middleware: ["old middleware"]
+  type: fs
+Revision: 2
+Stats: null
+Store:
+  options:
+    api: true
+    pubsub: false
+  type: ipfs
+Update:
+  address: ""
+  daemonize: false
+  type: fs
+Webapp:
+  analyticstoken: ""
+  enabled: true
+  entrypointhash: /ipfs/QmXofmXcQKnYTMjsfhgTGqzzLLPyS9enaHsfaRR5AxTGBK
+  entrypointupdateaddress: /ipns/webapp.qri.io
+  port: 0

--- a/config/testdata/invalid.yaml
+++ b/config/testdata/invalid.yaml
@@ -1,0 +1,62 @@
+# yaml file that contains old fields qri must safely ignore
+API:
+  nonexistentField: true
+CLI:
+  colorizeoutput: true
+Logging:
+  levels:
+    lib: info
+P2P:
+  addrs: null
+  autoNAT: false
+  bootstrapaddrs: []
+  enabled: true
+  httpgatewayaddr: ""
+  peerid: QmdJQpcmGMkNtKYv5bviZ7z9kPh7uLKSMzqdSbemYs3XpH
+  port: 0
+  privkey: ""
+  profilereplication: full
+  pubkey: ""
+  qribootstrapaddrs:
+  - /ip4/35.193.162.149/tcp/4001/ipfs/QmTZxETL4YCCzB1yFx4GT1te68henVHD1XPQMkHZ1N22mm
+  - /ip4/35.239.80.82/tcp/4001/ipfs/QmdpGkbqDYRPCcwLYnEm8oYGz2G9aUZn9WwPjqvqw3XUAc
+  - /ip4/35.225.152.38/tcp/4001/ipfs/QmTRqTLbKndFC2rp6VzpyApxHCLrFV35setF1DQZaRWPVf
+  - /ip4/35.202.155.225/tcp/4001/ipfs/QmegNYmwHUQFc3v3eemsYUVf3WiSg4RcMrh3hovA5LncJ2
+  - /ip4/35.238.10.180/tcp/4001/ipfs/QmessbA6uGLJ7HTwbUJ2niE49WbdPfzi27tdYXdAaGRB4G
+  - /ip4/35.238.105.35/tcp/4001/ipfs/Qmc353gHY5Wx5iHKHPYj3QDqHP4hVA1MpoSsT6hwSyVx3r
+  - /ip4/35.239.138.186/tcp/4001/ipfs/QmT9YHJF2YkysLqWhhiVTL5526VFtavic3bVueF9rCsjVi
+  - /ip4/35.226.44.58/tcp/4001/ipfs/QmQS2ryqZrjJtPKDy9VTkdPwdUSpTi1TdpGUaqAVwfxcNh
+Profile:
+  color: ""
+  created: "2020-06-01T09:39:36-04:00"
+  description: ""
+  email: deprecated@qri.io
+  homeurl: ""
+  id: QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W
+  name: ""
+  peername: deprecated
+  photo: https://qri-user-images.storage.googleapis.com/1570029792579.png
+  poster: /ipfs/QmSN2yHp4qFy1xLCRVQNJKAjgbwHYPAho9fT7C3vAM426c
+  thumb: ""
+  twitter: ""
+  type: peer
+  updated: "2018-04-19T18:10:46.627471799-04:00"
+RPC:
+  address: /ip4/127.0.0.1/tcp/2504
+  enabled: true
+Registry:
+  location: http://localhost:3002
+Remote:
+  acceptsizemax: 0
+  accepttimeoutms: 0
+  allowremoves: false
+  enabled: false
+  requireallblocks: false
+Remotes: null
+Render:
+  defaultTemplateHash: /ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw
+  templateUpdateAddress: /ipns/defaulttmpl.qri.io
+Repo:
+  type: fs
+Revision: 2
+Stats: null

--- a/config/testdata/simple.yaml
+++ b/config/testdata/simple.yaml
@@ -1,5 +1,6 @@
 API: null
 CLI: null
+Filesystems: null
 Logging: null
 P2P: null
 Profile:


### PR DESCRIPTION
The basis is:
- Non-existing config means default to all (same as it was)
- If specified it creates all the named individual stores
- Empty array means disable all


Changes based on https://github.com/qri-io/rfcs/blob/master/text/0029-config_revision.md#remove-stale-configuration-fields
Addressing item No3 from #1346

Migration also needs to be implemented once the rest is done.