### PR TITLE
fix: simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,58 +1,44 @@
 ---
 name: "🐞 Bug report"
-about: Report a bug
+about: Report a bug.
 ---
 <!--
-
 Hello! Thanks for taking an interest in Qri.
 
 Please search open and closed issues before submitting.
 
 Existing issues often contain information about workarounds, resolution, or progress updates.
 
+✂️ You can delete any html comments. ✂️
+
 Thanks for your help.
 
 -->
 
-
-### Environment
-
-<!-- OS version
-# macOS
-❯ sw_vers
-
-# linux
-❯ lsb_release -a
-
-# windows
-c:\> systeminfo
--->
-
-```
-# OS info
-✍️ paste
-
-# qri version
-❯ qri version
-
-✍️ paste
-
-```
-
-### Expected Behavior
-<!-- ✍️ What did you expect to happen? -->
+### What version of qri are you using (`qri version`)?
 
 
-### Actual Behavior
-<!-- ✍️ What actually happened? -->
+
+### What is your OS and version?
 
 
-<!--
-Optional additional information
 
-### Related Issues
-### Suggested Fix
+### What did you do?
 
-Thank you for your time.
 
--->
+
+### What happened?
+
+
+
+### What did you expect to happen?
+
+
+
+<!-- Optional additional information. 
+     ✂️ Cut any that do not apply. -->
+
+### Please link any related issues.
+### Do you have a suggested fix?
+
+<!-- Thank you for your time. -->

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,33 +1,36 @@
 ---
 name: "🚀 Feature request"
-about: Suggest a feature
+about: Suggest a feature.
 ---
 <!--
-
 Hello! Thanks for taking an interest in Qri.
 
 Please search open and closed issues before submitting.
 
 Existing issues often contain information about workarounds, resolution, or progress updates.
 
+✂️ You can delete any html comments. ✂️
+
 Thanks for your help.
 
 -->
 
-### Description
-<!-- ✍️ A clear and concise description of the problem or missing capability... -->
+### What feature or capability would you like?
 
 
-### Describe the solution you’d like
-<!-- ✍️ If you have a solution in mind, please describe it. -->
+
+### Do you have a proposed solution?
 
 
-### Describe alternatives you’ve considered
-<!-- ✍️ Have you considered any alternative solutions or workarounds? -->
+
+### Have you considered any alternative solutions or workarounds?
 
 
-<!--
 
-Thank you for your time.
+<!-- Optional additional information. 
+     ✂️ Cut any that do not apply. -->
 
--->
+### Do you have any examples of similar features in other software?
+### Please link any related issues.
+
+<!-- Thank you for your time. -->

--- a/.github/ISSUE_TEMPLATE/3-support-request.md
+++ b/.github/ISSUE_TEMPLATE/3-support-request.md
@@ -1,6 +1,6 @@
 ---
 name: "❓ Support request"
-about: Questions and requests for support
+about: Questions and requests for support.
 ---
 
       🛑          🛑          🛑


### PR DESCRIPTION
Switch headers to questions.
This allows removal of many of the descriptive comments.

closes #1394