### PR TITLE
feat(cmd): add migrate flag to connect command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN mkdir -p $IPFS_PATH && mkdir -p $QRI_PATH \
 # VOLUME $QRI_PATH
 
 # Set binary as entrypoint, initalizing ipfs & qri repos if none is mounted
-CMD ["qri", "connect", "--setup"]
+CMD ["qri", "connect", "--setup", "--migrate"]

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -42,6 +42,7 @@ peers & swapping data.`,
 	}
 
 	cmd.Flags().BoolVarP(&o.Setup, "setup", "", false, "run setup if necessary, reading options from environment variables")
+	cmd.Flags().BoolVarP(&o.Migrate, "migrate", "", false, "automatically run migrations if necessary")
 	cmd.Flags().StringVarP(&o.Registry, "registry", "", "", "specify registry to setup with. only works when --setup is true")
 
 	return cmd
@@ -53,6 +54,7 @@ type ConnectOptions struct {
 	inst     *lib.Instance
 	Registry string
 	Setup    bool
+	Migrate  bool
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -74,6 +76,15 @@ func (o *ConnectOptions) Complete(f Factory, args []string) (err error) {
 		}
 	} else if !QRIRepoInitialized(repoPath) {
 		return errors.New(repo.ErrNoRepo, "no qri repo exists\nhave you run 'qri setup'?")
+	}
+
+	if o.Migrate {
+		// any required migration by default interrupts all commands with a prompt
+		// users setting the migrate flag are indicating we should skip the migration
+		// prompt, which is this only possible prompt in the `connect` command.
+		// setting noPrompt to true prior to calling init will have the effect
+		// of auto-running migrations
+		noPrompt = true
 	}
 
 	if err = f.Init(); err != nil {


### PR DESCRIPTION
this is important for zero-input environments like docker and qri desktop, which need a surefire way to get to a running qri node without interruption. callers that want no prompts at all should now use:

```
$ qri connect --setup --migrate
```

To auto-run setup when the qri repo path is empty, and auto run migrations before startup.