### PR TITLE
refactor(fsi,base): remove calls to CanonicalizeDatasetRef from base.TransformApply, fsi package

### DIFF
--- a/dsref/load.go
+++ b/dsref/load.go
@@ -2,9 +2,13 @@ package dsref
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/qri-io/dataset"
 )
+
+// ErrNoHistory indicates a resolved reference has no HEAD path
+var ErrNoHistory = fmt.Errorf("no history")
 
 // Loader loads and opens a dataset. The only useful implementation of the
 // loader interface is in github.com/qri-io/qri/lib.

--- a/fsi/status.go
+++ b/fsi/status.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/base/component"
 	"github.com/qri-io/qri/base/dsfs"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/repo"
 )
 
@@ -185,16 +186,12 @@ func (fsi *FSI) CalculateStateTransition(ctx context.Context, prev, next compone
 }
 
 // StatusAtVersion gets changes that happened at a particular version in a dataset's history.
-func (fsi *FSI) StatusAtVersion(ctx context.Context, refStr string) (changes []StatusItem, err error) {
-	ref, err := repo.ParseDatasetRef(refStr)
-	if err != nil {
-		return nil, err
+func (fsi *FSI) StatusAtVersion(ctx context.Context, ref dsref.Ref) (changes []StatusItem, err error) {
+	if ref.Path == "" {
+		return nil, fmt.Errorf("path is required to determine status at version")
 	}
 
 	var next, prev *dataset.Dataset
-	if err := repo.CanonicalizeDatasetRef(fsi.repo, &ref); err != nil {
-		return nil, err
-	}
 	if next, err = dsfs.LoadDataset(ctx, fsi.repo.Store(), ref.Path); err != nil {
 		return nil, err
 	}

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -137,13 +137,18 @@ func (m *FSIMethods) StatusForAlias(alias *string, res *[]StatusItem) (err error
 
 // WhatChanged gets changes that happened at a particular version in the history of the given
 // dataset reference. Not used for FSI.
-func (m *FSIMethods) WhatChanged(ref *string, res *[]StatusItem) (err error) {
+func (m *FSIMethods) WhatChanged(refstr *string, res *[]StatusItem) (err error) {
 	if m.inst.rpc != nil {
-		return checkRPCError(m.inst.rpc.Call("FSIMethods.WhatChanged", ref, res))
+		return checkRPCError(m.inst.rpc.Call("FSIMethods.WhatChanged", refstr, res))
 	}
 	ctx := context.TODO()
 
-	*res, err = m.inst.fsi.StatusAtVersion(ctx, *ref)
+	ref, _, err := m.inst.ParseAndResolveRef(ctx, *refstr, "local")
+	if err != nil {
+		return err
+	}
+
+	*res, err = m.inst.fsi.StatusAtVersion(ctx, ref)
 	return err
 }
 

--- a/lib/load.go
+++ b/lib/load.go
@@ -101,6 +101,11 @@ Replace "me" with your username for the reference:
 			return nil, err
 		}
 
+		if ref.Path == "" {
+			err = qerr.New(dsref.ErrNoHistory, fmt.Sprintf("can't load dataset %q, it has no saved versions", ref.Human()))
+			return nil, err
+		}
+
 		return loader.LoadDataset(ctx, ref, source)
 	}
 }


### PR DESCRIPTION
sneaking in a little extra refactoring before we ship a release