### PR TITLE
chore(libp2p2): adjust imports to point to non-deprecated packages

### DIFF
--- a/logbook/logsync/p2p_test.go
+++ b/logbook/logsync/p2p_test.go
@@ -8,7 +8,6 @@ import (
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	host "github.com/libp2p/go-libp2p-core/host"
 	peer "github.com/libp2p/go-libp2p-core/peer"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	pstoremem "github.com/libp2p/go-libp2p-peerstore/pstoremem"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -29,7 +28,7 @@ func TestP2PLogsync(t *testing.T) {
 	})
 
 	// connect a & b
-	if err := aHost.Connect(tr.Ctx, pstore.PeerInfo{ID: bHost.ID(), Addrs: bHost.Addrs()}); err != nil {
+	if err := aHost.Connect(tr.Ctx, peer.AddrInfo{ID: bHost.ID(), Addrs: bHost.Addrs()}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/p2p/connected.go
+++ b/p2p/connected.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	peer "github.com/libp2p/go-libp2p-core/peer"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
+	peerstore "github.com/libp2p/go-libp2p-core/peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -18,8 +18,9 @@ type pinfoPod struct {
 	Addrs []string
 }
 
-func (pod pinfoPod) Decode() (pstore.PeerInfo, error) {
-	pi := pstore.PeerInfo{}
+func (pod pinfoPod) Decode() (
+	peer.AddrInfo, error) {
+	pi := peer.AddrInfo{}
 	id, err := peer.IDB58Decode(pod.ID)
 	if err != nil {
 		return pi, err
@@ -86,7 +87,7 @@ func (n *QriNode) handleConnected(ws *WrappedStream, msg Message) (hangup bool) 
 		log.Debug(err.Error())
 		return
 	}
-	n.host.Peerstore().AddAddrs(pinfo.ID, pinfo.Addrs, pstore.TempAddrTTL)
+	n.host.Peerstore().AddAddrs(pinfo.ID, pinfo.Addrs, peerstore.ConnectedAddrTTL)
 
 	// request this peer's profile to connect two node's knowledge of each other
 	if _, err := n.RequestProfile(context.TODO(), pinfo.ID); err != nil {

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"time"
 
-	pstore "github.com/libp2p/go-libp2p-peerstore"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+	peerstore "github.com/libp2p/go-libp2p-core/peerstore"
 	discovery "github.com/libp2p/go-libp2p/p2p/discovery"
 )
 
 // StartDiscovery initiates peer discovery, allocating a discovery
 // services if one doesn't exist, then registering to be notified on peer discovery
-func (n *QriNode) StartDiscovery(bootstrapPeers chan pstore.PeerInfo) error {
+func (n *QriNode) StartDiscovery(bootstrapPeers chan peer.AddrInfo) error {
 	if n.Discovery == nil {
 		service, err := discovery.NewMdnsService(context.Background(), n.host, time.Second*5, QriServiceTag)
 		if err != nil {
@@ -35,7 +36,7 @@ func (n *QriNode) StartDiscovery(bootstrapPeers chan pstore.PeerInfo) error {
 
 // HandlePeerFound deals with the discovery of a peer that may or may not support
 // the qri protocol
-func (n *QriNode) HandlePeerFound(pinfo pstore.PeerInfo) {
+func (n *QriNode) HandlePeerFound(pinfo peer.AddrInfo) {
 	log.Debugf("found peer %s", pinfo.ID)
 	err := n.UpgradeToQriConnection(pinfo)
 	if err != nil && err != ErrQriProtocolNotSupported {
@@ -45,9 +46,9 @@ func (n *QriNode) HandlePeerFound(pinfo pstore.PeerInfo) {
 
 // DiscoverPeerstoreQriPeers handles the case where a store has seen peers that
 // support the qri protocol, but we haven't added them to our own peers list
-func (n *QriNode) DiscoverPeerstoreQriPeers(store pstore.Peerstore) {
+func (n *QriNode) DiscoverPeerstoreQriPeers(store peerstore.Peerstore) {
 	for _, pid := range store.Peers() {
-		if _, err := n.host.Peerstore().Get(pid, qriSupportKey); err == pstore.ErrNotFound {
+		if _, err := n.host.Peerstore().Get(pid, qriSupportKey); err == peerstore.ErrNotFound {
 			if supports, err := n.supportsQriProtocol(pid); err == nil && supports {
 				// TODO - slow this down plz
 				if err := n.UpgradeToQriConnection(store.PeerInfo(pid)); err != nil {

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -16,7 +16,7 @@ import (
 	host "github.com/libp2p/go-libp2p-core/host"
 	net "github.com/libp2p/go-libp2p-core/network"
 	peer "github.com/libp2p/go-libp2p-core/peer"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	pstoremem "github.com/libp2p/go-libp2p-peerstore/pstoremem"
 	discovery "github.com/libp2p/go-libp2p/p2p/discovery"
 	ma "github.com/multiformats/go-multiaddr"
@@ -193,7 +193,7 @@ func (n *QriNode) startOnlineServices(ctx context.Context) error {
 		return nil
 	}
 
-	bsPeers := make(chan pstore.PeerInfo, len(n.cfg.BootstrapAddrs))
+	bsPeers := make(chan peer.AddrInfo, len(n.cfg.BootstrapAddrs))
 
 	go func() {
 		// block until we have at least one successful bootstrap connection
@@ -292,7 +292,7 @@ func (n *QriNode) EncapsulatedAddresses() []ma.Multiaddr {
 }
 
 // makeBasicHost creates a LibP2P host from a NodeCfg
-func makeBasicHost(ctx context.Context, ps pstore.Peerstore, p2pconf *config.P2P) (host.Host, error) {
+func makeBasicHost(ctx context.Context, ps peerstore.Peerstore, p2pconf *config.P2P) (host.Host, error) {
 	pk, err := p2pconf.DecodePrivateKey()
 	if err != nil {
 		return nil, err
@@ -400,18 +400,18 @@ func (n *QriNode) handleStream(ws *WrappedStream, replies chan Message) {
 }
 
 // Keys returns the KeyBook for the node.
-func (n *QriNode) Keys() pstore.KeyBook {
+func (n *QriNode) Keys() peerstore.KeyBook {
 	return n.host.Peerstore()
 }
 
 // Addrs returns the AddrBook for the node.
-func (n *QriNode) Addrs() pstore.AddrBook {
+func (n *QriNode) Addrs() peerstore.AddrBook {
 	return n.host.Peerstore()
 }
 
 // SimplePeerInfo returns a PeerInfo with just the ID and Addresses.
-func (n *QriNode) SimplePeerInfo() pstore.PeerInfo {
-	return pstore.PeerInfo{
+func (n *QriNode) SimplePeerInfo() peer.AddrInfo {
+	return peer.AddrInfo{
 		ID:    n.host.ID(),
 		Addrs: n.host.Addrs(),
 	}

--- a/p2p/profile_test.go
+++ b/p2p/profile_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	// pstore "gx/ipfs/QmTTJcDL3gsnGDALjh2fDGg1onGRUdVgNL2hU2WEZcVrMX/go-libp2p-peerstore"
+	// peerstore "github.com/libp2p/go-libp2p-core/peerstore"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	p2ptest "github.com/qri-io/qri/p2p/test"
 )
@@ -116,7 +116,7 @@ func TestRequestProfileConnectNodes(t *testing.T) {
 // 	peers = peers[1:]
 
 // 	for _, peer := range peers {
-// 		p1.Addrs().AddAddr(peer.host.Network().LocalPeer(), peer.host.Network().ListenAddresses()[0], pstore.PermanentAddrTTL)
+// 		p1.Addrs().AddAddr(peer.host.Network().LocalPeer(), peer.host.Network().ListenAddresses()[0], peerstore.PermanentAddrTTL)
 // 	}
 
 // 	t.Logf("testing profile message with %d peers", len(peers))

--- a/p2p/qri_peers.go
+++ b/p2p/qri_peers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/qri-io/qri/repo/profile"
 
 	peer "github.com/libp2p/go-libp2p-core/peer"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -28,7 +27,7 @@ type QriPeer struct {
 // it records whether the peer supports Qri in the host Peerstore,
 // returns ErrQriProtocolNotSupported if the connection cannot be upgraded,
 // and sets a priority in the host Connection Manager if the connection is upgraded
-func (n *QriNode) UpgradeToQriConnection(pinfo pstore.PeerInfo) error {
+func (n *QriNode) UpgradeToQriConnection(pinfo peer.AddrInfo) error {
 	// bail early if we have seen this peer before
 	// OKAY
 	pid := pinfo.ID

--- a/p2p/test/ipfs.go
+++ b/p2p/test/ipfs.go
@@ -16,7 +16,6 @@ import (
 	repo "github.com/ipfs/go-ipfs/repo"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	peer "github.com/libp2p/go-libp2p-core/peer"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	qfs "github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/muxfs"
@@ -136,7 +135,7 @@ func MakeIPFSSwarm(ctx context.Context, fullIdentity bool, n int) ([]*core.IpfsN
 	}
 
 	bsinf := corebs.BootstrapConfigWithPeers(
-		[]pstore.PeerInfo{
+		[]peer.AddrInfo{
 			nodes[0].Peerstore.PeerInfo(nodes[0].Identity),
 		},
 	)

--- a/p2p/test/p2ptest.go
+++ b/p2p/test/p2ptest.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ipfs/go-cid"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	host "github.com/libp2p/go-libp2p-core/host"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/qri-io/dag"
 	"github.com/qri-io/qri/config"
@@ -25,8 +25,8 @@ import (
 // TestablePeerNode is used by tests only. Implemented by QriNode
 type TestablePeerNode interface {
 	Host() host.Host
-	SimplePeerInfo() pstore.PeerInfo
-	UpgradeToQriConnection(pstore.PeerInfo) error
+	SimplePeerInfo() peer.AddrInfo
+	UpgradeToQriConnection(peer.AddrInfo) error
 	GoOnline(ctx context.Context) error
 }
 
@@ -146,7 +146,7 @@ func NewAvailableTestNode(ctx context.Context, r repo.Repo, f *TestNodeFactory) 
 // - add a tag for each peer in the connmanager
 func ConnectNodes(ctx context.Context, nodes []TestablePeerNode) error {
 	var wg sync.WaitGroup
-	connect := func(n TestablePeerNode, pinfo pstore.PeerInfo) error {
+	connect := func(n TestablePeerNode, pinfo peer.AddrInfo) error {
 		if err := n.Host().Connect(ctx, pinfo); err != nil {
 			return fmt.Errorf("error connecting nodes: %s", err)
 		}
@@ -171,7 +171,7 @@ func ConnectNodes(ctx context.Context, nodes []TestablePeerNode) error {
 // They support the qri protocol and have exchanged profile
 func ConnectQriNodes(ctx context.Context, nodes []TestablePeerNode) error {
 	var wgConnect sync.WaitGroup
-	connect := func(n TestablePeerNode, pinfo pstore.PeerInfo) error {
+	connect := func(n TestablePeerNode, pinfo peer.AddrInfo) error {
 		if err := n.Host().Connect(ctx, pinfo); err != nil {
 			return fmt.Errorf("error connecting nodes: %s", err)
 		}

--- a/p2p/test/testable_node_test.go
+++ b/p2p/test/testable_node_test.go
@@ -14,7 +14,6 @@ import (
 	net "github.com/libp2p/go-libp2p-core/network"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	protocol "github.com/libp2p/go-libp2p-core/protocol"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	pstoremem "github.com/libp2p/go-libp2p-peerstore/pstoremem"
 )
 
@@ -41,8 +40,8 @@ func (n *TestableNode) Host() host.Host {
 }
 
 // SimplePeerInfo returns the PeerInfo of the TestableNode
-func (n *TestableNode) SimplePeerInfo() pstore.PeerInfo {
-	return pstore.PeerInfo{
+func (n *TestableNode) SimplePeerInfo() peer.AddrInfo {
+	return peer.AddrInfo{
 		ID:    n.host.ID(),
 		Addrs: n.host.Addrs(),
 	}
@@ -50,7 +49,7 @@ func (n *TestableNode) SimplePeerInfo() pstore.PeerInfo {
 
 // UpgradeToQriConnection upgrades the connection from a basic connection
 // to a Qri connection
-func (n *TestableNode) UpgradeToQriConnection(pinfo pstore.PeerInfo) error {
+func (n *TestableNode) UpgradeToQriConnection(pinfo peer.AddrInfo) error {
 	// bail early if we have seen this peer before
 	if _, err := n.Host().Peerstore().Get(pinfo.ID, TestQriSupportKey); err == nil {
 		return nil


### PR DESCRIPTION
More recent libp2p updates have deprecated some packages that we were relying on. This commit points to the newer/correct packages