### PR TITLE
fix(lib.Get): add FSIPath when ref.Path is prefixed with "/fsi"

### DIFF
--- a/api/fsi_test.go
+++ b/api/fsi_test.go
@@ -122,7 +122,7 @@ func TestNoHistory(t *testing.T) {
 	dsHandler := NewDatasetHandlers(run.Inst, false)
 
 	// Expected response for dataset head, regardless of fsi parameter
-	expectBody := `{"data":{"peername":"peer","name":"test_ds","dataset":{"bodyPath":"fsi_init_dir/body.csv","meta":{"qri":"md:0"},"name":"test_ds","peername":"peer","qri":"ds:0","structure":{"format":"csv","qri":"st:0"}},"published":false},"meta":{"code":200}}`
+	expectBody := `{"data":{"peername":"peer","name":"test_ds","fsiPath":"fsi_init_dir","dataset":{"bodyPath":"fsi_init_dir/body.csv","meta":{"qri":"md:0"},"name":"test_ds","peername":"peer","qri":"ds:0","structure":{"format":"csv","qri":"st:0"}},"published":false},"meta":{"code":200}}`
 
 	// Dataset with a link to the filesystem, but no history and the api request says fsi=false
 	gotStatusCode, gotBodyString := APICall("/peer/test_ds", dsHandler.GetHandler(""))

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -241,8 +241,12 @@ func (m *DatasetMethods) Get(p *GetParams, res *GetResult) error {
 
 	res.Ref = &ref
 	res.Dataset = ds
-	// TODO (b5) - FSIPath is determined differently now: by checking .Path for
-	// an /fsi prefix
+
+	// TODO (b5) - replace this prefix check with a call to qfs.PathKind when it
+	// supports the fsi prefix
+	if strings.HasPrefix(ref.Path, "/fsi") {
+		res.FSIPath = strings.TrimPrefix(ref.Path, "/fsi")
+	}
 	// TODO (b5) - Published field is longer set as part of Reference Resolution
 	// getting publication status should be delegated to a new function
 


### PR DESCRIPTION
closes #1417 