### PR TITLE
fix(rpc): shut down gracefully after completed RPC call

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,42 +5,32 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
-	stdlog "log"
 	"net/http"
-	"net/rpc"
 	"time"
 
 	golog "github.com/ipfs/go-log"
-	ma "github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr-net"
 	"github.com/qri-io/apiutil"
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/version"
 )
 
-var log = golog.Logger("qriapi")
-
-// APIVersion is the version string that is written in API responses
-var APIVersion = version.String
+var (
+	log = golog.Logger("qriapi")
+	// APIVersion is the version string that is written in API responses
+	APIVersion = version.String
+)
 
 // LocalHostIP is the IP address for localhost
-const LocalHostIP = "127.0.0.1"
-
-// DefaultTemplateHash is the hash of the default render template
-const DefaultTemplateHash = "/ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw"
-
-// TemplateUpdateAddress is the URI for the template update
-const TemplateUpdateAddress = "/ipns/defaulttmpl.qri.io"
+const (
+	LocalHostIP = "127.0.0.1"
+	// DefaultTemplateHash is the hash of the default render template
+	DefaultTemplateHash = "/ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw"
+	// TemplateUpdateAddress is the URI for the template update
+	TemplateUpdateAddress = "/ipns/defaulttmpl.qri.io"
+)
 
 func init() {
-	// We don't use the log package, and the net/rpc package spits out some complaints b/c
-	// a few methods don't conform to the proper signature (comment this out & run 'qri connect' to see errors)
-	// so we're disabling the log package for now. This is potentially very stupid.
-	// TODO (b5): remove dep on net/rpc package entirely
-	stdlog.SetOutput(ioutil.Discard)
-
 	golog.SetLogLevel("qriapi", "info")
 }
 
@@ -126,42 +116,6 @@ func (s Server) Serve(ctx context.Context) (err error) {
 
 	// http.ListenAndServe will not return unless there's an error
 	return StartServer(cfg.API, server)
-}
-
-// ServeRPC checks for a configured RPC port, and registers a listner if so
-func (s Server) ServeRPC(ctx context.Context) {
-	cfg := s.Config()
-	if !cfg.RPC.Enabled || cfg.RPC.Address == "" {
-		return
-	}
-	maAddress := cfg.RPC.Address
-	addr, err := ma.NewMultiaddr(maAddress)
-	if err != nil {
-		log.Errorf("cannot start RPC: error parsing RPC address %s: %w", maAddress, err.Error())
-	}
-
-	mal, err := manet.Listen(addr)
-	if err != nil {
-		log.Infof("RPC listen on address %d error: %w", cfg.RPC.Address, err)
-		return
-	}
-	listener := manet.NetListener(mal)
-
-	for _, rcvr := range lib.Receivers(s.Instance) {
-		if err := rpc.Register(rcvr); err != nil {
-			log.Errorf("cannot start RPC: error registering RPC receiver %s: %w", rcvr.CoreRequestsName(), err.Error())
-			return
-		}
-	}
-
-	go func() {
-		<-ctx.Done()
-		log.Info("closing RPC")
-		listener.Close()
-	}()
-
-	rpc.Accept(listener)
-	return
 }
 
 // HandleIPFSPath responds to IPFS Hash requests with raw data

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,7 +1,7 @@
 // Package cmd defines the CLI interface. It relies heavily on the spf13/cobra
 // package. Much of its structure is adapted from kubernetes/kubernetes/tree/master/cmd
 // The `help` message for each command uses backticks rather than quotes when
-// refering to commands by name, even though it is cumbersome to maintain.
+// referring to commands by name, even though it is cumbersome to maintain.
 // Using backticks means we can get better formatting when auto generating markdown
 // documentation from the command help messages.
 package cmd

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -98,7 +98,7 @@ func TestFetchCommand(t *testing.T) {
 	err = b.ExecCommand("qri log peer_b/test_movies")
 	expectErr := `reference not found`
 	if err == nil {
-		t.Fatal("expected fetch on non-existant log to error")
+		t.Fatal("expected fetch on non-existent log to error")
 	}
 	if expectErr != err.Error() {
 		t.Errorf("error mismatch, expect: %s, got: %s", expectErr, err)

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -82,7 +82,7 @@ https://github.com/qri-io/qri/issues`,
 type QriOptions struct {
 	ioes.IOStreams
 
-	// TODO (b5) - this context should be refactored away, prefering to pass
+	// TODO (b5) - this context should be refactored away, preferring to pass
 	// this stored context object down through function calls
 	ctx       context.Context
 	releasers sync.WaitGroup

--- a/cmd/ref_select.go
+++ b/cmd/ref_select.go
@@ -110,7 +110,7 @@ const (
 
 // GetCurrentRefSelect returns the current reference selection. This could be explicitly provided
 // as command-line arguments, or could be determined by being in a linked directory, or could be
-// selected by the `use` command. This order is also the precendence, from most important to least.
+// selected by the `use` command. This order is also the precedence, from most important to least.
 // This is the recommended method for command-line commands to get references.
 // If an Ensurer is passed in, it is used to ensure that the ref in the .qri-ref linkfile matches
 // what is in the repo.

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -114,7 +114,7 @@ $ qri config set registry.location ""`,
 
 	signup := &cobra.Command{
 		Use:   "signup",
-		Short: "create a registery profile & connect your local keypair",
+		Short: "create a registry profile & connect your local keypair",
 		Long: `Signup creates a profile for you on the configured registry.
 (qri is configred to use qri.cloud as a registry by default.)
 

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -72,7 +72,7 @@ commit message and title to the save.`,
 	cmd.Flags().BoolVar(&o.Force, "force", false, "force a new commit, even if no changes are detected")
 	cmd.Flags().BoolVarP(&o.KeepFormat, "keep-format", "k", false, "convert incoming data to stored data format")
 	// TODO(dlong): --no-render is deprecated, viz are being phased out, in favor of readme.
-	cmd.Flags().BoolVar(&o.NoRender, "no-render", false, "don't store a rendered version of the the vizualization ")
+	cmd.Flags().BoolVar(&o.NoRender, "no-render", false, "don't store a rendered version of the the visualization")
 	cmd.Flags().BoolVarP(&o.NewName, "new", "n", false, "save a new dataset only, using an available name")
 	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "experimental: build and use dscache if none exists")
 	cmd.Flags().StringVar(&o.Drop, "drop", "", "comma-separated list of components to remove")

--- a/cmd/whatchanged.go
+++ b/cmd/whatchanged.go
@@ -16,7 +16,7 @@ func NewWhatChangedCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 		Hidden: true,
 		Short:  "shows what changed at a particular commit",
 		Long: `Shows what changed for components at a particular commit, that is, which
-were added, modified or removed. This is analagous to the status command,
+were added, modified or removed. This is analogous to the status command,
 except only available for dataset versions in history.`,
 		Example: `  # Show what changed for the head commit
   $ qri whatchanged me/dataset_name`,

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -214,8 +214,12 @@ func NewNetworkIntegrationTestRunner(t *testing.T, prefix string) *NetworkIntegr
 }
 
 func (tr *NetworkIntegrationTestRunner) Cleanup() {
-	tr.RegistryHTTPServer.Close()
-	tr.registryRepo.Delete()
+	if tr.RegistryHTTPServer != nil {
+		tr.RegistryHTTPServer.Close()
+	}
+	if tr.registryRepo != nil {
+		tr.registryRepo.Delete()
+	}
 	if tr.nasimRepo != nil {
 		tr.nasimRepo.Delete()
 	}
@@ -230,9 +234,11 @@ func (tr *NetworkIntegrationTestRunner) InitNasim(t *testing.T) *Instance {
 		t.Fatal(err)
 	}
 
-	cfg := r.GetConfig()
-	cfg.Registry.Location = tr.RegistryHTTPServer.URL
-	r.WriteConfigFile()
+	if tr.RegistryHTTPServer != nil {
+		cfg := r.GetConfig()
+		cfg.Registry.Location = tr.RegistryHTTPServer.URL
+		r.WriteConfigFile()
+	}
 	tr.nasimRepo = &r
 
 	if tr.Nasim, err = NewInstance(tr.Ctx, r.QriPath); err != nil {
@@ -248,10 +254,12 @@ func (tr *NetworkIntegrationTestRunner) InitHinshun(t *testing.T) *Instance {
 		t.Fatal(err)
 	}
 
+	if tr.RegistryHTTPServer != nil {
+		cfg := r.GetConfig()
+		cfg.Registry.Location = tr.RegistryHTTPServer.URL
+		r.WriteConfigFile()
+	}
 	tr.hinshunRepo = &r
-	cfg := tr.hinshunRepo.GetConfig()
-	cfg.Registry.Location = tr.RegistryHTTPServer.URL
-	tr.hinshunRepo.WriteConfigFile()
 
 	if tr.Hinshun, err = NewInstance(tr.Ctx, tr.hinshunRepo.QriPath); err != nil {
 		t.Fatal(err)
@@ -266,9 +274,11 @@ func (tr *NetworkIntegrationTestRunner) InitAdnan(t *testing.T) *Instance {
 		t.Fatal(err)
 	}
 
-	cfg := r.GetConfig()
-	cfg.Registry.Location = tr.RegistryHTTPServer.URL
-	r.WriteConfigFile()
+	if tr.RegistryHTTPServer != nil {
+		cfg := r.GetConfig()
+		cfg.Registry.Location = tr.RegistryHTTPServer.URL
+		r.WriteConfigFile()
+	}
 	tr.adnanRepo = &r
 
 	if tr.Adnan, err = NewInstance(tr.Ctx, r.QriPath); err != nil {

--- a/lib/rpc.go
+++ b/lib/rpc.go
@@ -48,7 +48,7 @@ func Receivers(inst *Instance) []Methods {
 	}
 }
 
-// ServeRPC checks for a configured RPC port, and registers a listner if so
+// ServeRPC checks for a configured RPC port, and registers a listener if so
 func (inst *Instance) ServeRPC(ctx context.Context) {
 	cfg := inst.cfg
 	if !cfg.RPC.Enabled || cfg.RPC.Address == "" {

--- a/lib/rpc.go
+++ b/lib/rpc.go
@@ -1,0 +1,85 @@
+package lib
+
+import (
+	"context"
+	"encoding/gob"
+	"encoding/json"
+	"io/ioutil"
+	stdlog "log"
+	"net/rpc"
+
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr-net"
+)
+
+func init() {
+	// We don't use the log package, and the net/rpc package spits out some complaints b/c
+	// a few methods don't conform to the proper signature (comment this out & run 'qri connect' to see errors)
+	// so we're disabling the log package for now. This is potentially very stupid.
+	// TODO (b5): remove dep on net/rpc package entirely
+	stdlog.SetOutput(ioutil.Discard)
+
+	// Fields like dataset.Structure.Schema contain data of arbitrary types,
+	// registering with the gob package prevents errors when sending them
+	// over net/rpc calls.
+	gob.Register(json.RawMessage{})
+	gob.Register([]interface{}{})
+	gob.Register(map[string]interface{}{})
+}
+
+// Receivers returns a slice of CoreRequests that defines the full local
+// API of lib methods
+func Receivers(inst *Instance) []Methods {
+	return []Methods{
+		NewDatasetMethods(inst),
+		NewRegistryClientMethods(inst),
+		NewRemoteMethods(inst),
+		NewLogMethods(inst),
+		NewPeerMethods(inst),
+		NewProfileMethods(inst),
+		NewConfigMethods(inst),
+		NewSearchMethods(inst),
+		NewSQLMethods(inst),
+		NewRenderMethods(inst),
+		NewFSIMethods(inst),
+
+		// TODO (b5) - deprecate ExportRequests
+		NewExportRequests(inst.Node(), nil),
+	}
+}
+
+// ServeRPC checks for a configured RPC port, and registers a listner if so
+func (inst *Instance) ServeRPC(ctx context.Context) {
+	cfg := inst.cfg
+	if !cfg.RPC.Enabled || cfg.RPC.Address == "" {
+		return
+	}
+	maAddress := cfg.RPC.Address
+	addr, err := ma.NewMultiaddr(maAddress)
+	if err != nil {
+		log.Errorf("cannot start RPC: error parsing RPC address %s: %w", maAddress, err.Error())
+	}
+
+	mal, err := manet.Listen(addr)
+	if err != nil {
+		log.Infof("RPC listen on address %d error: %w", cfg.RPC.Address, err)
+		return
+	}
+	listener := manet.NetListener(mal)
+
+	for _, rcvr := range Receivers(inst) {
+		if err := rpc.Register(rcvr); err != nil {
+			log.Errorf("cannot start RPC: error registering RPC receiver %s: %w", rcvr.CoreRequestsName(), err.Error())
+			return
+		}
+	}
+
+	go func() {
+		<-ctx.Done()
+		log.Info("closing RPC")
+		listener.Close()
+	}()
+
+	rpc.Accept(listener)
+	return
+}

--- a/lib/rpc_test.go
+++ b/lib/rpc_test.go
@@ -1,0 +1,50 @@
+package lib
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRPCRequest(t *testing.T) {
+	// TODO (b5) - shouldn't need the network test runner for this. use the
+	// standard test runner once it uses lib.NewInstance instead of
+	// NewInstanceFromConfigAndNode
+	tr := NewNetworkIntegrationTestRunner(t, "rpc")
+	defer tr.Cleanup()
+
+	adnanInst := tr.InitAdnan(t)
+
+	ref := InitWorldBankDataset(t, adnanInst)
+
+	repoLockCtx, closeAdnanInst := context.WithCancel(context.Background())
+	defer closeAdnanInst()
+	go adnanInst.ServeRPC(repoLockCtx)
+
+	rpcCtx, closeAdnanRPC := context.WithCancel(context.Background())
+	defer closeAdnanRPC()
+
+	// another node is connected
+	adnanRPCInst, err := NewInstance(rpcCtx, tr.adnanRepo.QriPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := &GetResult{}
+	err = NewDatasetMethods(adnanInst).Get(&GetParams{
+		Refstr: ref.AliasString(),
+	}, res)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := <-adnanRPCInst.Shutdown(); err != nil {
+		t.Error(err)
+	}
+	if err := <-adnanInst.Shutdown(); err != nil {
+		if !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
CLI commands running over RPC were hanging after completion thanks to the RPC client side
instance never firing on the shutdown channel.

The fix for this was one line: add `go inst.waitForAllDone()` to lib.NewInstance when returning
an RPC-backed instance. All other changes are in service of testing that line.

* Moved the `ServeRPC` method down from the API onto the instance itself, making testing easier
* colocated all the rpc stuff into one file: rpc.go, which should make it easier to refactor
  in the future
* re-worked some of the NetworkIntegrationTestRunner in lib, then realized it was overkill
  for the RPC test.