### PR TITLE
feat(logbook): write push & pull operations, add logbook diagnostic output format

### DIFF
--- a/base/log_test.go
+++ b/base/log_test.go
@@ -92,7 +92,7 @@ func TestDatasetLogForeign(t *testing.T) {
 	ref.Path = "QmExample"
 	foreignBuilder.Commit(ctx, t, initID, "their commit", ref.Path)
 	foreignBook := foreignBuilder.Logbook()
-	foreignLog, err := foreignBook.UserDatasetRef(ctx, ref)
+	foreignLog, err := foreignBook.UserDatasetBranchesLog(ctx, initID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -159,8 +159,8 @@ The logbook command shows entries for a dataset, from newest to oldest.`,
 			}
 			if o.Raw {
 				return o.RawLogs()
-			} else if o.Diagnostic {
-				return o.LogbookDiagnostic()
+			} else if o.Summary {
+				return o.LogbookSummary()
 			}
 			return o.Logbook()
 		},
@@ -169,7 +169,7 @@ The logbook command shows entries for a dataset, from newest to oldest.`,
 	cmd.Flags().IntVar(&o.PageSize, "page-size", 25, "page size of results, default 25")
 	cmd.Flags().IntVar(&o.Page, "page", 1, "page number of results, default 1")
 	cmd.Flags().BoolVar(&o.Raw, "raw", false, "full logbook in raw JSON format. overrides all other flags")
-	cmd.Flags().BoolVar(&o.Diagnostic, "diagnostic", false, "print one oplog per line in the format 'MODEL ID OPCOUNT NAME'overrides all other flags")
+	cmd.Flags().BoolVar(&o.Summary, "summary", false, "print one oplog per line in the format 'MODEL ID OPCOUNT NAME'. overrides all other flags")
 
 	return cmd
 }
@@ -178,21 +178,21 @@ The logbook command shows entries for a dataset, from newest to oldest.`,
 type LogbookOptions struct {
 	ioes.IOStreams
 
-	PageSize        int
-	Page            int
-	Refs            *RefSelect
-	Raw, Diagnostic bool
+	PageSize     int
+	Page         int
+	Refs         *RefSelect
+	Raw, Summary bool
 
 	LogMethods *lib.LogMethods
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *LogbookOptions) Complete(f Factory, args []string) (err error) {
-	if o.Raw && o.Diagnostic {
-		return fmt.Errorf("cannot use diagnostic & raw flags at once")
+	if o.Raw && o.Summary {
+		return fmt.Errorf("cannot use summary & raw flags at once")
 	}
 
-	if o.Raw || o.Diagnostic {
+	if o.Raw || o.Summary {
 		if len(args) != 0 {
 			return fmt.Errorf("can't use dataset reference. the raw flag shows the entire logbook")
 		}
@@ -255,10 +255,10 @@ func (o *LogbookOptions) RawLogs() error {
 	return nil
 }
 
-// LogbookDiagnostic prints a logbook overview
-func (o *LogbookOptions) LogbookDiagnostic() error {
+// LogbookSummary prints a logbook overview
+func (o *LogbookOptions) LogbookSummary() error {
 	var res string
-	if err := o.LogMethods.LogbookDiagnostic(&struct{}{}, &res); err != nil {
+	if err := o.LogMethods.LogbookSummary(&struct{}{}, &res); err != nil {
 		return err
 	}
 

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -67,7 +67,6 @@ commit message and title to the save.`,
 	cmd.Flags().StringVarP(&o.Recall, "recall", "", "", "restore revisions from dataset history")
 	// cmd.Flags().BoolVarP(&o.ShowValidation, "show-validation", "s", false, "display a list of validation errors upon adding")
 	cmd.Flags().StringSliceVar(&o.Secrets, "secrets", nil, "transform secrets as comma separated key,value,key,value,... sequence")
-	cmd.Flags().BoolVarP(&o.Publish, "publish", "p", false, "publish this dataset to the registry")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "simulate saving a dataset")
 	cmd.Flags().BoolVar(&o.Force, "force", false, "force a new commit, even if no changes are detected")
 	cmd.Flags().BoolVarP(&o.KeepFormat, "keep-format", "k", false, "convert incoming data to stored data format")
@@ -95,7 +94,6 @@ type SaveOptions struct {
 
 	Replace        bool
 	ShowValidation bool
-	Publish        bool
 	DryRun         bool
 	KeepFormat     bool
 	Force          bool
@@ -158,7 +156,6 @@ func (o *SaveOptions) Run() (err error) {
 		ScriptOutput:        o.ErrOut,
 		FilePaths:           o.FilePaths,
 		Private:             false,
-		Publish:             o.Publish,
 		DryRun:              o.DryRun,
 		Recall:              o.Recall,
 		Drop:                o.Drop,

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -126,22 +126,21 @@ func TestSaveRun(t *testing.T) {
 		bodypath    string
 		title       string
 		message     string
-		publish     bool
 		dryrun      bool
 		noRender    bool
 		expect      string
 		err         string
 		msg         string
 	}{
-		{"no data", "me/bad_dataset", "", "", "", "", false, false, true, "", "no changes to save", ""},
-		{"bad dataset file", "me/cities", "bad/filpath.json", "", "", "", false, false, true, "", "open bad/filpath.json: no such file or directory", ""},
-		{"bad body file", "me/cities", "", "bad/bodypath.csv", "", "", false, false, true, "", "opening dataset.bodyPath 'bad/bodypath.csv': path not found", ""},
-		{"good inputs, dryrun", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_ten.csv", "", "", false, true, true, "dataset saved: peer/movies\n", "", ""},
-		{"good inputs", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_ten.csv", "", "", true, false, true, "dataset saved: peer/movies@/map/QmVDSrf4BpupXYmDJc6eXanFVW9DS6g3Pfkkx6YqkcUjEQ\nthis dataset has 1 validation errors\n", "", ""},
-		{"add rows, dry run", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "Added 10 more rows", "Adding to the number of rows in dataset", false, true, true, "dataset saved: peer/movies\n", "", ""},
-		{"add rows, save", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "Added 10 more rows", "Adding to the number of rows in dataset", true, false, true, "dataset saved: peer/movies@/map/QmZof1Gc95VFxaAXBq28pTYLe4nQ3TMi4ceBL7ExDkXyyj\nthis dataset has 1 validation errors\n", "", ""},
-		{"no changes", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "trying to add again", "hopefully this errors", false, false, true, "", "error saving: no changes", ""},
-		{"add viz", "me/movies", "testdata/movies/dataset_with_viz.json", "", "", "", false, false, false, "dataset saved: peer/movies@/map/QmXDJLrEePbBGro5m9K9edszqN89XMePrampGhBq7QkyoF\nthis dataset has 1 validation errors\n", "", ""},
+		{"no data", "me/bad_dataset", "", "", "", "", false, true, "", "no changes to save", ""},
+		{"bad dataset file", "me/cities", "bad/filpath.json", "", "", "", false, true, "", "open bad/filpath.json: no such file or directory", ""},
+		{"bad body file", "me/cities", "", "bad/bodypath.csv", "", "", false, true, "", "opening dataset.bodyPath 'bad/bodypath.csv': path not found", ""},
+		{"good inputs, dryrun", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_ten.csv", "", "", true, true, "dataset saved: peer/movies\n", "", ""},
+		{"good inputs", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_ten.csv", "", "", false, true, "dataset saved: peer/movies@/map/QmVDSrf4BpupXYmDJc6eXanFVW9DS6g3Pfkkx6YqkcUjEQ\nthis dataset has 1 validation errors\n", "", ""},
+		{"add rows, dry run", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "Added 10 more rows", "Adding to the number of rows in dataset", true, true, "dataset saved: peer/movies\n", "", ""},
+		{"add rows, save", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "Added 10 more rows", "Adding to the number of rows in dataset", false, true, "dataset saved: peer/movies@/map/QmZof1Gc95VFxaAXBq28pTYLe4nQ3TMi4ceBL7ExDkXyyj\nthis dataset has 1 validation errors\n", "", ""},
+		{"no changes", "me/movies", "testdata/movies/dataset.json", "testdata/movies/body_twenty.csv", "trying to add again", "hopefully this errors", false, true, "", "error saving: no changes", ""},
+		{"add viz", "me/movies", "testdata/movies/dataset_with_viz.json", "", "", "", false, false, "dataset saved: peer/movies@/map/QmXDJLrEePbBGro5m9K9edszqN89XMePrampGhBq7QkyoF\nthis dataset has 1 validation errors\n", "", ""},
 	}
 
 	for _, c := range cases {
@@ -164,7 +163,6 @@ func TestSaveRun(t *testing.T) {
 			BodyPath:       c.bodypath,
 			Title:          c.title,
 			Message:        c.message,
-			Publish:        c.publish,
 			DryRun:         c.dryrun,
 			NoRender:       c.noRender,
 			DatasetMethods: dsm,

--- a/dsref/spec/resolve.go
+++ b/dsref/spec/resolve.go
@@ -208,9 +208,7 @@ func GenerateExampleOplog(ctx context.Context, journal *logbook.Book, dsname, he
 		return "", nil, err
 	}
 
-	// TODO (b5) - we need UserDatasetRef here b/c it returns the full hierarchy
-	// of oplogs. This method should take an InitID
-	lg, err := journal.UserDatasetRef(ctx, dsref.Ref{Username: username, Name: dsname})
+	lg, err := journal.UserDatasetBranchesLog(ctx, initID)
 	if err != nil {
 		return "", nil, err
 	}

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -434,8 +434,6 @@ type SaveParams struct {
 	// option to make dataset private. private data is not currently implimented,
 	// see https://github.com/qri-io/qri/issues/291 for updates
 	Private bool
-	// if true, set saved dataset to published
-	Publish bool
 	// run without saving, returning results
 	DryRun bool
 	// if true, res.Dataset.Body will be a fs.file of the body
@@ -721,23 +719,6 @@ func (m *DatasetMethods) Save(p *SaveParams, res *reporef.DatasetRef) error {
 
 	if p.ReturnBody {
 		if err = base.InlineJSONBody(datasetRef.Dataset); err != nil {
-			return err
-		}
-	}
-
-	if p.Publish {
-		if p.DryRun {
-			return fmt.Errorf("can't use publish & dry-run together")
-		}
-		var publishedRef reporef.DatasetRef
-		err = m.SetPublishStatus(&SetPublishStatusParams{
-			Ref:           datasetRef.String(),
-			PublishStatus: true,
-			// UpdateRegistry:    true,
-			// UpdateRegistryPin: true,
-		}, &publishedRef)
-
-		if err != nil {
 			return err
 		}
 	}

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -132,6 +132,17 @@ func TestReferencePulling(t *testing.T) {
 	ref := InitWorldBankDataset(t, nasim)
 	PublishToRegistry(t, nasim, ref.AliasString())
 
+	// - nasim's local repo should reflect publication
+	logRes := []DatasetLogItem{}
+	err := NewLogMethods(nasim).Log(&LogParams{Ref: ref.AliasString(), ListParams: ListParams{Limit: 1}}, &logRes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if logRes[0].Published != true {
+		t.Errorf("nasim has published HEAD. ref[0] published is false")
+	}
+
 	hinshun := tr.InitHinshun(t)
 	sqlm := NewSQLMethods(hinshun)
 
@@ -162,7 +173,7 @@ func TestReferencePulling(t *testing.T) {
 	dsm := NewDatasetMethods(adnan)
 
 	// run a transform script that relies on world_bank_population, which adnan's
-	// node should automatically pull to execute thisscript
+	// node should automatically pull to execute this script
 	tfScriptData := `
 wbp = load_dataset("nasim/world_bank_population")
 
@@ -184,6 +195,17 @@ def transform(ds, ctx):
 	res := &reporef.DatasetRef{}
 	if err := dsm.Save(saveParams, res); err != nil {
 		t.Fatal(err)
+	}
+
+	// - adnan's local repo should reflect nasim's publication
+	logRes = []DatasetLogItem{}
+	err = NewLogMethods(adnan).Log(&LogParams{Ref: ref.AliasString(), ListParams: ListParams{Limit: 1}}, &logRes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if logRes[0].Published != true {
+		t.Errorf("adnan's log expects head was published, ref[0] published is false")
 	}
 }
 

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -376,8 +376,7 @@ func AssertLogsEqual(a, b *Instance, ref *reporef.DatasetRef) error {
 func InitWorldBankDataset(t *testing.T, inst *Instance) *reporef.DatasetRef {
 	res := &reporef.DatasetRef{}
 	err := NewDatasetMethods(inst).Save(&SaveParams{
-		Publish: true,
-		Ref:     "me/world_bank_population",
+		Ref: "me/world_bank_population",
 		Dataset: &dataset.Dataset{
 			Meta: &dataset.Meta{
 				Title: "World Bank Population",
@@ -402,8 +401,7 @@ d,e,f,false,3`),
 func Commit2WorldBank(t *testing.T, inst *Instance) *reporef.DatasetRef {
 	res := &reporef.DatasetRef{}
 	err := NewDatasetMethods(inst).Save(&SaveParams{
-		Publish: true,
-		Ref:     "me/world_bank_population",
+		Ref: "me/world_bank_population",
 		Dataset: &dataset.Dataset{
 			Meta: &dataset.Meta{
 				Title: "World Bank Population",

--- a/lib/log.go
+++ b/lib/log.go
@@ -168,12 +168,12 @@ func (m *LogMethods) PlainLogs(p *PlainLogsParams, res *PlainLogs) (err error) {
 	return err
 }
 
-// LogbookDiagnostic returns a string overview of
-func (m *LogMethods) LogbookDiagnostic(p *struct{}, res *string) (err error) {
+// LogbookSummary returns a string overview of the logbook
+func (m *LogMethods) LogbookSummary(p *struct{}, res *string) (err error) {
 	if m.inst.rpc != nil {
 		return checkRPCError(m.inst.rpc.Call("LogMethods.Diagnostic", p, res))
 	}
 	ctx := context.TODO()
-	*res = m.inst.repo.Logbook().DiagnosticString(ctx)
+	*res = m.inst.repo.Logbook().SummaryString(ctx)
 	return nil
 }

--- a/lib/log.go
+++ b/lib/log.go
@@ -114,10 +114,6 @@ func (m *LogMethods) Log(params *LogParams, res *[]DatasetLogItem) error {
 		}
 	}
 
-	// TODO (b5) - store logs on pull
-	// if params.Pull {
-	// }
-
 	*res = items
 	return nil
 }
@@ -163,12 +159,21 @@ type PlainLogsParams struct {
 type PlainLogs = []logbook.PlainLog
 
 // PlainLogs encodes the full logbook as human-oriented json
-func (m *LogMethods) PlainLogs(p *PlainLogsParams, res *PlainLogs) error {
-	var err error
+func (m *LogMethods) PlainLogs(p *PlainLogsParams, res *PlainLogs) (err error) {
 	if m.inst.rpc != nil {
 		return checkRPCError(m.inst.rpc.Call("LogMethods.PlainLogs", p, res))
 	}
 	ctx := context.TODO()
 	*res, err = m.inst.repo.Logbook().PlainLogs(ctx)
 	return err
+}
+
+// LogbookDiagnostic returns a string overview of
+func (m *LogMethods) LogbookDiagnostic(p *struct{}, res *string) (err error) {
+	if m.inst.rpc != nil {
+		return checkRPCError(m.inst.rpc.Call("LogMethods.Diagnostic", p, res))
+	}
+	ctx := context.TODO()
+	*res = m.inst.repo.Logbook().DiagnosticString(ctx)
+	return nil
 }

--- a/lib/remote.go
+++ b/lib/remote.go
@@ -75,12 +75,12 @@ func (r *RemoteMethods) Publish(p *PublicationParams, res *dsref.Ref) error {
 	pro, _ := r.inst.Repo().Profile()
 	ref.ProfileID = pro.ID.String()
 
-	rref := reporef.RefFromDsref(ref)
-	if err = r.inst.RemoteClient().PushDataset(ctx, rref, addr); err != nil {
+	datasetRef := reporef.RefFromDsref(ref)
+	if err = r.inst.RemoteClient().PushDataset(ctx, datasetRef, addr); err != nil {
 		return err
 	}
-	rref.Published = true
-	if err = base.SetPublishStatus(r.inst.node.Repo, &rref, true); err != nil {
+	datasetRef.Published = true
+	if err = base.SetPublishStatus(r.inst.node.Repo, &datasetRef, datasetRef.Published); err != nil {
 		return err
 	}
 

--- a/lib/remote.go
+++ b/lib/remote.go
@@ -45,14 +45,18 @@ func (r *RemoteMethods) Publish(p *PublicationParams, res *dsref.Ref) error {
 		return checkRPCError(r.inst.rpc.Call("RemoteMethods.Publish", p, res))
 	}
 
-	ref, err := repo.ParseDatasetRef(p.Ref)
+	// TODO (b5) - need contexts yo
+	ctx := context.TODO()
+
+	ref, err := dsref.Parse(p.Ref)
 	if err != nil {
 		return err
 	}
 	if ref.Path != "" {
 		return fmt.Errorf("can only publish entire dataset, cannot use version %s", ref.Path)
 	}
-	if err = repo.CanonicalizeDatasetRef(r.inst.Repo(), &ref); err != nil {
+
+	if _, err := r.inst.ResolveReference(ctx, &ref, "local"); err != nil {
 		return err
 	}
 
@@ -61,27 +65,26 @@ func (r *RemoteMethods) Publish(p *PublicationParams, res *dsref.Ref) error {
 		return err
 	}
 
-	// TODO (b5) - need contexts yo
-	ctx := context.TODO()
-
-	// TODO (b5) - we're early in log syncronization days. This is going to fail a bunch
-	// while we work to upgrade the stack. Long term we may want to consider a mechanism
-	// for allowing partial completion where only one of logs or dataset pushing works
-	// by doing both in parallel and reporting issues on both
-	if pushLogsErr := r.inst.RemoteClient().PushLogs(ctx, reporef.ConvertToDsref(ref), addr); pushLogsErr != nil {
-		log.Errorf("pushing logs: %s", pushLogsErr)
-	}
-
-	if err = r.inst.RemoteClient().PushDataset(ctx, ref, addr); err != nil {
+	if err = r.inst.RemoteClient().PushLogs(ctx, ref, addr); err != nil {
 		return err
 	}
 
-	ref.Published = true
-	if err = base.SetPublishStatus(r.inst.node.Repo, &ref, ref.Published); err != nil {
+	// TODO (b5) - another example of where reference resolution needs to set
+	// the profileID, and isn't. the conversion to a reporef & dataset push will
+	// fail if profileID isn't specified
+	pro, _ := r.inst.Repo().Profile()
+	ref.ProfileID = pro.ID.String()
+
+	rref := reporef.RefFromDsref(ref)
+	if err = r.inst.RemoteClient().PushDataset(ctx, rref, addr); err != nil {
+		return err
+	}
+	rref.Published = true
+	if err = base.SetPublishStatus(r.inst.node.Repo, &rref, true); err != nil {
 		return err
 	}
 
-	*res = reporef.ConvertToDsref(ref)
+	*res = ref
 	return nil
 }
 

--- a/logbook/logbook_test.go
+++ b/logbook/logbook_test.go
@@ -473,13 +473,16 @@ func TestPushModel(t *testing.T) {
 		t.Errorf("expected branch log to have 3 operations. got: %d", len(lg.Logs[0].Logs[0].Ops))
 	}
 
-	t.Log(tr.Book.DiagnosticString(ctx) + "\n\n")
+	t.Log(tr.Book.SummaryString(ctx) + "\n\n")
 
 	if err = rollback(ctx); err != nil {
 		t.Errorf("rollback error: %q", err)
 	}
+	if err = rollback(ctx); err != nil {
+		t.Errorf("rollback error: %q", err)
+	}
 
-	t.Log(tr.Book.DiagnosticString(ctx))
+	t.Log(tr.Book.SummaryString(ctx))
 
 	lg, err = tr.Book.UserDatasetBranchesLog(ctx, initID)
 	if err != nil {
@@ -514,7 +517,7 @@ func TestPushModel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(lg.Logs[0].Logs[0].Ops) != 2 {
+	if len(lg.Logs[0].Logs[0].Ops) != 3 {
 		t.Errorf("expected branch log to have 3 operations after writing push & delete push. got: %d", len(lg.Logs[0].Logs[0].Ops))
 	}
 

--- a/logbook/logsync/http.go
+++ b/logbook/logsync/http.go
@@ -26,7 +26,10 @@ type httpClient struct {
 // httpClient exists to satisfy the Remote interface on the client side
 var _ remote = (*httpClient)(nil)
 
-// Put
+func (c *httpClient) addr() string {
+	return c.URL
+}
+
 func (c *httpClient) put(ctx context.Context, author identity.Author, r io.Reader) error {
 	req, err := http.NewRequest("PUT", c.URL, r)
 	if err != nil {

--- a/logbook/logsync/logsync_test.go
+++ b/logbook/logsync/logsync_test.go
@@ -445,6 +445,7 @@ func writeNasdaqLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, er
 	return dsref.Ref{
 		Username: book.AuthorName(),
 		Name:     name,
+		InitID:   initID,
 	}, nil
 }
 
@@ -487,6 +488,7 @@ func writeWorldBankLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref,
 	return dsref.Ref{
 		Username: book.AuthorName(),
 		Name:     name,
+		InitID:   initID,
 	}, nil
 }
 

--- a/logbook/logsync/p2p.go
+++ b/logbook/logsync/p2p.go
@@ -46,6 +46,10 @@ type p2pClient struct {
 // assert at compile time that p2pClient implements DagSyncable
 var _ remote = (*p2pClient)(nil)
 
+func (c *p2pClient) addr() string {
+	return c.remotePeerID.Pretty()
+}
+
 func (c *p2pClient) put(ctx context.Context, author identity.Author, r io.Reader) (err error) {
 	data, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/logbook/types.go
+++ b/logbook/types.go
@@ -76,7 +76,7 @@ func newBranchLog(l *oplog.Log) *BranchLog {
 
 // Append adds an op to the BranchLog
 func (blog *BranchLog) Append(op oplog.Op) {
-	if op.Model != BranchModel && op.Model != CommitModel && op.Model != PublicationModel {
+	if op.Model != BranchModel && op.Model != CommitModel && op.Model != PushModel {
 		log.Errorf("cannot Append, incorrect model %d for BranchLog", op.Model)
 		return
 	}

--- a/remote/mock_client.go
+++ b/remote/mock_client.go
@@ -73,7 +73,7 @@ func (c *MockClient) CloneLogs(ctx context.Context, ref dsref.Ref, remoteAddr st
 	ref.Path = "QmExample"
 	foreignBuilder.Commit(ctx, nil, initID, "their commit", ref.Path)
 	foreignBook := foreignBuilder.Logbook()
-	foreignLog, err := foreignBook.UserDatasetRef(ctx, ref)
+	foreignLog, err := foreignBook.UserDatasetBranchesLog(ctx, initID)
 	if err != nil {
 		panic(err)
 	}

--- a/remote/peer_sync_client_test.go
+++ b/remote/peer_sync_client_test.go
@@ -47,7 +47,8 @@ func TestAddDataset(t *testing.T) {
 		t.Error("expected add of invalid ref to error")
 	}
 
-	if err := cli.AddDataset(tr.Ctx, &worldBankRef, ""); err != nil {
+	wbpRef := reporef.RefFromDsref(worldBankRef)
+	if err := cli.AddDataset(tr.Ctx, &wbpRef, ""); err != nil {
 		t.Error(err.Error())
 	}
 }
@@ -72,7 +73,8 @@ func TestClientFeedsAndPreviews(t *testing.T) {
 	defer cleanup()
 
 	worldBankRef := writeWorldBankPopulation(tr.Ctx, t, tr.NodeA.Repo)
-	publishRef(t, tr.NodeA.Repo, &worldBankRef)
+	wbp := reporef.RefFromDsref(worldBankRef)
+	setRefPublished(t, tr.NodeA.Repo, &wbp)
 
 	rem := tr.NodeARemote(t)
 	server := tr.RemoteTestServer(rem)
@@ -103,7 +105,7 @@ func TestClientFeedsAndPreviews(t *testing.T) {
 		t.Errorf("feeds result mismatch (-want +got): \n%s", diff)
 	}
 
-	ds, err := cli.Preview(tr.Ctx, reporef.ConvertToDsref(worldBankRef), server.URL)
+	ds, err := cli.Preview(tr.Ctx, worldBankRef, server.URL)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Prior to this commit we were _not_ recording push & delete operations in logbook. As per [RFC0030](https://github.com/qri-io/rfcs/blob/master/text/0030-replace_publish_clone_with_push_pull.md) we're now recording pushes of specific versions to a given remote within the oplog.

To do this, we make an optimistic write _before_ pushing or deleteing logs that adds an operation assuming it's successful. This way the receiver of the log gets the most up-to-date log that is signed with the operation included. If the push or delete operation fails, we roll back the log, removing the operation.

This approach tolerates faults better. the result of having an extra push / delete operation is less problematic than having a log that is short by one operation on a remote.

With this in place, logbook can now accurately report which versions of a dataset have been published, and has a running record of _where_ those versions have been published.

This PR also adapts a few more logbook functions to work with initIDs instead of references.

I've also added a "Diagnostic" method that's turned out to be very useful for quickly understanding the contents of a logbook by printing `MODEL ID OPCOUNT NAME` in an indented hierarchy. This was valuable enough to merit adding to the logbook command as a flag. Sample output:

```
user icm3gkoaoqn4vpcgzx7rmqsupcdcuec7fgqdq5z4kinvjprshqqq 2 nyc-transit-data
  dataset s3cql3s7fbay7abohm3qqdas7cm4ymu47jplqog5hxos5ytgaywa 2 turnstile_daily_counts_2020
    branch 2bz6mglcqlxa72nb3b7hnz4akrn6swi6iaredvzbgiwf5lp7fg5q 12 main
  dataset w5nl6h7fgwvu6gtfuxjo7fx4lwnerl7uuqycmu2ydrvdx4n76c7a 3 turnstile_daily_counts_2019
    branch 3ave4lm42mym2iuzyazv5b3ackdpvmtredcy4gdgbdsf3ulqxxoq 4 main
  dataset zngx523lbvukv4vebomvpzwsccvab5nuxf5c6h3svjdakpblotea 5 turnstiles_station_list
    branch vyznxsyekkjcfwfpor2svc7v5if2ec7bfq2p5u65xr3xkvnuhqoq 3 main
```