### PR TITLE
fix(sql): properly handle dashes in dataset names

### DIFF
--- a/sql/preprocess/preprocess.go
+++ b/sql/preprocess/preprocess.go
@@ -192,7 +192,8 @@ func (p *processor) processTableRef(text string) error {
 
 func toLegalName(refStr string) string {
 	refStr = strings.Replace(refStr, "@", "_at_", 1)
-	return strings.Replace(refStr, "/", "_", -1)
+	refStr = strings.ReplaceAll(refStr, "/", "_")
+	return strings.ReplaceAll(refStr, "-", "_")
 }
 
 // scan reads one token from the input stream

--- a/sql/preprocess/preprocess_test.go
+++ b/sql/preprocess/preprocess_test.go
@@ -56,6 +56,14 @@ func TestPrepropcess(t *testing.T) {
 		},
 
 		{
+			"SELECT * FROM nyc-transit-data/turnstile_daily_counts_2019 t LIMIT 10",
+			"SELECT * FROM nyc_transit_data_turnstile_daily_counts_2019 t LIMIT 10",
+			map[string]string{
+				"nyc_transit_data_turnstile_daily_counts_2019": "nyc-transit-data/turnstile_daily_counts_2019",
+			},
+		},
+
+		{
 			"SELECT (SELECT 1)",
 			"SELECT (SELECT 1)",
 			map[string]string{},


### PR DESCRIPTION
we have legacy users that include dashes, need to support sql'ing 'em.

closes #1388