### PR TITLE
feat(lib): `OptNoBootstrap` option func for `NewInstance`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/qri-io/doggos v0.1.0
 	github.com/qri-io/ioes v0.1.1
 	github.com/qri-io/jsonschema v0.2.0
-	github.com/qri-io/qfs v0.5.0
+	github.com/qri-io/qfs v0.5.1-0.20200708234218-75277f16442d
 	github.com/qri-io/starlib v0.4.2
 	github.com/russross/blackfriday/v2 v2.0.2-0.20190629151518-3e56bb68c887
 	github.com/sergi/go-diff v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1023,6 +1023,10 @@ github.com/qri-io/jsonschema v0.2.0/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANP
 github.com/qri-io/qfs v0.1.1-0.20200623175200-23690284798a/go.mod h1:NP4Va1b0/V4nbyPdX3FmZ4cJTPatn0d5FZF5GBxcIJA=
 github.com/qri-io/qfs v0.5.0 h1:B6nhA9ndyttTsemo7NikigE9GcbUFZQ+oKfMqj4+Qdw=
 github.com/qri-io/qfs v0.5.0/go.mod h1:NP4Va1b0/V4nbyPdX3FmZ4cJTPatn0d5FZF5GBxcIJA=
+github.com/qri-io/qfs v0.5.1-0.20200708232839-f1aed6213e23 h1:xD8AHaeG/qhPMNDZg79ubginswpPsAIAVXlB9mVKyk0=
+github.com/qri-io/qfs v0.5.1-0.20200708232839-f1aed6213e23/go.mod h1:NP4Va1b0/V4nbyPdX3FmZ4cJTPatn0d5FZF5GBxcIJA=
+github.com/qri-io/qfs v0.5.1-0.20200708234218-75277f16442d h1:HSYcZU/rEjB83fzSzE1etcCgpwEkwjVb2zbUGSxi11o=
+github.com/qri-io/qfs v0.5.1-0.20200708234218-75277f16442d/go.mod h1:NP4Va1b0/V4nbyPdX3FmZ4cJTPatn0d5FZF5GBxcIJA=
 github.com/qri-io/starlib v0.4.2 h1:ZGzmzT9fOqdluezcwhAZAbTn/v6kMg1tC6ALVjQPhpQ=
 github.com/qri-io/starlib v0.4.2/go.mod h1:2xlZ9r2UV4LF4G9mpYPBWo7CtXtdW0h1RoGIkZ8elOE=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -21,6 +21,7 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qfs/muxfs"
+	"github.com/qri-io/qfs/qipfs"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/config/migrate"
 	"github.com/qri-io/qri/dscache"
@@ -174,6 +175,22 @@ func OptCheckConfigMigrations(interactive bool) Option {
 			return err
 		}
 
+		return nil
+	}
+}
+
+// OptNoBootstrap ensures the node will not attempt to bootstrap to any other nodes
+// in the network
+func OptNoBootstrap() Option {
+	return func(o *InstanceOptions) error {
+		// ensure qri p2p bootstrap addresses are empty
+		o.Cfg.P2P.BootstrapAddrs = []string{}
+		// if we have a qipfs config, pass the `disableBootstrap` flag
+		for _, qfsCfg := range o.Cfg.Filesystems {
+			if qfsCfg.Type == qipfs.FilestoreType {
+				qfsCfg.Config["disableBootstrap"] = true
+			}
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
Using this option will disable bootstrapping to any qri or ipfs nodes

This has been confirmed to work via testground

depends on qri-io/qfs#42
closes #1434 