### PR TITLE
fix(docker): qri must be built from go 1.14 or higher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.7
+FROM golang:1.14.6
 LABEL maintainer="sparkle_pony_2000@qri.io"
 
 ADD . /go/src/github.com/qri-io/qri


### PR DESCRIPTION
this'll fix breaking builds over at the docker auto-build: https://hub.docker.com/repository/docker/qriio/qri-auto