### PR TITLE
chore(logging): add debug logging along save path

### DIFF
--- a/base/dataset_prepare.go
+++ b/base/dataset_prepare.go
@@ -35,6 +35,7 @@ func PrepareSaveRef(
 	bodyPathNameHint string,
 	wantNewName bool,
 ) (dsref.Ref, bool, error) {
+	log.Debugf("PrepareSaveRef refStr=%q bodyPathNameHint=%q wantNewName=%t", refStr, bodyPathNameHint, wantNewName)
 
 	var badCaseErr error
 
@@ -97,6 +98,7 @@ func PrepareSaveRef(
 		}
 
 		// we have a valid previous reference & an initID, return!
+		log.Debugf("PrepareSaveRef found previous initID=%q", ref.InitID)
 		return ref, false, nil
 	}
 
@@ -110,6 +112,7 @@ func PrepareSaveRef(
 	}
 
 	ref.InitID, err = book.WriteDatasetInit(ctx, ref.Name)
+	log.Debugf("PrepareSaveRef created new initID=%q ref.Username=%q ref.Name=%q", ref.InitID, ref.Username, ref.Name)
 	return ref, true, err
 }
 
@@ -189,7 +192,7 @@ func InferValues(pro *profile.Profile, ds *dataset.Dataset) error {
 func ValidateDataset(ds *dataset.Dataset) (err error) {
 	// Ensure that dataset structure is valid
 	if err = validate.Dataset(ds); err != nil {
-		log.Debug(err.Error())
+		log.Debugf("ValidateDataset error=%q", err.Error())
 		err = fmt.Errorf("invalid dataset: %s", err.Error())
 		return
 	}

--- a/base/friendly/friendly.go
+++ b/base/friendly/friendly.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	logger "github.com/ipfs/go-log"
+	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/deepdiff"
 )
 
-var log = logger.Logger("friendly")
+var log = golog.Logger("friendly")
 
 const smallNumberOfChangesToBody = 3
 
@@ -23,6 +23,7 @@ type ComponentChanges struct {
 // DiffDescriptions creates a friendly message from diff operations. If there's no differences
 // found, return empty strings.
 func DiffDescriptions(headDeltas, bodyDeltas []*deepdiff.Delta, bodyStats *deepdiff.Stats, assumeBodyChanged bool) (string, string) {
+	log.Debugf("DiffDescriptions len(headDeltas)=%d len(bodyDeltas)=%d bodyStats=%v assumeBodyChanged=%t", len(headDeltas), len(bodyDeltas), bodyStats, assumeBodyChanged)
 	if len(headDeltas) == 0 && len(bodyDeltas) == 0 {
 		return "", ""
 	}
@@ -41,6 +42,7 @@ func DiffDescriptions(headDeltas, bodyDeltas []*deepdiff.Delta, bodyStats *deepd
 	componentsToCheck := []string{"meta", "structure", "readme", "viz", "transform", "body"}
 	for _, compName := range componentsToCheck {
 		if changes, ok := perComponentChanges[compName]; ok {
+			log.Debugf("checking component named=%q", compName)
 			changedComponents = append(changedComponents, compName)
 
 			// Decide heuristically which type of message to use for this component

--- a/base/revisions.go
+++ b/base/revisions.go
@@ -127,6 +127,7 @@ func Drop(ds *dataset.Dataset, revStr string) error {
 	if revStr == "" {
 		return nil
 	}
+	log.Debugf("Drop revStr=%q", revStr)
 
 	revs, err := dsref.ParseRevs(revStr)
 	if err != nil {

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -372,7 +372,7 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 	// if logAll is enabled, turn on debug level logging for all qri packages. Packages need to
 	// be explicitly enumerated here
 	if o.logAll {
-		allPackages := []string{"qriapi", "qrip2p", "base", "cmd", "config", "dsref", "fsi", "lib", "logbook", "repo"}
+		allPackages := []string{"qriapi", "qrip2p", "base", "cmd", "config", "dsref", "dsfs", "friendly", "fsi", "lib", "logbook", "repo"}
 		for _, name := range allPackages {
 			golog.SetLogLevel(name, "debug")
 		}


### PR DESCRIPTION
this makes qri save --log-all actually do something useful. I think this is also a better general pattern for logging. Lots of debug statements. Maybe we should change --log-all to --verbose?

I'm again going to do a self-review b/c it's the weekend & we're trying to ship things