### PR TITLE
feat(oplog): extension interface for sparse-parent logs

### DIFF
--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -929,10 +929,10 @@ func (m *DatasetMethods) Pull(p *PullParams, res *dataset.Dataset) error {
 	if err := qfs.AbsPath(&p.LinkDir); err != nil {
 		return err
 	}
-
 	if m.inst.rpc != nil {
 		return checkRPCError(m.inst.rpc.Call("DatasetMethods.Pull", p, res))
 	}
+
 	ctx := context.TODO()
 
 	ref, source, err := m.inst.ParseAndResolveRef(ctx, p.Ref, "network")

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -684,6 +684,7 @@ type Instance struct {
 // Connect takes an instance online
 func (inst *Instance) Connect(ctx context.Context) (err error) {
 	oldRemoteClientExisted := inst.remoteClient != nil
+	log.Debugf("inst.Connect oldRemoteClientExisted=%t", oldRemoteClientExisted)
 
 	if err = inst.node.GoOnline(ctx); err != nil {
 		log.Debugf("taking node online: %s", err.Error())
@@ -696,7 +697,7 @@ func (inst *Instance) Connect(ctx context.Context) (err error) {
 	// the additions. We fix that by re-initializing the client and remote with the new
 	// instance
 	if inst.remoteClient, err = remote.NewClient(ctx, inst.node, inst.bus); err != nil {
-		log.Debugf("initializing remote client: %s", err.Error())
+		log.Debugf("remote.NewClient error=%q", err)
 		return
 	}
 	go func() {
@@ -716,11 +717,11 @@ func (inst *Instance) Connect(ctx context.Context) (err error) {
 			return err
 		}
 		if inst.remote, err = remote.NewRemote(inst.node, inst.cfg.Remote, localResolver, inst.remoteOptsFunc); err != nil {
-			log.Errorf("error initializing remote: %s", err.Error())
+			log.Debugf("remote.NewRemote error=%q", err)
 			return err
 		}
 		if err = inst.remote.GoOnline(ctx); err != nil {
-			log.Errorf("error starting dsync services: %s", err.Error())
+			log.Debugf("remote.GoOnline error=%q", err)
 			return err
 		}
 	}

--- a/lib/resolve.go
+++ b/lib/resolve.go
@@ -11,6 +11,7 @@ import (
 
 // ParseAndResolveRef combines reference parsing and resolution
 func (inst *Instance) ParseAndResolveRef(ctx context.Context, refStr, source string) (dsref.Ref, string, error) {
+	log.Debugf("inst.ParseAndResolveRef refStr=%q source=%q", refStr, source)
 	ref, err := dsref.Parse(refStr)
 	if err != nil {
 		return ref, "", fmt.Errorf("%q is not a valid dataset reference: %w", refStr, err)
@@ -48,6 +49,7 @@ func (inst *Instance) ParseAndResolveRefWithWorkingDir(ctx context.Context, refS
 // ResolveReference finds the identifier & HEAD path for a dataset reference.
 // the mode parameter determines which subsystems of Qri to use when resolving
 func (inst *Instance) ResolveReference(ctx context.Context, ref *dsref.Ref, mode string) (string, error) {
+	log.Debugf("inst.ResolveReference ref=%q mode=%q", ref, mode)
 	if inst == nil {
 		return "", dsref.ErrRefNotFound
 	}
@@ -59,6 +61,7 @@ func (inst *Instance) ResolveReference(ctx context.Context, ref *dsref.Ref, mode
 
 	resolver, err := inst.resolverForMode(mode)
 	if err != nil {
+		log.Debug("inst.resolverForMode error=%q", err)
 		return "", err
 	}
 

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	logger "github.com/ipfs/go-log"
+	golog "github.com/ipfs/go-log"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qfs"
@@ -42,8 +42,7 @@ var (
 	// This is mainly here for tests to override
 	NewTimestamp = func() int64 { return time.Now().UnixNano() }
 
-	// package logger
-	log = logger.Logger("logbook")
+	log = golog.Logger("logbook")
 )
 
 const (
@@ -848,11 +847,13 @@ func (book *Book) latestSavePath(branchLog *oplog.Log) string {
 //       branch
 //       ...
 func (book Book) UserDatasetBranchesLog(ctx context.Context, datasetInitID string) (*oplog.Log, error) {
+	log.Debugf("UserDatasetBranchesLog datasetInitID=%q", datasetInitID)
 	if datasetInitID == "" {
 		return nil, fmt.Errorf("%w: cannot use the empty string as an init id", ErrNotFound)
 	}
 	dsLog, err := book.store.Get(ctx, datasetInitID)
 	if err != nil {
+		log.Debugf("store error=%q datasetInitID=%q", err, datasetInitID)
 		return nil, err
 	}
 

--- a/logbook/logbook_test.go
+++ b/logbook/logbook_test.go
@@ -303,7 +303,7 @@ func TestUserDatasetBranchesLog(t *testing.T) {
 	}
 
 	if _, err := tr.Book.UserDatasetBranchesLog(tr.Ctx, tr.renameInitID); err != nil {
-		t.Errorf("expected LogBytes with proper ref to not return a wrap of logbook.ErrAccessDenied. got: %q", err)
+		t.Error(err)
 	}
 
 	got, err := tr.Book.UserDatasetBranchesLog(tr.Ctx, tr.worldBankInitID)

--- a/logbook/oplog/log_test.go
+++ b/logbook/oplog/log_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -227,7 +228,7 @@ func TestLogGetID(t *testing.T) {
 	ctx := tr.Ctx
 
 	got, err := tr.Journal.Get(ctx, "nonsense")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("expected not-found error for missing ID. got: %s", err)
 	}
 
@@ -280,7 +281,7 @@ func TestLogMerge(t *testing.T) {
 	left := &Log{
 		Signature: []byte{1, 2, 3},
 		Ops: []Op{
-			Op{
+			{
 				Type:     OpTypeInit,
 				Model:    0x1,
 				AuthorID: "author",
@@ -290,13 +291,13 @@ func TestLogMerge(t *testing.T) {
 		Logs: []*Log{
 			{
 				Ops: []Op{
-					Op{
+					{
 						Type:     OpTypeInit,
 						Model:    0x0002,
 						AuthorID: "author",
 						Name:     "child_a",
 					},
-					Op{
+					{
 						Type:  OpTypeInit,
 						Model: 0x0456,
 					},
@@ -307,13 +308,13 @@ func TestLogMerge(t *testing.T) {
 
 	right := &Log{
 		Ops: []Op{
-			Op{
+			{
 				Type:     OpTypeInit,
 				Model:    0x1,
 				AuthorID: "author",
 				Name:     "root",
 			},
-			Op{
+			{
 				Type:  OpTypeInit,
 				Model: 0x0011,
 			},
@@ -321,7 +322,7 @@ func TestLogMerge(t *testing.T) {
 		Logs: []*Log{
 			{
 				Ops: []Op{
-					Op{
+					{
 						Type:     OpTypeInit,
 						Model:    0x0002,
 						AuthorID: "author",
@@ -331,7 +332,7 @@ func TestLogMerge(t *testing.T) {
 			},
 			{
 				Ops: []Op{
-					Op{
+					{
 						Type:     OpTypeInit,
 						Model:    0x0002,
 						AuthorID: "buthor",
@@ -346,13 +347,13 @@ func TestLogMerge(t *testing.T) {
 
 	expect := &Log{
 		Ops: []Op{
-			Op{
+			{
 				Type:     OpTypeInit,
 				Model:    0x1,
 				AuthorID: "author",
 				Name:     "root",
 			},
-			Op{
+			{
 				Type:  OpTypeInit,
 				Model: 0x0011,
 			},
@@ -360,21 +361,22 @@ func TestLogMerge(t *testing.T) {
 		Logs: []*Log{
 			{
 				Ops: []Op{
-					Op{
+					{
 						Type:     OpTypeInit,
 						Model:    0x0002,
 						AuthorID: "author",
 						Name:     "child_a",
 					},
-					Op{
+					{
 						Type:  OpTypeInit,
 						Model: 0x0456,
 					},
 				},
 			},
 			{
+				ParentID: "adguqcqnrpc2rwxdykvsvengsccd5kew3x7jhs52rspg2f5nbina",
 				Ops: []Op{
-					Op{
+					{
 						Type:     OpTypeInit,
 						Model:    0x0002,
 						AuthorID: "buthor",


### PR DESCRIPTION
logbook was relying on an under-specified property of the `opstore.Logstore` interface: some  implementations _always_ fetch the Parent log as part of a Get request.

`logbook.UserDatasetBranchLog` was using this, which blew up when used with a different implementation. The solution to this is to push the logic needed by `logbook.UserDatasetBranchLog` into the oplog package, and implement it using explicit calls to a `oplog.Logstore`.

In the future I'd like to both work on the `Logstore` API and write a set of spec tests that implementations can validate against, much like we've done with `dsref.RefResolver`.

At the same time I've defined an exention interface that holds these explicit calls and an optional method logstores can implement to speed up this process. There are situations where this can be done with a single trip to a database. The extension interface provides this as an upgrade path without any changes to the logbook or opstore packages