### PR TITLE
fix(lib): don't panic when resolving without a registry

### DIFF
--- a/dsref/resolve.go
+++ b/dsref/resolve.go
@@ -95,6 +95,10 @@ type sequentialResolver []Resolver
 
 func (sr sequentialResolver) ResolveRef(ctx context.Context, ref *Ref) (string, error) {
 	for _, resolver := range sr {
+		if resolver == nil {
+			continue
+		}
+
 		resolvedSource, err := resolver.ResolveRef(ctx, ref)
 		if err != nil {
 			if errors.Is(err, ErrRefNotFound) {

--- a/lib/resolve.go
+++ b/lib/resolve.go
@@ -110,5 +110,9 @@ func (inst *Instance) defaultResolver() dsref.Resolver {
 }
 
 func (inst *Instance) registryResolver() dsref.Resolver {
-	return inst.remoteClient.NewRemoteRefResolver(inst.cfg.Registry.Location)
+	var location string
+	if inst.cfg.Registry != nil {
+		location = inst.cfg.Registry.Location
+	}
+	return inst.remoteClient.NewRemoteRefResolver(location)
 }

--- a/lib/resolve_test.go
+++ b/lib/resolve_test.go
@@ -1,0 +1,40 @@
+package lib
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/qri-io/qri/dsref"
+	repotest "github.com/qri-io/qri/repo/test"
+)
+
+func TestResolveReference(t *testing.T) {
+	tr, err := repotest.NewTempRepo("ruh_roh", "inst_resolve_ref", repotest.NewTestCrypto())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tr.Delete()
+
+	cfg := tr.GetConfig()
+	cfg.Registry = nil
+	tr.WriteConfigFile()
+
+	ctx := context.Background()
+	inst, err := NewInstance(ctx, tr.QriPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := &dsref.Ref{
+		Username: "example",
+		Name:     "dataset",
+	}
+	_, err = inst.ResolveReference(ctx, ref, "")
+	if !errors.Is(err, dsref.ErrRefNotFound) {
+		t.Errorf(`unexpected error resolving ref with 
+default resolver and no configured registry. 
+want: %q
+got:  %q`, dsref.ErrRefNotFound, err)
+	}
+}


### PR DESCRIPTION
going back to shipping code with real tests again 😄. Cloud code uncovered this issue. It's panicking because the registry doesn't have a registry.