### PR TITLE
fix(setup): Fix setup, add many unit tests

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -145,7 +145,7 @@ func (o *SetupOptions) DoSetup(f Factory) (err error) {
 	if o.Username != "" {
 		cfg.Profile.Peername = o.Username
 	} else if !o.Anonymous {
-		cfg.Profile.Peername = inputText(o.Out, o.In, "choose username (leave empty to generate a default name):", "")
+		cfg.Profile.Peername = prompt(o.Out, o.In, "choose username (leave empty to generate a default name):")
 	}
 
 	// If a username was passed with the --username flag or entered by prompt, make sure its valid

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -7,12 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/qri-io/doggos"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
-	"github.com/qri-io/qri/registry"
 	"github.com/qri-io/qri/repo/gen"
 	"github.com/spf13/cobra"
 )
@@ -36,9 +34,9 @@ running setup. If setup has already been run, by default Qri won’t let you
 overwrite this info.
 
 Use the ` + "`--remove`" + ` to remove your Qri repo. This deletes your entire repo, 
-including all your datasets, and de-registers your peername from the registry.`,
-		Example: `  # Run setup with a peername of your choosing:
-  $ qri setup --peername=your_great_peername`,
+including all your datasets, and de-registers your username from the registry.`,
+		Example: `  # Run setup with a username of your choosing:
+  $ qri setup --username=your_great_username`,
 		Annotations: map[string]string{
 			"group": "other",
 		},
@@ -51,12 +49,12 @@ including all your datasets, and de-registers your peername from the registry.`,
 		},
 	}
 
-	cmd.Flags().BoolVarP(&o.Anonymous, "anonymous", "a", false, "use an auto-generated peername")
+	cmd.Flags().BoolVarP(&o.Anonymous, "anonymous", "a", false, "use an auto-generated username")
 	cmd.Flags().BoolVarP(&o.Overwrite, "overwrite", "", false, "overwrite repo if one exists")
 	cmd.Flags().BoolVarP(&o.IPFS, "init-ipfs", "", true, "initialize an IPFS repo if one isn't present")
 	cmd.Flags().BoolVarP(&o.Remove, "remove", "", false, "permanently remove qri, overrides all setup options")
 	cmd.Flags().StringVarP(&o.Registry, "registry", "", "", "override default registry URL, set to 'none' to remove registry")
-	cmd.Flags().StringVarP(&o.Peername, "peername", "", "", "choose your desired peername")
+	cmd.Flags().StringVarP(&o.Username, "username", "", "", "choose your desired username")
 	cmd.Flags().StringVarP(&o.IPFSConfigData, "ipfs-config", "", "", "json-encoded configuration data, specify a filepath with '@' prefix")
 	cmd.Flags().StringVarP(&o.ConfigData, "config-data", "", "", "json-encoded configuration data, specify a filepath with '@' prefix")
 	cmd.Flags().BoolVar(&o.GimmeDoggo, "gimme-doggo", false, "create and display a doggo name only")
@@ -74,7 +72,7 @@ type SetupOptions struct {
 	Overwrite      bool
 	IPFS           bool
 	Remove         bool
-	Peername       string
+	Username       string
 	Registry       string
 	IPFSConfigData string
 	ConfigData     string
@@ -136,21 +134,25 @@ func (o *SetupOptions) DoSetup(f Factory) (err error) {
 
 		err = json.Unmarshal([]byte(o.ConfigData), cfg)
 		if cfg.Profile != nil {
-			o.Peername = cfg.Profile.Peername
+			o.Username = cfg.Profile.Peername
 		}
 		if err != nil {
 			return err
 		}
 	}
 
-	if o.Peername != "" {
-		cfg.Profile.Peername = o.Peername
-	} else if cfg.Profile.Peername == doggos.DoggoNick(cfg.Profile.ID) && !o.Anonymous {
-		cfg.Profile.Peername = inputText(o.Out, o.In, "choose a peername:", doggos.DoggoNick(cfg.Profile.ID))
+	// Handle the --username flag, or prompt the user for a username
+	if o.Username != "" {
+		cfg.Profile.Peername = o.Username
+	} else if !o.Anonymous {
+		cfg.Profile.Peername = inputText(o.Out, o.In, "choose username (leave empty to generate a default name):", "")
 	}
 
-	if err := dsref.EnsureValidUsername(cfg.Profile.Peername); err != nil {
-		return err
+	// If a username was passed with the --username flag or entered by prompt, make sure its valid
+	if cfg.Profile.Peername != "" {
+		if err := dsref.EnsureValidUsername(cfg.Profile.Peername); err != nil {
+			return err
+		}
 	}
 
 	if o.Registry == "none" {
@@ -174,20 +176,7 @@ func (o *SetupOptions) DoSetup(f Factory) (err error) {
 		p.SetupIPFSConfigData = []byte(o.IPFSConfigData)
 	}
 
-	for {
-		err := lib.Setup(p)
-		if err != nil {
-			if err == registry.ErrUsernameTaken {
-				printWarning(o.Out, "peername '%s' already taken", cfg.Profile.Peername)
-				cfg.Profile.Peername = inputText(o.Out, o.In, "choose a peername:", doggos.DoggoNick(cfg.Profile.ID))
-				continue
-			} else {
-				return err
-			}
-		}
-		break
-	}
-	return nil
+	return lib.Setup(p)
 }
 
 // CreateAndDisplayDoggo creates and display a doggo name

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -2,11 +2,22 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
+	"github.com/qri-io/ioes"
+	test_peers "github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/repo/gen"
+	repotest "github.com/qri-io/qri/repo/test"
+	"github.com/spf13/cobra"
 )
 
+// Test that setup command object can be created
 func TestSetupComplete(t *testing.T) {
 	run := NewTestRunner(t, "test_peer", "qri_test_setup_complete")
 	defer run.Delete()
@@ -27,6 +38,7 @@ func TestSetupComplete(t *testing.T) {
 	opt.Complete(f, nil)
 }
 
+// Test that setup run with --gimme-doggo command returns a default nickname
 func TestSetupGimmeDoggo(t *testing.T) {
 	run := NewTestRunner(t, "test_peer", "qri_test_gimme_doggo")
 	defer run.Delete()
@@ -36,4 +48,268 @@ func TestSetupGimmeDoggo(t *testing.T) {
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("unexpected (-want +got):\n%s", diff)
 	}
+}
+
+// Test that setup with no input will use the suggested username
+func TestSetupWithNoInput(t *testing.T) {
+	ctx := context.Background()
+	info := test_peers.GetTestPeerInfo(0)
+
+	qriHome := createTmpQriHome(t)
+	cmd, shutdown := newCommand(ctx, qriHome, repotest.NewTestCrypto())
+
+	cmdText := "qri setup"
+	if err := executeCommand(cmd, cmdText); err != nil {
+		timedShutdown(fmt.Sprintf("ExecCommand: %q\n", cmdText), shutdown)
+		t.Fatal(err)
+	}
+
+	configData := readConfigFile(t, qriHome)
+
+	username := configData["Profile"].(map[string]interface{})["peername"]
+	expect := "testnick"
+	if username != expect {
+		t.Errorf("setup didn't create correct username, expect: %s, got: %s", expect, username)
+	}
+
+	profileID := configData["Profile"].(map[string]interface{})["id"]
+	if profileID != info.EncodedPeerID {
+		t.Errorf("setup didn't create correct profileID, expect: %s, got: %s", info.EncodedPeerID, profileID)
+	}
+
+	privkey := configData["Profile"].(map[string]interface{})["privkey"]
+	if privkey != info.EncodedPrivKey {
+		t.Errorf("setup didn't create correct private key")
+	}
+}
+
+// Test that setup with a response on stdin will use that username from stdin
+func TestSetupUsernameOnStdin(t *testing.T) {
+	ctx := context.Background()
+	info := test_peers.GetTestPeerInfo(0)
+
+	qriHome := createTmpQriHome(t)
+	stdinText := "qri_test_name"
+	cmd, shutdown := newCommandWithStdin(ctx, qriHome, stdinText, repotest.NewTestCrypto())
+
+	cmdText := "qri setup"
+	if err := executeCommand(cmd, cmdText); err != nil {
+		timedShutdown(fmt.Sprintf("ExecCommand: %q\n", cmdText), shutdown)
+		t.Fatal(err)
+	}
+
+	configData := readConfigFile(t, qriHome)
+
+	username := configData["Profile"].(map[string]interface{})["peername"]
+	expect := "qri_test_name"
+	if username != expect {
+		t.Errorf("setup didn't create correct username, expect: %s, got: %s", expect, username)
+	}
+
+	profileID := configData["Profile"].(map[string]interface{})["id"]
+	if profileID != info.EncodedPeerID {
+		t.Errorf("setup didn't create correct profileID, expect: %s, got: %s", info.EncodedPeerID, profileID)
+	}
+
+	privkey := configData["Profile"].(map[string]interface{})["privkey"]
+	if privkey != info.EncodedPrivKey {
+		t.Errorf("setup didn't create correct private key")
+	}
+}
+
+// Test that setup with the --username flag will use that value
+func TestSetupUsernameFlag(t *testing.T) {
+	ctx := context.Background()
+	info := test_peers.GetTestPeerInfo(0)
+
+	qriHome := createTmpQriHome(t)
+	cmd, shutdown := newCommand(ctx, qriHome, repotest.NewTestCrypto())
+
+	cmdText := "qri setup --username qri_cool_user"
+	if err := executeCommand(cmd, cmdText); err != nil {
+		timedShutdown(fmt.Sprintf("ExecCommand: %q\n", cmdText), shutdown)
+		t.Fatal(err)
+	}
+
+	configData := readConfigFile(t, qriHome)
+
+	username := configData["Profile"].(map[string]interface{})["peername"]
+	expect := "qri_cool_user"
+	if username != expect {
+		t.Errorf("setup didn't create correct username, expect: %s, got: %s", expect, username)
+	}
+
+	profileID := configData["Profile"].(map[string]interface{})["id"]
+	if profileID != info.EncodedPeerID {
+		t.Errorf("setup didn't create correct profileID, expect: %s, got: %s", info.EncodedPeerID, profileID)
+	}
+
+	privkey := configData["Profile"].(map[string]interface{})["privkey"]
+	if privkey != info.EncodedPrivKey {
+		t.Errorf("setup didn't create correct private key")
+	}
+}
+
+// Test that setup will fail if passed an invalid username from stdin
+func TestSetupInvalidStdinResponse(t *testing.T) {
+	ctx := context.Background()
+
+	qriHome := createTmpQriHome(t)
+	stdinText := "_not_valid_name"
+	cmd, shutdown := newCommandWithStdin(ctx, qriHome, stdinText, repotest.NewTestCrypto())
+
+	cmdText := "qri setup"
+	err := executeCommand(cmd, cmdText)
+	if err != nil {
+		timedShutdown(fmt.Sprintf("ExecCommand: %q\n", cmdText), shutdown)
+	}
+	if err == nil {
+		t.Fatal("expected setup to fail due to invalid username, did not get an error")
+	}
+	expectErr := `username must start with a lower-case letter, and only contain lower-case letters, numbers, dashes, and underscores`
+	if expectErr != err.Error() {
+		t.Errorf("error mismatch, expect %s, got %s", expectErr, err.Error())
+	}
+}
+
+// Test that setup will fail if passed an invalid username from the --username flag
+func TestSetupInvalidUsernameFlag(t *testing.T) {
+	ctx := context.Background()
+
+	qriHome := createTmpQriHome(t)
+	cmd, shutdown := newCommand(ctx, qriHome, repotest.NewTestCrypto())
+
+	cmdText := "qri setup --username InvalidUser"
+	err := executeCommand(cmd, cmdText)
+	if err != nil {
+		timedShutdown(fmt.Sprintf("ExecCommand: %q\n", cmdText), shutdown)
+	}
+	if err == nil {
+		t.Fatal("expected setup to fail due to invalid username, did not get an error")
+	}
+	expectErr := `username may not contain any upper-case letters`
+	if expectErr != err.Error() {
+		t.Errorf("error mismatch, expect %s, got %s", expectErr, err.Error())
+	}
+}
+
+// Test that setup with the QRI_SETUP_CONFIG_DATA envvar will use that username
+func TestSetupConfigData(t *testing.T) {
+	ctx := context.Background()
+	info := test_peers.GetTestPeerInfo(0)
+
+	qriHome := createTmpQriHome(t)
+	cmd, shutdown := newCommand(ctx, qriHome, repotest.NewTestCrypto())
+
+	os.Setenv("QRI_SETUP_CONFIG_DATA", `{"profile":{"peername":"qri_my_fav_user"}}`)
+	defer os.Setenv("QRI_SETUP_CONFIG_DATA", "")
+
+	cmdText := "qri setup"
+	if err := executeCommand(cmd, cmdText); err != nil {
+		timedShutdown(fmt.Sprintf("ExecCommand: %q\n", cmdText), shutdown)
+		t.Fatal(err)
+	}
+
+	configData := readConfigFile(t, qriHome)
+
+	username := configData["Profile"].(map[string]interface{})["peername"]
+	expect := "qri_my_fav_user"
+	if username != expect {
+		t.Errorf("setup didn't create correct username, expect: %s, got: %s", expect, username)
+	}
+
+	profileID := configData["Profile"].(map[string]interface{})["id"]
+	if profileID != info.EncodedPeerID {
+		t.Errorf("setup didn't create correct profileID, expect: %s, got: %s", info.EncodedPeerID, profileID)
+	}
+
+	privkey := configData["Profile"].(map[string]interface{})["privkey"]
+	if privkey != info.EncodedPrivKey {
+		t.Errorf("setup didn't create correct private key")
+	}
+}
+
+// Test that setup also works with real crypto
+func TestSetupRealCrypto(t *testing.T) {
+	ctx := context.Background()
+
+	qriHome := createTmpQriHome(t)
+	// NOTE: This test uses a real instance of the crypto generator. This will
+	// be noticably slower than the other tests, and will also act non-deterministically.
+	// Do not use this function in other tests, it is only used here to explicitly
+	// verify that it works in this one case.
+	cmd, shutdown := newCommand(ctx, qriHome, gen.NewCryptoSource())
+
+	cmdText := "qri setup"
+	if err := executeCommand(cmd, cmdText); err != nil {
+		timedShutdown(fmt.Sprintf("ExecCommand: %q\n", cmdText), shutdown)
+		t.Fatal(err)
+	}
+
+	configData := readConfigFile(t, qriHome)
+
+	username := configData["Profile"].(map[string]interface{})["peername"].(string)
+	// NOTE: Shortest name I've ever seen is `snow_puli`
+	if len(username) < 9 {
+		t.Errorf("setup used real crypto, username seems wrong, got %s", username)
+	}
+
+	profileID := configData["Profile"].(map[string]interface{})["id"].(string)
+	if len(profileID) != 46 {
+		t.Errorf("setup used real crypto, profileID seems wrong, len is %d", len(profileID))
+	}
+
+	privkey := configData["Profile"].(map[string]interface{})["privkey"].(string)
+	if len(privkey) != 1592 && len(privkey) != 1596 && len(privkey) != 1600 {
+		t.Errorf("setup used real crypto, privkey seems wrong, len is %d", len(privkey))
+	}
+}
+
+func createTmpQriHome(t *testing.T) string {
+	tmpPath, err := ioutil.TempDir("", "qri_test_setup")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qriHome := filepath.Join(tmpPath, "qri_home")
+	err = os.MkdirAll(qriHome, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Setenv("QRI_PATH", qriHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return qriHome
+}
+
+func readConfigFile(t *testing.T, path string) map[string]interface{} {
+	configContents, err := ioutil.ReadFile(filepath.Join(path, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configData := make(map[string]interface{})
+	err = yaml.Unmarshal(configContents, &configData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return configData
+}
+
+func newCommand(ctx context.Context, path string, generator gen.CryptoGenerator) (*cobra.Command, func() <-chan error) {
+	return newCommandWithStdin(ctx, path, "", generator)
+}
+
+func newCommandWithStdin(ctx context.Context, path, stdinText string, generator gen.CryptoGenerator) (*cobra.Command, func() <-chan error) {
+	streams, in, _, _ := ioes.NewTestIOStreams()
+	if stdinText != "" {
+		in.WriteString(stdinText)
+	}
+	cmd, shutdown := NewQriCommand(ctx, path, generator, streams)
+	cmd.SetOutput(streams.Out)
+	return cmd, shutdown
 }

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -50,6 +50,10 @@ func TestSetupGimmeDoggo(t *testing.T) {
 	}
 }
 
+// NOTE: These tests below do not use the TestRunner. This is because the TestRunner creates
+// its own MockRepo, which removes the need to run `qri setup`. Since the whole idea here is
+// to test `qri setup`'s behavior, we cannot use that functionality.
+
 // Test that setup with no input will use the suggested username
 func TestSetupWithNoInput(t *testing.T) {
 	ctx := context.Background()
@@ -278,6 +282,13 @@ func createTmpQriHome(t *testing.T) string {
 	}
 
 	err = os.Setenv("QRI_PATH", qriHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Clear this envvar in order to get tests to pass on continuous build. If this
+	// envvar is set, it will override other configuration.
+	err = os.Setenv("QRI_SETUP_CONFIG_DATA", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/setup.go
+++ b/lib/setup.go
@@ -68,6 +68,8 @@ func Setup(p SetupParams) error {
 	if cfg.Profile.PrivKey == "" {
 		cfg.Profile.PrivKey = cfg.P2P.PrivKey
 		cfg.Profile.ID = cfg.P2P.PeerID
+	}
+	if cfg.Profile.Peername == "" {
 		cfg.Profile.Peername = p.Generator.GenerateNickname(cfg.P2P.PeerID)
 	}
 


### PR DESCRIPTION
Due to a recent refactoring, the `qri setup` command was no longer prompting for a username. This caused the username validation to fail. Passing a username via the `--username` flag was also ignored, as the code in lib/setup.go would overwrite it. Fix these problems, add tests to make sure they won't happen again.

Rename the `--peername` flag to `--username` for `qri setup`