### PR TITLE
feat(access): API Authentication with JSON Web Tokens

### DIFF
--- a/access/context.go
+++ b/access/context.go
@@ -1,0 +1,27 @@
+package access
+
+import (
+	"context"
+)
+
+// CtxKey defines a distinct type for context keys used by the access
+// package
+type CtxKey string
+
+// TokenCtxKey is the key for adding an access token to a context.Context
+const TokenCtxKey CtxKey = "Token"
+
+// CtxWithToken adds a token value to a context
+func CtxWithToken(ctx context.Context, t Token) context.Context {
+	return context.WithValue(ctx, TokenCtxKey, t)
+}
+
+// TokenFromCtx extracts a Dataset reference from a given
+// context if one is set, returning nil otherwise
+func TokenFromCtx(ctx context.Context) Token {
+	iface := ctx.Value(TokenCtxKey)
+	if ref, ok := iface.(Token); ok {
+		return ref
+	}
+	return Token{}
+}

--- a/access/spec/token_source.go
+++ b/access/spec/token_source.go
@@ -1,0 +1,42 @@
+package spec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/qri-io/qri/access"
+	cfgtest "github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/repo/profile"
+)
+
+// AssertTokenSourceSpec ensures a TokenSource implementation behaves as
+// expected
+func AssertTokenSourceSpec(t *testing.T, newTokenSource func(ctx context.Context) access.TokenSource) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := newTokenSource(ctx)
+
+	p1 := &profile.Profile{
+		ID:       profile.IDB58DecodeOrEmpty(cfgtest.GetTestPeerInfo(1).EncodedPeerID),
+		Peername: "username",
+	}
+
+	raw, err := source.CreateToken(p1, 0)
+	if err != nil {
+		t.Errorf("source should allow creating key with valid profile & zero duration. got: %q", err)
+	}
+
+	p := &jwt.Parser{
+		UseJSONNumber:        true,
+		SkipClaimsValidation: false,
+	}
+	if _, _, err := p.ParseUnverified(raw, &access.TokenClaims{}); err != nil {
+		t.Errorf("created token must parse with acces.TokenClaims. got: %q", err)
+	}
+
+	if _, err := access.ParseToken(raw, source); err != nil {
+		t.Errorf("source must create tokens that parse with it's own verification keys. error: %q", err)
+	}
+}

--- a/access/spec/token_store.go
+++ b/access/spec/token_store.go
@@ -1,0 +1,130 @@
+package spec
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/qri-io/qri/access"
+	cfgtest "github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/repo/profile"
+)
+
+// AssertTokenStoreSpec ensures an access.TokenStore implementation behaves as
+// expected
+func AssertTokenStoreSpec(t *testing.T, newTokenStore func(context.Context) access.TokenStore) {
+	prevTs := access.Timestamp
+	access.Timestamp = func() time.Time { return time.Time{} }
+	defer func() { access.Timestamp = prevTs }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pk := cfgtest.GetTestPeerInfo(0).PrivKey
+	tokens, err := access.NewPrivKeyTokenSource(pk)
+	if err != nil {
+		t.Fatalf("creating local tokens: %q", err)
+	}
+	store := newTokenStore(ctx)
+
+	results, err := store.ListTokens(ctx, 0, -1)
+	if err != nil {
+		t.Errorf("listing all tokens of an empty store shouldn't error. got: %q ", err)
+	}
+	if len(results) > 0 {
+		t.Errorf("new store should return no results. got: %d", len(results))
+	}
+
+	_, err = store.RawToken(ctx, "this doesn't exist")
+	if !errors.Is(err, access.ErrTokenNotFound) {
+		t.Errorf("expected store.RawToken(nonexistent key) to return a wrap of access.ErrTokenNotFound. got: %q", err)
+	}
+	err = store.DeleteToken(ctx, "this also doesn't exist")
+	if !errors.Is(err, access.ErrTokenNotFound) {
+		t.Errorf("expected store.D key to return a wrap of access.ErrTokenNotFound. got: %q", err)
+	}
+	if err := store.PutToken(ctx, "_bad_key", "not.a.key"); err == nil {
+		t.Errorf("putting an invalid json web token should error. got nil")
+	}
+
+	p1 := &profile.Profile{
+		ID:       profile.IDB58DecodeOrEmpty(cfgtest.GetTestPeerInfo(1).EncodedPeerID),
+		Peername: "local_user",
+	}
+	t1Raw, err := tokens.CreateToken(p1, 0)
+	if err != nil {
+		t.Fatalf("creating token: %q", err)
+	}
+
+	if err := store.PutToken(ctx, "_root", t1Raw); err != nil {
+		t.Errorf("putting root key shouldn't error. got: %q", err)
+	}
+
+	results, err = store.ListTokens(ctx, 0, -1)
+	if err != nil {
+		t.Errorf("listing all tokens of an empty store shouldn't error. got: %q ", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("result length mismatch listing keys after adding `root` key. expected 1, got: %d", len(results))
+	}
+
+	p2 := &profile.Profile{
+		ID:       profile.IDB58DecodeOrEmpty(cfgtest.GetTestPeerInfo(1).EncodedPeerID),
+		Peername: "user_2",
+	}
+	t2Raw, err := tokens.CreateToken(p2, time.Millisecond*10)
+	if err != nil {
+		t.Fatalf("creating token: %q", err)
+	}
+
+	secondKey := "http://registry.qri.cloud"
+	if err := store.PutToken(ctx, secondKey, t2Raw); err != nil {
+		t.Errorf("putting a second token with key=%q shouldn't error. got: %q", secondKey, err)
+	}
+
+	results, err = store.ListTokens(ctx, 0, -1)
+	if err != nil {
+		t.Errorf("listing all tokens of an empty store shouldn't error. got: %q ", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("result length mismatch listing keys after adding second key. expected 2, got: %d", len(results))
+	}
+
+	expect := []access.RawToken{
+		{
+			Key: "_root",
+			Raw: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJRbVdZZ0Q0OXI5SG51WEVwcFFFcTFhN1NVVXJ5amE0UU5zOUU2WENIMlBheUNEIiwidXNlcm5hbWUiOiJsb2NhbF91c2VyIn0.hu1B92X8cLBRNtNNiwm_qn4T-s8WlDlsa0swNgeyUPJ921LfojmHobkuW4oRvNEjkq_OP2gkaZ_F0YyUgAM8K-pVg30L-jNG9cqA1EUx4cQ90ZSbMxvXzRmBevBa3Wq-RHErnGw-K7EvtZfuPrp60LuDBKkGCuAwfKV8D9O-6U4lrragFgfw3zWRdovnb28fO2W6sqP8azGDcY8klpysjx7W4V-qVynJ981_ex_G1wPbk1dov59MDlY6yoxt1rucyF5-f4oo9jv6k194Tigw3Uv6JR889kK5x87ruiApghfQIBosAd-hm79Xz0RmLahykoZZTbVASW6NcIPvqvZ5TA",
+		},
+		{
+			Key: secondKey,
+			Raw: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOi02MjEzNTU5NjgwMCwic3ViIjoiUW1XWWdENDlyOUhudVhFcHBRRXExYTdTVVVyeWphNFFOczlFNlhDSDJQYXlDRCIsInVzZXJuYW1lIjoidXNlcl8yIn0.V4ZlinPrjRBf6EiZPylrigXHEQ-5k8e54-G5o1OQEu9hAWmZAGlm5OdcAfWRLueWR8bk_9NFYwAzg7CaSvM0suPqHlFbCXS0tQynG3m9ptu_bucfEAaDdoNmBMyPrB7w6rLauFVh0TcwiTRV3KkrzbeKdo0Q6fDoRFy5ZuP5zPDxt_UOC50zIpdw5F4MH3OBbfjjfpR0XA8Q1tslOg5JWh21pCR-C8gyC5jJ9ilNsdwggXY0mkHl9f0utwMewPfC6b7i01t9kVtknI5Wg6dq_CuZlDuOs83LcL6xThRBiosmFZ-2I3b8nSPxfg_gouOBOSa5yFOcYxJsHHDKe-RIfw",
+		},
+	}
+
+	if diff := cmp.Diff(expect, results); diff != "" {
+		t.Errorf("mistmatched list keys results. (-want +got):\n%s", diff)
+	}
+
+	results, err = store.ListTokens(ctx, 1, 1)
+	if err != nil {
+		t.Errorf("listing all tokens of an empty store shouldn't error. got: %q ", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("result length mismatch listing keys after adding `root` key. expected 1, got: %d", len(results))
+	}
+
+	if diff := cmp.Diff(expect[1:], results); diff != "" {
+		t.Errorf("mistmatched list keys with offset=1, limit=1. results. (-want +got):\n%s", diff)
+	}
+
+	if err := store.DeleteToken(ctx, secondKey); err != nil {
+		t.Errorf("store.DeleteToken shouldn't error for existing key. got: %q", err)
+	}
+
+	_, err = store.RawToken(ctx, secondKey)
+	if !errors.Is(err, access.ErrTokenNotFound) {
+		t.Errorf("store.RawToken() for a just-deleted key must return a wrap of access.ErrTokenNotFound. got: %q", err)
+	}
+}

--- a/access/token.go
+++ b/access/token.go
@@ -1,0 +1,279 @@
+package access
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/qri-io/qfs"
+	"github.com/qri-io/qri/repo/profile"
+)
+
+var (
+	// Timestamp is a replacable function for getting the current time,
+	// can be overridden for tests
+	Timestamp = func() time.Time { return time.Now() }
+	// ErrTokenNotFound is returned by stores that cannot find an access token
+	// for a given key
+	ErrTokenNotFound = errors.New("access token not found")
+	// ErrInvalidToken indicates an access token is invalid
+	ErrInvalidToken = errors.New("invalid access token")
+	// DefaultTokenTTL is the default
+	DefaultTokenTTL = time.Hour * 24 * 14
+)
+
+// Token abstracts a json web token
+type Token = jwt.Token
+
+// TokenClaims is a JWT Claims object
+type TokenClaims struct {
+	*jwt.StandardClaims
+	Username string `json:"username"`
+}
+
+// ParseToken will parse, validate and return a token
+func ParseToken(tokenString string, tokens TokenSource) (*Token, error) {
+	return jwt.Parse(tokenString, tokens.VerificationKey)
+}
+
+// TokenSource creates tokens, and provides a verification key for all tokens
+// it creates
+//
+// implementations of TokenSource must conform to the assertion test defined
+// in the spec subpackage
+type TokenSource interface {
+	CreateToken(pro *profile.Profile, ttl time.Duration) (string, error)
+	// VerifyKey returns the verification key for a given token
+	VerificationKey(t *Token) (interface{}, error)
+}
+
+type pkTokenSource struct {
+	pk            crypto.PrivKey
+	signingMethod jwt.SigningMethod
+	verifyKey     *rsa.PublicKey
+	signKey       *rsa.PrivateKey
+}
+
+// assert pkTokenSource implements tokens at compile time
+var _ TokenSource = (*pkTokenSource)(nil)
+
+// NewPrivKeyTokenSource creates an authentication interface backed by a single
+// private key. Intended for a node running as remote, or providing a public API
+func NewPrivKeyTokenSource(privKey crypto.PrivKey) (TokenSource, error) {
+	methodStr := ""
+	keyType := privKey.Type().String()
+	switch keyType {
+	case "RSA":
+		methodStr = "RS256"
+	default:
+		return nil, fmt.Errorf("unsupported key type for token creation: %q", keyType)
+	}
+
+	signingMethod := jwt.GetSigningMethod(methodStr)
+
+	rawPrivBytes, err := privKey.Raw()
+	if err != nil {
+		return nil, err
+	}
+	signKey, err := x509.ParsePKCS1PrivateKey(rawPrivBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	rawPubBytes, err := privKey.GetPublic().Raw()
+	if err != nil {
+		return nil, err
+	}
+	verifyKeyiface, err := x509.ParsePKIXPublicKey(rawPubBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	verifyKey, ok := verifyKeyiface.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("public key is not an RSA key. got type: %T", verifyKeyiface)
+	}
+
+	return &pkTokenSource{
+		pk:            privKey,
+		signingMethod: signingMethod,
+		verifyKey:     verifyKey,
+		signKey:       signKey,
+	}, nil
+}
+
+// CreateToken returns a new JWT token
+func (a *pkTokenSource) CreateToken(pro *profile.Profile, ttl time.Duration) (string, error) {
+	// create a signer for rsa 256
+	t := jwt.New(a.signingMethod)
+
+	var exp int64
+	if ttl != time.Duration(0) {
+		exp = Timestamp().Add(ttl).In(time.UTC).Unix()
+	}
+
+	// set our claims
+	t.Claims = &TokenClaims{
+		StandardClaims: &jwt.StandardClaims{
+			Subject: pro.ID.String(),
+			// set the expire time
+			// see http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-20#section-4.1.4
+			ExpiresAt: exp,
+		},
+		Username: pro.Peername,
+	}
+
+	// Creat token string
+	return t.SignedString(a.signKey)
+}
+
+// VerifyKey returns the verification key
+func (a *pkTokenSource) VerificationKey(t *Token) (interface{}, error) {
+	return a.verifyKey, nil
+}
+
+// TokenStore is a store intended for clients, who need to persist secret jwts
+// given to them by other remotes for API access. It deals in raw,
+// string-formatted json web tokens, which are more useful when working with
+// APIs, but validates the tokens are well-formed when placed in the store
+//
+// implementations of TokenStore must conform to the assertion test defined
+// in the spec subpackage
+type TokenStore interface {
+	PutToken(ctx context.Context, key, rawToken string) error
+	RawToken(ctx context.Context, key string) (rawToken string, err error)
+	DeleteToken(ctx context.Context, key string) (err error)
+	ListTokens(ctx context.Context, offset, limit int) (results []RawToken, err error)
+}
+
+// RawToken is a struct that binds a key to a raw token string
+type RawToken struct {
+	Key string
+	Raw string
+}
+
+// RawTokens is a list of tokens that implements sorting by keys
+type RawTokens []RawToken
+
+func (rts RawTokens) Len() int           { return len(rts) }
+func (rts RawTokens) Less(a, b int) bool { return rts[a].Key < rts[b].Key }
+func (rts RawTokens) Swap(i, j int)      { rts[i], rts[j] = rts[j], rts[i] }
+
+type qfsTokenStore struct {
+	path string
+	fs   qfs.Filesystem
+
+	toksLk sync.Mutex
+	toks   map[string]string
+}
+
+var _ TokenStore = (*qfsTokenStore)(nil)
+
+// NewTokenStore creates a token store with a qfs.Filesystem
+func NewTokenStore(filepath string, fs qfs.Filesystem) (TokenStore, error) {
+	toks := map[string]string{}
+	if f, err := fs.Get(context.Background(), filepath); err == nil {
+		rawToks := []RawToken{}
+		if err := json.NewDecoder(f).Decode(&rawToks); err != nil {
+			return nil, fmt.Errorf("invalid token store file: %w", err)
+		}
+		for _, t := range rawToks {
+			toks[t.Key] = t.Raw
+		}
+	}
+
+	return &qfsTokenStore{
+		path: filepath,
+		fs:   fs,
+		toks: toks,
+	}, nil
+}
+
+func (st *qfsTokenStore) PutToken(ctx context.Context, key string, raw string) error {
+	p := &jwt.Parser{
+		UseJSONNumber:        true,
+		SkipClaimsValidation: false,
+	}
+	if _, _, err := p.ParseUnverified(raw, &TokenClaims{}); err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidToken, err)
+	}
+
+	st.toksLk.Lock()
+	defer st.toksLk.Unlock()
+
+	st.toks[key] = raw
+	return st.save(ctx)
+}
+
+func (st *qfsTokenStore) RawToken(ctx context.Context, key string) (rawToken string, err error) {
+	t, ok := st.toks[key]
+	if !ok {
+		return "", ErrTokenNotFound
+	}
+	return t, nil
+}
+
+func (st *qfsTokenStore) DeleteToken(ctx context.Context, key string) (err error) {
+	st.toksLk.Lock()
+	defer st.toksLk.Unlock()
+
+	if _, ok := st.toks[key]; !ok {
+		return ErrTokenNotFound
+	}
+	delete(st.toks, key)
+	return st.save(ctx)
+}
+
+func (st *qfsTokenStore) ListTokens(ctx context.Context, offset, limit int) ([]RawToken, error) {
+	var results []RawToken
+
+	toks := st.toRawTokens()
+	for i := 0; i < len(toks); i++ {
+		if offset > 0 {
+			offset--
+			continue
+		}
+		results = append(results, toks[i])
+		if limit > 0 && len(results) == limit {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+func (st *qfsTokenStore) toRawTokens() RawTokens {
+	toks := make(RawTokens, len(st.toks))
+	i := 0
+	for key, t := range st.toks {
+		toks[i] = RawToken{
+			Key: key,
+			Raw: t,
+		}
+		i++
+	}
+	sort.Sort(toks)
+	return toks
+}
+
+func (st *qfsTokenStore) save(ctx context.Context) error {
+	data, err := json.MarshalIndent(st.toRawTokens(), "", "  ")
+	if err != nil {
+		return err
+	}
+	f := qfs.NewMemfileBytes(st.path, data)
+	path, err := st.fs.Put(ctx, f)
+	if err != nil {
+		return err
+	}
+	st.path = path
+	return nil
+}

--- a/access/token_test.go
+++ b/access/token_test.go
@@ -1,0 +1,66 @@
+package access_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/qri-io/qfs"
+	"github.com/qri-io/qri/access"
+	access_spec "github.com/qri-io/qri/access/spec"
+	cfgtest "github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/repo/profile"
+)
+
+func TestPrivKeyTokens(t *testing.T) {
+	prevTs := access.Timestamp
+	access.Timestamp = func() time.Time { return time.Time{} }
+	defer func() { access.Timestamp = prevTs }()
+
+	peerInfo := cfgtest.GetTestPeerInfo(0)
+	tokens, err := access.NewPrivKeyTokenSource(peerInfo.PrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pro := &profile.Profile{
+		ID:       profile.IDB58MustDecode(peerInfo.EncodedPeerID),
+		Peername: "doug",
+	}
+
+	tokenString, err := tokens.CreateToken(pro, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJRbWVMMm1kVmthMWVhaEtFTmplaEs2dEJ4a2twazVkTlExcU1jZ1dpN0hyYjRCIiwidXNlcm5hbWUiOiJkb3VnIn0.ZNVGEvqDvCsY1H8dsWJILCIrcOTlLxC_5F-in7jWyfmT4RDatk3-ygVCCH-tYqvXx3dzf-U7qOSR8aR3E5Irvax84WoT0nwR7m51R36WaLPt_dXvtb4jLpjuqUdj5hGdBl2OA-UUuIlI7EzBftlNi6AMDQkcYbX8JWT-Jk47cVxM9f9DWDZphQlgEGm6Czdk5SCfIX1oORkN58zwIaOqP29aba6gzTgl3BMaTAJUkzy-i8dD98xLQXdXIYHxUzsLPAD-WjIEf7lmMetz2ls8okYq8EGyHVYhko_b6t8b5_VZA-GnFnB8D2JkAlcWEIJ_jxuNHHK7g0MTF1GPUT4s1A`
+	if expect != tokenString {
+		t.Errorf("token mismatch. expected: %q.\ngot: %q", expect, tokenString)
+	}
+
+	tokenWithExpiryString, err := tokens.CreateToken(pro, time.Hour)
+	expect = `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOi02MjEzNTU5MzIwMCwic3ViIjoiUW1lTDJtZFZrYTFlYWhLRU5qZWhLNnRCeGtrcGs1ZE5RMXFNY2dXaTdIcmI0QiIsInVzZXJuYW1lIjoiZG91ZyJ9.d7XPhsj7hkyxg1JzC59hfu90RYem5q6Pie-ofJhdlGk_sY5bH8gcqG90LndMh4_LglEvtrwf_SVFcM1b78qhNon_Yo91kG_K_MmyExa-AlpY65Ji_kpRWcnI8hl-mxrZ2MzxPjvAEOa6c80DUWgTFKlkrgf9RnZlqq-nHnxHHXbVKYI3girsDgWynaIhR53yMBDIhbTCZaQ8XKtU_Pr0L1dJAW7YvOo2H01VM4LI_UQqhCmEbTnQX1Zee0tg88IMzLl7WsdNNOzUsf7dCYWGerLtzxGbxR0wweXbqVJBlzIl0Upke8-FBuZIbcdGSniy4DX643KrNnp_FnzQ8oBHTA`
+	if expect != tokenWithExpiryString {
+		t.Errorf("token mismatch. expected: %q.\ngot: %q", expect, tokenWithExpiryString)
+	}
+
+	access_spec.AssertTokenSourceSpec(t, func(ctx context.Context) access.TokenSource {
+		source, err := access.NewPrivKeyTokenSource(peerInfo.PrivKey)
+		if err != nil {
+			panic(err)
+		}
+		return source
+	})
+}
+
+func TestTokenStore(t *testing.T) {
+	fs := qfs.NewMemFS()
+
+	access_spec.AssertTokenStoreSpec(t, func(ctx context.Context) access.TokenStore {
+		ts, err := access.NewTokenStore("tokens.json", fs)
+		if err != nil {
+			panic(err)
+		}
+		return ts
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/beme/abide v0.0.0-20190723115211-635a09831760
 	github.com/cheggaaa/pb/v3 v3.0.4
 	github.com/cube2222/octosql v0.2.1-0.20200319150444-e5a71fa20dbe
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/fsnotify/fsnotify v1.4.9


### PR DESCRIPTION
When finished this should:
* [ ] define interfaces for both creating and storing JWTs
* [ ] make any node running with an API a source of JSON web tokens
* [ ] support authenticated API requests with an `Auth: Bearer [token]` header
* [ ] support a local store of JWTS, keyed by remote location

