### PR TITLE
feat(api): qri can serve a simple webui

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -254,5 +254,9 @@ func NewServerRoutes(s Server) *http.ServeMux {
 	sqlh := NewSQLHandlers(s.Instance, cfg.API.ReadOnly)
 	m.Handle("/sql", s.middleware(sqlh.QueryHandler("/sql")))
 
+	if !cfg.API.DisableWebui {
+		m.Handle("/webui", s.middleware(WebuiHandler))
+	}
+
 	return m
 }

--- a/api/webui.go
+++ b/api/webui.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"net/http"
+)
+
+// WebuiHandler returns the webui html
+func WebuiHandler(w http.ResponseWriter, r *http.Request) {
+	template := `
+	<!doctype html><html><head><link href="https://storage.googleapis.com/qri-static/bundle.css" rel="stylesheet"></head><head><title>Qri Remote Webapp</title><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="script-src 'self' https://storage.googleapis.com https://qri.io https://qri.cloud"><body><div class="titlebar"></div><div id="root"></div><script src="https://storage.googleapis.com/qri-static/bundle.js"></script></body></head></html>
+	`
+	w.Write([]byte(template))
+	return
+}

--- a/config/api.go
+++ b/config/api.go
@@ -31,8 +31,12 @@ type API struct {
 	AllowedOrigins []string `json:"allowedorigins"`
 	// whether to allow requests from addresses other than localhost
 	ServeRemoteTraffic bool `json:"serveremotetraffic"`
-	// APIWebsocketAddress specifies the multiaddress to listen for websocket
+	// WebsocketAddress specifies the multiaddress to listen for websocket
 	WebsocketAddress string `json:"websocketaddress"`
+	// DisableWebui when true stops qri from serving the webui when the node is online
+	// TODO (ramfox): when we next have a config migration, we should probably rename this to
+	// EnableWebui and default to true. the double negative here can be confusing.
+	DisableWebui bool `json:"disablewebui"`
 }
 
 // SetArbitrary is an interface implementation of base/fill/struct in order to safely
@@ -71,6 +75,10 @@ func (a API) Validate() error {
         "description": "time in seconds to stop the server after",
         "type": "integer"
       },
+      "disablewebui": {
+        "description": "when true, disables qri from serving the webui when the node is online",
+        "type": "boolean"
+      },
       "allowedorigins": {
         "description": "Support CORS signing from a list of origins",
         "type": "array",
@@ -94,6 +102,7 @@ func DefaultAPI() *API {
 			"http://app.qri.io",
 			"https://app.qri.io",
 		},
+		DisableWebui: false,
 	}
 }
 
@@ -106,6 +115,7 @@ func (a *API) Copy() *API {
 		ReadOnly:           a.ReadOnly,
 		DisconnectAfter:    a.DisconnectAfter,
 		ServeRemoteTraffic: a.ServeRemoteTraffic,
+		DisableWebui:       a.DisableWebui,
 	}
 	if a.AllowedOrigins != nil {
 		res.AllowedOrigins = make([]string, len(a.AllowedOrigins))


### PR DESCRIPTION
This allows qri to serve a webui at `localhost:2503/webui`

The webui makes requests to the qri api at `localhost:2503`, since this was the specified "BACKEND_URL" when bundled.

However, we maybe can dynamically set this for the webui, by using the baseurl of the URL that is serving the webui.

We also have `http://localhost:2503` as an allowed content provider in our html's 'Content-Security-Provider', this is easy enough to fix, with golang templates and a field called `WebappUrl` or `RemoteUrl` or something in the config.

-----

Edit: turns out this wasn't an issue at all, was able to adjust the webapp and everything worked great! You can test yourself that it doesn't rely on `localhost:2503` by changing the port on which you are serving the API, and checking the webui at that port