### PR TITLE
feat(validate): tabular output of validation errors on CLI, configure output format

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/olekukonko/tablewriter"
 	"github.com/qri-io/deepdiff"
 	qrierr "github.com/qri-io/qri/errors"
 	"github.com/qri-io/qri/lib"
@@ -210,4 +211,22 @@ func printRefSelect(w io.Writer, refset *RefSelect) {
 	}
 	printInfo(w, refset.String())
 	fmt.Fprintln(w, "")
+}
+
+func renderTable(writer io.Writer, header []string, data [][]string) {
+	table := tablewriter.NewWriter(writer)
+	table.SetHeader(header)
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("  ")
+	table.SetNoWhiteSpace(true)
+	table.AppendBulk(data)
+	table.Render()
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -165,13 +165,18 @@ func (o *ValidateOptions) Run() (err error) {
 }
 
 func tabularValidationData(st *dataset.Structure, errs []jsonschema.KeyError) ([]string, [][]string) {
-	header := []string{"#", "path", "error"}
-	data := make([][]string, len(errs))
+	var (
+		header []string
+		data   = make([][]string, len(errs))
+	)
 
 	if st.Depth == 2 {
 		header = []string{"#", "row", "col", "value", "error"}
 		for i, e := range errs {
 			paths := strings.Split(e.PropertyPath, "/")
+			if len(paths) < 3 {
+				paths = []string{"", "", ""}
+			}
 			data[i] = []string{strconv.FormatInt(int64(i), 10), paths[1], paths[2], valStr(e.InvalidValue), e.Message}
 		}
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.5
 	github.com/multiformats/go-multicodec v0.1.6
 	github.com/multiformats/go-multihash v0.0.13
+	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pkg/errors v0.9.1
 	github.com/qri-io/apiutil v0.2.0
 	github.com/qri-io/dag v0.2.2-0.20200725180936-93d90d47ff6e

--- a/go.sum
+++ b/go.sum
@@ -989,6 +989,7 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
 	"github.com/qri-io/dataset/dstest"
-	"github.com/qri-io/jsonschema"
 	"github.com/qri-io/qfs/cafs"
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/base/dsfs"
@@ -1079,16 +1078,16 @@ Pirates of the Caribbean: At World's End ,foo
 	run.MustWriteFile(t, schemaFilename, schemaB)
 
 	cases := []struct {
-		p         ValidateDatasetParams
+		p         ValidateParams
 		numErrors int
 		err       string
 	}{
-		{ValidateDatasetParams{Ref: ""}, 0, "bad arguments provided"},
-		{ValidateDatasetParams{Ref: "me"}, 0, "cannot find dataset: peer"},
-		{ValidateDatasetParams{Ref: "me/movies"}, 4, ""},
-		{ValidateDatasetParams{Ref: "me/movies", BodyFilename: bodyFilename}, 1, ""},
-		{ValidateDatasetParams{Ref: "me/movies", SchemaFilename: schemaFilename}, 5, ""},
-		{ValidateDatasetParams{SchemaFilename: schemaFilename, BodyFilename: bodyFilename}, 1, ""},
+		{ValidateParams{Ref: ""}, 0, "bad arguments provided"},
+		{ValidateParams{Ref: "me"}, 0, "cannot find dataset: peer"},
+		{ValidateParams{Ref: "me/movies"}, 4, ""},
+		{ValidateParams{Ref: "me/movies", BodyFilename: bodyFilename}, 1, ""},
+		{ValidateParams{Ref: "me/movies", SchemaFilename: schemaFilename}, 5, ""},
+		{ValidateParams{SchemaFilename: schemaFilename, BodyFilename: bodyFilename}, 1, ""},
 	}
 
 	mr, err := testrepo.NewTestRepo()
@@ -1103,16 +1102,15 @@ Pirates of the Caribbean: At World's End ,foo
 	inst := NewInstanceFromConfigAndNode(ctx, config.DefaultConfigForTesting(), node)
 	m := NewDatasetMethods(inst)
 	for i, c := range cases {
-		got := []jsonschema.KeyError{}
-		err := m.Validate(&c.p, &got)
+		res := &ValidateResponse{}
+		err := m.Validate(&c.p, res)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch: expected: %s, got: %s", i, c.err, err.Error())
 			continue
 		}
 
-		if len(got) != c.numErrors {
-			t.Errorf("case %d error count mismatch. expected: %d, got: %d", i, c.numErrors, len(got))
-			t.Log(got)
+		if len(res.Errors) != c.numErrors {
+			t.Errorf("case %d error count mismatch. expected: %d, got: %d", i, c.numErrors, len(res.Errors))
 			continue
 		}
 	}


### PR DESCRIPTION
🕺 fancy demo:  https://asciinema.org/a/ThZ0dfFnnVasD0SAusozNR6Vo

make default output easier to interpret by formatting results as a table. when body data is tabular (structure.depth of 2), split path into "ROW" / "COLUMN" columns for easier reading.

Add an "output" flag that supports modifying the resulting output.

closes #1530, closes #1531