### PR TITLE
refactor(init): rename flag `source-body-path` to `body`

### DIFF
--- a/.circleci/user_benchmarks.sh
+++ b/.circleci/user_benchmarks.sh
@@ -32,7 +32,7 @@ run_bench_rows () {
   size_human=$(du -h $filename | awk '{print $1}' | tr -d 'M')
 
   echo "bench $name: init"
-  time_command qri init --source-body-path $filename --format CSV --name $name
+  time_command qri init --body $filename --format CSV --name $name
   echo "${rows},$size_human,init,$results" >> ../perf.csv
 
   echo "bench $name: save"

--- a/cmd/fsi_integration_test.go
+++ b/cmd/fsi_integration_test.go
@@ -407,7 +407,7 @@ func TestInitWithJsonSourceBodyPath(t *testing.T) {
 	workDir := run.CreateAndChdirToWorkDir("json_body")
 
 	// Init as a linked directory.
-	run.MustExec(t, fmt.Sprintf("qri init --name json_body --source-body-path %s", sourceFile))
+	run.MustExec(t, fmt.Sprintf("qri init --name json_body --body %s", sourceFile))
 
 	// Verify the directory contains the files that we expect.
 	dirContents := listDirectory(workDir)
@@ -417,7 +417,7 @@ func TestInitWithJsonSourceBodyPath(t *testing.T) {
 	}
 }
 
-// Test that init can use a source-body-path named "body.csv" without error
+// Test that init can use a --body named "body.csv" without error
 func TestInitSourceBodyFileNamedBody(t *testing.T) {
 	run := NewFSITestRunner(t, "test_peer_init_named_body", "qri_test_init_named_body")
 	defer run.Delete()
@@ -433,7 +433,7 @@ func TestInitSourceBodyFileNamedBody(t *testing.T) {
 	copyFile(t, sourceFile, "body.csv")
 
 	// Init as a linked directory.
-	run.MustExec(t, fmt.Sprintf("qri init --name init-named-body --source-body-path body.csv"))
+	run.MustExec(t, fmt.Sprintf("qri init --name init-named-body --body body.csv"))
 
 	// Verify the directory contains the files that we expect.
 	dirContents := listDirectory(workDir)
@@ -1118,7 +1118,7 @@ func TestInitWithSourceBodyPath(t *testing.T) {
 	workDir := run.CreateAndChdirToWorkDir("init_source")
 
 	// Init with a source body path.
-	run.MustExec(t, fmt.Sprintf("qri init --name init_source --source-body-path %s", sourceFile))
+	run.MustExec(t, fmt.Sprintf("qri init --name init_source --body %s", sourceFile))
 
 	// Verify the directory contains the files that we expect.
 	dirContents := listDirectory(workDir)
@@ -1377,7 +1377,7 @@ func TestInitMetaFailsToWrite(t *testing.T) {
 	}
 }
 
-// Test that if source-body-path doesn't exist, init will rollback
+// Test that if body doesn't exist, init will rollback
 func TestInitSourceBodyPathDoesNotExist(t *testing.T) {
 	run := NewFSITestRunner(t, "test_peer_init_source_not_found", "qri_test_init_source_not_found")
 	defer run.Delete()
@@ -1385,7 +1385,7 @@ func TestInitSourceBodyPathDoesNotExist(t *testing.T) {
 	workDir := run.CreateAndChdirToWorkDir("source_not_found")
 
 	// Init as a linked directory.
-	err := run.ExecCommand("qri init --name source_not_found --source-body-path not_found.json")
+	err := run.ExecCommand("qri init --name source_not_found --body not_found.json")
 	if err == nil {
 		t.Fatal("expected error trying to init, did not get an error")
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,9 +18,22 @@ func NewInitCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init [PATH]",
 		Short: "initialize a dataset directory",
-		Long: `'initialize' creates a new dataset, links it to the current or specified
-directory, and creates starter files for the dataset's components.`,
-		Example: ``,
+		Long: `'initialize' creates a new dataset, links it to the current directory,
+and creates starter files for the dataset's components. You can also specify an
+already existing body file using the 'body' flag.`,
+		Example: `  # initialize a new dataset, linking it to the current directory:
+
+  $ mkdir earthquakes && cd earthquakes
+  $ qri init
+  Name of new dataset [earthquakes]: 
+  Format of dataset, csv or json [csv]: csv
+  initialized working directory for new dataset user/earthquakes
+	
+	# initialize a new dataset, specifying a file to use as the body of the dataset:
+	
+  $ qri init --body /Users/datasets/earthquakes.csv --name earthquakes
+  initialized working directory for new dataset user/earthquakes
+`,
 		Annotations: map[string]string{
 			"group": "workdir",
 		},
@@ -34,7 +47,7 @@ directory, and creates starter files for the dataset's components.`,
 
 	cmd.Flags().StringVar(&o.Name, "name", "", "name of the dataset")
 	cmd.Flags().StringVar(&o.Format, "format", "", "format of dataset")
-	cmd.Flags().StringVar(&o.SourceBodyPath, "source-body-path", "", "path to the body file")
+	cmd.Flags().StringVar(&o.SourceBodyPath, "body", "", "path to the body file")
 	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "experimental: build and use dscache if none exists")
 
 	return cmd
@@ -99,7 +112,7 @@ func (o *InitOptions) Run() (err error) {
 		return err
 	}
 
-	// If --source-body-path flag is set, use that to figure out the format
+	// If --body flag is set, use that to figure out the format
 	if o.SourceBodyPath != "" {
 		ext := filepath.Ext(o.SourceBodyPath)
 		if strings.HasPrefix(ext, ".") {

--- a/cmd/remove_integration_test.go
+++ b/cmd/remove_integration_test.go
@@ -862,7 +862,7 @@ func TestRemoveWorksAfterDeletingWorkingDirectoryFromInit(t *testing.T) {
 	workDir := run.CreateAndChdirToWorkDir("remove_rm_wd")
 
 	// Init as a linked directory.
-	run.MustExec(t, fmt.Sprintf("qri init --name remove_rm_wd --source-body-path %s", sourceFile))
+	run.MustExec(t, fmt.Sprintf("qri init --name remove_rm_wd --body %s", sourceFile))
 
 	// Go up one directory
 	parentDir := filepath.Dir(workDir)
@@ -886,7 +886,7 @@ func TestRemoveWorksAfterDeletingWorkingDirectoryFromInit(t *testing.T) {
 	workDir = run.CreateAndChdirToWorkDir("remove_rm_wd")
 
 	// Init as a linked directory.
-	err = run.ExecCommand(fmt.Sprintf("qri init --name remove_rm_wd --source-body-path %s", sourceFile))
+	err = run.ExecCommand(fmt.Sprintf("qri init --name remove_rm_wd --body %s", sourceFile))
 	if err != nil {
 		t.Errorf("should be able to init dataset with the removed name, got %q", err)
 	}

--- a/fsi/init.go
+++ b/fsi/init.go
@@ -133,7 +133,7 @@ to create a working directory for an existing dataset`
 			}
 		}, rollback)
 
-	// Derive format from --source-body-path if provided.
+	// Derive format from --body if provided.
 	if p.Format == "" && p.SourceBodyPath != "" {
 		ext := filepath.Ext(p.SourceBodyPath)
 		if len(ext) > 0 {
@@ -239,7 +239,7 @@ to create a working directory for an existing dataset`
 
 // CanInitDatasetWorkDir returns nil if the directory can init a dataset, or an error if not
 func (fsi *FSI) CanInitDatasetWorkDir(dir, sourceBodyPath string) error {
-	// Get the source-body-path relative to the directory that we're initializing.
+	// Get the body relative to the directory that we're initializing.
 	relBodyPath := sourceBodyPath
 	if strings.HasPrefix(relBodyPath, dir) {
 		relBodyPath = strings.TrimPrefix(relBodyPath, dir)


### PR DESCRIPTION
Also, added examples to the `qri init --help` message

PR adding `body` flag to quickstart cli tutorial forthcoming.

closes #1524 