### PR TITLE
bug(profile): add check for qri config before running code against it

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -84,6 +84,8 @@ Depending on what work you are doing and what has changed, tests may take up to 
 
 If everything is marked "ok", you are in the clear. Any extended output is a sign that a test has failed. Be sure to fix any bugs that are indicated or tests that no longer pass.
 
+You may run just the tests for a specific package by running the `go test` command from that directory. You may also target specific tests to run based off a regex match of the test's name. For example, running `go test --run TestSetup` will execute any test that has the TestSetup prefix (tests named TestsSetupOne, TestSetup, and TestSetupWithAnotherName would all run). To see a verbose printout of all tests regardless of pass/skip/fail status, you may add the `-v` flag.
+
 #### CLI Help Style
 
 When creating or editing CLI commands, we try and follow a few style rules to keep things consistent:

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -672,7 +672,7 @@ func TestSetupHappensBeforeOtherCommands(t *testing.T) {
 	stdinText := "qri_test_name"
 	cmd, shutdown := newCommandWithStdin(ctx, qriHome, stdinText, repotest.NewTestCrypto())
 
-	cmdTextList := [8]string{"qri add", "qri connect", "qri diff", "qri get", "qri init", "qri list", "qri pull", "qri search"}
+	cmdTextList := [7]string{"qri add", "qri connect", "qri diff", "qri get", "qri init", "qri list", "qri search"}
 	expect := "no qri repo exists\nhave you run 'qri setup'?"
 
 	for _, cmdText := range cmdTextList {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -669,10 +669,9 @@ func TestSetupHappensBeforeOtherCommands(t *testing.T) {
 	ctx := context.Background()
 
 	qriHome := createTmpQriHome(t)
-	stdinText := "qri_test_name"
-	cmd, shutdown := newCommandWithStdin(ctx, qriHome, stdinText, repotest.NewTestCrypto())
+	cmd, shutdown := newCommand(ctx, qriHome, repotest.NewTestCrypto())
 
-	cmdTextList := [7]string{"qri add", "qri connect", "qri diff", "qri get", "qri init", "qri list", "qri search"}
+	cmdTextList := [7]string{"qri connect", "qri diff", "qri get", "qri init", "qri list", "qri pull", "qri search"}
 	expect := "no qri repo exists\nhave you run 'qri setup'?"
 
 	for _, cmdText := range cmdTextList {

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/api"
-	"github.com/qri-io/qri/errors"
 	"github.com/qri-io/qri/lib"
-	"github.com/qri-io/qri/repo"
 	"github.com/spf13/cobra"
 )
 
@@ -57,10 +55,7 @@ type ConnectOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *ConnectOptions) Complete(f Factory, args []string) (err error) {
-	repoPath := f.RepoPath()
-
-	repoErr := lib.QriRepoExists(repoPath)
-	if repoErr != nil && o.Setup {
+	if o.Setup {
 		so := &SetupOptions{
 			IOStreams: o.IOStreams,
 			IPFS:      true,
@@ -73,8 +68,6 @@ func (o *ConnectOptions) Complete(f Factory, args []string) (err error) {
 		if err = so.DoSetup(f); err != nil {
 			return err
 		}
-	} else if repoErr != nil {
-		return errors.New(repo.ErrNoRepo, "no qri repo exists\nhave you run 'qri setup'?")
 	}
 
 	if err = f.Init(); err != nil {

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -122,7 +122,7 @@ func NewQriOptions(ctx context.Context, repoPath string, generator gen.CryptoGen
 	}
 }
 
-// Init will initialize the internal state
+// Init will initialize the internal state before any command is run (excluding `qri setup`)
 func (o *QriOptions) Init() (err error) {
 	if o.inst != nil {
 		return

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/rpc"
 	"os"
@@ -127,6 +128,11 @@ func (o *QriOptions) Init() (err error) {
 		return
 	}
 	setNoPrompt(o.NoPrompt)
+
+	repoErr := lib.QriRepoExists(o.repoPath)
+	if repoErr != nil {
+		return errors.New("no qri repo exists\nhave you run 'qri setup'?")
+	}
 
 	opts := []lib.Option{
 		lib.OptIOStreams(o.IOStreams), // transfer iostreams to instance

--- a/go.sum
+++ b/go.sum
@@ -989,6 +989,7 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
closes #1492 

- [x] Add code to confirm a config exists before executing code against it & display useful error to user

- [x] Add test