### PR TITLE
fix(`Validate`): allow validation of FSI dataset w/ no history

### DIFF
--- a/base/dataset_prepare.go
+++ b/base/dataset_prepare.go
@@ -145,46 +145,66 @@ func InferValues(pro *profile.Profile, ds *dataset.Dataset) error {
 	// if we don't have a structure or schema then attempt to determine one
 	body := ds.BodyFile()
 	if body != nil && (ds.Structure == nil || ds.Structure.Schema == nil) {
-		// use a TeeReader that writes to a buffer to preserve data
-		buf := &bytes.Buffer{}
-		tr := io.TeeReader(body, buf)
-		var df dataset.DataFormat
-
-		df, err := detect.ExtensionDataFormat(body.FileName())
-		if err != nil {
-			log.Debug(err.Error())
-			err = fmt.Errorf("invalid data format: %s", err.Error())
+		if err := InferStructure(ds); err != nil {
 			return err
 		}
-
-		guessedStructure, _, err := detect.FromReader(df, tr)
-		if err != nil {
-			log.Debug(err.Error())
-			err = fmt.Errorf("determining dataset structure: %s", err.Error())
-			return err
-		}
-
-		// attach the structure, schema, and formatConfig, as appropriate
-		if ds.Structure == nil {
-			ds.Structure = guessedStructure
-		}
-		if ds.Structure.Schema == nil {
-			ds.Structure.Schema = guessedStructure.Schema
-		}
-		if ds.Structure.FormatConfig == nil {
-			ds.Structure.FormatConfig = guessedStructure.FormatConfig
-		}
-
-		// glue whatever we just read back onto the reader
-		// TODO (b5)- this may ruin readers that transparently depend on a read-closer
-		// we should consider a method on qfs.File that allows this non-destructive read pattern
-		ds.SetBodyFile(qfs.NewMemfileReader(body.FileName(), io.MultiReader(buf, body)))
 	}
 
 	if ds.Transform != nil && ds.Transform.ScriptFile() == nil && ds.Transform.IsEmpty() {
 		ds.Transform = nil
 	}
 
+	return nil
+}
+
+// InferStructure infers the Structure field of the dataset, guarenteeing
+// that the structure will contain a Format, FormatConfig, and Schema, based
+// on the given dataset body. It will not write over any Structure, Format,
+// FormatConfig, or Schema that already exists.
+func InferStructure(ds *dataset.Dataset) error {
+	if ds == nil {
+		return fmt.Errorf("empty dataset")
+	}
+
+	body := ds.BodyFile()
+	if body == nil {
+		return fmt.Errorf("empty body")
+	}
+	// use a TeeReader that writes to a buffer to preserve data
+	buf := &bytes.Buffer{}
+	tr := io.TeeReader(body, buf)
+	var df dataset.DataFormat
+
+	df, err := detect.ExtensionDataFormat(body.FileName())
+	if err != nil {
+		log.Debug(err.Error())
+		return fmt.Errorf("invalid data format: %s", err.Error())
+	}
+
+	guessedStructure, _, err := detect.FromReader(df, tr)
+	if err != nil {
+		log.Debug(err.Error())
+		return fmt.Errorf("determining dataset structure: %s", err.Error())
+	}
+
+	// attach the structure, schema, and formatConfig, as appropriate
+	if ds.Structure == nil {
+		ds.Structure = guessedStructure
+	}
+	if ds.Structure.Schema == nil {
+		ds.Structure.Schema = guessedStructure.Schema
+	}
+	if ds.Structure.FormatConfig == nil {
+		ds.Structure.FormatConfig = guessedStructure.FormatConfig
+	}
+	if ds.Structure.Format == "" {
+		ds.Structure.Format = guessedStructure.Format
+	}
+
+	// glue whatever we just read back onto the reader
+	// TODO (b5)- this may ruin readers that transparently depend on a read-closer
+	// we should consider a method on qfs.File that allows this non-destructive read pattern
+	ds.SetBodyFile(qfs.NewMemfileReader(body.FileName(), io.MultiReader(buf, body)))
 	return nil
 }
 

--- a/base/dataset_prepare.go
+++ b/base/dataset_prepare.go
@@ -157,7 +157,7 @@ func InferValues(pro *profile.Profile, ds *dataset.Dataset) error {
 	return nil
 }
 
-// InferStructure infers the Structure field of the dataset, guarenteeing
+// InferStructure infers the Structure field of the dataset, guaranteeing
 // that the structure will contain a Format, FormatConfig, and Schema, based
 // on the given dataset body. It will not write over any Structure, Format,
 // FormatConfig, or Schema that already exists.

--- a/base/dataset_prepare_test.go
+++ b/base/dataset_prepare_test.go
@@ -110,20 +110,14 @@ func TestInferValues(t *testing.T) {
 	}
 }
 
-func TestInferValuesStructure(t *testing.T) {
-	r := newTestRepo(t)
-	pro, err := r.Profile()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+func TestInferStructure(t *testing.T) {
 	ds := &dataset.Dataset{
 		Name: "animals",
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("animals.csv",
 		[]byte("Animal,Sound,Weight\ncat,meow,1.4\ndog,bark,3.7\n")))
 
-	if err = InferValues(pro, ds); err != nil {
+	if err := InferStructure(ds); err != nil {
 		t.Error(err)
 	}
 
@@ -142,13 +136,7 @@ func TestInferValuesStructure(t *testing.T) {
 	}
 }
 
-func TestInferValuesSchema(t *testing.T) {
-	r := newTestRepo(t)
-	pro, err := r.Profile()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+func TestInferStructureSchema(t *testing.T) {
 	ds := &dataset.Dataset{
 		Name: "animals",
 		Structure: &dataset.Structure{
@@ -157,7 +145,7 @@ func TestInferValuesSchema(t *testing.T) {
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("animals.csv",
 		[]byte("Animal,Sound,Weight\ncat,meow,1.4\ndog,bark,3.7\n")))
-	if err = InferValues(pro, ds); err != nil {
+	if err := InferStructure(ds); err != nil {
 		t.Error(err)
 	}
 

--- a/base/validate.go
+++ b/base/validate.go
@@ -17,7 +17,10 @@ func Validate(ctx context.Context, r repo.Repo, body qfs.File, st *dataset.Struc
 		return nil, fmt.Errorf("body passed to Validate must not be nil")
 	}
 	if st == nil {
-		return nil, fmt.Errorf("st passed to Validate must not be nil")
+		return nil, fmt.Errorf("structure passed to Validate must not be nil")
+	}
+	if st.Schema == nil {
+		return nil, fmt.Errorf("structure.Schema passed to Validate must not be nil")
 	}
 
 	// jsonschema assumes body is json, convert the format if necessary
@@ -28,6 +31,7 @@ func Validate(ctx context.Context, r repo.Repo, body qfs.File, st *dataset.Struc
 		}
 		file, err := ConvertBodyFormat(body, st, &convert)
 		if err != nil {
+			log.Debugf("base.Validate: ConvertBodyFormat error: %s", err)
 			return nil, err
 		}
 		body = file
@@ -36,10 +40,12 @@ func Validate(ctx context.Context, r repo.Repo, body qfs.File, st *dataset.Struc
 	// jsonschema does not handle data streams, have to read the whole body
 	data, err := ioutil.ReadAll(body)
 	if err != nil {
+		log.Debugf("base.Validate: ioutil.ReadAll error: %s", err)
 		return nil, err
 	}
 	jsch, err := st.JSONSchema()
 	if err != nil {
+		log.Debugf("base.Validate: JSONSchema error: %s", err)
 		return nil, err
 	}
 	return jsch.ValidateBytes(ctx, data)

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -95,7 +95,7 @@ func TestValidateRun(t *testing.T) {
 		{"", "", "", "", "table",
 			"bad arguments provided", "please provide a dataset name, or a supply the --body and --schema or --structure flags"},
 		{"peer/bad_dataset", "", "", "", "table",
-			"cannot find dataset: peer/bad_dataset", ""},
+			"reference not found", ""},
 		{"", "bad/filepath", "", "table", "testdata/days_of_week_schema.json",
 			"error opening body file: bad/filepath", ""},
 		{"", "testdata/days_of_week.csv", "bad/schema_filepath", "", "",

--- a/fsi/fsi.go
+++ b/fsi/fsi.go
@@ -106,6 +106,14 @@ func (fsi *FSI) ResolvedPath(ref *dsref.Ref) error {
 	return ErrNoLink
 }
 
+// IsFSIPath is a utility function that returns whether the given path is a
+// local filesystem path
+// TODO (ramfox) - remove this function & replace with a call to qfs.PathKind when it
+// supports the fsi prefix
+func IsFSIPath(path string) bool {
+	return strings.HasPrefix(path, "/fsi")
+}
+
 // ListLinks returns a list of linked datasets and their connected
 // directories
 func (fsi *FSI) ListLinks(offset, limit int) ([]dsref.VersionInfo, error) {

--- a/go.sum
+++ b/go.sum
@@ -989,6 +989,7 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -242,9 +242,7 @@ func (m *DatasetMethods) Get(p *GetParams, res *GetResult) error {
 	res.Ref = &ref
 	res.Dataset = ds
 
-	// TODO (b5) - replace this prefix check with a call to qfs.PathKind when it
-	// supports the fsi prefix
-	if strings.HasPrefix(ref.Path, "/fsi") {
+	if fsi.IsFSIPath(ref.Path) {
 		res.FSIPath = fsi.FilesystemPathToLocal(ref.Path)
 	}
 	// TODO (b5) - Published field is longer set as part of Reference Resolution
@@ -304,9 +302,7 @@ func (m *DatasetMethods) Get(p *GetParams, res *GetResult) error {
 			return err
 		}
 
-		// TODO (b5) - replace this prefix check with a call to qfs.PathKind when it
-		// supports the fsi prefix
-		if strings.HasPrefix(ref.Path, "/fsi") {
+		if fsi.IsFSIPath(ref.Path) {
 			// TODO(dustmop): Need to handle the special case where an FSI directory has a body
 			// but no structure, which should infer a schema in order to read the body. Once that
 			// works we can remove the fsi.GetBody call and just use base.ReadBody.
@@ -1015,16 +1011,14 @@ func (m *DatasetMethods) Validate(p *ValidateParams, res *ValidateResponse) erro
 
 	// if there is both a bodyfilename and a schema/structure
 	// we don't need to resolve any references
-	if !(p.BodyFilename != "" && schemaFlagType != "") {
+	if p.BodyFilename == "" || schemaFlagType == "" {
 		// TODO (ramfox): we need consts in `dsref` for "local", "network", "p2p"
 		ref, _, err = m.inst.ParseAndResolveRefWithWorkingDir(ctx, p.Ref, "local")
 		if err != nil {
 			return err
 		}
 
-		// TODO (b5) - replace this prefix check with a call to qfs.PathKind when it
-		// supports the fsi prefix
-		if strings.HasPrefix(ref.Path, "/fsi") {
+		if fsi.IsFSIPath(ref.Path) {
 			fsiPath = fsi.FilesystemPathToLocal(ref.Path)
 		}
 	}

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -1117,43 +1117,24 @@ Pirates of the Caribbean: At World's End ,foo
 }
 
 func TestDatasetRequestsValidateFSI(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
-	defer done()
+	tr := newTestRunner(t)
+	defer tr.Delete()
 
-	mr, err := testrepo.NewTestRepo()
-	if err != nil {
-		t.Fatalf("error allocating test repo: %s", err.Error())
-	}
-	node, err := p2p.NewQriNode(mr, config.DefaultP2PForTesting(), event.NilBus, nil)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	inst := NewInstanceFromConfigAndNode(ctx, config.DefaultConfigForTesting(), node)
-
-	// we need some fsi stuff to fully test remove
-	methods := NewFSIMethods(inst)
-	// create datasets working directory
-	datasetsDir, err := ioutil.TempDir("", "QriTestValidateFSIDataset")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(datasetsDir)
-
-	// initialize an example no-history dataset
-	initp := &InitFSIDatasetParams{
+	workDir := tr.CreateAndChdirToWorkDir("remove_no_history")
+	initP := &InitFSIDatasetParams{
 		Name:   "validate_test",
-		Dir:    datasetsDir,
+		Dir:    workDir,
 		Format: "csv",
 		Mkdir:  "validate_test",
 	}
-	var datasetName string
-	if err := methods.InitDataset(initp, &datasetName); err != nil {
+	var refstr string
+	if err := NewFSIMethods(tr.Instance).InitDataset(initP, &refstr); err != nil {
 		t.Fatal(err)
 	}
-	m := NewDatasetMethods(inst)
 
-	vp := &ValidateParams{Ref: datasetName}
+	m := NewDatasetMethods(tr.Instance)
+
+	vp := &ValidateParams{Ref: refstr}
 	vr := &ValidateResponse{}
 	if err := m.Validate(vp, vr); err != nil {
 		t.Fatal(err)

--- a/lib/load.go
+++ b/lib/load.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/base"
@@ -58,9 +57,9 @@ func (inst *Instance) loadLocalDataset(ctx context.Context, ref dsref.Ref) (*dat
 		err error
 	)
 
-	if strings.HasPrefix(ref.Path, "/fsi") {
+	if fsi.IsFSIPath(ref.Path) {
 		// Has an FSI Path, load from working directory
-		if ds, err = fsi.ReadDir(strings.TrimPrefix(ref.Path, "/fsi")); err != nil {
+		if ds, err = fsi.ReadDir(fsi.FilesystemPathToLocal(ref.Path)); err != nil {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
- Pull out logic from `InferValues` and create `InferStructure` function that infers a structure from a body. Adjust tests to test `InferStructure` directly.
- Adjust `lib.Validate` to use `ParseAndResolveRefWithWorkingDir` & `fsi.FilesystemPathToLocal` (to catch any fsiPath), rather then `CanonicalizeDatasetRef`
- Add `TestDatasetRequestValidateFSI` to catch errors when trying to validate a fsi dataset w/ no history

closes #1535 