### PR TITLE
fix(sql): Truncate unexpected columns during join

### DIFF
--- a/sql/qds/datasource.go
+++ b/sql/qds/datasource.go
@@ -179,7 +179,7 @@ func (rs *RecordStream) Next(ctx context.Context) (*execution.Record, error) {
 
 	aliasedRecord := make(map[octosql.VariableName]octosql.Value)
 	if rec, ok := ent.Value.([]interface{}); ok {
-		for i, x := range rec {
+		for i, x := range rec[:len(rs.aliasedFields)] {
 			switch v := x.(type) {
 			case string:
 				aliasedRecord[rs.aliasedFields[i]] = octosql.MakeString(v)


### PR DESCRIPTION
This fixes the symptom in #1503 though I know it's likely this isn't the best way to deal with it. At least it points to where the problem is.

Basically, `xristosk/bandcamp_artists` (in its current version, as I type) has more columns than column headers in its csv representation. This causes an index error when doing a join against another table. This fix just truncates the row to match the headers. These unnamed columns don't show up on [the qri.cloud page](https://qri.cloud/xristosk/bandcamp_artists) either, so I figured maybe you've been truncating it elsewhere in the codebase as well.