### PR TITLE
fix(event bus): encoded fields use lower-case names in JSON

### DIFF
--- a/event/dataset.go
+++ b/event/dataset.go
@@ -24,12 +24,12 @@ const (
 
 // DsChange represents the result of a change to a dataset
 type DsChange struct {
-	InitID     string
-	TopIndex   int
-	ProfileID  string
-	Username   string
-	PrettyName string
-	HeadRef    string
-	Info       *dsref.VersionInfo
-	Dir        string
+	InitID     string             `json:"initID"`
+	TopIndex   int                `json:"topIndex"`
+	ProfileID  string             `json:"profileID"`
+	Username   string             `json:"username"`
+	PrettyName string             `json:"prettyName"`
+	HeadRef    string             `json:"headRef"`
+	Info       *dsref.VersionInfo `json:"info"`
+	Dir        string             `json:"dir"`
 }

--- a/event/filesystem.go
+++ b/event/filesystem.go
@@ -12,9 +12,9 @@ const (
 
 // FSICreateLinkEvent describes an FSI created link
 type FSICreateLinkEvent struct {
-	FSIPath  string
-	Username string
-	Dsname   string
+	FSIPath  string `json:"fsiPath"`
+	Username string `json:"username"`
+	Dsname   string `json:"dsName"`
 }
 
 const (
@@ -32,9 +32,9 @@ const (
 
 // WatchfsChange represents events for filesystem changes
 type WatchfsChange struct {
-	Username    string
-	Dsname      string
-	Source      string
-	Destination string
-	Time        time.Time
+	Username    string    `json:"username"`
+	Dsname      string    `json:"dsName"`
+	Source      string    `json:"source"`
+	Destination string    `json:"destination"`
+	Time        time.Time `json:"time"`
 }

--- a/event/remote.go
+++ b/event/remote.go
@@ -40,7 +40,7 @@ const (
 
 // RemoteEvent encapsulates the push / pull progress of a dataset version
 type RemoteEvent struct {
-	Ref        dsref.Ref
-	RemoteAddr string
-	Progress   dag.Completion
+	Ref        dsref.Ref      `json:"ref"`
+	RemoteAddr string         `json:"remoteAddr"`
+	Progress   dag.Completion `json:"progress"`
 }


### PR DESCRIPTION
to keep over-the-wire coding consistent, use lowerCaseFieldNames for any struct that's being sent as an event & piped over a websocket.