### PR TITLE
fix(connect): only run `DoSetup` if there is existing repo

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -46,6 +46,8 @@ import (
 var (
 	// ErrBadArgs is an error for when a user provides bad arguments
 	ErrBadArgs = errors.New("bad arguments provided")
+	// ErrNoRepo is an error for  when a repo does not exist at a given path
+	ErrNoRepo = errors.New("no repo exists")
 
 	log = golog.Logger("lib")
 )

--- a/lib/setup.go
+++ b/lib/setup.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/qri-io/qfs/qipfs"
 	"github.com/qri-io/qri/config"
-	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/gen"
 )
 
@@ -21,7 +20,7 @@ func QriRepoExists(path string) error {
 	if !os.IsNotExist(err) {
 		return nil
 	}
-	return repo.ErrNoRepo
+	return ErrNoRepo
 }
 
 // SetupParams encapsulates arguments for Setup


### PR DESCRIPTION
If a user runs `qri connect --setup`, but already has a repo, proceed
forward with spinning up the qri daemon. Only run `DoSetup` if a
repository cannot be found.