### PR TITLE
test(windows): Fix lib/ unit tests for Windows platform

### DIFF
--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/qri-io/dataset"
@@ -389,4 +390,9 @@ func (m *FSIMethods) EnsureRef(p *EnsureParams, out *dsref.VersionInfo) error {
 	vi, err := m.inst.fsi.ModifyLinkDirectory(p.Dir, ref)
 	*out = *vi
 	return err
+}
+
+// PathJoinPosix joins two paths, and makes it explicitly clear we want POSIX slashes
+func PathJoinPosix(left, right string) string {
+	return path.Join(left, right)
 }

--- a/lib/fsi_test.go
+++ b/lib/fsi_test.go
@@ -199,7 +199,7 @@ func TestDscacheCheckout(t *testing.T) {
 	run.ChdirToRoot()
 
 	// Checkout the dataset, which should update the dscache
-	checkoutPath := filepath.Join(run.TmpDir, "cities_ds")
+	checkoutPath := PathJoinPosix(run.TmpDir, "cities_ds")
 	run.Checkout("me/cities_ds", checkoutPath)
 
 	// Access the dscache

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -527,7 +527,8 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 	go inst.waitForAllDone()
 	go func() {
 		if err := inst.bus.Publish(ctx, event.ETInstanceConstructed, nil); err != nil {
-			log.Error(err)
+			log.Debugf("instance construction: %w", err)
+			err = nil
 		}
 	}()
 

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -248,10 +249,15 @@ func addNowTransformDataset(t *testing.T, node *p2p.QriNode) dsref.Ref {
 }
 
 func TestInstanceEventSubscription(t *testing.T) {
+	timeoutMs := time.Millisecond*250
+	if runtime.GOOS == "windows" {
+		// TODO(dustmop): Why is windows slow? Perhaps its due to the IPFS lock.
+		timeoutMs = time.Millisecond*2500
+	}
 	// TODO (b5) - can't use testrunner for this test because event busses aren't
 	// wired up correctly in the test runner constructor. The proper fix is to have
 	// testrunner build it's instance using NewInstance
-	ctx, done := context.WithTimeout(context.Background(), time.Millisecond*250)
+	ctx, done := context.WithTimeout(context.Background(), timeoutMs)
 	defer done()
 
 	tmpDir, err := ioutil.TempDir("", "event_sub_test")

--- a/lib/test_runner_test.go
+++ b/lib/test_runner_test.go
@@ -131,7 +131,7 @@ func (tr *testRunner) ChdirToRoot() {
 }
 
 func (tr *testRunner) CreateAndChdirToWorkDir(subdir string) string {
-	tr.WorkDir = filepath.Join(tr.TmpDir, subdir)
+	tr.WorkDir = PathJoinPosix(tr.TmpDir, subdir)
 	err := os.Mkdir(tr.WorkDir, 0755)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Some FSI tests check explicit paths. For now, always use POSIX style forward slashes, instead of mixing them with Windows slashes. Increase the timeout for event bus publishing.

Treat "event bus is closed" event as debug, instead of error