### PR TITLE
fix(init): TargetDir for init, can be absolute, is created if needed

### DIFF
--- a/api/fsi.go
+++ b/api/fsi.go
@@ -142,18 +142,11 @@ func (h *FSIHandlers) InitHandler(routePrefix string) http.HandlerFunc {
 
 func (h *FSIHandlers) initHandler(routePrefix string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Backwards compatibility shim for now, can use either "dir" or "filepath".
-		// TODO: Update desktop to always use "dir", delete "filepath".
-		dir := r.FormValue("dir")
-		if dir == "" && r.FormValue("filepath") != "" {
-			dir = r.FormValue("filepath")
-		}
-		p := &lib.InitFSIDatasetParams{
-			Dir:            dir,
-			Name:           r.FormValue("name"),
-			Format:         r.FormValue("format"),
-			Mkdir:          r.FormValue("mkdir"),
-			SourceBodyPath: r.FormValue("sourcebodypath"),
+		p := &lib.InitDatasetParams{
+			TargetDir: r.FormValue("targetdir"),
+			Name:      r.FormValue("name"),
+			Format:    r.FormValue("format"),
+			BodyPath:  r.FormValue("bodypath"),
 		}
 
 		var name string

--- a/api/fsi_test.go
+++ b/api/fsi_test.go
@@ -98,9 +98,9 @@ func TestNoHistory(t *testing.T) {
 
 	// Create a linked dataset without saving, it has no versions in the repository
 	ref, err := run.Inst.FSI().InitDataset(fsi.InitParams{
-		Dir:    workDir,
-		Name:   "test_ds",
-		Format: "csv",
+		TargetDir: workDir,
+		Name:      "test_ds",
+		Format:    "csv",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -222,6 +222,7 @@ func (run *TestRunner) ExecCommand(cmdText string) error {
 // ExecCommandWithStdin executes the given command string with the string as stdin content
 func (run *TestRunner) ExecCommandWithStdin(ctx context.Context, cmdText, stdinText string) error {
 	setNoColor(true)
+	run.Streams.In = strings.NewReader(stdinText)
 	cmd, shutdown := NewQriCommand(ctx, run.RepoPath, run.RepoRoot.TestCrypto, run.Streams)
 	cmd.SetOutput(run.OutStream)
 	run.CmdR = cmd

--- a/fsi/init_test.go
+++ b/fsi/init_test.go
@@ -1,6 +1,9 @@
 package fsi
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -11,11 +14,64 @@ func TestInitDataset(t *testing.T) {
 	fsi := NewFSI(paths.testRepo, nil)
 
 	_, err := fsi.InitDataset(InitParams{
-		Name:   "test_ds",
-		Dir:    paths.firstDir,
-		Format: "csv",
+		Name:      "test_ds",
+		TargetDir: paths.firstDir,
+		Format:    "csv",
 	})
 	if err != nil {
 		t.Fatalf(err.Error())
+	}
+}
+
+func TestSplitDirByExist(t *testing.T) {
+	tmps := NewTmpPaths()
+	defer tmps.Close()
+
+	// Create one directory
+	if err := os.Mkdir(filepath.Join(tmps.firstDir, "create"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Split a path with two components after the existing directory
+	subjectDir := filepath.Join(tmps.firstDir, "create/this/path")
+	foundDir, missingDir := SplitDirByExist(subjectDir)
+
+	if !strings.HasSuffix(foundDir, "/create") {
+		t.Errorf("expected foundDir to have suffix \"/create\", got: %q", foundDir)
+	}
+	expectDir := "this/path"
+	if missingDir != expectDir {
+		t.Errorf("expected: %q, got: %q", expectDir, missingDir)
+	}
+
+	// Create another directory
+	if err := os.Mkdir(filepath.Join(tmps.firstDir, "create/this"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Split again
+	subjectDir = filepath.Join(tmps.firstDir, "create/this/path")
+	foundDir, missingDir = SplitDirByExist(subjectDir)
+
+	if !strings.HasSuffix(foundDir, "/create/this") {
+		t.Errorf("expected foundDir to have suffix \"/create/this\", got: %q", foundDir)
+	}
+	expectDir = "path"
+	if missingDir != expectDir {
+		t.Errorf("expected: %q, got: %q", expectDir, missingDir)
+	}
+
+	// Create last directory
+	if err := os.Mkdir(filepath.Join(tmps.firstDir, "create/this/path"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Split again
+	subjectDir = filepath.Join(tmps.firstDir, "create/this/path")
+	foundDir, missingDir = SplitDirByExist(subjectDir)
+
+	if !strings.HasSuffix(foundDir, "/create/this/path") {
+		t.Errorf("expected foundDir to have suffix \"/create/this/path\", got: %q", foundDir)
+	}
+	expectDir = ""
+	if missingDir != expectDir {
+		t.Errorf("expected: %q, got: %q", expectDir, missingDir)
 	}
 }

--- a/fsi/status_test.go
+++ b/fsi/status_test.go
@@ -39,9 +39,9 @@ func TestStatusValid(t *testing.T) {
 
 	fsi := NewFSI(paths.testRepo, nil)
 	_, err := fsi.InitDataset(InitParams{
-		Name:   "test_ds",
-		Dir:    paths.firstDir,
-		Format: "csv",
+		Name:      "test_ds",
+		TargetDir: paths.firstDir,
+		Format:    "csv",
 	})
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -87,9 +87,9 @@ func TestStatusInvalidDataset(t *testing.T) {
 
 	fsi := NewFSI(paths.testRepo, nil)
 	_, err := fsi.InitDataset(InitParams{
-		Name:   "test_ds",
-		Dir:    paths.firstDir,
-		Format: "csv",
+		Name:      "test_ds",
+		TargetDir: paths.firstDir,
+		Format:    "csv",
 	})
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -115,9 +115,9 @@ func TestStatusInvalidMeta(t *testing.T) {
 
 	fsi := NewFSI(paths.testRepo, nil)
 	_, err := fsi.InitDataset(InitParams{
-		Name:   "test_ds",
-		Dir:    paths.firstDir,
-		Format: "csv",
+		Name:      "test_ds",
+		TargetDir: paths.firstDir,
+		Format:    "csv",
 	})
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -141,9 +141,9 @@ func TestStatusNotFound(t *testing.T) {
 
 	fsi := NewFSI(paths.testRepo, nil)
 	_, err := fsi.InitDataset(InitParams{
-		Name:   "test_ds",
-		Dir:    paths.firstDir,
-		Format: "csv",
+		Name:      "test_ds",
+		TargetDir: paths.firstDir,
+		Format:    "csv",
 	})
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -776,10 +776,10 @@ func TestRenameNoHistory(t *testing.T) {
 	defer tr.Delete()
 
 	workDir := tr.CreateAndChdirToWorkDir("remove_no_history")
-	initP := &InitFSIDatasetParams{
-		Dir:    workDir,
-		Name:   "remove_no_history",
-		Format: "csv",
+	initP := &InitDatasetParams{
+		TargetDir: workDir,
+		Name:      "remove_no_history",
+		Format:    "csv",
 	}
 	var refstr string
 	if err := NewFSIMethods(tr.Instance).InitDataset(initP, &refstr); err != nil {
@@ -838,11 +838,10 @@ func TestDatasetRequestsRemove(t *testing.T) {
 	defer os.RemoveAll(datasetsDir)
 
 	// initialize an example no-history dataset
-	initp := &InitFSIDatasetParams{
-		Name:   "no_history",
-		Dir:    datasetsDir,
-		Format: "csv",
-		Mkdir:  "no_history",
+	initp := &InitDatasetParams{
+		Name:      "no_history",
+		TargetDir: filepath.Join(datasetsDir, "no_history"),
+		Format:    "csv",
 	}
 	var noHistoryName string
 	if err := fsim.InitDataset(initp, &noHistoryName); err != nil {
@@ -1121,11 +1120,10 @@ func TestDatasetRequestsValidateFSI(t *testing.T) {
 	defer tr.Delete()
 
 	workDir := tr.CreateAndChdirToWorkDir("remove_no_history")
-	initP := &InitFSIDatasetParams{
-		Name:   "validate_test",
-		Dir:    workDir,
-		Format: "csv",
-		Mkdir:  "validate_test",
+	initP := &InitDatasetParams{
+		Name:      "validate_test",
+		TargetDir: filepath.Join(workDir, "validate_test"),
+		Format:    "csv",
 	}
 	var refstr string
 	if err := NewFSIMethods(tr.Instance).InitDataset(initP, &refstr); err != nil {

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -340,12 +340,19 @@ func (m *FSIMethods) Restore(p *RestoreParams, out *string) (err error) {
 	return nil
 }
 
-// InitFSIDatasetParams proxies parameters to initialization
-type InitFSIDatasetParams = fsi.InitParams
+// InitDatasetParams proxies parameters to initialization
+type InitDatasetParams = fsi.InitParams
 
-// InitDataset creates a new dataset and FSI link
-func (m *FSIMethods) InitDataset(p *InitFSIDatasetParams, refstr *string) (err error) {
-	if err = qfs.AbsPath(&p.SourceBodyPath); err != nil {
+// InitDataset creates a new dataset in a working directory
+func (m *FSIMethods) InitDataset(p *InitDatasetParams, refstr *string) (err error) {
+	if err = qfs.AbsPath(&p.BodyPath); err != nil {
+		return err
+	}
+
+	if p.TargetDir == "" {
+		p.TargetDir = "."
+	}
+	if err = qfs.AbsPath(&p.TargetDir); err != nil {
 		return err
 	}
 
@@ -364,10 +371,10 @@ func (m *FSIMethods) InitDataset(p *InitFSIDatasetParams, refstr *string) (err e
 }
 
 // CanInitDatasetWorkDir returns nil if the directory can init a dataset, or an error if not
-func (m *FSIMethods) CanInitDatasetWorkDir(p *InitFSIDatasetParams, ok *bool) error {
-	dir := p.Dir
-	sourceBodyPath := p.SourceBodyPath
-	return m.inst.fsi.CanInitDatasetWorkDir(dir, sourceBodyPath)
+func (m *FSIMethods) CanInitDatasetWorkDir(p *InitDatasetParams, ok *bool) error {
+	targetPath := p.TargetDir
+	bodyPath := p.BodyPath
+	return m.inst.fsi.CanInitDatasetWorkDir(targetPath, bodyPath)
 }
 
 // EnsureParams holds values for EnsureRef call

--- a/lib/test_runner_test.go
+++ b/lib/test_runner_test.go
@@ -209,12 +209,18 @@ func (tr *testRunner) Init(refstr, format string) error {
 	}
 	m := NewFSIMethods(tr.Instance)
 	out := ""
-	p := InitFSIDatasetParams{
-		Name:   ref.Name,
-		Dir:    tr.WorkDir,
-		Format: format,
+	p := InitDatasetParams{
+		Name:      ref.Name,
+		TargetDir: tr.WorkDir,
+		Format:    format,
 	}
 	return m.InitDataset(&p, &out)
+}
+
+func (tr *testRunner) InitWithParams(p *InitDatasetParams) error {
+	m := NewFSIMethods(tr.Instance)
+	out := ""
+	return m.InitDataset(p, &out)
 }
 
 func (tr *testRunner) Checkout(refstr, dir string) error {


### PR DESCRIPTION
Prior to this change, lib.InitDataset would take two parameters, Dir which would need to exist already, and Mkdir which would be created but could only be a single directory name instead of a relative path. Fix this problem, and also add multiple tests, and cleanup some TODOs.