### PR TITLE
chore(dockerfile): use two-image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,70 @@
-FROM golang:1.14.6
+# build image to construct the binary
+FROM golang:1.14.6-alpine AS builder
 LABEL maintainer="sparkle_pony_2000@qri.io"
 
-ADD . /go/src/github.com/qri-io/qri
+RUN apk update && apk upgrade && \
+apk add --no-cache bash git openssh
 
-ENV GO111MODULE=on
+# RUN apk add --no-cache autoconf automake libtool gettext gettext-dev make g++ texinfo curl
+# WORKDIR /root
+# RUN wget https://github.com/emcrisostomo/fswatch/releases/download/1.14.0/fswatch-1.14.0.tar.gz
+# RUN tar -xvzf fswatch-1.14.0.tar.gz
+# WORKDIR /root/fswatch-1.14.0
+# RUN ./configure
+# RUN make && make install
 
-# run build
-RUN cd /go/src/github.com/qri-io/qri && make build
+# build environment variables:
+#   * enable go modules
+#   * use goproxy
+#   * disable cgo for our builds
+#   * ensure target os is linux
+ENV GO111MODULE=on \
+  GOPROXY=https://proxy.golang.org \
+  CGO_ENABLED=0 \
+  GOOS=linux
 
-# set default port to 8080, default log level, QRI_PATH env, IPFS_PATH env
-ENV PORT=8080 IPFS_LOGGING="" QRI_PATH=/data/qri IPFS_PATH=/data/ipfs
+# need to update to latest ca-certificates, otherwise TLS won't work properly.
+# Informative:
+# https://hackernoon.com/alpine-docker-image-with-secured-communication-ssl-tls-go-restful-api-128eb6b54f1f
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache \
+    ca-certificates \
+    && update-ca-certificates 2>/dev/null || true
 
-# Ports for Swarm TCP, Swarm uTP, API, Gateway, Swarm Websockets
-EXPOSE 4001 4002/udp 5001 8080 8081
+# add local files to cloud backend
+ADD . /qri
+WORKDIR /qri
+
+# install to produce a binary called "main" in the pwd
+#   -a flag rebuild all the packages we’re using,
+#      which means all the imports will be rebuilt with cgo disabled.
+#   -installsuffix cgo keeps output separate in build caches
+#   -o sets the output name to main
+#   . says "build this package"
+RUN go build -a -installsuffix cgo -o main .
+
+# *** production image ***
+# use alpine as base for smaller images
+FROM alpine:latest as production
+LABEL maintainer="sparkle_pony_2000@qri.io" 
 
 # create directories for IPFS & QRI, setting proper owners
-RUN mkdir -p $IPFS_PATH && mkdir -p $QRI_PATH \
-  && adduser --disabled-password --home $IPFS_PATH --uid 1000 --gid 100 ipfs \
-  && chown 1000:100 $IPFS_PATH \
-  && chown 1000:100 $QRI_PATH
+RUN mkdir -p $QRI_PATH /app
 
-# Expose the fs-repo & qri-repos as volumes.
-# Important this happens after the USER directive so permission are correct.
-# VOLUME $IPFS_PATH
-# VOLUME $QRI_PATH
+WORKDIR /app
+
+# Copy our static executable, qri and IPFS directories, which are empty
+COPY --from=builder /qri/main /bin/qri
+
+# need to update to latest ca-certificates, otherwise TLS won't work properly.
+# Informative:
+# https://hackernoon.com/alpine-docker-image-with-secured-communication-ssl-tls-go-restful-api-128eb6b54f1f
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache \
+    ca-certificates \
+    && update-ca-certificates 2>/dev/null || true
 
 # Set binary as entrypoint
 # the setup flag initalizes ipfs & qri repos if none is mounted

--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,16 @@ require-goversion:
 	fi;
 
 require-govvv:
-	$(eval govvv_loc := $(shell which govvv))
-	@if [ "$(govvv_loc)" == "" ]; then go install github.com/ahmetb/govvv; fi;
-
-govvv_version_flags:= $(shell govvv -flags -pkg $(PKG) -version $(QRI_VERSION))
+ifeq (,$(shell which govvv))
+	@echo "installing govvv"
+	$(shell go install github.com/ahmetb/govvv)
+endif
 
 build: require-goversion require-govvv
-	$(BUILD_FLAGS) go build -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} $(govvv_version_flags)" .
+	$(BUILD_FLAGS) go build -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} $(shell govvv -flags -pkg $(PKG) -version $(QRI_VERSION))" .
 
 install: require-goversion require-govvv
-	$(BUILD_FLAGS) go install -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} $(govvv_version_flags)" .
+	$(BUILD_FLAGS) go install -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} $(shell govvv -flags -pkg $(PKG) -version $(QRI_VERSION))" .
 .PHONY: install
 
 dscache_fbs:


### PR DESCRIPTION
fix an issue in makefiles that's super prominent when make is used in conjunction with dockerfiles, drop size of production docker images from ~586MB to ~75MB