### PR TITLE
feat(version): add info from git and golang to qri version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ QRI_VERSION?="0.9.14-dev"
 BUILD_FLAGS?=CGO_ENABLED=0
 PKG=$(shell go list ./version)
 GOLANG_VERSION=$(shell go version | awk '{print $$3}')
-GOVVV_FLAGS=$(shell govvv -flags -pkg $(PKG) -version $(QRI_VERSION))
 
 require-goversion:
 	$(eval minver := go1.13)
@@ -24,11 +23,17 @@ require-goversion:
 		fi; \
 	fi;
 
-build: require-goversion
-	$(BUILD_FLAGS) go build -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} ${GOVVV_FLAGS}" .
+require-govvv:
+	$(eval govvv_loc := $(shell which govvv))
+	@if [ "$(govvv_loc)" == "" ]; then go install github.com/ahmetb/govvv; fi;
 
-install: require-goversion
-	$(BUILD_FLAGS) go install -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} ${GOVVV_FLAGS}" .
+govvv_version_flags:= $(shell govvv -flags -pkg $(PKG) -version $(QRI_VERSION))
+
+build: require-goversion require-govvv
+	$(BUILD_FLAGS) go build -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} $(govvv_version_flags)" .
+
+install: require-goversion require-govvv
+	$(BUILD_FLAGS) go install -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} $(govvv_version_flags)" .
 .PHONY: install
 
 dscache_fbs:
@@ -51,33 +56,3 @@ cli-docs:
 
 update-changelog:
 	conventional-changelog -p angular -i CHANGELOG.md -s
-
-build-cross-platform:
-	@echo "building qri_windows_amd64"
-	mkdir qri_windows_amd64
-	env GOOS=windows GOARCH=amd64 go build -o qri_windows_amd64/qri .
-	zip -r qri_windows_amd64.zip qri_windows_amd64 && rm -r qri_windows_amd64
-	@echo "building qri_windows_386"
-	mkdir qri_windows_386
-	env GOOS=windows GOARCH=386 go build -o qri_windows_386/qri .
-	zip -r qri_windows_386.zip qri_windows_386 && rm -r qri_windows_386
-	@echo "building qri_linux_arm"
-	mkdir qri_linux_arm
-	env GOOS=linux GOARCH=arm go build -o qri_linux_arm/qri .
-	zip -r qri_linux_arm.zip qri_linux_arm && rm -r qri_linux_arm
-	@echo "building qri_linux_amd64"
-	mkdir qri_linux_amd64
-	env GOOS=linux GOARCH=amd64 go build -o qri_linux_amd64/qri .
-	zip -r qri_linux_amd64.zip qri_linux_amd64 && rm -r qri_linux_amd64
-	@echo "building qri_linux_386"
-	mkdir qri_linux_386
-	env GOOS=linux GOARCH=386 go build -o qri_linux_386/qri .
-	zip -r qri_linux_386.zip qri_linux_386 && rm -r qri_linux_386
-	@echo "building qri_darwin_386"
-	mkdir qri_darwin_386
-	env GOOS=darwin GOARCH=386 go build -o qri_darwin_386/qri .
-	zip -r qri_darwin_386.zip qri_darwin_386 && rm -r qri_darwin_386	
-	@echo "building qri_darwin_amd64"
-	mkdir qri_darwin_amd64
-	env GOOS=darwin GOARCH=amd64 go build -o qri_darwin_amd64/qri .
-	zip -r qri_darwin_amd64.zip qri_darwin_amd64 && rm -r qri_darwin_amd64

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 
 default: build
 
+QRI_VERSION?="0.9.14-dev"
+
+BUILD_FLAGS?=CGO_ENABLED=0
+PKG=$(shell go list ./version)
+GOLANG_VERSION=$(shell go version | awk '{print $$3}')
+GOVVV_FLAGS=$(shell govvv -flags -pkg $(PKG) -version $(QRI_VERSION))
+
 require-goversion:
 	$(eval minver := go1.13)
 # Get the version of the current go binary
@@ -18,24 +25,11 @@ require-goversion:
 	fi;
 
 build: require-goversion
-	go install
+	$(BUILD_FLAGS) go build -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} ${GOVVV_FLAGS}" .
 
-build-latest:
-	git checkout master && git pull
-	build
-
-update-qri-deps: require-gopath
-	cd $$GOPATH/src/github.com/qri-io/qri && git checkout master && git pull && gx install
-	cd $$GOPATH/src/github.com/qri-io/qfs && git checkout master && git pull
-	cd $$GOPATH/src/github.com/qri-io/qri/registry && git checkout master && git pull
-	cd $$GOPATH/src/github.com/qri-io/dataset && git checkout master && git pull
-	cd $$GOPATH/src/github.com/qri-io/varName && git checkout master && git pull
-	cd $$GOPATH/src/github.com/qri-io/deepdiff && git checkout master && git pull
-	cd $$GOPATH/src/github.com/qri-io/jsonschema && git checkout master && git pull
-	cd $$GOPATH/src/github.com/qri-io/starlib && git checkout master && git pull
-	cd $$GOPATH/src/github.com/qri-io/dag && git checkout master && git pull
-	cd $$GOPATH/src/github.com/qri-io/ioes && git checkout master && git pull
-	cd $$GOPATH/src/github.com/qri-io/qri
+install: require-goversion
+	$(BUILD_FLAGS) go install -ldflags="-X ${PKG}.GolangVersion=${GOLANG_VERSION} ${GOVVV_FLAGS}" .
+.PHONY: install
 
 dscache_fbs:
 	cd dscache && flatc --go def.fbs

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Qri](https://img.shields.io/badge/made%20by-qri-magenta.svg?style=flat-square)](https://qri.io) [![GoDoc](https://godoc.org/github.com/qri-io/qri?status.svg)](http://godoc.org/github.com/qri-io/qri) [![License](https://img.shields.io/github/license/qri-io/qri.svg?style=flat-square)](./LICENSE) [![Codecov](https://img.shields.io/codecov/c/github/qri-io/qri.svg?style=flat-square)](https://codecov.io/gh/qri-io/qri) [![CI](https://img.shields.io/circleci/project/github/qri-io/qri.svg?style=flat-square)](https://circleci.com/gh/qri-io/qri)
 
-<h1 align="center">Qri Backend and CLI</h1>
+<h1 align="center">Qri CLI</h1>
 
 <div align="center">
   <img alt="logo" src="https://qri.io/img/blobs/blob_trio.png" width="128">
 </div>
 <div align="center">
-  <strong>a global dataset version control system (GDVCS) built on the distributed web</strong>
+  <strong>a dataset version control system built on the distributed web</strong>
 </div>
 
 <div align="center">
@@ -54,7 +54,7 @@
 | "I want to help build the Qri backend" | [Read the Contributing guides](https://github.com/qri-io/qri/blob/master/CONTRIBUTOR.md) |
 | "I want to build Qri from source" | [Build Qri from source](#build)
 
-__qri is a global dataset version control system (GDVCS) built on the distributed web__
+__qri is a global dataset version control system built on the distributed web__
 
 Breaking that down:
 
@@ -71,6 +71,77 @@ If you’re unfamiliar with *version control,* particularly the distributed kind
 4. **Sync** _How do I handle changes in data?_
 
 Because qri is *global* and *content-addressed*, adding data to qri also checks the entire network to see if someone has added it before. Since qri is focused solely on datasets, it can provide meaningful search results. Every change on qri is associated with a peer, creating an audit-able trail you can use to quickly see what has changed and who has changed it. All datasets on qri are automatically described at the time of ingest using a flexible schema that makes data naturally inter-operate. Qri comes with tools to turn *all* datasets on the network into a JSON API with a single command. Finally, all changes in qri are tracked & synced.
+
+<a id="build"></a>
+## Building From Source
+
+To build qri you'll need the [go programming language](https://golang.org/dl/) on your machine.
+
+```shell
+$ git clone https://github.com/qri-io/qri
+$ cd qri
+$ make install
+```
+
+If this is your first time building, this command will have a lot of output. That's good! Its means it's working :) It'll take a minute or two to build.
+
+After this is done, there will be a new binary `qri` in your `~/go/bin` directory if using go modules, and `$GOPATH/bin` directory otherwise. You should be able to run:
+
+```shell
+$ qri help
+```
+and see help output.
+
+### Building on Windows
+
+To start, make sure that you have enabled [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development). A library that we depend on needs it enabled in order to properly handle symlinks. If not done, you'll likely get the error message "A required privilege is not held by the client".
+
+You should not need to Run As Administrator to build or run `qri`. We do not recommend using administrator to run `qri`.
+
+#### Shell
+
+For your shell, we recommend using [msys2](https://www.msys2.org/). Other shells, such as `cmd`, `Powershell`, or `cygwin` may also be usable, but `msys2` makes it easy to install our required dependencies. IPFS also recommends `msys2`, and `qri` is built on top of IPFS.
+
+#### Dependencies
+
+Building depends upon having `git` and `make` installed. If using `msys2`, you can easily install these by using the package manager "pacman". In a shell, type:
+
+```shell
+pacman -S git make
+```
+
+Assuming you've also installed `go` using the official Windows installer linked above, you will also need to add `go` to your `PATH` by modifying your environment variable. See the next section on "Environment variables" for more information.
+
+Due to how msys2 treats the `PATH` variable, you also need to add a new environment variable `MSYS2_PATH_TYPE`, with the value `inherit`, using the same procedure.
+
+Once these steps are complete, proceed to <a href="#building">building</a>.
+
+### Building on Rasberry PI
+
+On a Raspberry PI, you'll need to increase your swap file size in order to build. Normal desktop and server linux OSes should be fine to proceed to <a href="#building">building</a>.
+
+One symptom of having not enough swap space is the `go install` command producing an error message ending with:
+
+```
+link: signal: killed
+```
+
+To increase your swapfile size, first turn off the swapfile:
+
+```
+sudo dphys-swapfile swapoff
+```
+
+Then edit `/etc/dphys-swapfile` as root and set `CONF_SWAPSIZE` to 1024.
+
+Finally turn on the swapfile again:
+
+```
+sudo dphys-swapfile swapon
+```
+
+Otherwise linux machines with reduced memory will have other ways to increase their swap file sizes. Check documentation for your particular machine.
+
 
 ## Packages
 
@@ -98,94 +169,6 @@ The following packages are not under Qri, but are important dependencies, so we 
 | Package | Version |
 |--------|-------|
 | `ipfs` | [![ipfs version](https://img.shields.io/badge/ipfs-v0.6.0-blue.svg)](https://github.com/ipfs/go-ipfs/) |
-
-<a id="build"></a>
-## Building From Source
-
-To build qri you'll need the [go programming language](https://golang.org/dl/) on your machine. We require at least `go` version 1.13 to build qri.
-
-If you are new to using `go`, you should set your PATH environment variable to include the location that your go tool installs binaries to, which is usually `~/go/bin`. For more information about environment variables see [this tutorial](https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html).
-
-Building then depends upon your operating system:
-
-### Mac OSX
-
-Having `go` installed is enough, proceed to <a href="#building">building</a>.
-
-### Windows
-
-To start, make sure that you have enabled [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development). A library that we depend on needs it enabled in order to properly handle symlinks. If not done, you'll likely get the error message "A required privilege is not held by the client".
-
-You should not need to Run As Administrator to build or run `qri`. We do not recommend using administrator to run `qri`.
-
-#### Shell
-
-For your shell, we recommend using [msys2](https://www.msys2.org/). Other shells, such as `cmd`, `Powershell`, or `cygwin` may also be usable, but `msys2` makes it easy to install our required dependencies. IPFS also recommends `msys2`, and `qri` is built on top of IPFS.
-
-#### Dependencies
-
-Building depends upon having `git` and `make` installed. If using `msys2`, you can easily install these by using the package manager "pacman". In a shell, type:
-
-```shell
-pacman -S git make
-```
-
-Assuming you've also installed `go` using the official Windows installer linked above, you will also need to add `go` to your `PATH` by modifying your environment variable. See the next section on "Environment variables" for more information.
-
-Due to how msys2 treats the `PATH` variable, you also need to add a new environment variable `MSYS2_PATH_TYPE`, with the value `inherit`, using the same procedure.
-
-Once these steps are complete, proceed to <a href="#building">building</a>.
-
-### Linux
-
-On a Raspberry PI, you'll need to increase your swap file size in order to build. Normal desktop and server linux OSes should be fine to proceed to <a href="#building">building</a>.
-
-One symptom of having not enough swap space is the `go install` command producing an error message ending with:
-
-```
-link: signal: killed
-```
-
-To increase your swapfile size, first turn off the swapfile:
-
-```
-sudo dphys-swapfile swapoff
-```
-
-Then edit `/etc/dphys-swapfile` as root and set `CONF_SWAPSIZE` to 1024.
-
-Finally turn on the swapfile again:
-
-```
-sudo dphys-swapfile swapon
-```
-
-Otherwise linux machines with reduced memory will have other ways to increase their swap file sizes. Check documentation for your particular machine.
-
-### Building
-
-In your terminal, navigate to some directory that you want to work within. Let's say we're using a directory in our home folder called "go-code".
-
-```shell
-$ cd go-code
-$ git clone https://github.com/qri-io/qri
-```
-
-Once this repository is cloned, enter it and install:
-
-```shell
-$ cd qri
-$ go install
-```
-
-If this is your first time building, this command will have a lot of output. That's good! Its means it's working :) It'll take a minute or two to build.
-
-After this is done, there will be a new binary `qri` in your `~/go/bin` directory if using go modules, and `$GOPATH/bin` directory otherwise. You should be able to run:
-
-```shell
-$ qri help
-```
-and see help output.
 
 
 ###### This documentation has been adapted from the [Cycle.js](https://github.com/cyclejs/cyclejs) documentation.

--- a/api/api.go
+++ b/api/api.go
@@ -17,7 +17,7 @@ import (
 var (
 	log = golog.Logger("qriapi")
 	// APIVersion is the version string that is written in API responses
-	APIVersion = version.String
+	APIVersion = version.Version
 )
 
 const (

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,7 +19,7 @@ For updates & further information check https://github.com/qri-io/qri/releases`,
 		},
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			printInfo(ioStreams.Out, version.String)
+			printInfo(ioStreams.Out, version.Summary())
 			return nil
 		},
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/version"
 	"github.com/spf13/cobra"
@@ -8,6 +11,8 @@ import (
 
 // NewVersionCommand creates a new `qri version` cobra command that prints the current qri version
 func NewVersionCommand(_ Factory, ioStreams ioes.IOStreams) *cobra.Command {
+	var format string
+
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "print the version number",
@@ -19,9 +24,22 @@ For updates & further information check https://github.com/qri-io/qri/releases`,
 		},
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			printInfo(ioStreams.Out, version.Summary())
+			switch format {
+			case "json":
+				data, err := json.Marshal(version.Map())
+				if err != nil {
+					return err
+				}
+				printInfo(ioStreams.Out, string(data))
+			case "pretty":
+				printInfo(ioStreams.Out, version.Summary())
+			default:
+				return fmt.Errorf("unrecognized output format: %q", format)
+			}
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&format, "format", "pretty", "output format. One of (pretty|json)")
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/qri-io/qri
 go 1.13
 
 require (
+	github.com/ahmetb/govvv v0.3.0 // indirect
 	github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f
 	github.com/beme/abide v0.0.0-20190723115211-635a09831760
 	github.com/cheggaaa/pb/v3 v3.0.4

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
+github.com/ahmetb/govvv v0.3.0 h1:YGLGwEyiUwHFy5eh/RUhdupbuaCGBYn5T5GWXp+WJB0=
+github.com/ahmetb/govvv v0.3.0/go.mod h1:4WRFpdWtc/YtKgPFwa1dr5+9hiRY5uKAL08bOlxOR6s=
 github.com/alangpierce/go-forceexport v0.0.0-20160317203124-8f1d6941cd75/go.mod h1:uAXEEpARkRhCZfEvy/y0Jcc888f9tHCc1W7/UeEtreE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -13,7 +13,7 @@ import (
 var (
 	log = golog.Logger("qrip2p")
 	// QriServiceTag marks the type & version of the qri service
-	QriServiceTag = fmt.Sprintf("qri/%s", version.String)
+	QriServiceTag = fmt.Sprintf("qri/%s", version.Version)
 	// ErrNotConnected is for a missing required network connection
 	ErrNotConnected = fmt.Errorf("no p2p connection")
 	// ErrQriProtocolNotSupported is returned when a connection can't be upgraded

--- a/remote/client.go
+++ b/remote/client.go
@@ -741,7 +741,7 @@ func (c *client) signHTTPRequest(req *http.Request) error {
 	req.Header.Add("timestamp", now)
 	req.Header.Add("pid", peerID)
 	req.Header.Add("signature", b64Sig)
-	req.Header.Add("qri-version", version.String)
+	req.Header.Add("qri-version", version.Version)
 	return nil
 }
 

--- a/startf/transform.go
+++ b/startf/transform.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Version is the version of qri that this transform was run with
-var Version = version.String
+var Version = version.Version
 
 // ExecOpts defines options for execution
 type ExecOpts struct {

--- a/version/version.go
+++ b/version/version.go
@@ -19,10 +19,23 @@ var (
 	GolangVersion = "n/a"
 )
 
+// Map returns a summary of build info as a string map
+func Map() map[string]string {
+	return map[string]string{
+		"version":       Version,
+		"gitCommit":     GitCommit,
+		"gitBranch":     GitBranch,
+		"gitState":      GitState,
+		"gitSummary":    GitSummary,
+		"buildDate":     BuildDate,
+		"golangVersion": GolangVersion,
+	}
+}
+
 // Summary prints a summary of all build info.
 func Summary() string {
 	return fmt.Sprintf(
-		"version:\t%s\n\nbuild date:\t%s\ngit summary:\t%s\ngit branch:\t%s\ngit commit:\t%s\ngit state:\t%s\ngolang version:\t%s",
+		"version:\t%s\nbuild date:\t%s\ngit summary:\t%s\ngit branch:\t%s\ngit commit:\t%s\ngit state:\t%s\ngolang version:\t%s",
 		Version,
 		BuildDate,
 		GitSummary,

--- a/version/version.go
+++ b/version/version.go
@@ -21,6 +21,12 @@ var (
 
 // Map returns a summary of build info as a string map
 func Map() map[string]string {
+	if Version == "n/a" {
+		return map[string]string{
+			"error": `This qri binary was not built with version information. Please build using 'make install' instead of 'go install'`,
+		}
+	}
+
 	return map[string]string{
 		"version":       Version,
 		"gitCommit":     GitCommit,
@@ -34,6 +40,10 @@ func Map() map[string]string {
 
 // Summary prints a summary of all build info.
 func Summary() string {
+	if Version == "n/a" {
+		return `Warning! This qri binary was not built with version information. Please build using 'make install' instead of 'go install'`
+	}
+
 	return fmt.Sprintf(
 		"version:\t%s\nbuild date:\t%s\ngit summary:\t%s\ngit branch:\t%s\ngit commit:\t%s\ngit state:\t%s\ngolang version:\t%s",
 		Version,

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,34 @@
 package version
 
-// String is the version number of qri
-const String = "0.9.14-dev"
+import "fmt"
+
+var (
+	// Version is set by govvv at build time
+	Version = "n/a"
+	// GitCommit is set by govvv at build time
+	GitCommit = "n/a"
+	// GitBranch  is set by govvv at build time
+	GitBranch = "n/a"
+	// GitState  is set by govvv at build time
+	GitState = "n/a"
+	// GitSummary is set by govvv at build time
+	GitSummary = "n/a"
+	// BuildDate  is set by govvv at build time
+	BuildDate = "n/a"
+	// GolangVersion is set by govvv at build time
+	GolangVersion = "n/a"
+)
+
+// Summary prints a summary of all build info.
+func Summary() string {
+	return fmt.Sprintf(
+		"version:\t%s\n\nbuild date:\t%s\ngit summary:\t%s\ngit branch:\t%s\ngit commit:\t%s\ngit state:\t%s\ngolang version:\t%s",
+		Version,
+		BuildDate,
+		GitSummary,
+		GitBranch,
+		GitCommit,
+		GitState,
+		GolangVersion,
+	)
+}


### PR DESCRIPTION
before:
```
$ qri version
0.9.14-dev
```

after:
```
$ qri version
version:	0.9.14-dev
build date:	2020-11-30T20:32:33Z
git summary:	v0.9.13-56-gb6834436-dirty
git branch:	feat_version_add_git_info
git commit:	b6834436
git state:	dirty
golang version:	go1.15
```

Also adds  `$ qri version --format=json` flag to get this info printed as JSON, which tools like qri desktop's `main` process may be able to make use of