### PR TITLE
feat(save): support custom timestamps on commit

### DIFF
--- a/base/dsfs/compute_fields.go
+++ b/base/dsfs/compute_fields.go
@@ -168,8 +168,12 @@ func (cff *computeFieldsFile) handleRows(ctx context.Context) {
 	}
 
 	cff.Lock()
-	// assign timestamp early. saving process on large files can take many minutes
-	cff.ds.Commit.Timestamp = Timestamp()
+	if cff.ds.Commit.Timestamp.IsZero() {
+		// assign timestamp early. saving process on large files can take many minutes
+		cff.ds.Commit.Timestamp = Timestamp()
+	} else {
+		cff.ds.Commit.Timestamp = cff.ds.Commit.Timestamp.In(time.UTC)
+	}
 	cff.acc = dsstats.NewAccumulator(st)
 	cff.Unlock()
 

--- a/base/dsfs/dataset.go
+++ b/base/dsfs/dataset.go
@@ -111,6 +111,8 @@ func DerefDataset(ctx context.Context, store qfs.Filesystem, ds *dataset.Dataset
 
 // SaveSwitches represents options for saving a dataset
 type SaveSwitches struct {
+	// Use a custom timestamp, defaults to time.Now if unset
+	Time time.Time
 	// Replace is whether the save is a full replacement or a set of patches to previous
 	Replace bool
 	// Pin is whether the dataset should be pinned

--- a/cmd/testdata/movies/dataset.json
+++ b/cmd/testdata/movies/dataset.json
@@ -6,7 +6,6 @@
   },
   "commit": {
     "qri": "cm:0",
-    "timestamp": "2017-03-01T01:00:00.000Z",
     "title": "removing rows",
     "message": "removing rows for test purposes"
   },

--- a/repo/test/testdata/cities/input.dataset.json
+++ b/repo/test/testdata/cities/input.dataset.json
@@ -2,7 +2,6 @@
   "qri": "ds:0",
   "commit": {
     "qri": "cm:0",
-    "timestamp": "2017-01-01T01:00:00.000Z",
     "title": "initial commit"
   },
   "meta": {

--- a/repo/test/testdata/counter/input.dataset.json
+++ b/repo/test/testdata/counter/input.dataset.json
@@ -2,7 +2,6 @@
   "qri": "ds:0",
   "commit": {
     "qri": "cm:0",
-    "timestamp": "2017-02-01T01:00:00.000Z",
     "title": "initial commit"
   },
   "meta": {

--- a/repo/test/testdata/craigslist/input.dataset.json
+++ b/repo/test/testdata/craigslist/input.dataset.json
@@ -2,8 +2,7 @@
   "qri": "ds:0",
   "commit" : {
     "qri" : "cm:0",
-    "title" : "initial commit",
-    "timestamp": "2017-04-01T01:00:00.000Z"
+    "title" : "initial commit"
   },
   "structure": {
     "checksum": "QmPT7t4GQaBN4uxCdv3PD8A5vWaJ1ELCKCaZEjYYvUhe4W",

--- a/repo/test/testdata/flourinated_compounds_in_fast_food_packaging/input.dataset.json
+++ b/repo/test/testdata/flourinated_compounds_in_fast_food_packaging/input.dataset.json
@@ -1,8 +1,7 @@
 {
   "commit" : {
     "qri" : "cm:0",
-    "title" : "initial commit",
-    "timestamp": "2017-05-01T01:00:00.000Z"
+    "title" : "initial commit"
   },
   "meta" : {
     "title" : "Fluorinated Compounds in U.S. Fast Food Packaging",

--- a/repo/test/testdata/movies/input.dataset.json
+++ b/repo/test/testdata/movies/input.dataset.json
@@ -6,7 +6,6 @@
   },
   "commit": {
     "qri": "cm:0",
-    "timestamp": "2017-03-01T01:00:00.000Z",
     "title": "initial commit"
   },
   "structure": {

--- a/repo/test/testdata/sitemap/input.dataset.json
+++ b/repo/test/testdata/sitemap/input.dataset.json
@@ -7,7 +7,6 @@
   },
   "commit": {
     "qri": "cm:0",
-    "timestamp": "2017-06-01T01:00:00.000Z",
     "title": "initial commit"
   },
   "structure": {


### PR DESCRIPTION
This will let [qri-git](https://github.com/qri-io/qri-git) match timestamps from git on import.

setting the input dataset commit.Timestamp value will now be preserved instead of being overwritten with the current time. Input timestamp will ALWAYS be converted to UTC time zone.

This change makes it much easier to generate dataset histories with commit timestamps that aren't in chronological order, which is perfectly fine according to spec, but will cause bugs for any code that relies on such an assumption.