### PR TITLE
feat: save progress bars

### DIFF
--- a/base/archive/archive_test.go
+++ b/base/archive/archive_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/base/dsfs"
 	testPeers "github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/event"
 )
 
 func TestGenerateFilename(t *testing.T) {
@@ -132,7 +133,7 @@ func testFS() (qfs.Filesystem, map[string]string, error) {
 	ds.SetBodyFile(dataf)
 
 	fs := qfs.NewMemFS()
-	dskey, err := dsfs.WriteDataset(ctx, nil, fs, ds, pk, dsfs.SaveSwitches{})
+	dskey, err := dsfs.WriteDataset(ctx, nil, fs, event.NilBus, ds, pk, dsfs.SaveSwitches{})
 	if err != nil {
 		return fs, ns, err
 	}
@@ -179,7 +180,7 @@ func testFSWithVizAndTransform() (qfs.Filesystem, map[string]string, error) {
 	privKey := testPeers.GetTestPeerInfo(10).PrivKey
 
 	var dsLk sync.Mutex
-	dskey, err := dsfs.WriteDataset(ctx, &dsLk, st, ds, privKey, dsfs.SaveSwitches{Pin: true})
+	dskey, err := dsfs.WriteDataset(ctx, &dsLk, st, event.NilBus, ds, privKey, dsfs.SaveSwitches{Pin: true})
 	if err != nil {
 		return st, ns, err
 	}

--- a/base/dsfs/commit.go
+++ b/base/dsfs/commit.go
@@ -70,12 +70,14 @@ func commitFileAddFunc(privKey crypto.PrivKey, pub event.Publisher) addWriteFile
 		}
 
 		hook := func(ctx context.Context, f qfs.File, added map[string]string) (io.Reader, error) {
-			go event.PublishLogError(ctx, pub, log, event.ETDatasetSaveProgress, event.DsSaveEvent{
+			if evtErr := pub.Publish(ctx, event.ETDatasetSaveProgress, event.DsSaveEvent{
 				Username:   ds.Peername,
 				Name:       ds.Name,
 				Message:    "finalizing",
 				Completion: 0.9,
-			})
+			}); evtErr != nil {
+				log.Debugw("publish event errored", "error", evtErr)
+			}
 
 			if cff, ok := wfs.body.(*computeFieldsFile); ok {
 				updateScriptPaths(ds, added)

--- a/base/dsfs/commit.go
+++ b/base/dsfs/commit.go
@@ -16,6 +16,7 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/base/friendly"
 	"github.com/qri-io/qri/base/toqtype"
+	"github.com/qri-io/qri/event"
 )
 
 // Timestamp is an function for getting commit timestamps
@@ -62,13 +63,19 @@ func loadCommit(ctx context.Context, fs qfs.Filesystem, path string) (st *datase
 	return dataset.UnmarshalCommit(data)
 }
 
-func commitFileAddFunc(privKey crypto.PrivKey) addWriteFileFunc {
+func commitFileAddFunc(privKey crypto.PrivKey, pub event.Publisher) addWriteFileFunc {
 	return func(ds *dataset.Dataset, wfs *writeFiles) error {
 		if ds.Commit == nil {
 			return nil
 		}
 
 		hook := func(ctx context.Context, f qfs.File, added map[string]string) (io.Reader, error) {
+			go event.PublishLogError(ctx, pub, log, event.ETDatasetSaveProgress, event.DsSaveEvent{
+				Username:   ds.Peername,
+				Name:       ds.Name,
+				Message:    "finalizing",
+				Completion: 0.9,
+			})
 
 			if cff, ok := wfs.body.(*computeFieldsFile); ok {
 				updateScriptPaths(ds, added)

--- a/base/dsfs/compute_fields.go
+++ b/base/dsfs/compute_fields.go
@@ -213,12 +213,17 @@ func (cff *computeFieldsFile) handleRows(ctx context.Context, pub event.Publishe
 	// publish here so we know that if the user sees the "processing body file"
 	// message, we know that a compute-fields-file has made it all the way through
 	// setup
-	go event.PublishLogError(ctx, pub, log, event.ETDatasetSaveProgress, event.DsSaveEvent{
-		Username:   cff.ds.Peername,
-		Name:       cff.ds.Name,
-		Message:    "processing body file",
-		Completion: 0.1,
-	})
+	go func() {
+		evtErr := pub.Publish(ctx, event.ETDatasetSaveProgress, event.DsSaveEvent{
+			Username:   cff.ds.Peername,
+			Name:       cff.ds.Name,
+			Message:    "processing body file",
+			Completion: 0.1,
+		})
+		if evtErr != nil {
+			log.Debugw("ignored error while publishing save progress", "evtErr", evtErr)
+		}
+	}()
 
 	go func() {
 		err = dsio.EachEntry(r, func(i int, ent dsio.Entry, err error) error {

--- a/base/dsfs/dataset.go
+++ b/base/dsfs/dataset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/validate"
 	"github.com/qri-io/qfs"
+	"github.com/qri-io/qri/event"
 )
 
 // number of entries to per batch when processing body data in WriteDataset
@@ -142,6 +143,7 @@ func CreateDataset(
 	ctx context.Context,
 	source qfs.Filesystem,
 	destination qfs.Filesystem,
+	pub event.Publisher,
 	ds *dataset.Dataset,
 	prev *dataset.Dataset,
 	pk crypto.PrivKey,
@@ -192,17 +194,34 @@ func CreateDataset(
 	}
 
 	// lock for editing dataset pointer
-	var dsLk = &sync.Mutex{}
+	var (
+		dsLk     = &sync.Mutex{}
+		peername = ds.Peername
+		name     = ds.Name
+	)
 
-	bodyFile, err := newComputeFieldsFile(ctx, dsLk, source, pk, ds, prev, sw)
+	bodyFile, err := newComputeFieldsFile(ctx, dsLk, source, pub, pk, ds, prev, sw)
 	if err != nil {
 		return "", err
 	}
 	ds.SetBodyFile(bodyFile)
 
-	path, err := WriteDataset(ctx, dsLk, destination, ds, pk, sw)
+	go event.PublishLogError(ctx, pub, log, event.ETDatasetSaveStarted, event.DsSaveEvent{
+		Username:   peername,
+		Name:       name,
+		Message:    "save started",
+		Completion: 0,
+	})
+
+	path, err := WriteDataset(ctx, dsLk, destination, pub, ds, pk, sw)
 	if err != nil {
 		log.Debug(err.Error())
+		event.PublishLogError(ctx, pub, log, event.ETDatasetSaveCompleted, event.DsSaveEvent{
+			Username:   peername,
+			Name:       name,
+			Error:      err,
+			Completion: 1.0,
+		})
 		return "", err
 	}
 
@@ -211,9 +230,22 @@ func CreateDataset(
 	// the caller doesn't use the ds arg afterward
 	// might make sense to have a wrapper function that writes and loads on success
 	if err := DerefDataset(ctx, destination, ds); err != nil {
+		event.PublishLogError(ctx, pub, log, event.ETDatasetSaveCompleted, event.DsSaveEvent{
+			Username:   peername,
+			Name:       name,
+			Error:      err,
+			Completion: 1.0,
+		})
 		return path, err
 	}
-	return path, nil
+
+	return path, pub.Publish(ctx, event.ETDatasetSaveCompleted, event.DsSaveEvent{
+		Username:   peername,
+		Name:       name,
+		Message:    "dataset saved",
+		Path:       path,
+		Completion: 1.0,
+	})
 }
 
 // WriteDataset persists a datasets to a destination filesystem
@@ -221,6 +253,7 @@ func WriteDataset(
 	ctx context.Context,
 	dsLk *sync.Mutex,
 	destination qfs.Filesystem,
+	pub event.Publisher,
 	ds *dataset.Dataset,
 	pk crypto.PrivKey,
 	sw SaveSwitches,
@@ -240,7 +273,7 @@ func WriteDataset(
 		addStatsFile,
 		addReadmeFile,
 		vizFilesAddFunc(destination, sw),
-		commitFileAddFunc(pk),
+		commitFileAddFunc(pk, pub),
 		addDatasetFile,
 	}
 

--- a/base/dsfs/testdata_test.go
+++ b/base/dsfs/testdata_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qfs"
 	testPeers "github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/event"
 )
 
 var AirportCodes = &dataset.Dataset{
@@ -178,7 +179,7 @@ func makeFilestore() (map[string]string, qfs.Filesystem, error) {
 
 		ds.SetBodyFile(qfs.NewMemfileBytes(fmt.Sprintf("/body.%s", ds.Structure.Format), data))
 
-		dskey, err := WriteDataset(ctx, &sync.Mutex{}, fs, ds, pk, SaveSwitches{Pin: true})
+		dskey, err := WriteDataset(ctx, &sync.Mutex{}, fs, event.NilBus, ds, pk, SaveSwitches{Pin: true})
 		if err != nil {
 			return datasets, nil, fmt.Errorf("dataset: %s write error: %s", k, err.Error())
 		}

--- a/base/dsfs/transform_test.go
+++ b/base/dsfs/transform_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qri-io/dataset/dstest"
 	"github.com/qri-io/qfs"
 	testPeers "github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/event"
 )
 
 func TestLoadTransform(t *testing.T) {
@@ -45,7 +46,7 @@ func TestLoadTransformScript(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	path, err := CreateDataset(ctx, fs, fs, tc.Input, nil, privKey, SaveSwitches{Pin: true, ShouldRender: true})
+	path, err := CreateDataset(ctx, fs, fs, event.NilBus, tc.Input, nil, privKey, SaveSwitches{Pin: true, ShouldRender: true})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -64,7 +65,7 @@ func TestLoadTransformScript(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	tc.Input.Transform.ScriptPath = transformPath
-	path, err = CreateDataset(ctx, fs, fs, tc.Input, nil, privKey, SaveSwitches{Pin: true, ShouldRender: true})
+	path, err = CreateDataset(ctx, fs, fs, event.NilBus, tc.Input, nil, privKey, SaveSwitches{Pin: true, ShouldRender: true})
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/base/save.go
+++ b/base/save.go
@@ -146,7 +146,7 @@ func CreateDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, d
 		return
 	}
 
-	if path, err = dsfs.CreateDataset(ctx, r.Filesystem(), writeDest, ds, dsPrev, r.PrivateKey(), sw); err != nil {
+	if path, err = dsfs.CreateDataset(ctx, r.Filesystem(), writeDest, r.Bus(), ds, dsPrev, r.PrivateKey(), sw); err != nil {
 		log.Debugf("dsfs.CreateDataset: %s", err)
 		return nil, err
 	}

--- a/base/save_test.go
+++ b/base/save_test.go
@@ -1,7 +1,6 @@
 package base
 
 import (
-	"bytes"
 	"context"
 	"testing"
 
@@ -123,7 +122,6 @@ func TestCreateDataset(t *testing.T) {
 		},
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("/body.json", []byte("[]")))
-	PrintProgressBarsOnSave(&bytes.Buffer{}, r.Bus())
 
 	if _, err := CreateDataset(ctx, r, r.Filesystem().DefaultWriteFS(), &dataset.Dataset{}, &dataset.Dataset{}, SaveSwitches{Pin: true, ShouldRender: true}); err == nil {
 		t.Error("expected bad dataset to error")

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -2,19 +2,25 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
 	"github.com/qri-io/deepdiff"
 	qrierr "github.com/qri-io/qri/errors"
+	"github.com/qri-io/qri/event"
 	"github.com/qri-io/qri/lib"
+	"github.com/vbauerster/mpb/v5"
+	"github.com/vbauerster/mpb/v5/decor"
 )
 
 var noPrompt = false
@@ -229,4 +235,113 @@ func renderTable(writer io.Writer, header []string, data [][]string) {
 	table.SetNoWhiteSpace(true)
 	table.AppendBulk(data)
 	table.Render()
+}
+
+// PrintProgressBarsOnEvents writes save progress data to the given writer
+func PrintProgressBarsOnEvents(w io.Writer, bus event.Bus) {
+	var lock sync.Mutex
+	// initialize progress container, with custom width
+	p := mpb.New(mpb.WithWidth(80))
+	progress := map[string]*mpb.Bar{}
+
+	// wire up a subscription to print download progress to streams
+	bus.Subscribe(func(_ context.Context, typ event.Type, payload interface{}) error {
+		lock.Lock()
+		defer lock.Unlock()
+
+		switch evt := payload.(type) {
+		case event.DsSaveEvent:
+			evtID := fmt.Sprintf("%s/%s", evt.Username, evt.Name)
+			cpl := int64(math.Ceil(evt.Completion * 100))
+
+			switch typ {
+			case event.ETDatasetSaveStarted:
+				bar, exists := progress[evtID]
+				if !exists {
+					bar = addElapsedBar(p, 100, "saving")
+					progress[evtID] = bar
+				}
+				bar.SetCurrent(cpl)
+			case event.ETDatasetSaveProgress:
+				bar, exists := progress[evtID]
+				if !exists {
+					bar = addElapsedBar(p, 100, "saving")
+					progress[evtID] = bar
+				}
+				bar.SetCurrent(cpl)
+			case event.ETDatasetSaveCompleted:
+				if bar, exists := progress[evtID]; exists {
+					bar.SetTotal(100, true)
+					delete(progress, evtID)
+				}
+			}
+		case event.RemoteEvent:
+			switch typ {
+			case event.ETRemoteClientPushVersionProgress:
+				bar, exists := progress[evt.Ref.String()]
+				if !exists {
+					bar = addBar(p, int64(len(evt.Progress)), "pushing")
+					progress[evt.Ref.String()] = bar
+				}
+				bar.SetCurrent(int64(evt.Progress.CompletedBlocks()))
+			case event.ETRemoteClientPushVersionCompleted:
+				if bar, exists := progress[evt.Ref.String()]; exists {
+					bar.SetCurrent(int64(len(evt.Progress)))
+					delete(progress, evt.Ref.String())
+				}
+
+			case event.ETRemoteClientPullVersionProgress:
+				bar, exists := progress[evt.Ref.String()]
+				if !exists {
+					bar = addBar(p, int64(len(evt.Progress)), "pulling")
+					progress[evt.Ref.String()] = bar
+				}
+				bar.SetCurrent(int64(evt.Progress.CompletedBlocks()))
+			case event.ETRemoteClientPullVersionCompleted:
+				if bar, exists := progress[evt.Ref.String()]; exists {
+					bar.SetCurrent(int64(len(evt.Progress)))
+					delete(progress, evt.Ref.String())
+				}
+			}
+		}
+
+		if len(progress) == 0 {
+			p.Wait()
+			p = mpb.New(mpb.WithWidth(80))
+		}
+		return nil
+	},
+		event.ETDatasetSaveStarted,
+		event.ETDatasetSaveProgress,
+		event.ETDatasetSaveCompleted,
+
+		event.ETRemoteClientPushVersionProgress,
+		event.ETRemoteClientPushVersionCompleted,
+		event.ETRemoteClientPullVersionProgress,
+		event.ETRemoteClientPullVersionCompleted,
+	)
+}
+
+func addBar(p *mpb.Progress, total int64, title string) *mpb.Bar {
+	return p.AddBar(100,
+		mpb.PrependDecorators(
+			// display our name with one space on the right
+			decor.Name(title, decor.WC{W: len(title) + 1, C: decor.DidentRight}),
+			// replace ETA decorator with "done" message, OnComplete event
+			decor.OnComplete(
+				decor.AverageETA(decor.ET_STYLE_GO, decor.WC{W: 4}), "done",
+			),
+		))
+}
+
+func addElapsedBar(p *mpb.Progress, total int64, title string) *mpb.Bar {
+	return p.AddBar(100,
+		mpb.PrependDecorators(
+			// display our name with one space on the right
+			decor.Name(title, decor.WC{W: len(title) + 1, C: decor.DidentRight}),
+			// replace ETA decorator with "done" message, OnComplete event
+			decor.OnComplete(
+				decor.Elapsed(decor.ET_STYLE_GO, decor.WC{W: 4}), "done",
+			),
+		))
 }

--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -1,8 +1,15 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"runtime"
 	"testing"
+
+	"github.com/qri-io/dag"
+	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/event"
 )
 
 func TestDoesCommandExist(t *testing.T) {
@@ -13,5 +20,36 @@ func TestDoesCommandExist(t *testing.T) {
 		if doesCommandExist("ls111") == true {
 			t.Error("ls111 command should not exist!")
 		}
+	}
+}
+
+func TestProgressBars(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := event.NewBus(ctx)
+
+	buf := &bytes.Buffer{}
+	PrintProgressBarsOnEvents(buf, bus)
+
+	ref := dsref.MustParse("c/d")
+
+	events := []struct {
+		t event.Type
+		p interface{}
+	}{
+		{event.ETDatasetSaveStarted, event.DsSaveEvent{Username: "a", Name: "b", Completion: 0.1}},
+		{event.ETDatasetSaveProgress, event.DsSaveEvent{Username: "a", Name: "b", Completion: 0.2}},
+		{event.ETDatasetSaveProgress, event.DsSaveEvent{Username: "a", Name: "b", Completion: 0.3}},
+		{event.ETDatasetSaveCompleted, event.DsSaveEvent{Username: "a", Name: "b", Completion: 0.3, Error: fmt.Errorf("oh noes")}},
+
+		{event.ETRemoteClientPullVersionProgress, event.RemoteEvent{Ref: ref, Progress: dag.Completion{0, 1, 1}}},
+		{event.ETRemoteClientPushVersionProgress, event.RemoteEvent{Ref: ref, Progress: dag.Completion{0, 1, 1}}},
+		{event.ETRemoteClientPullVersionCompleted, event.RemoteEvent{Ref: ref, Progress: dag.Completion{0, 1, 1}, Error: fmt.Errorf("ooooh noes")}},
+		{event.ETRemoteClientPushVersionCompleted, event.RemoteEvent{Ref: ref, Progress: dag.Completion{0, 1, 1}, Error: fmt.Errorf("ooooh noes")}},
+	}
+
+	for _, e := range events {
+		bus.Publish(ctx, e.t, e.p)
 	}
 }

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -161,6 +161,14 @@ func (o *QriOptions) Init() (err error) {
 	}
 	setNoColor(!shouldColorOutput)
 
+	// TODO (b5) - this is a hack to make progress bars not show up while running
+	// tests. It does have the real-world implication that "shouldColorOutput"
+	// being false also disables progress bars, which may be what we want (ahem: TTY
+	// detection), but even if so, isn't the right use of this variable name
+	if shouldColorOutput {
+		PrintProgressBarsOnEvents(o.IOStreams.ErrOut, o.inst.Bus())
+	}
+
 	log.Debugf("running cmd %q", os.Args)
 
 	return

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -145,9 +145,6 @@ func (o *SaveOptions) Validate() error {
 func (o *SaveOptions) Run() (err error) {
 	printRefSelect(o.ErrOut, o.Refs)
 
-	o.StartSpinner()
-	defer o.StopSpinner()
-
 	p := &lib.SaveParams{
 		Ref:      o.Refs.Ref(),
 		BodyPath: o.BodyPath,
@@ -169,17 +166,12 @@ func (o *SaveOptions) Run() (err error) {
 	}
 
 	if o.Secrets != nil {
-		// Stop the spinner so the user can see the prompt, and the answer they type will
-		// not be erased. Output the message to error stream in case stdout is captured.
-		o.StopSpinner()
 		if !confirm(o.ErrOut, o.In, `
 Warning: You are providing secrets to a dataset transformation.
 Never provide secrets to a transformation you do not trust.
 continue?`, true) {
 			return
 		}
-		// Restart the spinner.
-		o.StartSpinner()
 		if p.Secrets, err = parseSecrets(o.Secrets...); err != nil {
 			return err
 		}
@@ -190,7 +182,6 @@ continue?`, true) {
 		return err
 	}
 
-	o.StopSpinner()
 	ref := dsref.ConvertDatasetToVersionInfo(res).SimpleRef()
 	ref.ProfileID = ""
 	printSuccess(o.ErrOut, "dataset saved: %s", ref.String())

--- a/event/dataset.go
+++ b/event/dataset.go
@@ -20,6 +20,19 @@ const (
 	// ETDatasetCreateLink is when a dataset is linked to a working directory
 	// payload is a DsChange
 	ETDatasetCreateLink = Type("dataset:CreateLink")
+
+	// ETDatasetSaveStarted fires when saving a dataset starts
+	// subscriptions do not block the publisher
+	// payload will be a DsSaveEvent
+	ETDatasetSaveStarted = Type("dataset:SaveStarted")
+	// ETDatasetSaveProgress indicates a change in progress of dataset version
+	// creation.
+	// subscriptions do not block the publisher
+	// payload will be a DsSaveEvent
+	ETDatasetSaveProgress = Type("dataset:SaveProgress")
+	// ETDatasetSaveCompleted indicates creating a dataset version finished
+	// payload will be a DsSaveEvent
+	ETDatasetSaveCompleted = Type("dataset:SaveCompleted")
 )
 
 // DsChange represents the result of a change to a dataset
@@ -32,4 +45,19 @@ type DsChange struct {
 	HeadRef    string             `json:"headRef"`
 	Info       *dsref.VersionInfo `json:"info"`
 	Dir        string             `json:"dir"`
+}
+
+// DsSaveEvent represents a change in version creation progress
+type DsSaveEvent struct {
+	Username string `json:"username"`
+	Name     string `json:"name"`
+	// either message or error will be populated. message should be human-centric
+	// description of progress
+	Message string `json:"message"`
+	// saving error. only populated on failed ETSaveDatasetCompleted event
+	Error error `json:"error,omitempty"`
+	// completion pct from 0-1
+	Completion float64 `json:"complete"`
+	// only populated on successful ETDatasetSaveCompleted
+	Path string `json:"path,omitempty"`
 }

--- a/event/event.go
+++ b/event/event.go
@@ -40,16 +40,6 @@ type Publisher interface {
 	Publish(ctx context.Context, t Type, payload interface{}) error
 }
 
-// PublishLogError is a convenience function that fires an event to a publisher
-// and logs any error using an external logger. Exists to make publishing in a
-// goroutine a one-liner, eg:
-//   go event.PublishLogErr(ctx, pub, log, event.ETSaveStarted, payload)
-func PublishLogError(ctx context.Context, pub Publisher, logger golog.StandardLogger, t Type, payload interface{}) {
-	if err := pub.Publish(ctx, t, payload); err != nil {
-		logger.Debug(err)
-	}
-}
-
 // Bus is a central coordination point for event publication and subscription
 // zero or more subscribers register eventTypes to be notified of, a publisher
 // writes a topic event to the bus, which broadcasts to all subscribers of that

--- a/event/remote.go
+++ b/event/remote.go
@@ -43,4 +43,5 @@ type RemoteEvent struct {
 	Ref        dsref.Ref      `json:"ref"`
 	RemoteAddr string         `json:"remoteAddr"`
 	Progress   dag.Completion `json:"progress"`
+	Error      error          `json:"error,omitempty"`
 }

--- a/go.mod
+++ b/go.mod
@@ -53,10 +53,12 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/theckman/go-flock v0.7.1
 	github.com/ugorji/go/codec v1.1.7
+	github.com/vbauerster/mpb v3.4.0+incompatible
+	github.com/vbauerster/mpb/v5 v5.3.0
 	go.starlark.net v0.0.0-20200619143648-50ca820fafb9
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
+	golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed
 	golang.org/x/text v0.3.3
 	gopkg.in/yaml.v2 v2.3.0
 	nhooyr.io/websocket v1.8.6

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cB
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/alangpierce/go-forceexport v0.0.0-20160317203124-8f1d6941cd75/go.mod h1:uAXEEpARkRhCZfEvy/y0Jcc888f9tHCc1W7/UeEtreE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -1242,6 +1244,11 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/vbauerster/mpb v1.1.3 h1:IRgic8VFaURXkW0VxDLkNOiNaAgtw0okB2YIaVvJDI4=
+github.com/vbauerster/mpb v3.4.0+incompatible h1:mfiiYw87ARaeRW6x5gWwYRUawxaW1tLAD8IceomUCNw=
+github.com/vbauerster/mpb v3.4.0+incompatible/go.mod h1:zAHG26FUhVKETRu+MWqYXcI70POlC6N8up9p1dID7SU=
+github.com/vbauerster/mpb/v5 v5.3.0 h1:vgrEJjUzHaSZKDRRxul5Oh4C72Yy/5VEMb0em+9M0mQ=
+github.com/vbauerster/mpb/v5 v5.3.0/go.mod h1:4yTkvAb8Cm4eylAp6t0JRq6pXDkFJ4krUlDqWYkakAs=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=
@@ -1482,6 +1489,8 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed h1:WBkVNH1zd9jg/dK4HCM4lNANnmd12EHC9z+LmcCG4ns=
+golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/lib/load_test.go
+++ b/lib/load_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dsref"
 	dsrefspec "github.com/qri-io/qri/dsref/spec"
+	"github.com/qri-io/qri/event"
 )
 
 func TestLoadDataset(t *testing.T) {
@@ -24,6 +25,7 @@ func TestLoadDataset(t *testing.T) {
 			tr.Ctx,
 			fs,
 			fs.DefaultWriteFS(),
+			event.NilBus,
 			ds,
 			nil,
 			tr.Instance.repo.PrivateKey(),

--- a/lib/websocket.go
+++ b/lib/websocket.go
@@ -91,6 +91,7 @@ func (inst *Instance) ServeWebsocket(ctx context.Context) {
 		event.ETDeletedFile,
 		event.ETRenamedFolder,
 		event.ETRemovedFolder,
+
 		event.ETRemoteClientPushVersionProgress,
 		event.ETRemoteClientPushVersionCompleted,
 		event.ETRemoteClientPushDatasetCompleted,
@@ -98,6 +99,10 @@ func (inst *Instance) ServeWebsocket(ctx context.Context) {
 		event.ETRemoteClientPullVersionCompleted,
 		event.ETRemoteClientPullDatasetCompleted,
 		event.ETRemoteClientRemoveDatasetCompleted,
+
+		event.ETDatasetSaveStarted,
+		event.ETDatasetSaveProgress,
+		event.ETDatasetSaveCompleted,
 	)
 
 	// Start http server for websocket.

--- a/remote/mock_client.go
+++ b/remote/mock_client.go
@@ -187,7 +187,7 @@ func (c *MockClient) createTheirDataset(ctx context.Context, ref *dsref.Ref) err
 
 	// Store with dsfs
 	sw := dsfs.SaveSwitches{}
-	path, err := dsfs.CreateDataset(ctx, fs, fs.DefaultWriteFS(), &ds, nil, other.info.PrivKey, sw)
+	path, err := dsfs.CreateDataset(ctx, fs, fs.DefaultWriteFS(), event.NilBus, &ds, nil, other.info.PrivKey, sw)
 	if err != nil {
 		return err
 	}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -103,7 +103,6 @@ func TestDatasetPullPushDeleteFeedsPreviewHTTP(t *testing.T) {
 	)
 
 	progBuf := &bytes.Buffer{}
-	PrintProgressBarsOnPushPull(progBuf, tr.NodeB.Repo.Bus())
 
 	relRef := &dsref.Ref{Username: wbp.Username, Name: wbp.Name}
 	if _, err := cli.NewRemoteRefResolver(server.URL).ResolveRef(tr.Ctx, relRef); err != nil {

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -218,7 +218,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 
 	sw := dsfs.SaveSwitches{Pin: true, ShouldRender: true}
 	fs := r.Filesystem()
-	if path, err = dsfs.CreateDataset(ctx, fs, fs.DefaultWriteFS(), ds, nil, r.PrivateKey(), sw); err != nil {
+	if path, err = dsfs.CreateDataset(ctx, fs, fs.DefaultWriteFS(), r.Bus(), ds, nil, r.PrivateKey(), sw); err != nil {
 		return
 	}
 	if ds.PreviousPath != "" && ds.PreviousPath != "/" {


### PR DESCRIPTION
add save event publication to `dsfs`, move all progress bar output up into `cmd` package and replace progress bar package with `mpb` which has explicit support for displaying multiple progress bars at once. To pull this off `lib.Instance` gets
a new `inst.Bus()` accessor method.

This setup brings progress bar output closer to the way desktop / API driven events display progress.

This PR mainly lays the foundations of getting a save progress bar up. On truly large datasets the progress reported will kinda hang for a while around 10% completion while the body file is processing, then suddenly jump to 90%, and finish. This is  because we don't have an API in `qfs` for getting the size of a file, so we can't properly track expected time to ingest. I'll ship the fix for that once we land some API refactoring in qfs.