### PR TITLE
fix(save): remove dataset field computing deadlock

### DIFF
--- a/base/dsfs/commit.go
+++ b/base/dsfs/commit.go
@@ -90,7 +90,6 @@ func commitFileAddFunc(privKey crypto.PrivKey, pub event.Publisher) addWriteFile
 					log.Debugf("ensureCommitTitleAndMessage: %s", err)
 					return nil, fmt.Errorf("error saving: %w", err)
 				}
-
 			}
 
 			replaceComponentsWithRefs(ds, added, wfs.body.FullPath())

--- a/base/dsfs/structure.go
+++ b/base/dsfs/structure.go
@@ -48,14 +48,14 @@ func structureFileAddFunc(destFS qfs.Filesystem) addWriteFileFunc {
 		ds.Structure.DropTransientValues()
 
 		if wfs.body == nil {
+			log.Debugf("body is nil, using json structure file")
 			wfs.structure, err = JSONFile(PackageFileStructure.Filename(), ds.Structure)
 			return err
 		}
 
 		hook := func(ctx context.Context, f qfs.File, added map[string]string) (io.Reader, error) {
 			if processingFile, ok := wfs.body.(doneProcessingFile); ok {
-				err := <-processingFile.DoneProcessing()
-				if err != nil {
+				if err := <-processingFile.DoneProcessing(); err != nil {
 					return nil, err
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -38,8 +38,9 @@ require (
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pkg/errors v0.9.1
-	github.com/qri-io/dag v0.2.2-0.20201110155527-8fad5beb70f5
 	github.com/qri-io/dataset v0.2.1-0.20201201155506-9b4fc79ffde8
+	github.com/qri-io/dag v0.2.2-0.20201208212257-ae00241c4b48
+	github.com/qri-io/dataset v0.2.1-0.20201124144731-82162a0f76e6
 	github.com/qri-io/deepdiff v0.2.1-0.20200807143746-d02d9f531f5b
 	github.com/qri-io/didmod v0.0.0-20201123165422-8b2e224c993a
 	github.com/qri-io/doggos v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1126,8 +1126,8 @@ github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/qri-io/compare v0.1.0 h1:A/MRx3uEnJ/iMjfJY1VOqH9CYs9zFSEYaFVeXuGfmis=
 github.com/qri-io/compare v0.1.0/go.mod h1:i/tVuDGRXVxhuZ8ZUieF23u6rQ6wLGJl7KKWpoMRaTE=
-github.com/qri-io/dag v0.2.2-0.20201110155527-8fad5beb70f5 h1:xeMaT6fLTvdrFOOP2N2+x68EL/uZrm4XC0zs1vjLiXo=
-github.com/qri-io/dag v0.2.2-0.20201110155527-8fad5beb70f5/go.mod h1:1AwOy3yhcZTAXzaF4wGSdnrp87u3PBOrsWXUjOtQCXo=
+github.com/qri-io/dag v0.2.2-0.20201208212257-ae00241c4b48 h1:6fTW2iHGbaEKQt9u8+04kB3m33KSGLqxF/2pWNleeEg=
+github.com/qri-io/dag v0.2.2-0.20201208212257-ae00241c4b48/go.mod h1:1AwOy3yhcZTAXzaF4wGSdnrp87u3PBOrsWXUjOtQCXo=
 github.com/qri-io/dataset v0.2.1-0.20201124144731-82162a0f76e6 h1:a9CYZQ+DCzwqg8BgEN5oKboBoxueaYf0EKPnXeR/Mhk=
 github.com/qri-io/dataset v0.2.1-0.20201124144731-82162a0f76e6/go.mod h1:HtwGskdCECbOON0iVQHEEm6fykwDqharlqabc1ssj3Y=
 github.com/qri-io/dataset v0.2.1-0.20201201155506-9b4fc79ffde8 h1:/9pbWabRT9BbjFp1AjdAsXKT2NQp+mGmyvnTylPyEHY=

--- a/logbook/logbook_test.go
+++ b/logbook/logbook_test.go
@@ -543,9 +543,7 @@ func TestDatasetLogNaming(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error writing valid dataset name: %s", err)
 	}
-	if _, err = tr.Book.WriteDatasetInit(tr.Ctx, "airport_codes"); err == nil {
-		t.Error("expected initializing a name that already exists to error")
-	}
+
 	if err = tr.Book.WriteDatasetRename(tr.Ctx, firstInitID, "iata_airport_codes"); err != nil {
 		t.Errorf("unexpected error renaming dataset: %s", err)
 	}
@@ -624,6 +622,29 @@ func TestDatasetLogNaming(t *testing.T) {
 
 	if diff := cmp.Diff(expect, got); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+
+	if _, err = tr.Book.WriteDatasetInit(tr.Ctx, "overwrite"); err != nil {
+		t.Fatalf("unexpected error writing valid dataset name: %s", err)
+	}
+	if _, err = tr.Book.WriteDatasetInit(tr.Ctx, "overwrite"); err != nil {
+		t.Fatalf("unexpected error overwrite an empty dataset history: %s", err)
+	}
+	err = tr.Book.WriteVersionSave(tr.Ctx, firstInitID, &dataset.Dataset{
+		Peername: tr.Username,
+		Name:     "atmospheric_particulates",
+		Commit: &dataset.Commit{
+			Timestamp: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			Title:     "initial commit",
+		},
+		Path: "HashOfVersion1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = tr.Book.WriteDatasetInit(tr.Ctx, "overwrite"); err != nil {
+		t.Error("expected initializing a name that exists with a history to error")
 	}
 }
 


### PR DESCRIPTION
@chriswhong was getting a spinning-wheel on save that was hanging forever on a very small dataset. Turns out it's a concurrency problem.

The dsfs.computeFieldsFile `Read` and `handleRows` methods were both contending for the same mutex lock, which would deadlock the program. Fix this by using a `dsio.TrackedReader` to count bytes instead of local state, which drops the need for taking the lock on calls to `Read`. Should yeild a microscopic performance bump as well.

Another problem that crops out of this state: users understandably use SIGKILL to get out of the hung process, which is leaving the dataset name "taken" and causing errors on re-running save.

If a user starts the save process but abandons it midway with SIGKILL qri's currently structured to terminate without any cleanup. This means the 'rollback' procedure in an errored save never fires, and the dataset name is left taken but not in the user's list of datasets. This (admittedly hacky) solution checks for stray histories in this exact state (name and branch logs declared, no version save) and considers them safe to remove before creating a new replacement log. Fix that too