### PR TITLE
fix(changes): column renames are properly handled now

### DIFF
--- a/changes/changes.go
+++ b/changes/changes.go
@@ -218,8 +218,6 @@ func (svc *service) matchColumns(leftColCount, rightColCount int, leftColItems, 
 		maxColCount = rightColCount
 	}
 
-	columns := make([]*ChangeReportDeltaComponent, maxColCount)
-
 	type cIndex struct {
 		LPos int
 		RPos int
@@ -248,6 +246,8 @@ func (svc *service) matchColumns(leftColCount, rightColCount int, leftColItems, 
 			}
 		}
 	}
+
+	columns := make([]*ChangeReportDeltaComponent, len(colIndex))
 
 	i := 0
 	for k, v := range colIndex {


### PR DESCRIPTION
Change reports now allocate column diffs based on max unique columns detected not by length of the left or right side.