### PR TITLE
refactor(api): adjust `Server` & middleware funcs to make the qri api more extensible by outside packages

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -35,11 +35,14 @@ func init() {
 // Create one with New, start it up with Serve
 type Server struct {
 	*lib.Instance
+	Mux *http.ServeMux
 }
 
 // New creates a new qri server from a p2p node & configuration
 func New(inst *lib.Instance) (s Server) {
-	return Server{Instance: inst}
+	s = Server{Instance: inst}
+	s.Mux = NewServerRoutes(s)
+	return s
 }
 
 // Serve starts the server. It will block while the server is running
@@ -51,9 +54,9 @@ func (s Server) Serve(ctx context.Context) (err error) {
 		return err
 	}
 
-	server := &http.Server{}
-	mux := NewServerRoutes(s)
-	server.Handler = mux
+	server := &http.Server{
+		Handler: s.Mux,
+	}
 
 	go s.ServeRPC(ctx)
 	go s.ServeWebsocket(ctx)
@@ -133,82 +136,82 @@ func NewServerRoutes(s Server) *http.ServeMux {
 
 	m := http.NewServeMux()
 
-	m.Handle("/", s.noLogMiddleware(HomeHandler))
-	m.Handle("/health", s.noLogMiddleware(HealthCheckHandler))
-	m.Handle("/ipfs/", s.middleware(s.HandleIPFSPath))
+	m.Handle("/", s.NoLogMiddleware(HomeHandler))
+	m.Handle("/health", s.NoLogMiddleware(HealthCheckHandler))
+	m.Handle("/ipfs/", s.Middleware(s.HandleIPFSPath))
 
 	proh := NewProfileHandlers(s.Instance, cfg.API.ReadOnly)
-	m.Handle("/me", s.middleware(proh.ProfileHandler))
-	m.Handle("/profile", s.middleware(proh.ProfileHandler))
-	m.Handle("/profile/photo", s.middleware(proh.ProfilePhotoHandler))
-	m.Handle("/profile/poster", s.middleware(proh.PosterHandler))
+	m.Handle("/me", s.Middleware(proh.ProfileHandler))
+	m.Handle("/profile", s.Middleware(proh.ProfileHandler))
+	m.Handle("/profile/photo", s.Middleware(proh.ProfilePhotoHandler))
+	m.Handle("/profile/poster", s.Middleware(proh.PosterHandler))
 
 	ph := NewPeerHandlers(s.Instance, cfg.API.ReadOnly)
-	m.Handle("/peers", s.middleware(ph.PeersHandler))
-	m.Handle("/peers/", s.middleware(ph.PeerHandler))
-	m.Handle("/connect/", s.middleware(ph.ConnectToPeerHandler))
-	m.Handle("/connections", s.middleware(ph.ConnectionsHandler))
+	m.Handle("/peers", s.Middleware(ph.PeersHandler))
+	m.Handle("/peers/", s.Middleware(ph.PeerHandler))
+	m.Handle("/connect/", s.Middleware(ph.ConnectToPeerHandler))
+	m.Handle("/connections", s.Middleware(ph.ConnectionsHandler))
 
 	if cfg.Remote != nil && cfg.Remote.Enabled {
 		log.Info("running in `remote` mode")
 
 		remh := NewRemoteHandlers(s.Instance)
-		m.Handle("/remote/dsync", s.middleware(remh.DsyncHandler))
-		m.Handle("/remote/logsync", s.middleware(remh.LogsyncHandler))
-		m.Handle("/remote/refs", s.middleware(remh.RefsHandler))
+		m.Handle("/remote/dsync", s.Middleware(remh.DsyncHandler))
+		m.Handle("/remote/logsync", s.Middleware(remh.LogsyncHandler))
+		m.Handle("/remote/refs", s.Middleware(remh.RefsHandler))
 	}
 
 	dsh := NewDatasetHandlers(s.Instance, cfg.API.ReadOnly)
-	m.Handle("/list", s.middleware(dsh.ListHandler))
-	m.Handle("/list/", s.middleware(dsh.PeerListHandler))
-	m.Handle("/save", s.middleware(dsh.SaveHandler))
-	m.Handle("/save/", s.middleware(dsh.SaveHandler))
-	m.Handle("/remove/", s.middleware(dsh.RemoveHandler))
-	m.Handle("/get/", s.middleware(dsh.GetHandler))
-	m.Handle("/rename", s.middleware(dsh.RenameHandler))
-	m.Handle("/diff", s.middleware(dsh.DiffHandler))
-	m.Handle("/changes", s.middleware(dsh.ChangesHandler))
+	m.Handle("/list", s.Middleware(dsh.ListHandler))
+	m.Handle("/list/", s.Middleware(dsh.PeerListHandler))
+	m.Handle("/save", s.Middleware(dsh.SaveHandler))
+	m.Handle("/save/", s.Middleware(dsh.SaveHandler))
+	m.Handle("/remove/", s.Middleware(dsh.RemoveHandler))
+	m.Handle("/get/", s.Middleware(dsh.GetHandler))
+	m.Handle("/rename", s.Middleware(dsh.RenameHandler))
+	m.Handle("/diff", s.Middleware(dsh.DiffHandler))
+	m.Handle("/changes", s.Middleware(dsh.ChangesHandler))
 	// Deprecated, use /get/username/name?component=body or /get/username/name/body.csv
-	m.Handle("/body/", s.middleware(dsh.BodyHandler))
-	m.Handle("/stats/", s.middleware(dsh.StatsHandler))
-	m.Handle("/unpack/", s.middleware(dsh.UnpackHandler))
+	m.Handle("/body/", s.Middleware(dsh.BodyHandler))
+	m.Handle("/stats/", s.Middleware(dsh.StatsHandler))
+	m.Handle("/unpack/", s.Middleware(dsh.UnpackHandler))
 
 	remClientH := NewRemoteClientHandlers(s.Instance, cfg.API.ReadOnly)
-	m.Handle("/push/", s.middleware(remClientH.PushHandler))
-	m.Handle("/pull/", s.middleware(dsh.PullHandler))
-	m.Handle("/feeds", s.middleware(remClientH.FeedsHandler))
-	m.Handle("/preview/", s.middleware(remClientH.DatasetPreviewHandler))
+	m.Handle("/push/", s.Middleware(remClientH.PushHandler))
+	m.Handle("/pull/", s.Middleware(dsh.PullHandler))
+	m.Handle("/feeds", s.Middleware(remClientH.FeedsHandler))
+	m.Handle("/preview/", s.Middleware(remClientH.DatasetPreviewHandler))
 
 	fsih := NewFSIHandlers(s.Instance, cfg.API.ReadOnly)
-	m.Handle("/status/", s.middleware(fsih.StatusHandler("/status")))
-	m.Handle("/whatchanged/", s.middleware(fsih.WhatChangedHandler("/whatchanged")))
-	m.Handle("/init/", s.middleware(fsih.InitHandler("/init")))
-	m.Handle("/checkout/", s.middleware(fsih.CheckoutHandler("/checkout")))
-	m.Handle("/restore/", s.middleware(fsih.RestoreHandler("/restore")))
-	m.Handle("/fsi/write/", s.middleware(fsih.WriteHandler("/fsi/write")))
+	m.Handle("/status/", s.Middleware(fsih.StatusHandler("/status")))
+	m.Handle("/whatchanged/", s.Middleware(fsih.WhatChangedHandler("/whatchanged")))
+	m.Handle("/init/", s.Middleware(fsih.InitHandler("/init")))
+	m.Handle("/checkout/", s.Middleware(fsih.CheckoutHandler("/checkout")))
+	m.Handle("/restore/", s.Middleware(fsih.RestoreHandler("/restore")))
+	m.Handle("/fsi/write/", s.Middleware(fsih.WriteHandler("/fsi/write")))
 
 	renderh := NewRenderHandlers(s.Instance)
-	m.Handle("/render", s.middleware(renderh.RenderHandler))
-	m.Handle("/render/", s.middleware(renderh.RenderHandler))
+	m.Handle("/render", s.Middleware(renderh.RenderHandler))
+	m.Handle("/render/", s.Middleware(renderh.RenderHandler))
 
 	lh := NewLogHandlers(s.Instance)
-	m.Handle("/history/", s.middleware(lh.LogHandler))
+	m.Handle("/history/", s.Middleware(lh.LogHandler))
 
 	rch := NewRegistryClientHandlers(s.Instance, cfg.API.ReadOnly)
-	m.Handle("/registry/profile/new", s.middleware(rch.CreateProfileHandler))
-	m.Handle("/registry/profile/prove", s.middleware(rch.ProveProfileKeyHandler))
+	m.Handle("/registry/profile/new", s.Middleware(rch.CreateProfileHandler))
+	m.Handle("/registry/profile/prove", s.Middleware(rch.ProveProfileKeyHandler))
 
 	sh := NewSearchHandlers(s.Instance)
-	m.Handle("/search", s.middleware(sh.SearchHandler))
+	m.Handle("/search", s.Middleware(sh.SearchHandler))
 
 	sqlh := NewSQLHandlers(s.Instance, cfg.API.ReadOnly)
-	m.Handle("/sql", s.middleware(sqlh.QueryHandler("/sql")))
+	m.Handle("/sql", s.Middleware(sqlh.QueryHandler("/sql")))
 
 	tfh := NewTransformHandlers(s.Instance)
-	m.Handle("/apply", s.middleware(tfh.ApplyHandler("/apply")))
+	m.Handle("/apply", s.Middleware(tfh.ApplyHandler("/apply")))
 
 	if !cfg.API.DisableWebui {
-		m.Handle("/webui", s.middleware(WebuiHandler))
+		m.Handle("/webui", s.Middleware(WebuiHandler))
 	}
 
 	return m

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -8,12 +8,13 @@ import (
 	"github.com/qri-io/qri/api/util"
 )
 
-// middleware handles request logging
-func (s Server) middleware(handler http.HandlerFunc) http.HandlerFunc {
+// Middleware handles request logging
+func (s Server) Middleware(handler http.HandlerFunc) http.HandlerFunc {
 	return s.mwFunc(handler, true)
 }
 
-func (s Server) noLogMiddleware(handler http.HandlerFunc) http.HandlerFunc {
+// NoLogMiddleware runs middleware without logging the request
+func (s Server) NoLogMiddleware(handler http.HandlerFunc) http.HandlerFunc {
 	return s.mwFunc(handler, false)
 }
 


### PR DESCRIPTION
Adds `Mux` field to `Server` struct (type `http.ServeMux`). A new `Mux`
is created in the `api.New` function when it returns a new `Server`.

The `Middleware` and `NoLogMiddleware` functions are now exported.

closes #1611 