### PR TITLE
fix(repo): Don't use blank path for new repo in tests

### DIFF
--- a/key/store.go
+++ b/key/store.go
@@ -27,6 +27,10 @@ func NewStore(cfg *config.Config) (Store, error) {
 
 	switch cfg.Repo.Type {
 	case "fs":
+		// Don't create a localstore with the empty path, this will use the current directory
+		if cfg.Path() == "" {
+			return nil, fmt.Errorf("new key.LocalStore requires non-empty path")
+		}
 		return NewLocalStore(filepath.Join(filepath.Dir(cfg.Path()), "keystore.json"))
 	case "mem":
 		return NewMemStore()

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -356,6 +356,12 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		return
 	}
 
+	// If configuration does not have a path assigned, but the repo has a path and
+	// is stored on the filesystem, add that path to the configuration.
+	if cfg.Repo.Type == "fs" && cfg.Path() == "" {
+		cfg.SetPath(filepath.Join(repoPath, "config.yal"))
+	}
+
 	inst := &Instance{
 		cancel: cancel,
 		doneCh: make(chan struct{}),

--- a/profile/store.go
+++ b/profile/store.go
@@ -53,6 +53,11 @@ func NewStore(cfg *config.Config) (Store, error) {
 		return nil, err
 	}
 
+	// Don't create a localstore with the empty path, this will use the current directory
+	if cfg.Repo.Type == "fs" && cfg.Path() == "" {
+		return nil, fmt.Errorf("new Profile.FilesystemStore requires non-empty path")
+	}
+
 	keyStore, err := key.NewStore(cfg)
 	if err != nil {
 		return nil, err

--- a/repo/buildrepo/build.go
+++ b/repo/buildrepo/build.go
@@ -34,6 +34,11 @@ func New(ctx context.Context, path string, cfg *config.Config, opts ...func(o *O
 		opt(o)
 	}
 
+	// Don't create a localstore with the empty path, this will use the current directory
+	if cfg.Repo.Type == "fs" && cfg.Path() == "" {
+		return nil, fmt.Errorf("buildRepo.New using filesystem requires non-empty path")
+	}
+
 	var err error
 	if o.Profiles == nil {
 		if o.Profiles, err = profile.NewStore(cfg); err != nil {


### PR DESCRIPTION
Real runs of qri read the config from a path, which sets that path. Most tests use a mem repo. The test TestNewInstanceWithAccessControlPolicy uniquely uses a fs repo but that config doesn't know the repo path. By not setting that path, running this test would create json and json.lock files when creating a KeyStore and ProfileStore.

Fixes https://github.com/qri-io/qri/issues/1601