### PR TITLE
refactor(profile): add active profile method stub and thread context …

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -80,7 +80,7 @@ func testConfigAndSetter() (cfg *config.Config, setCfg func(*config.Config) erro
 
 func newTestInstanceWithProfileFromNode(ctx context.Context, node *p2p.QriNode) *lib.Instance {
 	cfg := config.DefaultConfigForTesting()
-	pro, _ := node.Repo.Profile()
+	pro, _ := node.Repo.Profile(ctx)
 	cfg.Profile, _ = pro.Encode()
 	return lib.NewInstanceFromConfigAndNode(ctx, cfg, node)
 }

--- a/api/fsi.go
+++ b/api/fsi.go
@@ -144,7 +144,7 @@ func (h *FSIHandlers) initHandler(routePrefix string) http.HandlerFunc {
 		}
 
 		var name string
-		if err := h.InitDataset(p, &name); err != nil {
+		if err := h.InitDataset(r.Context(), p, &name); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}

--- a/api/fsi_test.go
+++ b/api/fsi_test.go
@@ -86,6 +86,7 @@ func TestFSIHandlers(t *testing.T) {
 // statusHandler
 // each test should test responses for a dataset with no history, fsi=true and fsi=false
 func TestNoHistory(t *testing.T) {
+	ctx := context.Background()
 	run := NewAPITestRunner(t)
 	defer run.Delete()
 
@@ -93,7 +94,7 @@ func TestNoHistory(t *testing.T) {
 	workDir := run.MustMakeWorkDir(t, subDir)
 
 	// Create a linked dataset without saving, it has no versions in the repository
-	ref, err := run.Inst.FSI().InitDataset(fsi.InitParams{
+	ref, err := run.Inst.FSI().InitDataset(ctx, fsi.InitParams{
 		TargetDir: workDir,
 		Name:      "test_ds",
 		Format:    "csv",

--- a/api/profile.go
+++ b/api/profile.go
@@ -45,7 +45,7 @@ func (h *ProfileHandlers) ProfileHandler(w http.ResponseWriter, r *http.Request)
 func (h *ProfileHandlers) getProfileHandler(w http.ResponseWriter, r *http.Request) {
 	args := true
 	res := &config.ProfilePod{}
-	if err := h.GetProfile(&args, res); err != nil {
+	if err := h.GetProfile(r.Context(), &args, res); err != nil {
 		log.Infof("error getting profile: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return

--- a/api/profile_test.go
+++ b/api/profile_test.go
@@ -84,7 +84,7 @@ func TestProfilePhotoHandler(t *testing.T) {
 	cfg := config.DefaultConfigForTesting()
 	// newTestNode uses a different profile. assign here so instance config.Profile
 	// node config.Profile match
-	pro, _ := node.Repo.Profile()
+	pro, _ := node.Repo.Profile(ctx)
 	cfg.Profile, _ = pro.Encode()
 
 	// TODO (b5) - hack until tests have better instance-generation primitives
@@ -143,7 +143,7 @@ func TestProfilePosterHandler(t *testing.T) {
 	cfg := config.DefaultConfigForTesting()
 	// newTestNode uses a different profile. assign here so instance config.Profile
 	// node config.Profile match
-	pro, _ := node.Repo.Profile()
+	pro, _ := node.Repo.Profile(ctx)
 	cfg.Profile, _ = pro.Encode()
 
 	// TODO (b5) - hack until tests have better instance-generation primitives

--- a/api/registry.go
+++ b/api/registry.go
@@ -43,7 +43,7 @@ func (h *RegistryClientHandlers) CreateProfileHandler(w http.ResponseWriter, r *
 		return
 	}
 
-	err = h.CreateProfile(r.Context(), p, &ok)
+	err = h.CreateProfile(p, &ok)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
@@ -71,7 +71,7 @@ func (h *RegistryClientHandlers) ProveProfileKeyHandler(w http.ResponseWriter, r
 		return
 	}
 
-	if err := h.ProveProfileKey(r.Context(), p, &ok); err != nil {
+	if err := h.ProveProfileKey(p, &ok); err != nil {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/api/registry.go
+++ b/api/registry.go
@@ -43,7 +43,7 @@ func (h *RegistryClientHandlers) CreateProfileHandler(w http.ResponseWriter, r *
 		return
 	}
 
-	err = h.CreateProfile(p, &ok)
+	err = h.CreateProfile(r.Context(), p, &ok)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
@@ -71,7 +71,7 @@ func (h *RegistryClientHandlers) ProveProfileKeyHandler(w http.ResponseWriter, r
 		return
 	}
 
-	if err := h.ProveProfileKey(p, &ok); err != nil {
+	if err := h.ProveProfileKey(r.Context(), p, &ok); err != nil {
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/base/base_test.go
+++ b/base/base_test.go
@@ -96,7 +96,7 @@ func updateCitiesDataset(t *testing.T, r repo.Repo, title string) dsref.Ref {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	pro, err := r.Profile()
+	pro, err := r.Profile(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/base/dataset.go
+++ b/base/dataset.go
@@ -191,7 +191,7 @@ func ListDatasets(ctx context.Context, r repo.Repo, term string, limit, offset i
 	hasUnlistableRefs := false
 
 	for _, ref := range res {
-		if err := repo.CanonicalizeProfile(r, &ref); err != nil {
+		if err := repo.CanonicalizeProfile(ctx, r, &ref); err != nil {
 			// This occurs when two profileIDs map to the same username, which can happen
 			// when a user creates a new profile using an old username. We should ignore
 			// references that can't be resolved this way, since other references in

--- a/base/dataset_prepare_test.go
+++ b/base/dataset_prepare_test.go
@@ -21,12 +21,13 @@ func TestPrepareSaveRef(t *testing.T) {
 	}()
 
 	r := newTestRepo(t)
+	ctx := context.Background()
 
-	pro, err := r.Profile()
+	pro, err := r.Profile(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.Background()
+
 	book := r.Logbook()
 
 	book.WriteDatasetInit(ctx, "cities")
@@ -96,7 +97,8 @@ func TestPrepareSaveRef(t *testing.T) {
 
 func TestInferValues(t *testing.T) {
 	r := newTestRepo(t)
-	pro, err := r.Profile()
+	ctx := context.Background()
+	pro, err := r.Profile(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +168,8 @@ func TestInferStructureSchema(t *testing.T) {
 
 func TestInferValuesDontOverwriteSchema(t *testing.T) {
 	r := newTestRepo(t)
-	pro, err := r.Profile()
+	ctx := context.Background()
+	pro, err := r.Profile(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +214,8 @@ func TestInferValuesDontOverwriteSchema(t *testing.T) {
 
 func TestMaybeAddDefaultViz(t *testing.T) {
 	r := newTestRepo(t)
-	_, err := r.Profile()
+	ctx := context.Background()
+	_, err := r.Profile(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/base/dataset_test.go
+++ b/base/dataset_test.go
@@ -34,7 +34,7 @@ func TestListDatasets(t *testing.T) {
 		t.Error("expected no published datasets")
 	}
 
-	if err := SetPublishStatus(r, ref, true); err != nil {
+	if err := SetPublishStatus(ctx, r, ref, true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/base/log.go
+++ b/base/log.go
@@ -76,7 +76,7 @@ func DatasetLog(ctx context.Context, r repo.Repo, ref dsref.Ref, limit, offset i
 	}
 
 	// add a history entry b/c we didn't have one, but repo didn't error
-	if pro, err := r.Profile(); err == nil && ref.Username == pro.Peername {
+	if pro, err := r.Profile(ctx); err == nil && ref.Username == pro.Peername {
 		go func() {
 			if err := constructDatasetLogFromHistory(context.Background(), r, ref); err != nil {
 				log.Errorf("constructDatasetLogFromHistory: %s", err)

--- a/base/log_test.go
+++ b/base/log_test.go
@@ -147,7 +147,7 @@ func TestDatasetLogForeignTimeout(t *testing.T) {
 
 	vi := dsref.NewVersionInfoFromRef(ref)
 	// Add a reference to the repo which uses a path not in our filestore
-	err := repo.PutVersionInfoShim(mr, &vi)
+	err := repo.PutVersionInfoShim(ctx, mr, &vi)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestConstructDatasetLogFromHistory(t *testing.T) {
 	ref := updateCitiesDataset(t, mr, "")
 
 	// add the logbook back
-	p, err := mr.Profile()
+	p, err := mr.Profile(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/base/ref.go
+++ b/base/ref.go
@@ -14,8 +14,8 @@ import (
 
 // InLocalNamespace checks if a dataset ref is local, assumes the reference is
 // already resolved
-func InLocalNamespace(r repo.Repo, ref dsref.Ref) bool {
-	p, err := r.Profile()
+func InLocalNamespace(ctx context.Context, r repo.Repo, ref dsref.Ref) bool {
+	p, err := r.Profile(ctx)
 	if err != nil {
 		return false
 	}
@@ -24,14 +24,14 @@ func InLocalNamespace(r repo.Repo, ref dsref.Ref) bool {
 }
 
 // SetPublishStatus updates the Published field of a dataset ref
-func SetPublishStatus(r repo.Repo, ref dsref.Ref, published bool) error {
-	if !InLocalNamespace(r, ref) {
+func SetPublishStatus(ctx context.Context, r repo.Repo, ref dsref.Ref, published bool) error {
+	if !InLocalNamespace(ctx, r, ref) {
 		return fmt.Errorf("can't publish datasets that are not in your namespace")
 	}
 
 	vi := dsref.NewVersionInfoFromRef(ref)
 	vi.Published = published
-	return repo.PutVersionInfoShim(r, &vi)
+	return repo.PutVersionInfoShim(ctx, r, &vi)
 }
 
 // ReplaceRefIfMoreRecent replaces the given ref in the ref store, if
@@ -88,13 +88,13 @@ func RenameDatasetRef(ctx context.Context, r repo.Repo, ref dsref.Ref, newName s
 
 	// use the versionInfo returned from the delete to preserve fields like
 	// FSIPath when replaced
-	vi, err := repo.DeleteVersionInfoShim(r, ref)
+	vi, err := repo.DeleteVersionInfoShim(ctx, r, ref)
 	if err != nil {
 		return nil, err
 	}
 	vi.InitID = ref.InitID
 	vi.Name = newName
-	err = repo.PutVersionInfoShim(r, vi)
+	err = repo.PutVersionInfoShim(ctx, r, vi)
 	return vi, err
 }
 

--- a/base/ref_test.go
+++ b/base/ref_test.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -13,28 +14,30 @@ import (
 
 func TestInLocalNamespace(t *testing.T) {
 	r := newTestRepo(t)
+	ctx := context.Background()
 	ref := addCitiesDataset(t, r)
 
-	if !InLocalNamespace(r, ref) {
+	if !InLocalNamespace(ctx, r, ref) {
 		t.Errorf("expected %s true", ref.String())
 	}
 
 	ref = dsref.Ref{}
-	if InLocalNamespace(r, ref) {
+	if InLocalNamespace(ctx, r, ref) {
 		t.Errorf("expected %s false", ref.String())
 	}
 
 	ref = dsref.Ref{ProfileID: "fake"}
-	if InLocalNamespace(r, ref) {
+	if InLocalNamespace(ctx, r, ref) {
 		t.Errorf("expected %s false", ref.String())
 	}
 }
 
 func TestSetPublishStatus(t *testing.T) {
 	r := newTestRepo(t)
+	ctx := context.Background()
 	ref := addCitiesDataset(t, r)
 
-	if err := SetPublishStatus(r, ref, true); err != nil {
+	if err := SetPublishStatus(ctx, r, ref, true); err != nil {
 		t.Error(err)
 	}
 
@@ -46,7 +49,7 @@ func TestSetPublishStatus(t *testing.T) {
 		t.Errorf("expected published to equal true: %v,%v", ref, res)
 	}
 
-	if err := SetPublishStatus(r, ref, false); err != nil {
+	if err := SetPublishStatus(ctx, r, ref, false); err != nil {
 		t.Error(err)
 	}
 	res, err = repo.GetVersionInfoShim(r, ref)
@@ -57,19 +60,19 @@ func TestSetPublishStatus(t *testing.T) {
 		t.Errorf("expected published to equal false: %v,%v", ref, res)
 	}
 
-	if err := SetPublishStatus(r, dsref.Ref{Name: "foo"}, false); err == nil {
+	if err := SetPublishStatus(ctx, r, dsref.Ref{Name: "foo"}, false); err == nil {
 		t.Error("expected invalid reference to error")
 	}
 
 	outside := dsref.MustParse("a/b@QmX1oSPMbzkhk33EutuadL4sqsivsRKmMx5hAnZL2mRAM1/ipfs/Qmd")
 	vi := dsref.NewVersionInfoFromRef(outside)
-	if err := repo.PutVersionInfoShim(r, &vi); err != nil {
+	if err := repo.PutVersionInfoShim(ctx, r, &vi); err != nil {
 		t.Fatal(err)
 	}
 
 	r.Profiles().PutProfile(&profile.Profile{ID: profile.IDB58DecodeOrEmpty(outside.ProfileID), Peername: outside.Username})
 
-	if err := SetPublishStatus(r, outside, true); err == nil {
+	if err := SetPublishStatus(ctx, r, outside, true); err == nil {
 		t.Error("expected setting the publish status of a name outside peer's namespace to fail")
 	}
 }

--- a/base/remove.go
+++ b/base/remove.go
@@ -60,7 +60,7 @@ func RemoveEntireDataset(ctx context.Context, r repo.Repo, ref dsref.Ref, histor
 	if _, err := repo.GetVersionInfoShim(r, ref); err == nil {
 		didRemove = appendString(didRemove, "refstore")
 	}
-	if _, err := repo.DeleteVersionInfoShim(r, ref); err != nil {
+	if _, err := repo.DeleteVersionInfoShim(ctx, r, ref); err != nil {
 		log.Debugf("Remove, DeleteRef failed, error: %s", err)
 		removeErr = err
 	}
@@ -189,12 +189,12 @@ func RewindDatasetRef(ctx context.Context, r repo.Repo, curr, next dsref.Ref) (*
 		return nil, fmt.Errorf("error with existing reference: %s", err.Error())
 	}
 
-	if _, err := repo.DeleteVersionInfoShim(r, currVi.SimpleRef()); err != nil {
+	if _, err := repo.DeleteVersionInfoShim(ctx, r, currVi.SimpleRef()); err != nil {
 		return nil, err
 	}
 
 	nextVi.Path = next.Path
-	if err := repo.PutVersionInfoShim(r, nextVi); err != nil {
+	if err := repo.PutVersionInfoShim(ctx, r, nextVi); err != nil {
 		return nil, err
 	}
 	return nextVi, nil

--- a/base/remove_test.go
+++ b/base/remove_test.go
@@ -81,7 +81,7 @@ func TestRemoveNVersionsFromStore(t *testing.T) {
 
 	// remove the ds reference to the cities dataset before we populate
 	// the repo with cities datasets again
-	repo.DeleteVersionInfoShim(r, initDs)
+	repo.DeleteVersionInfoShim(ctx, r, initDs)
 
 	// create test repo and history
 	// create history of 10 versions

--- a/base/save.go
+++ b/base/save.go
@@ -23,7 +23,7 @@ var ErrNameTaken = fmt.Errorf("name already in use")
 func SaveDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, initID, prevPath string, changes *dataset.Dataset, sw SaveSwitches) (ds *dataset.Dataset, err error) {
 	log.Debugf("SaveDataset initID=%q prevPath=%q", initID, prevPath)
 	var pro *profile.Profile
-	if pro, err = r.Profile(); err != nil {
+	if pro, err = r.Profile(ctx); err != nil {
 		return nil, err
 	}
 	if initID == "" {
@@ -125,7 +125,7 @@ func CreateDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, d
 		resBody qfs.File
 	)
 
-	pro, err = r.Profile()
+	pro, err = r.Profile(ctx)
 	if err != nil {
 		log.Debugf("getting repo profile: %s", err)
 		return
@@ -146,7 +146,7 @@ func CreateDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, d
 		return
 	}
 
-	if path, err = dsfs.CreateDataset(ctx, r.Filesystem(), writeDest, r.Bus(), ds, dsPrev, r.PrivateKey(), sw); err != nil {
+	if path, err = dsfs.CreateDataset(ctx, r.Filesystem(), writeDest, r.Bus(), ds, dsPrev, r.PrivateKey(ctx), sw); err != nil {
 		log.Debugf("dsfs.CreateDataset: %s", err)
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func CreateDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, d
 	if ds.PreviousPath != "" && ds.PreviousPath != "/" {
 		// should be ok to skip this error. we may not have the previous
 		// reference locally
-		repo.DeleteVersionInfoShim(r, dsref.Ref{
+		repo.DeleteVersionInfoShim(ctx, r, dsref.Ref{
 			ProfileID: pro.ID.String(),
 			Username:  pro.Peername,
 			Name:      dsName,
@@ -176,7 +176,7 @@ func CreateDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, d
 	// and dscache, this will no longer be necessary, updating logbook will be enough.
 	vi := dsref.ConvertDatasetToVersionInfo(ds)
 
-	if err := repo.PutVersionInfoShim(r, &vi); err != nil {
+	if err := repo.PutVersionInfoShim(ctx, r, &vi); err != nil {
 		return nil, err
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 
@@ -125,8 +126,10 @@ func (o *InitOptions) Run() (err error) {
 		BodyPath:   o.BodyPath,
 		UseDscache: o.UseDscache,
 	}
+
+	ctx := context.TODO()
 	var refstr string
-	if err = o.FSIMethods.InitDataset(p, &refstr); err != nil {
+	if err = o.FSIMethods.InitDataset(ctx, p, &refstr); err != nil {
 		return err
 	}
 

--- a/cmd/ref_select.go
+++ b/cmd/ref_select.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -234,7 +235,8 @@ func (e *FSIRefLinkEnsurer) EnsureRef(refs *RefSelect) error {
 	}
 	p := lib.EnsureParams{Dir: refs.Dir(), Ref: refs.Ref()}
 	info := dsref.VersionInfo{}
+	ctx := context.TODO()
 	// Lib call matches the gorpc method signature, but `out` is not used
-	err := e.FSIMethods.EnsureRef(&p, &info)
+	err := e.FSIMethods.EnsureRef(ctx, &p, &info)
 	return err
 }

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -141,8 +142,9 @@ func (o *RegistryOptions) Signup() error {
 		Email:    o.Email,
 		Password: password,
 	}
+	ctx := context.TODO()
 	var ok bool
-	if err := o.RegistryClientMethods.CreateProfile(p, &ok); err != nil {
+	if err := o.RegistryClientMethods.CreateProfile(ctx, p, &ok); err != nil {
 		return err
 	}
 	printSuccess(o.ErrOut, "user %s created on registry, connected local key", o.Username)
@@ -160,8 +162,9 @@ func (o *RegistryOptions) Prove() error {
 		Email:    o.Email,
 		Password: password,
 	}
+	ctx := context.TODO()
 	var ok bool
-	if err := o.RegistryClientMethods.ProveProfileKey(p, &ok); err != nil {
+	if err := o.RegistryClientMethods.ProveProfileKey(ctx, p, &ok); err != nil {
 		return err
 	}
 	printSuccess(o.ErrOut, "proved user %s to registry, connected local key", o.Username)

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -142,9 +141,9 @@ func (o *RegistryOptions) Signup() error {
 		Email:    o.Email,
 		Password: password,
 	}
-	ctx := context.TODO()
+
 	var ok bool
-	if err := o.RegistryClientMethods.CreateProfile(ctx, p, &ok); err != nil {
+	if err := o.RegistryClientMethods.CreateProfile(p, &ok); err != nil {
 		return err
 	}
 	printSuccess(o.ErrOut, "user %s created on registry, connected local key", o.Username)
@@ -162,9 +161,9 @@ func (o *RegistryOptions) Prove() error {
 		Email:    o.Email,
 		Password: password,
 	}
-	ctx := context.TODO()
+
 	var ok bool
-	if err := o.RegistryClientMethods.ProveProfileKey(ctx, p, &ok); err != nil {
+	if err := o.RegistryClientMethods.ProveProfileKey(p, &ok); err != nil {
 		return err
 	}
 	printSuccess(o.ErrOut, "proved user %s to registry, connected local key", o.Username)

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -376,7 +376,7 @@ func (run *TestRunner) LookupVersionInfo(t *testing.T, refStr string) *dsref.Ver
 	// TODO(b5): me shortcut is handled by an instance, it'd be nice we had a
 	// function in the repo package that deduplicated this in both places
 	if dr.Username == "me" {
-		pro, err := r.Profile()
+		pro, err := r.Profile(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -429,7 +429,7 @@ func (run *TestRunner) ClearFSIPath(t *testing.T, refStr string) {
 		t.Fatal(err)
 	}
 
-	err = repo.CanonicalizeDatasetRef(r, &datasetRef)
+	err = repo.CanonicalizeDatasetRef(ctx, r, &datasetRef)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/fsi/fsi_test.go
+++ b/fsi/fsi_test.go
@@ -1,6 +1,7 @@
 package fsi
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -71,11 +72,12 @@ func (t *TmpPaths) Close() {
 }
 
 func TestCreateLink(t *testing.T) {
+	ctx := context.Background()
 	paths := NewTmpPaths()
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	vi, _, err := fsi.CreateLink(paths.firstDir, dsref.MustParse("peer/movies"))
+	vi, _, err := fsi.CreateLink(ctx, paths.firstDir, dsref.MustParse("peer/movies"))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -119,15 +121,16 @@ func TestResolvedRef(t *testing.T) {
 }
 
 func TestCreateLinkTwice(t *testing.T) {
+	ctx := context.Background()
 	paths := NewTmpPaths()
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, _, err := fsi.CreateLink(paths.firstDir, dsref.MustParse("peer/cities"))
+	_, _, err := fsi.CreateLink(ctx, paths.firstDir, dsref.MustParse("peer/cities"))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	_, _, err = fsi.CreateLink(paths.secondDir, dsref.MustParse("peer/movies"))
+	_, _, err = fsi.CreateLink(ctx, paths.secondDir, dsref.MustParse("peer/movies"))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -172,15 +175,16 @@ func TestCreateLinkTwice(t *testing.T) {
 }
 
 func TestCreateLinkAlreadyLinked(t *testing.T) {
+	ctx := context.Background()
 	paths := NewTmpPaths()
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, _, err := fsi.CreateLink(paths.firstDir, dsref.MustParse("peer/cities"))
+	_, _, err := fsi.CreateLink(ctx, paths.firstDir, dsref.MustParse("peer/cities"))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	_, _, err = fsi.CreateLink(paths.firstDir, dsref.MustParse("peer/cities"))
+	_, _, err = fsi.CreateLink(ctx, paths.firstDir, dsref.MustParse("peer/cities"))
 	if err == nil {
 		t.Errorf("expected an error, did not get one")
 		return
@@ -193,17 +197,18 @@ func TestCreateLinkAlreadyLinked(t *testing.T) {
 }
 
 func TestCreateLinkAgainOnceQriRefRemoved(t *testing.T) {
+	ctx := context.Background()
 	paths := NewTmpPaths()
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, _, err := fsi.CreateLink(paths.firstDir, dsref.MustParse("peer/cities"))
+	_, _, err := fsi.CreateLink(ctx, paths.firstDir, dsref.MustParse("peer/cities"))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
 	// Remove the .qri-ref link file, then CreateLink again.
 	os.Remove(filepath.Join(paths.firstDir, ".qri-ref"))
-	_, _, err = fsi.CreateLink(paths.firstDir, dsref.MustParse("peer/cities"))
+	_, _, err = fsi.CreateLink(ctx, paths.firstDir, dsref.MustParse("peer/cities"))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -235,11 +240,12 @@ func TestCreateLinkAgainOnceQriRefRemoved(t *testing.T) {
 
 // Test that ModifyLinkReference changes what is in the .qri-ref linkfile
 func TestModifyLinkReference(t *testing.T) {
+	ctx := context.Background()
 	paths := NewTmpPaths()
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, _, err := fsi.CreateLink(paths.firstDir, dsref.MustParse("peer/cities"))
+	_, _, err := fsi.CreateLink(ctx, paths.firstDir, dsref.MustParse("peer/cities"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +265,7 @@ func TestModifyLinkReference(t *testing.T) {
 	}
 
 	vi.Name = "cities_2"
-	err = repo.PutVersionInfoShim(paths.testRepo, vi)
+	err = repo.PutVersionInfoShim(ctx, paths.testRepo, vi)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,15 +289,16 @@ func TestModifyLinkReference(t *testing.T) {
 
 // Test that ModifyLinkDirectory changes the FSIPath in the repo
 func TestModifyLinkDirectory(t *testing.T) {
+	ctx := context.Background()
 	paths := NewTmpPaths()
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, _, err := fsi.CreateLink(paths.firstDir, dsref.MustParse("peer/movies"))
+	_, _, err := fsi.CreateLink(ctx, paths.firstDir, dsref.MustParse("peer/movies"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = fsi.ModifyLinkDirectory(paths.secondDir, dsref.MustParse("peer/movies"))
+	_, err = fsi.ModifyLinkDirectory(ctx, paths.secondDir, dsref.MustParse("peer/movies"))
 	if err != nil {
 		t.Errorf("expected ModifyLinkReference to succeed, got: %s", err.Error())
 	}
@@ -321,20 +328,21 @@ func TestModifyLinkDirectory(t *testing.T) {
 }
 
 func TestUnlink(t *testing.T) {
+	ctx := context.Background()
 	paths := NewTmpPaths()
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, _, err := fsi.CreateLink(paths.firstDir, dsref.MustParse("peer/cities"))
+	_, _, err := fsi.CreateLink(ctx, paths.firstDir, dsref.MustParse("peer/cities"))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
 
-	if err := fsi.Unlink(paths.firstDir, dsref.MustParse("peer/mismatched_reference")); err == nil {
+	if err := fsi.Unlink(ctx, paths.firstDir, dsref.MustParse("peer/mismatched_reference")); err == nil {
 		t.Errorf("expected unlinking mismatched reference to error")
 	}
 
-	if err := fsi.Unlink(paths.firstDir, dsref.MustParse("peer/cities")); err != nil {
+	if err := fsi.Unlink(ctx, paths.firstDir, dsref.MustParse("peer/cities")); err != nil {
 		t.Errorf("unlinking valid reference: %s", err.Error())
 	}
 }

--- a/fsi/init.go
+++ b/fsi/init.go
@@ -38,9 +38,7 @@ var PrepareToWrite = func(comp component.Component) {
 }
 
 // InitDataset creates a new dataset
-func (fsi *FSI) InitDataset(p InitParams) (ref dsref.Ref, err error) {
-	ctx := context.TODO()
-
+func (fsi *FSI) InitDataset(ctx context.Context, p InitParams) (ref dsref.Ref, err error) {
 	// Create a rollback handler
 	rollback := func() {
 		log.Debug("did rollback InitDataset due to error")
@@ -133,13 +131,13 @@ to create a working directory for an existing dataset`
 	// that both the exported CreateLink & Init can call
 	vi := ref.VersionInfo()
 	vi.FSIPath = p.TargetDir
-	if err := repo.PutVersionInfoShim(fsi.repo, &vi); err != nil {
+	if err := repo.PutVersionInfoShim(ctx, fsi.repo, &vi); err != nil {
 		return ref, err
 	}
 
 	// Create the link file, containing the dataset reference.
 	var undo func()
-	if _, undo, err = fsi.CreateLink(p.TargetDir, ref); err != nil {
+	if _, undo, err = fsi.CreateLink(ctx, p.TargetDir, ref); err != nil {
 		return ref, err
 	}
 	// If future steps fail, rollback the link creation.

--- a/fsi/init_test.go
+++ b/fsi/init_test.go
@@ -1,6 +1,7 @@
 package fsi
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,12 +9,13 @@ import (
 )
 
 func TestInitDataset(t *testing.T) {
+	ctx := context.Background()
 	paths := NewTmpPaths()
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
 
-	_, err := fsi.InitDataset(InitParams{
+	_, err := fsi.InitDataset(ctx, InitParams{
 		Name:      "test_ds",
 		TargetDir: paths.firstDir,
 		Format:    "csv",

--- a/fsi/status_test.go
+++ b/fsi/status_test.go
@@ -38,7 +38,7 @@ func TestStatusValid(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, err := fsi.InitDataset(InitParams{
+	_, err := fsi.InitDataset(ctx, InitParams{
 		Name:      "test_ds",
 		TargetDir: paths.firstDir,
 		Format:    "csv",
@@ -86,7 +86,7 @@ func TestStatusInvalidDataset(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, err := fsi.InitDataset(InitParams{
+	_, err := fsi.InitDataset(ctx, InitParams{
 		Name:      "test_ds",
 		TargetDir: paths.firstDir,
 		Format:    "csv",
@@ -114,7 +114,7 @@ func TestStatusInvalidMeta(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, err := fsi.InitDataset(InitParams{
+	_, err := fsi.InitDataset(ctx, InitParams{
 		Name:      "test_ds",
 		TargetDir: paths.firstDir,
 		Format:    "csv",
@@ -140,7 +140,7 @@ func TestStatusNotFound(t *testing.T) {
 	defer paths.Close()
 
 	fsi := NewFSI(paths.testRepo, nil)
-	_, err := fsi.InitDataset(InitParams{
+	_, err := fsi.InitDataset(ctx, InitParams{
 		Name:      "test_ds",
 		TargetDir: paths.firstDir,
 		Format:    "csv",

--- a/go.sum
+++ b/go.sum
@@ -1127,6 +1127,8 @@ github.com/qri-io/dag v0.2.2-0.20201208212257-ae00241c4b48 h1:6fTW2iHGbaEKQt9u8+
 github.com/qri-io/dag v0.2.2-0.20201208212257-ae00241c4b48/go.mod h1:1AwOy3yhcZTAXzaF4wGSdnrp87u3PBOrsWXUjOtQCXo=
 github.com/qri-io/dataset v0.2.1-0.20210126031523-f94fd2290107 h1:K5cgpsL+r8kz7XmV01b53KrdwWcdcuL5nrfMzrAYNoU=
 github.com/qri-io/dataset v0.2.1-0.20210126031523-f94fd2290107/go.mod h1:vlq9+Nu37koO3mrp25QGNOt68CLe2d2rAtB9cnDLV6E=
+github.com/qri-io/dataset v0.2.1-0.20210128201320-3b1209495e96 h1:SiP48nzhKLJbvM6SA+5wK53PKUs0FY0DWDylMPyi8S4=
+github.com/qri-io/dataset v0.2.1-0.20210128201320-3b1209495e96/go.mod h1:vlq9+Nu37koO3mrp25QGNOt68CLe2d2rAtB9cnDLV6E=
 github.com/qri-io/deepdiff v0.2.1-0.20200807143746-d02d9f531f5b h1:T8qEIv+qLi5mVWvSS329wJ+HbN7cfMwCWjRVzh/+upo=
 github.com/qri-io/deepdiff v0.2.1-0.20200807143746-d02d9f531f5b/go.mod h1:NrL/b7YvexgpGb4HEO3Rlx5RrMLDfxuKDf/XDAq5ac0=
 github.com/qri-io/didmod v0.0.0-20201123165422-8b2e224c993a h1:40BIa59lae2xZ7iieb3UU4/X57jZsWZ6QgqwdjDQhig=

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -75,11 +75,11 @@ func (m *DatasetMethods) List(p *ListParams, res *[]dsref.VersionInfo) error {
 		Peername:  p.Peername,
 		ProfileID: p.ProfileID,
 	}
-	if err := repo.CanonicalizeProfile(m.inst.repo, ref); err != nil {
+	if err := repo.CanonicalizeProfile(ctx, m.inst.repo, ref); err != nil {
 		return fmt.Errorf("error canonicalizing peer: %w", err)
 	}
 
-	pro, err := m.inst.repo.Profile()
+	pro, err := m.inst.repo.Profile(ctx)
 	if err != nil {
 		return err
 	}
@@ -549,7 +549,7 @@ func (m *DatasetMethods) Save(p *SaveParams, res *dataset.Dataset) error {
 		return err
 	}
 
-	pro, err := m.inst.repo.Profile()
+	pro, err := m.inst.repo.Profile(ctx)
 	if err != nil {
 		return err
 	}
@@ -676,7 +676,7 @@ func (m *DatasetMethods) Save(p *SaveParams, res *dataset.Dataset) error {
 	if fsiPath != "" {
 		vi := dsref.ConvertDatasetToVersionInfo(savedDs)
 		vi.FSIPath = fsiPath
-		if err = repo.PutVersionInfoShim(m.inst.repo, &vi); err != nil {
+		if err = repo.PutVersionInfoShim(ctx, m.inst.repo, &vi); err != nil {
 			return err
 		}
 	}
@@ -786,7 +786,7 @@ func (m *DatasetMethods) Remove(p *RemoveParams, res *RemoveResponse) error {
 		return err
 	}
 
-	if canonErr := repo.CanonicalizeDatasetRef(m.inst.repo, &ref); canonErr != nil && canonErr != repo.ErrNoHistory {
+	if canonErr := repo.CanonicalizeDatasetRef(ctx, m.inst.repo, &ref); canonErr != nil && canonErr != repo.ErrNoHistory {
 		log.Debugf("Remove, repo.CanonicalizeDatasetRef failed, error: %s", canonErr)
 		if p.Force {
 			didRemove, _ := base.RemoveEntireDataset(ctx, m.inst.repo, reporef.ConvertToDsref(ref), []DatasetLogItem{})
@@ -849,7 +849,7 @@ func (m *DatasetMethods) Remove(p *RemoveParams, res *RemoveResponse) error {
 		// removing all revisions of a dataset must unlink it
 		if ref.FSIPath != "" {
 			dr := reporef.ConvertToDsref(ref)
-			if err := m.inst.fsi.Unlink(ref.FSIPath, dr); err == nil {
+			if err := m.inst.fsi.Unlink(ctx, ref.FSIPath, dr); err == nil {
 				res.Unlinked = true
 			} else {
 				log.Errorf("during Remove, dataset did not unlink: %s", err)
@@ -1140,7 +1140,7 @@ func (m *DatasetMethods) Manifest(refstr *string, mfst *dag.Manifest) error {
 	if err != nil {
 		return err
 	}
-	if err = repo.CanonicalizeDatasetRef(m.inst.repo, &ref); err != nil {
+	if err = repo.CanonicalizeDatasetRef(ctx, m.inst.repo, &ref); err != nil {
 		return err
 	}
 
@@ -1185,7 +1185,7 @@ func (m *DatasetMethods) DAGInfo(s *DAGInfoParams, i *dag.Info) error {
 	if err != nil {
 		return err
 	}
-	if err = repo.CanonicalizeDatasetRef(m.inst.repo, &ref); err != nil {
+	if err = repo.CanonicalizeDatasetRef(ctx, m.inst.repo, &ref); err != nil {
 		return err
 	}
 

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -419,7 +419,7 @@ func TestDatasetRequestsListP2p(t *testing.T) {
 				t.Errorf("error listing dataset: %s", err.Error())
 			}
 			// Get number from end of peername, use that to find dataset name.
-			profile, _ := node.Repo.Profile()
+			profile, _ := node.Repo.Profile(ctx)
 			num := profile.Peername[len(profile.Peername)-1:]
 			index, _ := strconv.ParseInt(num, 10, 32)
 			expect := datasets[index]
@@ -695,7 +695,7 @@ func TestDatasetRequestsGetP2p(t *testing.T) {
 		go func(node *p2p.QriNode) {
 			defer wg.Done()
 			// Get number from end of peername, use that to create dataset name.
-			profile, _ := node.Repo.Profile()
+			profile, _ := node.Repo.Profile(ctx)
 			num := profile.Peername[len(profile.Peername)-1:]
 			index, _ := strconv.ParseInt(num, 10, 32)
 			name := datasets[index]
@@ -792,6 +792,7 @@ func TestDatasetRequestsRename(t *testing.T) {
 }
 
 func TestRenameNoHistory(t *testing.T) {
+	ctx := context.Background()
 	tr := newTestRunner(t)
 	defer tr.Delete()
 
@@ -802,7 +803,7 @@ func TestRenameNoHistory(t *testing.T) {
 		Format:    "csv",
 	}
 	var refstr string
-	if err := NewFSIMethods(tr.Instance).InitDataset(initP, &refstr); err != nil {
+	if err := NewFSIMethods(tr.Instance).InitDataset(ctx, initP, &refstr); err != nil {
 		t.Fatal(err)
 	}
 
@@ -864,7 +865,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 		Format:    "csv",
 	}
 	var noHistoryName string
-	if err := fsim.InitDataset(initp, &noHistoryName); err != nil {
+	if err := fsim.InitDataset(ctx, initp, &noHistoryName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1034,7 +1035,7 @@ func TestDatasetRequestsAddP2P(t *testing.T) {
 				defer wg.Done()
 
 				// Get ref to dataset that peer2 has.
-				profile, _ := p1.Repo.Profile()
+				profile, _ := p1.Repo.Profile(ctx)
 				num := profile.Peername[len(profile.Peername)-1:]
 				index, _ := strconv.ParseInt(num, 10, 32)
 				name := datasets[index]
@@ -1050,8 +1051,8 @@ func TestDatasetRequestsAddP2P(t *testing.T) {
 
 				err := dsm.Pull(p, got)
 				if err != nil {
-					pro1, _ := p0.Repo.Profile()
-					pro2, _ := p1.Repo.Profile()
+					pro1, _ := p0.Repo.Profile(ctx)
+					pro2, _ := p1.Repo.Profile(ctx)
 					t.Errorf("error adding dataset for %s from %s to %s: %s",
 						ref.Name, pro2.Peername, pro1.Peername, err.Error())
 				}
@@ -1136,6 +1137,7 @@ Pirates of the Caribbean: At World's End ,foo
 }
 
 func TestDatasetRequestsValidateFSI(t *testing.T) {
+	ctx := context.Background()
 	tr := newTestRunner(t)
 	defer tr.Delete()
 
@@ -1146,7 +1148,7 @@ func TestDatasetRequestsValidateFSI(t *testing.T) {
 		Format:    "csv",
 	}
 	var refstr string
-	if err := NewFSIMethods(tr.Instance).InitDataset(initP, &refstr); err != nil {
+	if err := NewFSIMethods(tr.Instance).InitDataset(ctx, initP, &refstr); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -56,7 +56,7 @@ func (m *FSIMethods) CreateLink(p *LinkParams, res *dsref.VersionInfo) (err erro
 		return err
 	}
 
-	res, _, err = m.inst.fsi.CreateLink(p.Dir, ref)
+	res, _, err = m.inst.fsi.CreateLink(ctx, p.Dir, ref)
 	return err
 }
 
@@ -90,7 +90,7 @@ func (m *FSIMethods) Unlink(p *LinkParams, res *string) (err error) {
 		p.Dir = vi.FSIPath
 	}
 
-	if err := m.inst.fsi.Unlink(p.Dir, ref); err != nil {
+	if err := m.inst.fsi.Unlink(ctx, p.Dir, ref); err != nil {
 		return err
 	}
 
@@ -210,7 +210,7 @@ func (m *FSIMethods) Checkout(p *CheckoutParams, out *string) (err error) {
 	log.Debugf("Checkout made directory %q", p.Dir)
 
 	// Create the link file, containing the dataset reference.
-	if _, _, err = m.inst.fsi.CreateLink(p.Dir, ref); err != nil {
+	if _, _, err = m.inst.fsi.CreateLink(ctx, p.Dir, ref); err != nil {
 		log.Debugf("Checkout, fsi.CreateLink failed, error: %s", ref)
 		return err
 	}
@@ -249,7 +249,7 @@ func (m *FSIMethods) Write(p *FSIWriteParams, res *[]StatusItem) (err error) {
 	}
 
 	datasetRef := reporef.RefFromDsref(ref)
-	err = repo.CanonicalizeDatasetRef(m.inst.node.Repo, &datasetRef)
+	err = repo.CanonicalizeDatasetRef(ctx, m.inst.node.Repo, &datasetRef)
 	if err != nil && err != repo.ErrNoHistory {
 		return err
 	}
@@ -344,7 +344,7 @@ func (m *FSIMethods) Restore(p *RestoreParams, out *string) (err error) {
 type InitDatasetParams = fsi.InitParams
 
 // InitDataset creates a new dataset in a working directory
-func (m *FSIMethods) InitDataset(p *InitDatasetParams, refstr *string) (err error) {
+func (m *FSIMethods) InitDataset(ctx context.Context, p *InitDatasetParams, refstr *string) (err error) {
 	if err = qfs.AbsPath(&p.BodyPath); err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func (m *FSIMethods) InitDataset(p *InitDatasetParams, refstr *string) (err erro
 		m.inst.Dscache().CreateNewEnabled = true
 	}
 
-	ref, err := m.inst.fsi.InitDataset(*p)
+	ref, err := m.inst.fsi.InitDataset(ctx, *p)
 	*refstr = ref.Human()
 	return err
 }
@@ -384,7 +384,7 @@ type EnsureParams struct {
 }
 
 // EnsureRef will modify the directory path in the repo for the given reference
-func (m *FSIMethods) EnsureRef(p *EnsureParams, out *dsref.VersionInfo) error {
+func (m *FSIMethods) EnsureRef(ctx context.Context, p *EnsureParams, out *dsref.VersionInfo) error {
 	if m.inst.rpc != nil {
 		return checkRPCError(m.inst.rpc.Call("FSIMethods.EnsureRef", p, out))
 	}
@@ -394,7 +394,7 @@ func (m *FSIMethods) EnsureRef(p *EnsureParams, out *dsref.VersionInfo) error {
 		return err
 	}
 
-	vi, err := m.inst.fsi.ModifyLinkDirectory(p.Dir, ref)
+	vi, err := m.inst.fsi.ModifyLinkDirectory(ctx, p.Dir, ref)
 	*out = *vi
 	return err
 }

--- a/lib/fsi_test.go
+++ b/lib/fsi_test.go
@@ -50,7 +50,7 @@ func TestFSIMethodsWrite(t *testing.T) {
 		Format:    "csv",
 	}
 	var noHistoryName string
-	if err := methods.InitDataset(initp, &noHistoryName); err != nil {
+	if err := methods.InitDataset(ctx, initp, &noHistoryName); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -632,7 +632,8 @@ func NewInstanceFromConfigAndNodeAndBus(ctx context.Context, cfg *config.Config,
 	ctx, cancel := context.WithCancel(ctx)
 
 	r := node.Repo
-	pro, err := r.Profile()
+	// TODO(aqru): should be owner?
+	pro, err := r.Profile(ctx)
 	if err != nil {
 		cancel()
 		panic(err)

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -214,7 +214,7 @@ func addCitiesDataset(t *testing.T, node *p2p.QriNode) dsref.Ref {
 }
 
 func saveDataset(ctx context.Context, r repo.Repo, ds *dataset.Dataset, sw base.SaveSwitches) (dsref.Ref, error) {
-	pro, err := r.Profile()
+	pro, err := r.Profile(ctx)
 	if err != nil {
 		return dsref.Ref{}, err
 	}

--- a/lib/load_test.go
+++ b/lib/load_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"testing"
 
 	"github.com/qri-io/dataset"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestLoadDataset(t *testing.T) {
+	ctx := context.Background()
 	tr := newTestRunner(t)
 	defer tr.Delete()
 
@@ -28,7 +30,7 @@ func TestLoadDataset(t *testing.T) {
 			event.NilBus,
 			ds,
 			nil,
-			tr.Instance.repo.PrivateKey(),
+			tr.Instance.repo.PrivateKey(ctx),
 			dsfs.SaveSwitches{},
 		)
 	})

--- a/lib/profile_test.go
+++ b/lib/profile_test.go
@@ -49,7 +49,7 @@ func TestProfileRequestsGet(t *testing.T) {
 
 	for i, c := range cases {
 		got := &config.ProfilePod{}
-		err := m.GetProfile(&c.in, got)
+		err := m.GetProfile(ctx, &c.in, got)
 
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch: expected: %s, got: %s", i, c.err, err)
@@ -222,7 +222,7 @@ func TestProfileRequestsSetPeername(t *testing.T) {
 
 	m := NewProfileMethods(inst)
 
-	pro, err := node.Repo.Profile()
+	pro, err := node.Repo.Profile(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -28,12 +28,12 @@ func (RegistryClientMethods) CoreRequestsName() string { return "registry" }
 type RegistryProfile = registry.Profile
 
 // CreateProfile creates a profile
-func (m RegistryClientMethods) CreateProfile(p *RegistryProfile, ok *bool) (err error) {
+func (m RegistryClientMethods) CreateProfile(ctx context.Context, p *RegistryProfile, ok *bool) (err error) {
 	if m.inst.rpc != nil {
 		return checkRPCError(m.inst.rpc.Call("RegistryClientMethods.CreateProfile", p, ok))
 	}
 
-	pro, err := m.inst.registry.CreateProfile(p, m.inst.repo.PrivateKey())
+	pro, err := m.inst.registry.CreateProfile(p, m.inst.repo.PrivateKey(ctx))
 	if err != nil {
 		return err
 	}
@@ -46,12 +46,12 @@ func (m RegistryClientMethods) CreateProfile(p *RegistryProfile, ok *bool) (err 
 
 // ProveProfileKey asserts to a registry that this user has control of a
 // specified private key
-func (m RegistryClientMethods) ProveProfileKey(p *RegistryProfile, ok *bool) error {
+func (m RegistryClientMethods) ProveProfileKey(ctx context.Context, p *RegistryProfile, ok *bool) error {
 	if m.inst.rpc != nil {
 		return checkRPCError(m.inst.rpc.Call("RegistryClientMethods.CreateProfile", p, ok))
 	}
 
-	pro, err := m.inst.registry.ProveProfileKey(p, m.inst.repo.PrivateKey())
+	pro, err := m.inst.registry.ProveProfileKey(p, m.inst.repo.PrivateKey(ctx))
 	if err != nil {
 		return err
 	}

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -28,11 +28,13 @@ func (RegistryClientMethods) CoreRequestsName() string { return "registry" }
 type RegistryProfile = registry.Profile
 
 // CreateProfile creates a profile
-func (m RegistryClientMethods) CreateProfile(ctx context.Context, p *RegistryProfile, ok *bool) (err error) {
+func (m RegistryClientMethods) CreateProfile(p *RegistryProfile, ok *bool) (err error) {
 	if m.inst.rpc != nil {
 		return checkRPCError(m.inst.rpc.Call("RegistryClientMethods.CreateProfile", p, ok))
 	}
 
+	ctx := context.TODO()
+	// TODO(arqu): this should take the profile PK instead of active PK once multi tenancy is supported
 	pro, err := m.inst.registry.CreateProfile(p, m.inst.repo.PrivateKey(ctx))
 	if err != nil {
 		return err
@@ -46,11 +48,13 @@ func (m RegistryClientMethods) CreateProfile(ctx context.Context, p *RegistryPro
 
 // ProveProfileKey asserts to a registry that this user has control of a
 // specified private key
-func (m RegistryClientMethods) ProveProfileKey(ctx context.Context, p *RegistryProfile, ok *bool) error {
+func (m RegistryClientMethods) ProveProfileKey(p *RegistryProfile, ok *bool) error {
 	if m.inst.rpc != nil {
 		return checkRPCError(m.inst.rpc.Call("RegistryClientMethods.CreateProfile", p, ok))
 	}
 
+	ctx := context.TODO()
+	// TODO(arqu): this should take the profile PK instead of active PK once multi tenancy is supported
 	pro, err := m.inst.registry.ProveProfileKey(p, m.inst.repo.PrivateKey(ctx))
 	if err != nil {
 		return err

--- a/lib/remote.go
+++ b/lib/remote.go
@@ -117,7 +117,7 @@ func (r *RemoteMethods) Push(p *PushParams, res *dsref.Ref) error {
 
 	datasetRef := reporef.RefFromDsref(ref)
 	datasetRef.Published = true
-	if err = base.SetPublishStatus(r.inst.node.Repo, ref, true); err != nil {
+	if err = base.SetPublishStatus(ctx, r.inst.node.Repo, ref, true); err != nil {
 		return err
 	}
 
@@ -174,7 +174,7 @@ func (r *RemoteMethods) Remove(p *PushParams, res *dsref.Ref) error {
 		return err
 	}
 
-	if err = base.SetPublishStatus(r.inst.node.Repo, ref, false); err != nil {
+	if err = base.SetPublishStatus(ctx, r.inst.node.Repo, ref, false); err != nil {
 		return err
 	}
 

--- a/lib/test_runner_test.go
+++ b/lib/test_runner_test.go
@@ -222,6 +222,7 @@ func (tr *testRunner) DiffWithParams(p *DiffParams) (string, error) {
 }
 
 func (tr *testRunner) Init(refstr, format string) error {
+	ctx := context.Background()
 	ref, err := dsref.Parse(refstr)
 	if err != nil {
 		return err
@@ -233,13 +234,14 @@ func (tr *testRunner) Init(refstr, format string) error {
 		TargetDir: tr.WorkDir,
 		Format:    format,
 	}
-	return m.InitDataset(&p, &out)
+	return m.InitDataset(ctx, &p, &out)
 }
 
 func (tr *testRunner) InitWithParams(p *InitDatasetParams) error {
+	ctx := context.Background()
 	m := NewFSIMethods(tr.Instance)
 	out := ""
-	return m.InitDataset(p, &out)
+	return m.InitDataset(ctx, p, &out)
 }
 
 func (tr *testRunner) Checkout(refstr, dir string) error {

--- a/p2p/list_peers.go
+++ b/p2p/list_peers.go
@@ -10,7 +10,7 @@ import (
 func ListPeers(node *QriNode, limit, offset int, onlineOnly bool) ([]*config.ProfilePod, error) {
 
 	r := node.Repo
-	user, err := r.Profile()
+	user, err := r.Owner()
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -209,7 +209,7 @@ func (n *QriNode) GoOnline(c context.Context) (err error) {
 		return err
 	}
 
-	p, err := n.Repo.Profile()
+	p, err := n.Repo.Owner()
 	if err != nil {
 		log.Errorf("error getting repo profile: %s\n", err.Error())
 		cancel()

--- a/p2p/p2p_deprecate.go
+++ b/p2p/p2p_deprecate.go
@@ -82,7 +82,7 @@ func (n *QriNode) handleProfile(ws *WrappedStream, msg Message) (hangup bool) {
 }
 
 func (n *QriNode) profileBytes() ([]byte, error) {
-	p, err := n.Repo.Profile()
+	p, err := n.Repo.Owner()
 	if err != nil {
 		log.Debugf("error getting repo profile: %s\n", err.Error())
 		return nil, err

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -78,7 +78,7 @@ func writeWorldBankPopulation(ctx context.Context, t *testing.T, r repo.Repo) re
 		t.Fatal(err)
 	}
 
-	pro, err := r.Profile()
+	pro, err := r.Owner()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/profile_service.go
+++ b/p2p/profile_service.go
@@ -148,7 +148,7 @@ func (q *QriProfileService) ProfileHandler(s network.Stream) {
 
 	log.Debugf("%s received a profile request from %s %s", ProfileProtocolID, p, s.Conn().RemoteMultiaddr())
 
-	pro, err = q.repo.Profile()
+	pro, err = q.repo.Owner()
 	if err != nil {
 		log.Debugf("%s error getting this node's profile: %s", ProfileProtocolID, err)
 		return

--- a/p2p/test/testable_node_test.go
+++ b/p2p/test/testable_node_test.go
@@ -57,14 +57,15 @@ func (n *TestableNode) TestStreamHandler(s net.Stream) {
 // GoOnline assumes the TestNode is not online, it will set
 // the StreamHandler and updates our profile with the underlying peerIDs
 func (n *TestableNode) GoOnline(_ context.Context) error {
-
+	// use a separate context
+	ctx := context.Background()
 	// add multistream handler for qri protocol to the host
 	// for more info on multistreams check github.com/multformats/go-multistream
 	// Setting the StreamHandler with the TestQriProtocol will let other peers
 	// know that we can speak the TestQriProtocol
 	n.Host().SetStreamHandler(TestQriProtocolID, n.TestStreamHandler)
 
-	p, err := n.Repo.Profile()
+	p, err := n.Repo.Profile(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting repo profile: %s", err.Error())
 	}

--- a/profile/store.go
+++ b/profile/store.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -25,6 +26,8 @@ type Store interface {
 	Owner() *Profile
 	// SetOwner handles updates to the current user profile at runtime
 	SetOwner(own *Profile) error
+	// Active is the active profile that represents the current user
+	Active(ctx context.Context) *Profile
 
 	// put a profile in the store
 	PutProfile(profile *Profile) error
@@ -100,7 +103,7 @@ func NewMemStore(owner *Profile, ks key.Store) (Store, error) {
 	}, nil
 }
 
-// Owner accesses the current user profile
+// Owner accesses the current owner user profile
 func (m *MemStore) Owner() *Profile {
 	return m.owner
 }
@@ -109,6 +112,11 @@ func (m *MemStore) Owner() *Profile {
 func (m *MemStore) SetOwner(own *Profile) error {
 	m.owner = own
 	return nil
+}
+
+// Active is the curernt active profile
+func (m *MemStore) Active(ctx context.Context) *Profile {
+	return m.Owner()
 }
 
 // PutProfile adds a peer to this store
@@ -247,7 +255,7 @@ func lockPath(filename string) string {
 	return fmt.Sprintf("%s.lock", filename)
 }
 
-// Owner accesses the current user profile
+// Owner accesses the current owner user profile
 func (r *LocalStore) Owner() *Profile {
 	return r.owner
 }
@@ -256,6 +264,11 @@ func (r *LocalStore) Owner() *Profile {
 func (r *LocalStore) SetOwner(own *Profile) error {
 	r.owner = own
 	return r.PutProfile(own)
+}
+
+// Active is the curernt active profile
+func (r *LocalStore) Active(ctx context.Context) *Profile {
+	return r.Owner()
 }
 
 // PutProfile adds a peer to the store

--- a/remote/client.go
+++ b/remote/client.go
@@ -127,13 +127,13 @@ func NewClient(ctx context.Context, node *p2p.QriNode, pub event.Publisher) (c C
 		})
 	}
 
-	pro, err := node.Repo.Profile()
+	pro, err := node.Repo.Profile(ctx)
 	if err != nil {
 		log.Debug("cannot get profile from repo, need username for access control on the remote to function")
 	}
 
 	cli := &client{
-		pk:      node.Repo.PrivateKey(),
+		pk:      node.Repo.PrivateKey(ctx),
 		profile: pro,
 		ds:      ds,
 		logsync: ls,
@@ -174,7 +174,7 @@ func (c *client) Feeds(ctx context.Context, remoteAddr string) (map[string][]dsr
 		return nil, err
 	}
 
-	if err := c.signHTTPRequest(req); err != nil {
+	if err := c.signHTTPRequest(ctx, req); err != nil {
 		return nil, err
 	}
 
@@ -218,7 +218,7 @@ func (c *client) Feed(ctx context.Context, remoteAddr, feedName string, page, pa
 		return nil, err
 	}
 
-	if err := c.signHTTPRequest(req); err != nil {
+	if err := c.signHTTPRequest(ctx, req); err != nil {
 		return nil, err
 	}
 
@@ -269,7 +269,7 @@ func (c *client) previewDatasetVersionHTTP(ctx context.Context, ref dsref.Ref, r
 		return nil, err
 	}
 
-	if err := c.signHTTPRequest(req); err != nil {
+	if err := c.signHTTPRequest(ctx, req); err != nil {
 		return nil, err
 	}
 
@@ -731,8 +731,8 @@ func addressType(remoteAddr string) string {
 	return ""
 }
 
-func (c *client) signHTTPRequest(req *http.Request) error {
-	pk := c.node.Repo.PrivateKey()
+func (c *client) signHTTPRequest(ctx context.Context, req *http.Request) error {
+	pk := c.node.Repo.PrivateKey(ctx)
 	now := fmt.Sprintf("%d", nowFunc().In(time.UTC).Unix())
 
 	// TODO (b5) - we shouldn't be calculating profile IDs here

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -95,7 +95,7 @@ func TestClientFeedsAndPreviews(t *testing.T) {
 
 	worldBankRef := writeWorldBankPopulation(tr.Ctx, t, tr.NodeA.Repo)
 	wbp := reporef.RefFromDsref(worldBankRef)
-	setRefPublished(t, tr.NodeA.Repo, &wbp)
+	setRefPublished(tr.Ctx, t, tr.NodeA.Repo, &wbp)
 
 	rem := tr.NodeARemote(t)
 	server := tr.RemoteTestServer(rem)

--- a/remote/mock_client.go
+++ b/remote/mock_client.go
@@ -279,7 +279,7 @@ func (c *MockClient) mockDagSync(ctx context.Context, ref dsref.Ref) (*dsref.Ver
 		Username:  ref.Username,
 		Name:      ref.Name,
 	}
-	if err := repo.PutVersionInfoShim(c.node.Repo, &vi); err != nil {
+	if err := repo.PutVersionInfoShim(ctx, c.node.Repo, &vi); err != nil {
 		return nil, err
 	}
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -424,7 +424,7 @@ func (r *Remote) dsPushComplete(ctx context.Context, info dag.Info, meta map[str
 
 	// TODO (b5) - this could overwrite any FSI links & other ref details,
 	// need to investigate
-	return repo.PutVersionInfoShim(r.node.Repo, &vi)
+	return repo.PutVersionInfoShim(ctx, r.node.Repo, &vi)
 }
 
 func (r *Remote) dsRemovePreCheck(ctx context.Context, info dag.Info, meta map[string]string) error {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -220,11 +220,11 @@ func TestFeeds(t *testing.T) {
 
 	wbp := writeWorldBankPopulation(tr.Ctx, t, tr.NodeA.Repo)
 	wbpRepoRef := reporef.RefFromDsref(wbp)
-	setRefPublished(t, tr.NodeA.Repo, &wbpRepoRef)
+	setRefPublished(tr.Ctx, t, tr.NodeA.Repo, &wbpRepoRef)
 
 	vvs := writeVideoViewStats(tr.Ctx, t, tr.NodeA.Repo)
 	vvsRepoRef := reporef.RefFromDsref(vvs)
-	setRefPublished(t, tr.NodeA.Repo, &vvsRepoRef)
+	setRefPublished(tr.Ctx, t, tr.NodeA.Repo, &vvsRepoRef)
 
 	aCfg := &config.Remote{
 		Enabled:       true,
@@ -483,8 +483,8 @@ func writeWorldBankPopulation(ctx context.Context, t *testing.T, r repo.Repo) ds
 	return saveDataset(ctx, r, "peer", ds)
 }
 
-func setRefPublished(t *testing.T, r repo.Repo, ref *reporef.DatasetRef) {
-	if err := base.SetPublishStatus(r, reporef.ConvertToDsref(*ref), true); err != nil {
+func setRefPublished(ctx context.Context, t *testing.T, r repo.Repo, ref *reporef.DatasetRef) {
+	if err := base.SetPublishStatus(ctx, r, reporef.ConvertToDsref(*ref), true); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -149,7 +149,12 @@ func (r *Repo) SetFilesystem(fs *muxfs.Mux) {
 }
 
 // Profile gives this repo's peer profile
-func (r *Repo) Profile() (*profile.Profile, error) {
+func (r *Repo) Profile(ctx context.Context) (*profile.Profile, error) {
+	return r.profiles.Active(ctx), nil
+}
+
+// Owner returns the owner profile for this repository
+func (r *Repo) Owner() (*profile.Profile, error) {
 	return r.profiles.Owner(), nil
 }
 
@@ -164,8 +169,8 @@ func (r *Repo) Dscache() *dscache.Dscache {
 }
 
 // PrivateKey returns this repo's private key
-func (r *Repo) PrivateKey() crypto.PrivKey {
-	return r.profiles.Owner().PrivKey
+func (r *Repo) PrivateKey(ctx context.Context) crypto.PrivKey {
+	return r.profiles.Active(ctx).PrivKey
 }
 
 // Profiles returns this repo's Peers implementation

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -149,8 +149,8 @@ func (r *MemRepo) SetFilesystem(fs *muxfs.Mux) {
 }
 
 // PrivateKey returns this repo's private key
-func (r *MemRepo) PrivateKey() crypto.PrivKey {
-	return r.profiles.Owner().PrivKey
+func (r *MemRepo) PrivateKey(ctx context.Context) crypto.PrivKey {
+	return r.profiles.Active(ctx).PrivKey
 }
 
 // RefCache gives access to the ephemeral Refstore
@@ -159,7 +159,12 @@ func (r *MemRepo) RefCache() Refstore {
 }
 
 // Profile returns the peer profile for this repository
-func (r *MemRepo) Profile() (*profile.Profile, error) {
+func (r *MemRepo) Profile(ctx context.Context) (*profile.Profile, error) {
+	return r.profiles.Active(ctx), nil
+}
+
+// Owner returns the owner profile for this repository
+func (r *MemRepo) Owner() (*profile.Profile, error) {
 	return r.profiles.Owner(), nil
 }
 

--- a/repo/refstore_test.go
+++ b/repo/refstore_test.go
@@ -388,7 +388,7 @@ func TestCanonicalizeDatasetRef(t *testing.T) {
 		}
 		got := &ref
 
-		err = CanonicalizeDatasetRef(memRepo, got)
+		err = CanonicalizeDatasetRef(ctx, memRepo, got)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
 			continue
@@ -445,7 +445,7 @@ func TestCanonicalizeDatasetRefFSI(t *testing.T) {
 		}
 		got := &ref
 
-		err = CanonicalizeDatasetRef(memRepo, got)
+		err = CanonicalizeDatasetRef(ctx, memRepo, got)
 		if err != nil {
 			t.Errorf("case %d got error: %s", i, err)
 			continue
@@ -545,7 +545,7 @@ func TestCanonicalizeProfile(t *testing.T) {
 		}
 		got := &ref
 
-		err = CanonicalizeProfile(repo, got)
+		err = CanonicalizeProfile(ctx, repo, got)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
 			continue

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -4,6 +4,7 @@
 package repo
 
 import (
+	"context"
 	"fmt"
 
 	golog "github.com/ipfs/go-log"
@@ -80,11 +81,13 @@ type Repo interface {
 	// Repos have a logbook for recording & storing operation logs
 	Logbook() *logbook.Book
 
-	// A repository must maintain profile information about the owner of this dataset.
+	// A repository must maintain profile information about the active profile of this dataset.
 	// The value returned by Profile() should represent the peer.
-	Profile() (*profile.Profile, error)
+	Profile(ctx context.Context) (*profile.Profile, error)
+	// A repository maintains the profile information of the owner
+	Owner() (*profile.Profile, error)
 	// PrivateKey hands over this repo's private key
-	PrivateKey() crypto.PrivKey
+	PrivateKey(ctx context.Context) crypto.PrivKey
 	// A repository must maintain profile information about encountered peers.
 	// Decsisions regarding retentaion of peers is left to the the implementation
 	Profiles() profile.Store

--- a/repo/test/spec/test.go
+++ b/repo/test/spec/test.go
@@ -6,6 +6,7 @@
 package spec
 
 import (
+	"context"
 	"testing"
 
 	"github.com/qri-io/qri/repo"
@@ -39,8 +40,9 @@ func RunRepoTests(t *testing.T, rmf RepoMakerFunc) {
 func testProfile(t *testing.T, rmf RepoMakerFunc) {
 	r, cleanup := rmf(t)
 	defer cleanup()
+	ctx := context.Background()
 
-	p, err := r.Profile()
+	p, err := r.Profile(ctx)
 	if err != nil {
 		t.Errorf("%s", string(p.ID))
 		t.Errorf("Unexpected Profile error: %s", err.Error())

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -202,7 +202,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 		path    string
 		resBody qfs.File
 	)
-	pro, err = r.Profile()
+	pro, err = r.Profile(ctx)
 	if err != nil {
 		return
 	}
@@ -218,7 +218,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 
 	sw := dsfs.SaveSwitches{Pin: true, ShouldRender: true}
 	fs := r.Filesystem()
-	if path, err = dsfs.CreateDataset(ctx, fs, fs.DefaultWriteFS(), r.Bus(), ds, nil, r.PrivateKey(), sw); err != nil {
+	if path, err = dsfs.CreateDataset(ctx, fs, fs.DefaultWriteFS(), r.Bus(), ds, nil, r.PrivateKey(ctx), sw); err != nil {
 		return
 	}
 	if ds.PreviousPath != "" && ds.PreviousPath != "/" {

--- a/sql/qds/datasource_test.go
+++ b/sql/qds/datasource_test.go
@@ -109,7 +109,7 @@ func (tr *testRunner) MustRun(t *testing.T, query string, cfg *octocfg.Config) s
 }
 
 func (tr *testRunner) loadDatasetFunc() dsref.ParseResolveLoad {
-	pro, _ := tr.repo.Profile()
+	pro, _ := tr.repo.Profile(tr.ctx)
 	loader := base.NewLocalDatasetLoader(tr.repo.Filesystem())
 	return newParseResolveLoadFunc(pro.Peername, tr.repo, loader)
 }

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -140,7 +140,7 @@ func TestStatsFSI(t *testing.T) {
 	}
 
 	fsiSvc := fsi.NewFSI(mr, nil)
-	vi, _, err := fsiSvc.CreateLink(fsiDir, ref)
+	vi, _, err := fsiSvc.CreateLink(ctx, fsiDir, ref)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/watchfs/watchfs_test.go
+++ b/watchfs/watchfs_test.go
@@ -76,6 +76,7 @@ func TestFilesysWatcher(t *testing.T) {
 }
 
 func TestWatchAllFSIPaths(t *testing.T) {
+	ctx := context.Background()
 
 	// set up a repo w/ a dataset that has an FSIPath
 	r, err := repotest.NewTestRepo()
@@ -83,7 +84,7 @@ func TestWatchAllFSIPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pro, err := r.Profile()
+	pro, err := r.Profile(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
…through to profile store


Since it's a bit hard on the eyes to review, a few quick higlights:
- Added `.Active(ctx)` which will later be fleshed out to return the "selected" profile instead of the owner
- Exposed an explicit `.Owner()` on repo to be able to perform work which is related to the repo owner
- All p2p stuff is linked to the `.Owner`, the owner should carry all the p2p stuff not temporary profiles
- The context is threaded through to all the `repo.Profile/Key` -> `profile_store...` actions but most of the entry points are either `context.TODO()` or `ctx.Background()` which need to be resolved and double checked in a subsequent refactor