### PR TITLE
refactor(apply): RPC > HTTP

### DIFF
--- a/api/transform.go
+++ b/api/transform.go
@@ -27,8 +27,8 @@ func (h TransformHandlers) ApplyHandler(prefix string) http.HandlerFunc {
 			return
 		}
 
-		res := lib.ApplyResult{}
-		if err := h.TransformMethods.Apply(&p, &res); err != nil {
+		res, err := h.TransformMethods.Apply(r.Context(), &p)
+		if err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"path/filepath"
@@ -98,14 +99,15 @@ func (o *ApplyOptions) Run() error {
 		}
 	}
 
+	ctx := context.TODO()
 	params := lib.ApplyParams{
 		Refstr:       o.Refs.Ref(),
 		Transform:    &tf,
 		ScriptOutput: o.Out,
 		Wait:         true,
 	}
-	res := lib.ApplyResult{}
-	if err = o.TransformMethods.Apply(&params, &res); err != nil {
+	res, err := o.TransformMethods.Apply(ctx, &params)
+	if err != nil {
 		return err
 	}
 

--- a/lib/test_runner_test.go
+++ b/lib/test_runner_test.go
@@ -178,10 +178,10 @@ func (tr *testRunner) MustGet(t *testing.T, refstr string) *dataset.Dataset {
 	return res.Dataset
 }
 
-func (tr *testRunner) ApplyWithParams(p *ApplyParams) (*dataset.Dataset, error) {
+func (tr *testRunner) ApplyWithParams(ctx context.Context, p *ApplyParams) (*dataset.Dataset, error) {
 	m := NewTransformMethods(tr.Instance)
-	res := ApplyResult{}
-	if err := m.Apply(p, &res); err != nil {
+	res, err := m.Apply(ctx, p)
+	if err != nil {
 		return nil, err
 	}
 	return res.Data, nil

--- a/lib/transform_test.go
+++ b/lib/transform_test.go
@@ -22,7 +22,7 @@ func TestApplyTransform(t *testing.T) {
 	}
 
 	// Apply a transformation
-	res, err := tr.ApplyWithParams(&ApplyParams{
+	res, err := tr.ApplyWithParams(tr.Ctx, &ApplyParams{
 		Refstr: "me/cities_ds",
 		Transform: &dataset.Transform{
 			ScriptPath: "testdata/cities_2/add_city.star",


### PR DESCRIPTION
First of several to come for transitioning from RPC to HTTP and moving `context` up to `api` & `cmd`