### PR TITLE
fix(apply): bad API endpoint for apply over HTTP

### DIFF
--- a/lib/transform.go
+++ b/lib/transform.go
@@ -63,7 +63,7 @@ func (m *TransformMethods) Apply(ctx context.Context, p *ApplyParams) (*ApplyRes
 	res := &ApplyResult{}
 
 	if m.inst.http != nil {
-		err = m.inst.http.Call(ctx, "TransformMethods.Apply", p, res)
+		err = m.inst.http.Call(ctx, AEApply, p, res)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I made a mistake while rebasing the recent apply RPC > HTTP PR which ended up not keeping the proper endpoint. This fixes it.