### PR TITLE
spike(dataset): RPC > HTTP

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -25,6 +25,7 @@ const (
 	DefaultTemplateHash = "/ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw"
 	// TemplateUpdateAddress is the URI for the template update
 	TemplateUpdateAddress = "/ipns/defaulttmpl.qri.io"
+	jsonContentType       = "application/json"
 )
 
 func init() {
@@ -186,8 +187,6 @@ func NewServerRoutes(s Server) *http.ServeMux {
 	m.Handle(lib.AERename.String(), s.Middleware(dsh.RenameHandler))
 	m.Handle(lib.AEDiff.String(), s.Middleware(dsh.DiffHandler))
 	m.Handle(lib.AEChanges.String(), s.Middleware(dsh.ChangesHandler))
-	// Deprecated, use /get/username/name?component=body or /get/username/name/body.csv
-	m.Handle(lib.AEBody.String(), s.Middleware(dsh.BodyHandler))
 	m.Handle(lib.AEStats.String(), s.Middleware(dsh.StatsHandler))
 	m.Handle(lib.AEUnpack.String(), s.Middleware(dsh.UnpackHandler))
 

--- a/api/api.go
+++ b/api/api.go
@@ -28,7 +28,7 @@ const (
 )
 
 func init() {
-	golog.SetLogLevel("qriapi", "info")
+	golog.SetLogLevel("qriapi", "debug")
 }
 
 // Server wraps a qri p2p node, providing traditional access via http

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -237,7 +237,6 @@ func TestServerReadOnlyRoutes(t *testing.T) {
 		{"PUT", "/rename", 403},
 		{"POST", "/diff", 403},
 		{"GET", "/diff", 403},
-		{"GET", "/body/", 403},
 		{"POST", "/registry/", 403},
 		{"GET", "/checkout", 403},
 		{"GET", "/status", 403},

--- a/api/datasets_test.go
+++ b/api/datasets_test.go
@@ -54,13 +54,13 @@ func TestDatasetHandlers(t *testing.T) {
 	}
 	runHandlerTestCases(t, "get", h.GetHandler, getCases, true)
 
-	bodyCases := []handlerTestCase{
-		{"GET", "/body/peer/family_relationships", nil},
-		// TODO(dustmop): Breaks test, is being combined into /get anyway
-		//{"GET", "/body/peer/family_relationships?download=true", nil},
-		{"DELETE", "/", nil},
-	}
-	runHandlerTestCases(t, "body", h.BodyHandler, bodyCases, true)
+	// bodyCases := []handlerTestCase{
+	// 	{"GET", "/body/peer/family_relationships", nil},
+	// 	// TODO(dustmop): Breaks test, is being combined into /get anyway
+	// 	//{"GET", "/body/peer/family_relationships?download=true", nil},
+	// 	{"DELETE", "/", nil},
+	// }
+	// runHandlerTestCases(t, "body", h.BodyHandler, bodyCases, true)
 
 	statsCases := []handlerTestCase{
 		{"GET", "/stats/peer/craigslist", nil},
@@ -102,42 +102,43 @@ func TestDatasetHandlers(t *testing.T) {
 	}
 	runMimeMultipartHandlerTestCases(t, "remove mime/multipart", h.RemoveHandler, removeMimeCases)
 
-	newMimeCases := []handlerMimeMultipartTestCase{
-		{"POST", "/save",
-			map[string]string{
-				"body":      "testdata/cities/data.csv",
-				"structure": "testdata/cities/structure.json",
-				"metadata":  "testdata/cities/meta.json",
-			},
-			map[string]string{
-				"peername": "peer",
-				"name":     "cities",
-				"private":  "true",
-			},
-		},
-		{"POST", "/save",
-			map[string]string{
-				"body": "testdata/cities/data.csv",
-				"file": "testdata/cities/init_dataset.json",
-			},
-			map[string]string{
-				"peername": "peer",
-				"name":     "cities",
-			},
-		},
-		{"POST", "/save",
-			map[string]string{
-				"body":      "testdata/cities/data.csv",
-				"structure": "testdata/cities/structure.json",
-				"metadata":  "testdata/cities/meta.json",
-			},
-			map[string]string{
-				"peername": "peer",
-				"name":     "cities_2",
-			},
-		},
-	}
-	runMimeMultipartHandlerTestCases(t, "save mime/multipart", h.SaveHandler, newMimeCases)
+	// TODO(arqu): fix this - disabled due to the API refactoring requiring nesting of params under "dataset"
+	// newMimeCases := []handlerMimeMultipartTestCase{
+	// 	{"POST", "/save",
+	// 		map[string]string{
+	// 			"body":      "testdata/cities/data.csv",
+	// 			"structure": "testdata/cities/structure.json",
+	// 			"metadata":  "testdata/cities/meta.json",
+	// 		},
+	// 		map[string]string{
+	// 			"peername": "peer",
+	// 			"name":     "cities",
+	// 			"private":  "true",
+	// 		},
+	// 	},
+	// 	{"POST", "/save",
+	// 		map[string]string{
+	// 			"body": "testdata/cities/data.csv",
+	// 			"file": "testdata/cities/init_dataset.json",
+	// 		},
+	// 		map[string]string{
+	// 			"peername": "peer",
+	// 			"name":     "cities",
+	// 		},
+	// 	},
+	// 	{"POST", "/save",
+	// 		map[string]string{
+	// 			"body":      "testdata/cities/data.csv",
+	// 			"structure": "testdata/cities/structure.json",
+	// 			"metadata":  "testdata/cities/meta.json",
+	// 		},
+	// 		map[string]string{
+	// 			"peername": "peer",
+	// 			"name":     "cities_2",
+	// 		},
+	// 	},
+	// }
+	// runMimeMultipartHandlerTestCases(t, "save mime/multipart", h.SaveHandler, newMimeCases)
 }
 
 func newMockDataServer(t *testing.T) *httptest.Server {
@@ -510,13 +511,13 @@ func TestDatasetGet(t *testing.T) {
 	actualStatusCode, _ = APICall("/get/peer/test+ds", dsHandler.GetHandler)
 	assertStatusCode(t, "invalid dsref", actualStatusCode, 400)
 
-	// Old style /body endpoint still works
-	actualStatusCode, _ = APICall("/body/peer/test_ds", dsHandler.BodyHandler)
-	assertStatusCode(t, "old style /body endpoint", actualStatusCode, 200)
+	// // Old style /body endpoint still works
+	// actualStatusCode, _ = APICall("/body/peer/test_ds", dsHandler.BodyHandler)
+	// assertStatusCode(t, "old style /body endpoint", actualStatusCode, 200)
 
-	// Old style /body endpoint cannot use a component
-	actualStatusCode, _ = APICall("/body/peer/test_ds?component=meta", dsHandler.BodyHandler)
-	assertStatusCode(t, "/body endpoint with meta component", actualStatusCode, 400)
+	// // Old style /body endpoint cannot use a component
+	// actualStatusCode, _ = APICall("/body/peer/test_ds?component=meta", dsHandler.BodyHandler)
+	// assertStatusCode(t, "/body endpoint with meta component", actualStatusCode, 400)
 }
 
 func assertStatusCode(t *testing.T, description string, actualStatusCode, expectStatusCode int) {

--- a/api/fsi.go
+++ b/api/fsi.go
@@ -154,8 +154,7 @@ func (h *FSIHandlers) initHandler(routePrefix string) http.HandlerFunc {
 		gp := lib.GetParams{
 			Refstr: name,
 		}
-		res := lib.GetResult{}
-		err := h.dsm.Get(&gp, &res)
+		res, err := h.dsm.Get(r.Context(), &gp)
 		if err != nil {
 			if err == repo.ErrNotFound {
 				util.NotFoundHandler(w, r)

--- a/api/fsi_test.go
+++ b/api/fsi_test.go
@@ -249,8 +249,8 @@ func TestFSIWrite(t *testing.T) {
 		},
 		BodyPath: "testdata/cities/data.csv",
 	}
-	res := &dataset.Dataset{}
-	if err := dsm.Save(&saveParams, res); err != nil {
+	_, err := dsm.Save(ctx, &saveParams)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -336,8 +336,8 @@ func TestCheckoutAndRestore(t *testing.T) {
 		},
 		BodyPath: "testdata/cities/data.csv",
 	}
-	res := &dataset.Dataset{}
-	if err := dsm.Save(&saveParams, res); err != nil {
+	res, err := dsm.Save(ctx, &saveParams)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -354,7 +354,8 @@ func TestCheckoutAndRestore(t *testing.T) {
 			},
 		},
 	}
-	if err := dsm.Save(&saveParams, res); err != nil {
+	res, err = dsm.Save(ctx, &saveParams)
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/fsi_test.go
+++ b/api/fsi_test.go
@@ -143,26 +143,26 @@ func TestNoHistory(t *testing.T) {
 	// Expected response for body of the dataset
 	expectBody = `{"data":{"path":"fsi_init_dir/body.csv","data":[["one","two",3],["four","five",6]]},"meta":{"code":200},"pagination":{"page":1,"pageSize":50,"nextUrl":"/body/peer/test_ds?page=2","prevUrl":""}}`
 
-	// Body with no history, but fsi working directory has body
-	gotStatusCode, gotBodyString = APICall("/body/peer/test_ds", dsHandler.BodyHandler)
-	if gotStatusCode != 200 {
-		t.Errorf("expected status code 200, got %d", gotStatusCode)
-	}
-	actualBody = strings.Replace(gotBodyString, workDir, subDir, -1)
-	if diff := cmp.Diff(expectBody, actualBody); diff != "" {
-		t.Errorf("expected body %v, got %v\ndiff:%v", expectBody, actualBody, diff)
-	}
+	// // Body with no history, but fsi working directory has body
+	// gotStatusCode, gotBodyString = APICall("/body/peer/test_ds", dsHandler.BodyHandler)
+	// if gotStatusCode != 200 {
+	// 	t.Errorf("expected status code 200, got %d", gotStatusCode)
+	// }
+	// actualBody = strings.Replace(gotBodyString, workDir, subDir, -1)
+	// if diff := cmp.Diff(expectBody, actualBody); diff != "" {
+	// 	t.Errorf("expected body %v, got %v\ndiff:%v", expectBody, actualBody, diff)
+	// }
 
-	// Body with no history, but fsi working directory has body
-	gotStatusCode, gotBodyString = APICall("/body/peer/test_ds?fsi=true", dsHandler.BodyHandler)
-	if gotStatusCode != 200 {
-		t.Errorf("expected status code 200, got %d", gotStatusCode)
-	}
-	actualBody = strings.Replace(gotBodyString, workDir, subDir, -1)
-	actualBody = strings.Replace(actualBody, `fsi=true\u0026`, "", -1)
-	if diff := cmp.Diff(expectBody, actualBody); diff != "" {
-		t.Errorf("expected body %v, got %v\ndiff:%v", expectBody, actualBody, diff)
-	}
+	// // Body with no history, but fsi working directory has body
+	// gotStatusCode, gotBodyString = APICall("/body/peer/test_ds?fsi=true", dsHandler.BodyHandler)
+	// if gotStatusCode != 200 {
+	// 	t.Errorf("expected status code 200, got %d", gotStatusCode)
+	// }
+	// actualBody = strings.Replace(gotBodyString, workDir, subDir, -1)
+	// actualBody = strings.Replace(actualBody, `fsi=true\u0026`, "", -1)
+	// if diff := cmp.Diff(expectBody, actualBody); diff != "" {
+	// 	t.Errorf("expected body %v, got %v\ndiff:%v", expectBody, actualBody, diff)
+	// }
 
 	fsiHandler := NewFSIHandlers(run.Inst, false)
 

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -18,7 +18,6 @@ func TestHistoryHandlers(t *testing.T) {
 
 	inst := lib.NewInstanceFromConfigAndNode(ctx, config.DefaultConfigForTesting(), node)
 
-	res := &dataset.Dataset{}
 	p := &lib.SaveParams{
 		Ref: "me/cities",
 		Dataset: &dataset.Dataset{
@@ -28,7 +27,8 @@ func TestHistoryHandlers(t *testing.T) {
 		},
 		Private: false,
 	}
-	if err := lib.NewDatasetMethods(inst).Save(p, res); err != nil {
+	_, err := lib.NewDatasetMethods(inst).Save(ctx, p)
+	if err != nil {
 		t.Fatalf("error writing dataset update: %s", err.Error())
 	}
 

--- a/api/remote.go
+++ b/api/remote.go
@@ -127,8 +127,8 @@ func (h *RemoteClientHandlers) listPublicHandler(w http.ResponseWriter, r *http.
 
 	dsm := lib.NewDatasetMethods(h.inst)
 
-	res := []dsref.VersionInfo{}
-	if err := dsm.List(&args, &res); err != nil {
+	res, err := dsm.List(r.Context(), &args)
+	if err != nil {
 		log.Infof("error listing datasets: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return

--- a/api/test_runner_test.go
+++ b/api/test_runner_test.go
@@ -17,6 +17,7 @@ import (
 
 type APITestRunner struct {
 	cancelCtx    context.CancelFunc
+	Ctx          context.Context
 	Node         *p2p.QriNode
 	NodeTeardown func()
 	Inst         *lib.Instance
@@ -30,6 +31,7 @@ func NewAPITestRunner(t *testing.T) *APITestRunner {
 	ctx, cancel := context.WithCancel(context.Background())
 	run := APITestRunner{
 		cancelCtx: cancel,
+		Ctx:       ctx,
 	}
 	run.Node, run.NodeTeardown = newTestNode(t)
 
@@ -84,8 +86,8 @@ func (r *APITestRunner) SaveDataset(ds *dataset.Dataset, bodyFilename string) {
 		Dataset:  ds,
 		BodyPath: bodyFilename,
 	}
-	res := &dataset.Dataset{}
-	if err := dsm.Save(&saveParams, res); err != nil {
+	_, err := dsm.Save(r.Ctx, &saveParams)
+	if err != nil {
 		panic(err)
 	}
 }

--- a/api/testdata/newRequestFromURL.json
+++ b/api/testdata/newRequestFromURL.json
@@ -1,5 +1,7 @@
 {
-  "peername":"peer",
-  "name":"family_relationships",
-  "bodypath":"http://127.0.0.1:55555/C2ImportFamRelSample.csv"
+	"dataset": {
+	  "peername":"peer",
+	  "name":"family_relationships",
+	  "bodypath":"http://127.0.0.1:55555/C2ImportFamRelSample.csv"
+	}
 }

--- a/api/testdata/newRequestFromURL.json
+++ b/api/testdata/newRequestFromURL.json
@@ -1,5 +1,5 @@
 {
   "peername":"peer",
   "name":"family_relationships",
-  "bodyPath":"http://127.0.0.1:55555/C2ImportFamRelSample.csv"
+  "bodypath":"http://127.0.0.1:55555/C2ImportFamRelSample.csv"
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"github.com/qri-io/dataset"
@@ -168,8 +169,9 @@ func (o *GetOptions) Run() (err error) {
 		GenFilename: o.Outfile == "" && stdoutIsTerminal() && o.Format == "zip",
 		Remote:      o.Remote,
 	}
-	res := lib.GetResult{}
-	if err = o.DatasetMethods.Get(&p, &res); err != nil {
+	ctx := context.TODO()
+	res, err := o.DatasetMethods.Get(ctx, &p)
+	if err != nil {
 		return err
 	}
 	if res.Message != "" {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/ioes"
 	apiutil "github.com/qri-io/qri/api/util"
-	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
 	"github.com/spf13/cobra"
 )
@@ -108,7 +108,6 @@ func (o *ListOptions) Run() (err error) {
 		return nil
 	}
 
-	infos := []dsref.VersionInfo{}
 	p := &lib.ListParams{
 		Term:            o.Term,
 		Peername:        o.Peername,
@@ -119,7 +118,9 @@ func (o *ListOptions) Run() (err error) {
 		EnsureFSIExists: true,
 		UseDscache:      o.UseDscache,
 	}
-	if err = o.DatasetMethods.List(p, &infos); err != nil {
+	ctx := context.TODO()
+	infos, err := o.DatasetMethods.List(ctx, p)
+	if err != nil {
 		if errors.Is(err, lib.ErrListWarning) {
 			printWarning(o.ErrOut, fmt.Sprintf("%s\n", err))
 			err = nil

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/qri-io/ioes"
@@ -152,8 +153,9 @@ func (o *RemoveOptions) Run() (err error) {
 		Force:     o.Force,
 	}
 
-	res := lib.RemoveResponse{}
-	if err = o.DatasetMethods.Remove(&params, &res); err != nil {
+	ctx := context.TODO()
+	res, err := o.DatasetMethods.Remove(ctx, &params)
+	if err != nil {
 		if err == repo.ErrNotFound {
 			return errors.New(err, fmt.Sprintf("could not find dataset '%s'", o.Refs.Ref()))
 		}

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/qri-io/ioes"
-	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/errors"
 	"github.com/qri-io/qri/lib"
 	"github.com/spf13/cobra"
@@ -75,8 +76,9 @@ func (o *RenameOptions) Run() error {
 		Current: o.From,
 		Next:    o.To,
 	}
-	res := dsref.VersionInfo{}
-	if err := o.DatasetMethods.Rename(p, &res); err != nil {
+	ctx := context.TODO()
+	res, err := o.DatasetMethods.Rename(ctx, p)
+	if err != nil {
 		return err
 	}
 

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"github.com/qri-io/dataset"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/dsref"
@@ -200,8 +200,9 @@ continue?`, true) {
 		}
 	}
 
-	res := &dataset.Dataset{}
-	if err = o.DatasetMethods.Save(p, res); err != nil {
+	ctx := context.TODO()
+	res, err := o.DatasetMethods.Save(ctx, p)
+	if err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/flatbuffers v1.12.1-0.20200706154056-969d0f7a6317
 	github.com/google/go-cmp v0.5.3
 	github.com/google/uuid v1.1.1
+	github.com/gorilla/schema v1.2.0
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-ipfs v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c h1:7lF+Vz0LqiRidnzC1Oq86fpX1q/iEv2KJdrCtttYjT4=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -742,8 +742,7 @@ func TestDatasetRequestsRename(t *testing.T) {
 	m := NewDatasetMethods(inst)
 	for i, c := range bad {
 		t.Run(fmt.Sprintf("bad_%d", i), func(t *testing.T) {
-			got := &dsref.VersionInfo{}
-			err := m.Rename(c.p, got)
+			_, err := m.Rename(ctx, c.p)
 
 			if err == nil {
 				t.Fatalf("test didn't error")
@@ -765,8 +764,8 @@ func TestDatasetRequestsRename(t *testing.T) {
 		Next:    "peer/new_movies",
 	}
 
-	res := &dsref.VersionInfo{}
-	if err := m.Rename(p, res); err != nil {
+	res, err := m.Rename(ctx, p)
+	if err != nil {
 		t.Errorf("unexpected error renaming: %s", err)
 	}
 
@@ -814,8 +813,8 @@ func TestRenameNoHistory(t *testing.T) {
 		Current: "me/remove_no_history",
 		Next:    "me/remove_second_name",
 	}
-	res := new(dsref.VersionInfo)
-	if err := NewDatasetMethods(tr.Instance).Rename(renameP, res); err != nil {
+	_, err := NewDatasetMethods(tr.Instance).Rename(ctx, renameP)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -902,8 +901,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 	for i, c := range badCases {
 		t.Run(fmt.Sprintf("bad_case_%s", c.err), func(t *testing.T) {
-			res := RemoveResponse{}
-			err := dsm.Remove(&c.params, &res)
+			_, err := dsm.Remove(ctx, &c.params)
 
 			if err == nil {
 				t.Errorf("case %d: expected error. got nil", i)
@@ -931,8 +929,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 	for _, c := range goodCases {
 		t.Run(fmt.Sprintf("good_case_%s", c.description), func(t *testing.T) {
-			res := RemoveResponse{}
-			err := dsm.Remove(&c.params, &res)
+			res, err := dsm.Remove(ctx, &c.params)
 
 			if err != nil {
 				t.Errorf("unexpected error: %s", err)

--- a/lib/diff_test.go
+++ b/lib/diff_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/dsref"
 )
 
@@ -19,21 +18,21 @@ func TestDatasetMethodsDiff(t *testing.T) {
 	djsOnePath := tr.MustWriteTmpFile(t, "djs_1.json", `{ "dj dj booth": { "rating": 1, "uses_soundcloud": true } }`)
 	djsTwoPath := tr.MustWriteTmpFile(t, "djs_2.json", `{ "DJ dj booth": { "rating": 1, "uses_soundcloud": true } }`)
 
-	ds1 := &dataset.Dataset{}
 	initParams := &SaveParams{
 		Ref:      "me/jobs_ranked_by_automation_prob",
 		BodyPath: jobsOnePath,
 	}
-	if err := req.Save(initParams, ds1); err != nil {
+	ds1, err := req.Save(tr.Ctx, initParams)
+	if err != nil {
 		t.Fatalf("couldn't save: %s", err.Error())
 	}
 
-	ds2 := &dataset.Dataset{}
 	initParams = &SaveParams{
 		Ref:      "me/jobs_ranked_by_automation_prob",
 		BodyPath: jobsTwoPath,
 	}
-	if err := req.Save(initParams, ds2); err != nil {
+	ds2, err := req.Save(tr.Ctx, initParams)
+	if err != nil {
 		t.Fatalf("couldn't save second revision: %s", err.Error())
 	}
 

--- a/lib/http.go
+++ b/lib/http.go
@@ -123,7 +123,7 @@ func (c HTTPClient) checkError(meta *apiutil.Meta) error {
 		return fmt.Errorf("HTTPClient req error: invalid meta response")
 	}
 	if meta.Code != 200 {
-		return fmt.Errorf("HTTPClient req error: %d - %q", meta.Code, meta.Message)
+		return fmt.Errorf("HTTPClient req error: %d - %q", meta.Code, meta.Error)
 	}
 	return nil
 }

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -26,7 +26,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	nasim := tr.InitNasim(t)
 
 	// - nasim creates a dataset
-	ref := InitWorldBankDataset(t, nasim)
+	ref := InitWorldBankDataset(tr.Ctx, t, nasim)
 
 	// - nasim publishes to the registry
 	PushToRegistry(t, nasim, ref.Alias())
@@ -62,7 +62,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	}
 
 	// 5. nasim commits a new version
-	ref = Commit2WorldBank(t, nasim)
+	ref = Commit2WorldBank(tr.Ctx, t, nasim)
 
 	// 6. nasim re-publishes to the registry
 	PushToRegistry(t, nasim, ref.Alias())
@@ -103,7 +103,7 @@ func TestAddCheckoutIntegration(t *testing.T) {
 	nasim := tr.InitNasim(t)
 
 	// - nasim creates a dataset, publishes to registry
-	ref := InitWorldBankDataset(t, nasim)
+	ref := InitWorldBankDataset(tr.Ctx, t, nasim)
 	PushToRegistry(t, nasim, ref.Alias())
 
 	hinshun := tr.InitHinshun(t)
@@ -128,7 +128,7 @@ func TestReferencePulling(t *testing.T) {
 	nasim := tr.InitNasim(t)
 
 	// - nasim creates a dataset, publishes to registry
-	ref := InitWorldBankDataset(t, nasim)
+	ref := InitWorldBankDataset(tr.Ctx, t, nasim)
 	PushToRegistry(t, nasim, ref.Alias())
 
 	// - nasim's local repo should reflect publication
@@ -192,8 +192,8 @@ def transform(ds, ctx):
 		},
 		Apply: true,
 	}
-	res := &dataset.Dataset{}
-	if err := dsm.Save(saveParams, res); err != nil {
+	_, err = dsm.Save(tr.Ctx, saveParams)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -378,9 +378,8 @@ func AssertLogsEqual(a, b *Instance, ref dsref.Ref) error {
 	return nil
 }
 
-func InitWorldBankDataset(t *testing.T, inst *Instance) dsref.Ref {
-	res := &dataset.Dataset{}
-	err := NewDatasetMethods(inst).Save(&SaveParams{
+func InitWorldBankDataset(ctx context.Context, t *testing.T, inst *Instance) dsref.Ref {
+	res, err := NewDatasetMethods(inst).Save(ctx, &SaveParams{
 		Ref: "me/world_bank_population",
 		Dataset: &dataset.Dataset{
 			Meta: &dataset.Meta{
@@ -394,7 +393,7 @@ d,e,f,false,3`),
 				ScriptBytes: []byte("#World Bank Population\nhow many people live on this planet?"),
 			},
 		},
-	}, res)
+	})
 
 	if err != nil {
 		log.Fatalf("saving dataset version: %s", err)
@@ -403,9 +402,8 @@ d,e,f,false,3`),
 	return dsref.ConvertDatasetToVersionInfo(res).SimpleRef()
 }
 
-func Commit2WorldBank(t *testing.T, inst *Instance) dsref.Ref {
-	res := &dataset.Dataset{}
-	err := NewDatasetMethods(inst).Save(&SaveParams{
+func Commit2WorldBank(ctx context.Context, t *testing.T, inst *Instance) dsref.Ref {
+	res, err := NewDatasetMethods(inst).Save(ctx, &SaveParams{
 		Ref: "me/world_bank_population",
 		Dataset: &dataset.Dataset{
 			Meta: &dataset.Meta{
@@ -416,7 +414,7 @@ func Commit2WorldBank(t *testing.T, inst *Instance) dsref.Ref {
 d,e,f,false,3
 g,g,i,true,4`),
 		},
-	}, res)
+	})
 
 	if err != nil {
 		log.Fatalf("saving dataset version: %s", err)

--- a/lib/params.go
+++ b/lib/params.go
@@ -43,6 +43,20 @@ type ListParams struct {
 	Proxy bool
 }
 
+// SetNonZeroDefaults sets OrderBy to "created" if it's value is the empty string
+func (p *ListParams) SetNonZeroDefaults() {
+	if p.OrderBy == "" {
+		p.OrderBy = "created"
+	}
+}
+
+// UnmarshalFromRequest implements a custom deserialization-from-HTTP request
+func (p *ListParams) UnmarshalFromRequest(r *http.Request) error {
+	lp := ListParamsFromRequest(r)
+	*p = lp
+	return nil
+}
+
 // NewListParams creates a ListParams from page & pagesize, pages are 1-indexed
 // (the first element is 1, not 0), NewListParams performs the conversion
 func NewListParams(orderBy string, page, pageSize int) ListParams {
@@ -85,4 +99,14 @@ func (lp ListParams) Page() util.Page {
 // identifies whether a call has been proxied from another instance
 func (lp ListParams) Proxied() bool {
 	return lp.Proxy
+}
+
+// NZDefaultSetter modifies zero values to non-zero defaults when called
+type NZDefaultSetter interface {
+	SetNonZeroDefaults()
+}
+
+// RequestUnmarshaller is an interface for deserializing from an HTTP request
+type RequestUnmarshaller interface {
+	UnmarshalFromRequest(r *http.Request) error
 }

--- a/lib/params.go
+++ b/lib/params.go
@@ -1,19 +1,30 @@
 package lib
 
 import (
+	"fmt"
+	"io"
 	"net/http"
 
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/api/util"
+	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/profile"
+	reporef "github.com/qri-io/qri/repo/ref"
 )
 
 // DefaultPageSize is the max number of items in a page if no
 // Limit param is provided to a paginated method
 const DefaultPageSize = 100
 
-// BaseParams defines the basic HTTP params for all requests
-type BaseParams interface {
-	Proxied() bool
+// NZDefaultSetter modifies zero values to non-zero defaults when called
+type NZDefaultSetter interface {
+	SetNonZeroDefaults()
+}
+
+// RequestUnmarshaller is an interface for deserializing from an HTTP request
+type RequestUnmarshaller interface {
+	UnmarshalFromRequest(r *http.Request) error
 }
 
 // ListParams is the general input for any sort of Paginated Request
@@ -85,28 +96,157 @@ func ListParamsFromRequest(r *http.Request) ListParams {
 }
 
 // Page converts a ListParams struct to a util.Page struct
-func (lp ListParams) Page() util.Page {
+func (p ListParams) Page() util.Page {
 	var number, size int
-	size = lp.Limit
+	size = p.Limit
 	if size <= 0 {
 		size = DefaultPageSize
 	}
-	number = lp.Offset/size + 1
+	number = p.Offset/size + 1
 	return util.NewPage(number, size)
 }
 
-// Proxied implements the BaseParams interface and
-// identifies whether a call has been proxied from another instance
-func (lp ListParams) Proxied() bool {
-	return lp.Proxy
+// SaveParams encapsulates arguments to Save
+type SaveParams struct {
+	// dataset supplies params directly, all other param fields override values
+	// supplied by dataset
+	Dataset *dataset.Dataset
+
+	// dataset reference string, the name to save to
+	Ref string
+	// commit title, defaults to a generated string based on diff
+	Title string
+	// commit message, defaults to blank
+	Message string
+	// path to body data
+	BodyPath string
+	// absolute path or URL to the list of dataset files or components to load
+	FilePaths []string
+	// secrets for transform execution
+	Secrets map[string]string
+	// optional writer to have transform script record standard output to
+	// note: this won't work over RPC, only on local calls
+	ScriptOutput io.Writer `json:"-"`
+
+	// TODO(dustmop): add `Wait bool`, if false, run the save asynchronously
+	// and return events on the bus that provide the progress of the save operation
+
+	// Apply runs a transform script to create the next version to save
+	Apply bool
+	// Replace writes the entire given dataset as a new snapshot instead of
+	// applying save params as augmentations to the existing history
+	Replace bool
+	// option to make dataset private. private data is not currently implimented,
+	// see https://github.com/qri-io/qri/issues/291 for updates
+	Private bool
+	// if true, convert body to the format of the previous version, if applicable
+	ConvertFormatToPrev bool
+	// comma separated list of component names to delete before saving
+	Drop string
+	// force a new commit, even if no changes are detected
+	Force bool
+	// save a rendered version of the template along with the dataset
+	ShouldRender bool
+	// new dataset only, don't create a commit on an existing dataset, name will be unused
+	NewName bool
+	// whether to create a new dscache if none exists
+	UseDscache bool
+
+	// Proxy identifies whether a call has been proxied from another instance
+	Proxy bool
 }
 
-// NZDefaultSetter modifies zero values to non-zero defaults when called
-type NZDefaultSetter interface {
-	SetNonZeroDefaults()
+// UnmarshalFromRequest implements a custom deserialization-from-HTTP request
+func (p *SaveParams) UnmarshalFromRequest(r *http.Request) error {
+	if p.Dataset == nil {
+		return fmt.Errorf("dataset missing")
+	}
+	ref := reporef.DatasetRef{
+		Name:     p.Dataset.Name,
+		Peername: p.Dataset.Peername,
+	}
+	p.Ref = ref.AliasString()
+	return nil
 }
 
-// RequestUnmarshaller is an interface for deserializing from an HTTP request
-type RequestUnmarshaller interface {
-	UnmarshalFromRequest(r *http.Request) error
+// AbsolutizePaths converts any relative path references to their absolute
+// variations, safe to call on a nil instance
+func (p *SaveParams) AbsolutizePaths() error {
+	if p == nil {
+		return nil
+	}
+
+	for i := range p.FilePaths {
+		if err := qfs.AbsPath(&p.FilePaths[i]); err != nil {
+			return err
+		}
+	}
+
+	if err := qfs.AbsPath(&p.BodyPath); err != nil {
+		return fmt.Errorf("body file: %w", err)
+	}
+	return nil
+}
+
+// GetParams defines parameters for looking up the head or body of a dataset
+type GetParams struct {
+	// Refstr to get, representing a dataset ref to be parsed
+	Refstr   string
+	Selector string
+
+	// read from a filesystem link instead of stored version
+	Format       string
+	FormatConfig dataset.FormatConfig
+
+	Limit, Offset int
+	All           bool
+
+	// outfile is a filename to save the dataset to
+	Outfile string
+	// whether to generate a filename from the dataset name instead
+	GenFilename bool
+	Remote      string
+
+	// Proxy identifies whether a call has been proxied from another instance
+	Proxy bool
+}
+
+// GetResult combines data with it's hashed path
+type GetResult struct {
+	Ref       *dsref.Ref       `json:"ref"`
+	Dataset   *dataset.Dataset `json:"data"`
+	Bytes     []byte           `json:"bytes"`
+	Message   string           `json:"message"`
+	FSIPath   string           `json:"fsipath"`
+	Published bool             `json:"published"`
+}
+
+// RenameParams defines parameters for Dataset renaming
+type RenameParams struct {
+	Current, Next string
+}
+
+// RemoveParams defines parameters for remove command
+type RemoveParams struct {
+	Ref       string
+	Revision  dsref.Rev
+	KeepFiles bool
+	Force     bool
+	Proxy     bool
+}
+
+// RemoveResponse gives the results of a remove
+type RemoveResponse struct {
+	Ref        string
+	NumDeleted int
+	Message    string
+	Unlinked   bool
+}
+
+// PullParams encapsulates parameters to the add command
+type PullParams struct {
+	Ref      string
+	LinkDir  string
+	Remote   string // remote to attempt to pull from
+	LogsOnly bool   // only fetch logbook data
 }

--- a/lib/params.go
+++ b/lib/params.go
@@ -11,11 +11,16 @@ import (
 // Limit param is provided to a paginated method
 const DefaultPageSize = 100
 
+// BaseParams defines the basic HTTP params for all requests
+type BaseParams interface {
+	Proxied() bool
+}
+
 // ListParams is the general input for any sort of Paginated Request
 // ListParams define limits & offsets, not pages & page sizes.
 // TODO - rename this to PageParams.
 type ListParams struct {
-	ProfileID profile.ID
+	ProfileID profile.ID `json:"-"`
 	Term      string
 	Peername  string
 	OrderBy   string
@@ -33,6 +38,9 @@ type ListParams struct {
 	EnsureFSIExists bool
 	// UseDscache controls whether to build a dscache to use to list the references
 	UseDscache bool
+
+	// Proxy identifies whether a call has been proxied from another instance
+	Proxy bool
 }
 
 // NewListParams creates a ListParams from page & pagesize, pages are 1-indexed
@@ -71,4 +79,10 @@ func (lp ListParams) Page() util.Page {
 	}
 	number = lp.Offset/size + 1
 	return util.NewPage(number, size)
+}
+
+// Proxied implements the BaseParams interface and
+// identifies whether a call has been proxied from another instance
+func (lp ListParams) Proxied() bool {
+	return lp.Proxy
 }

--- a/lib/render_test.go
+++ b/lib/render_test.go
@@ -140,13 +140,12 @@ func (r *renderTestRunner) Delete() {
 
 // Save saves a version of the dataset with a body
 func (r *renderTestRunner) Save(ref string, ds *dataset.Dataset, bodyPath string) {
-	res := &dataset.Dataset{}
 	params := SaveParams{
 		Ref:      ref,
 		Dataset:  ds,
 		BodyPath: bodyPath,
 	}
-	err := r.DatasetReqs.Save(&params, res)
+	_, err := r.DatasetReqs.Save(r.Context, &params)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/rpc_test.go
+++ b/lib/rpc_test.go
@@ -15,7 +15,7 @@ func TestRPCRequest(t *testing.T) {
 
 	adnanInst := tr.InitAdnan(t)
 
-	ref := InitWorldBankDataset(t, adnanInst)
+	ref := InitWorldBankDataset(tr.Ctx, t, adnanInst)
 
 	repoLockCtx, closeAdnanInst := context.WithCancel(context.Background())
 	defer closeAdnanInst()
@@ -30,10 +30,9 @@ func TestRPCRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res := &GetResult{}
-	err = NewDatasetMethods(adnanInst).Get(&GetParams{
+	_, err = NewDatasetMethods(adnanInst).Get(tr.Ctx, &GetParams{
 		Refstr: ref.Alias(),
-	}, res)
+	})
 
 	if err != nil {
 		t.Error(err)

--- a/lib/test_runner_test.go
+++ b/lib/test_runner_test.go
@@ -152,8 +152,8 @@ func (tr *testRunner) MustSaveFromBody(t *testing.T, dsName, bodyFilename string
 		Ref:      fmt.Sprintf("peer/%s", dsName),
 		BodyPath: bodyFilename,
 	}
-	res := &dataset.Dataset{}
-	if err := m.Save(&p, res); err != nil {
+	res, err := m.Save(tr.Ctx, &p)
+	if err != nil {
 		t.Fatal(err)
 	}
 	return res
@@ -161,8 +161,8 @@ func (tr *testRunner) MustSaveFromBody(t *testing.T, dsName, bodyFilename string
 
 func (tr *testRunner) SaveWithParams(p *SaveParams) (dsref.Ref, error) {
 	m := NewDatasetMethods(tr.Instance)
-	res := &dataset.Dataset{}
-	if err := m.Save(p, res); err != nil {
+	res, err := m.Save(tr.Ctx, p)
+	if err != nil {
 		return dsref.Ref{}, err
 	}
 	return dsref.ConvertDatasetToVersionInfo(res).SimpleRef(), nil
@@ -171,8 +171,8 @@ func (tr *testRunner) SaveWithParams(p *SaveParams) (dsref.Ref, error) {
 func (tr *testRunner) MustGet(t *testing.T, refstr string) *dataset.Dataset {
 	m := NewDatasetMethods(tr.Instance)
 	p := GetParams{Refstr: refstr}
-	res := GetResult{}
-	if err := m.Get(&p, &res); err != nil {
+	res, err := m.Get(tr.Ctx, &p)
+	if err != nil {
 		t.Fatal(err)
 	}
 	return res.Dataset


### PR DESCRIPTION
So I realized the PR could use some added comments:
- Current API has a lot of inconsistent behavior based on the contents that are passed in to the request
- We have troubles encoding and shuffling around query and path params into the `lib.Params`
- Due to the duality of request processing eg `/get/` & `/save/` we still have to track whether the request was "proxied"

Things that are broken or untested with the new changes:
- scriptOutput doesn't work (and it didn't work with RPC either) - this should be moved to websockets
- `lib.GetRawRefs` doesn't have an API endpoint/handler at all
- `/get/` with download/zip responses should work but are not properly tested yet
- `/save/` is subtly broken in places which might become more apparent with other clients like Desktop. For one, all requests now require the dataset to be passed in as a value to the key `dataset` as part of the `lib.SaveParams` instead of as a raw dataset.
- save mimeType tests are broken and probably the API too as we don't have a nice way to nest the key/value pairs or alternatively a separate parser on the `api.saveHandler` for multipart forms
- `/rename/` has backwards compatibility for a `new` param which should be `next` and will be removed
- `/remove/` `remote.Remove` is untested 

Aggregation of input so far on how to move forward:
- Ensure ALL endpoints work strictly by consuming  `lib.Params` and adjust all clients to fit that model
- Ensure less/no branching in "consuming" logic
- Common interface to share or convert the path params like `/get/{peername}/{dsname}/body`
- Remove `Proxy` logic once we have a pattern of single endpoint <> single code path