### PR TITLE
refactor(api): introduce UnmarshalFromRequest, update List API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,12 +2,16 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"time"
 
+	"github.com/gorilla/schema"
 	golog "github.com/ipfs/go-log"
 	apiutil "github.com/qri-io/qri/api/util"
 	"github.com/qri-io/qri/lib"
@@ -25,6 +29,7 @@ const (
 	DefaultTemplateHash = "/ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw"
 	// TemplateUpdateAddress is the URI for the template update
 	TemplateUpdateAddress = "/ipns/defaulttmpl.qri.io"
+	jsonContentType       = "application/json"
 )
 
 func init() {
@@ -230,4 +235,61 @@ func NewServerRoutes(s Server) *http.ServeMux {
 	}
 
 	return m
+}
+
+// snoop reads from an io.ReadCloser and restores it so it can be read again
+func snoop(body *io.ReadCloser) (io.ReadCloser, error) {
+	if body != nil && *body != nil {
+		result, err := ioutil.ReadAll(*body)
+		(*body).Close()
+
+		if err != nil {
+			return nil, err
+		}
+		if len(result) == 0 {
+			return nil, io.EOF
+		}
+
+		*body = ioutil.NopCloser(bytes.NewReader(result))
+		return ioutil.NopCloser(bytes.NewReader(result)), nil
+	}
+	return nil, io.EOF
+}
+
+var decoder = schema.NewDecoder()
+
+// UnmarshalParams deserialzes a lib req params stuct pointer from an HTTP
+// request
+func UnmarshalParams(r *http.Request, p interface{}) error {
+	// TODO(arqu): once APIs have a strict mapping to Params this line
+	// should be removed and should error out on unknown keys
+	decoder.IgnoreUnknownKeys(true)
+	if r.Method == http.MethodPost || r.Method == http.MethodPut {
+		defer func() {
+			if defSetter, ok := p.(lib.NZDefaultSetter); ok {
+				defSetter.SetNonZeroDefaults()
+			}
+		}()
+
+		if r.Header.Get("Content-Type") == jsonContentType {
+			body, err := snoop(&r.Body)
+			if err != nil && err != io.EOF {
+				return err
+			}
+			// this avoids resolving on empty body requests
+			// and tries to handle it almost like a GET
+			if err != io.EOF {
+				return json.NewDecoder(body).Decode(p)
+			}
+		}
+	}
+
+	if ru, ok := p.(lib.RequestUnmarshaller); ok {
+		return ru.UnmarshalFromRequest(r)
+	}
+
+	if err := r.ParseForm(); err != nil {
+		return err
+	}
+	return decoder.Decode(p, r.Form)
 }

--- a/api/remote.go
+++ b/api/remote.go
@@ -127,8 +127,8 @@ func (h *RemoteClientHandlers) listPublicHandler(w http.ResponseWriter, r *http.
 
 	dsm := lib.NewDatasetMethods(h.inst)
 
-	res := []dsref.VersionInfo{}
-	if err := dsm.List(&args, &res); err != nil {
+	res, err := dsm.List(r.Context(), &args)
+	if err != nil {
 		log.Infof("error listing datasets: %s", err.Error())
 		util.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/ioes"
 	apiutil "github.com/qri-io/qri/api/util"
-	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
 	"github.com/spf13/cobra"
 )
@@ -108,7 +108,6 @@ func (o *ListOptions) Run() (err error) {
 		return nil
 	}
 
-	infos := []dsref.VersionInfo{}
 	p := &lib.ListParams{
 		Term:            o.Term,
 		Peername:        o.Peername,
@@ -119,7 +118,9 @@ func (o *ListOptions) Run() (err error) {
 		EnsureFSIExists: true,
 		UseDscache:      o.UseDscache,
 	}
-	if err = o.DatasetMethods.List(p, &infos); err != nil {
+	ctx := context.TODO()
+	infos, err := o.DatasetMethods.List(ctx, p)
+	if err != nil {
 		if errors.Is(err, lib.ErrListWarning) {
 			printWarning(o.ErrOut, fmt.Sprintf("%s\n", err))
 			err = nil

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/flatbuffers v1.12.1-0.20200706154056-969d0f7a6317
 	github.com/google/go-cmp v0.5.3
 	github.com/google/uuid v1.1.1
+	github.com/gorilla/schema v1.2.0
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-ipfs v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c h1:7lF+Vz0LqiRidnzC1Oq86fpX1q/iEv2KJdrCtttYjT4=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -53,12 +53,17 @@ func NewDatasetMethods(inst *Instance) *DatasetMethods {
 }
 
 // List gets the reflist for either the local repo or a peer
-func (m *DatasetMethods) List(p *ListParams, res *[]dsref.VersionInfo) error {
-	if m.inst.rpc != nil {
+func (m *DatasetMethods) List(ctx context.Context, p *ListParams) ([]dsref.VersionInfo, error) {
+	if m.inst.http != nil {
+		res := []dsref.VersionInfo{}
+		p.Proxy = true
 		p.RPC = true
-		return checkRPCError(m.inst.rpc.Call("DatasetMethods.List", p, res))
+		err := m.inst.http.Call(ctx, AEList, p, &res)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
 	}
-	ctx := context.TODO()
 
 	// ensure valid limit value
 	if p.Limit <= 0 {
@@ -76,12 +81,12 @@ func (m *DatasetMethods) List(p *ListParams, res *[]dsref.VersionInfo) error {
 		ProfileID: p.ProfileID,
 	}
 	if err := repo.CanonicalizeProfile(ctx, m.inst.repo, ref); err != nil {
-		return fmt.Errorf("error canonicalizing peer: %w", err)
+		return nil, fmt.Errorf("error canonicalizing peer: %w", err)
 	}
 
 	pro, err := m.inst.repo.Profile(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// If the list operation leads to a warning, store it in this var
@@ -94,7 +99,7 @@ func (m *DatasetMethods) List(p *ListParams, res *[]dsref.VersionInfo) error {
 			log.Infof("building dscache from repo's logbook, profile, and dsref")
 			built, err := build.DscacheFromRepo(ctx, m.inst.repo)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			err = c.Assign(built)
 			if err != nil {
@@ -103,7 +108,7 @@ func (m *DatasetMethods) List(p *ListParams, res *[]dsref.VersionInfo) error {
 		}
 		refs, err = c.ListRefs()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		// Filter references so that only with a matching name are returned
 		if p.Term != "" {
@@ -135,10 +140,10 @@ func (m *DatasetMethods) List(p *ListParams, res *[]dsref.VersionInfo) error {
 			err = nil
 		}
 	} else {
-		return fmt.Errorf("listing datasets on a peer is not implemented")
+		return nil, fmt.Errorf("listing datasets on a peer is not implemented")
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if p.EnsureFSIExists {
@@ -167,18 +172,18 @@ func (m *DatasetMethods) List(p *ListParams, res *[]dsref.VersionInfo) error {
 	for i, r := range refs {
 		infos[i] = reporef.ConvertToVersionInfo(&r)
 	}
-	*res = infos
 
 	if listWarning != nil {
-		err = listWarning
+		return nil, listWarning
 	}
 
-	return err
+	return infos, nil
 }
 
 // ListRawRefs gets the list of raw references as string
 func (m *DatasetMethods) ListRawRefs(p *ListParams, text *string) error {
 	var err error
+	// TODO(arqu): implement api
 	if m.inst.rpc != nil {
 		return checkRPCError(m.inst.rpc.Call("DatasetMethods.ListRawRefs", p, text))
 	}

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -340,8 +340,7 @@ func TestDatasetRequestsList(t *testing.T) {
 
 	m := NewDatasetMethods(inst)
 	for _, c := range cases {
-		got := []dsref.VersionInfo{}
-		err := m.List(c.p, &got)
+		got, err := m.List(ctx, c.p)
 
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case '%s' error mismatch: expected: %s, got: %s", c.description, c.err, err)
@@ -413,8 +412,7 @@ func TestDatasetRequestsListP2p(t *testing.T) {
 			inst := NewInstanceFromConfigAndNode(ctx, config.DefaultConfigForTesting(), node)
 			m := NewDatasetMethods(inst)
 			p := &ListParams{OrderBy: "", Limit: 30, Offset: 0}
-			var res []dsref.VersionInfo
-			err := m.List(p, &res)
+			res, err := m.List(ctx, p)
 			if err != nil {
 				t.Errorf("error listing dataset: %s", err.Error())
 			}

--- a/lib/http.go
+++ b/lib/http.go
@@ -123,7 +123,7 @@ func (c HTTPClient) checkError(meta *apiutil.Meta) error {
 		return fmt.Errorf("HTTPClient req error: invalid meta response")
 	}
 	if meta.Code != 200 {
-		return fmt.Errorf("HTTPClient req error: %d - %q", meta.Code, meta.Message)
+		return fmt.Errorf("HTTPClient req error: %d - %q", meta.Code, meta.Error)
 	}
 	return nil
 }


### PR DESCRIPTION
Based on the work in https://github.com/qri-io/qri/pull/1633 this is to land the baseline refactoring and and example with List.
Subsequent PRs will convert rest of the handlers/endpoints to this format and move to the HTTPClient. 
Lastly the "not clear cut" endpoints like `/get/` and `/save` will be refactored and/or split.