### PR TITLE
feat(logbook): write run operations

### DIFF
--- a/base/dataset_prepare.go
+++ b/base/dataset_prepare.go
@@ -98,7 +98,7 @@ func PrepareSaveRef(
 		}
 
 		// we have a valid previous reference & an initID, return!
-		log.Debugf("PrepareSaveRef found previous initID=%q", ref.InitID)
+		log.Debugw("PrepareSaveRef found previous initID", "initID", ref.InitID, "path", ref.Path)
 		return ref, false, nil
 	}
 

--- a/base/dsfs/commit.go
+++ b/base/dsfs/commit.go
@@ -97,7 +97,7 @@ func commitFileAddFunc(privKey crypto.PrivKey, pub event.Publisher) addWriteFile
 			signedBytes, err := privKey.Sign(ds.SigningBytes())
 			if err != nil {
 				log.Debug(err.Error())
-				return nil, fmt.Errorf("error signing commit title: %s", err.Error())
+				return nil, fmt.Errorf("error signing commit title: %w", err)
 			}
 			ds.Commit.Signature = base64.StdEncoding.EncodeToString(signedBytes)
 			return JSONFile(PackageFileCommit.Filename(), ds.Commit)
@@ -173,7 +173,7 @@ func confirmByteChangesExist(ds, prev *dataset.Dataset, added map[string]string,
 		}
 	}
 
-	return fmt.Errorf("no changes")
+	return ErrNoChanges
 }
 
 // ensureCommitTitleAndMessage creates the commit and title, message, skipping
@@ -423,7 +423,7 @@ func generateCommitDescriptions(ctx context.Context, fs qfs.Filesystem, ds, prev
 		if forceIfNoChanges {
 			return "forced update", "forced update", nil
 		}
-		return "", "", fmt.Errorf("no changes")
+		return "", "", ErrNoChanges
 	}
 
 	log.Debugf("set friendly diff descriptions. shortTitle=%q message=%q", shortTitle, longMessage)

--- a/base/dsfs/compute_fields.go
+++ b/base/dsfs/compute_fields.go
@@ -329,7 +329,7 @@ func (cff *computeFieldsFile) flushBatch(ctx context.Context, buf *dsio.EntryBuf
 
 	if e := buf.Close(); e != nil {
 		log.Debugf("closing batch buffer: %s", e)
-		return 0, fmt.Errorf("error closing buffer: %s", e.Error())
+		return 0, fmt.Errorf("error closing buffer: %w", e)
 	}
 
 	if len(buf.Bytes()) == 0 {
@@ -339,7 +339,7 @@ func (cff *computeFieldsFile) flushBatch(ctx context.Context, buf *dsio.EntryBuf
 
 	var doc interface{}
 	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
-		return 0, fmt.Errorf("error parsing JSON bytes: %s", err.Error())
+		return 0, fmt.Errorf("error parsing JSON bytes: %w", err)
 	}
 	validationState := jsch.Validate(ctx, doc)
 

--- a/base/dsfs/doc.go
+++ b/base/dsfs/doc.go
@@ -1,8 +1,0 @@
-// Package dsfs glues datsets to cafs (content-addressed-file-system)
-package dsfs
-
-import (
-	logger "github.com/ipfs/go-log"
-)
-
-var log = logger.Logger("dsfs")

--- a/base/dsfs/dsfs.go
+++ b/base/dsfs/dsfs.go
@@ -1,0 +1,27 @@
+// Package dsfs glues datsets to cafs (content-addressed-file-system)
+package dsfs
+
+import (
+	"fmt"
+
+	logger "github.com/ipfs/go-log"
+)
+
+var (
+	log = logger.Logger("dsfs")
+	// ErrNoChanges indicates a save failed because no values changed, and
+	// force-saving was disabled
+	ErrNoChanges = fmt.Errorf("no changes")
+	// ErrNoReadme is the error for asking a dataset without a readme component
+	// for readme info
+	ErrNoReadme = fmt.Errorf("this dataset has no readme component")
+	// ErrNoTransform is the error for asking a dataset without a tranform
+	// component for transform info
+	ErrNoTransform = fmt.Errorf("this dataset has no transform component")
+	// ErrNoViz is the error for asking a dataset without a viz component for
+	// viz info
+	ErrNoViz = fmt.Errorf("this dataset has no viz component")
+	// ErrStrictMode indicates a dataset failed validation when it is required to
+	// pass (Structure.Strict == true)
+	ErrStrictMode = fmt.Errorf("dataset body did not validate against schema in strict-mode")
+)

--- a/base/dsfs/readme.go
+++ b/base/dsfs/readme.go
@@ -15,7 +15,7 @@ func DerefReadme(ctx context.Context, store qfs.Filesystem, ds *dataset.Dataset)
 		rm, err := loadReadme(ctx, store, ds.Readme.Path)
 		if err != nil {
 			log.Debug(err.Error())
-			return fmt.Errorf("loading dataset readme: %s", err)
+			return fmt.Errorf("loading dataset readme: %w", err)
 		}
 		rm.Path = ds.Readme.Path
 		ds.Readme = rm
@@ -28,13 +28,10 @@ func loadReadme(ctx context.Context, fs qfs.Filesystem, path string) (st *datase
 	data, err := fileBytes(fs.Get(ctx, path))
 	if err != nil {
 		log.Debug(err.Error())
-		return nil, fmt.Errorf("error loading readme file: %s", err.Error())
+		return nil, fmt.Errorf("error loading readme file: %w", err)
 	}
 	return dataset.UnmarshalReadme(data)
 }
-
-// ErrNoReadme is the error for asking a dataset without a readme component for readme info
-var ErrNoReadme = fmt.Errorf("this dataset has no readme component")
 
 // LoadReadmeScript loads script data from a dataset path if the given dataset has a readme script is specified
 // the returned qfs.File will be the value of dataset.Readme.ScriptPath

--- a/base/dsfs/structure.go
+++ b/base/dsfs/structure.go
@@ -9,10 +9,6 @@ import (
 	"github.com/qri-io/qfs"
 )
 
-// ErrStrictMode indicates a dataset failed validation when it is required to
-// pass (Structure.Strict == true)
-var ErrStrictMode = fmt.Errorf("dataset body did not validate against schema in strict-mode")
-
 // DerefStructure derferences a dataset's structure element if required
 // should be a no-op if ds.Structure is nil or isn't a reference
 func DerefStructure(ctx context.Context, store qfs.Filesystem, ds *dataset.Dataset) error {

--- a/base/dsfs/transform.go
+++ b/base/dsfs/transform.go
@@ -35,9 +35,6 @@ func loadTransform(ctx context.Context, fs qfs.Filesystem, path string) (q *data
 	return dataset.UnmarshalTransform(data)
 }
 
-// ErrNoTransform is the error for asking a dataset without a tranform component for viz info
-var ErrNoTransform = fmt.Errorf("this dataset has no transform component")
-
 // LoadTransformScript loads transform script data from a dataset path if the given dataset has a transform script specified
 // the returned qfs.File will be the value of dataset.Transform.ScriptPath
 // TODO - this is broken, assumes file is JSON. fix & test or depricate

--- a/base/dsfs/viz.go
+++ b/base/dsfs/viz.go
@@ -35,9 +35,6 @@ func loadViz(ctx context.Context, fs qfs.Filesystem, path string) (st *dataset.V
 	return dataset.UnmarshalViz(data)
 }
 
-// ErrNoViz is the error for asking a dataset without a viz component for viz info
-var ErrNoViz = fmt.Errorf("this dataset has no viz component")
-
 func vizFilesAddFunc(fs qfs.Filesystem, sw SaveSwitches) addWriteFileFunc {
 	return func(ds *dataset.Dataset, wfs *writeFiles) error {
 		if ds.Viz == nil {

--- a/base/save.go
+++ b/base/save.go
@@ -8,7 +8,6 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dsref"
-	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/repo"
 )
@@ -53,11 +52,7 @@ func SaveDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, ini
 			return nil, err
 		}
 
-		// TODO(dustmop): Stop removing the transform once we move to apply, and untangle the
-		// save command from applying a transform.
-		// remove the Transform & commit
-		// transform & commit must be created from scratch with each new version
-		mutable.Transform = nil
+		// remove the commit. commit must be created from scratch with each new version
 		mutable.Commit = nil
 	}
 
@@ -108,11 +103,6 @@ func SaveDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, ini
 		return nil, err
 	}
 
-	// Write the save to logbook
-	err = r.Logbook().WriteVersionSave(ctx, initID, ds)
-	if err != nil && err != logbook.ErrNoLogbook {
-		return ds, err
-	}
 	return ds, nil
 }
 

--- a/base/save.go
+++ b/base/save.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/repo"
+	"github.com/qri-io/qri/transform/run"
 )
 
 // SaveSwitches is an alias for the switches that control how saves happen
@@ -19,7 +20,16 @@ type SaveSwitches = dsfs.SaveSwitches
 var ErrNameTaken = fmt.Errorf("name already in use")
 
 // SaveDataset saves a version of the dataset for the given initID at the current path
-func SaveDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, initID, prevPath string, changes *dataset.Dataset, sw SaveSwitches) (ds *dataset.Dataset, err error) {
+func SaveDataset(
+	ctx context.Context,
+	r repo.Repo,
+	writeDest qfs.Filesystem,
+	initID string,
+	prevPath string,
+	changes *dataset.Dataset,
+	runState *run.State,
+	sw SaveSwitches,
+) (ds *dataset.Dataset, err error) {
 	log.Debugf("SaveDataset initID=%q prevPath=%q", initID, prevPath)
 	var pro *profile.Profile
 	if pro, err = r.Profile(ctx); err != nil {
@@ -103,6 +113,10 @@ func SaveDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, ini
 		return nil, err
 	}
 
+	// Write the save to logbook
+	if err = r.Logbook().WriteVersionSave(ctx, initID, ds, runState); err != nil {
+		return nil, err
+	}
 	return ds, nil
 }
 

--- a/base/test_runner_test.go
+++ b/base/test_runner_test.go
@@ -62,7 +62,7 @@ func (run *TestRunner) saveDataset(ds *dataset.Dataset, sw SaveSwitches) (dsref.
 		return dsref.Ref{}, err
 	}
 
-	ds, err := SaveDataset(run.Context, run.Repo, run.Repo.Filesystem().DefaultWriteFS(), ref.InitID, ref.Path, ds, sw)
+	ds, err := SaveDataset(run.Context, run.Repo, run.Repo.Filesystem().DefaultWriteFS(), ref.InitID, ref.Path, ds, nil, sw)
 	if err != nil {
 		return dsref.Ref{}, err
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -482,8 +482,8 @@ func TestSaveTransformModifiedButSameBody(t *testing.T) {
     created dataset from tf_123.star
 
 `, map[string]string{
-		"commit1": "/ipfs/Qmb18FaCYQMRbE4vH7G1sMnBr32opTBfKKeE6s7AYyR9YY",
-		"commit2": "/ipfs/QmSPaMdKzpEmodF7R6LzkTGHKtk4hvN6e6PsNKX1A6yW3g",
+		"commit1": "/ipfs/QmYSxB13nw1PWk6Y2itXxRiE42cvK5zzC9v6saGcDu8PFw",
+		"commit2": "/ipfs/QmZx6mYranv8ZFgwq7QVFoVVje2vPueC3MJYPy1LVnANmJ",
 	})
 	if diff := cmp.Diff(expect, output); diff != "" {
 		t.Errorf("log (-want +got):\n%s", diff)

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -21,29 +21,34 @@ func NewSaveCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
 		Use:     "save [DATASET]",
 		Aliases: []string{"commit"},
 		Short:   "save changes to a dataset",
-		Long: `Save is how you change a dataset, updating one or more of data, metadata, and structure. 
-You can also update your data via url. Every time you run save, an entry is added to 
-your dataset’s log (which you can see by running ` + "`qri log <dataset_reference>`" + `).
+		Long: `
+Save is how you change a dataset, updating one or more dataset components. Every
+time you run save, an entry is added to your dataset’s log (which you can see by
+running `[1:] + "`qri log <dataset_reference>`" + `).
 
-If the dataset you're changing has defined a transform, running ` + "`qri save`" + `
-will re execute the transform. To only re-run the transform, run save with no args.
+Dataset changes can be automated with a transform component adn the --apply flag
+For more on transforms see https://qri.io/docs/transforms/overview
+If the dataset you're changing has a transform, running ` + "`qri save --apply`" +
+			`
+will re-execute it to produce a new version
 
 Every time you save, you can provide a message about what you changed and why. 
 If you don’t provide a message Qri will automatically generate one for you.
-
-When you make an update and save a dataset that you originally added from a different
-peer, the dataset gets renamed from ` + "`peers_name/dataset_name`" + ` to ` + "`my_name/dataset_name`" + `.
-
 The ` + "`--message`" + `" and ` + "`--title`" + ` flags allow you to add a 
-commit message and title to the save.`,
+commit message and title to the save.
+
+When you make an update and save a dataset that you originally added from a 
+different peer, the dataset gets renamed from ` + "`peers_name/dataset_name`" +
+			` to
+` + "`my_name/dataset_name`" + `.`,
 		Example: `  # Save updated data to dataset annual_pop:
   $ qri save --body /path/to/data.csv me/annual_pop
 
   # Save updated dataset (no data) to annual_pop:
   $ qri save --file /path/to/dataset.yaml me/annual_pop
   
-  # Re-execute a dataset that has a transform:
-  $ qri save me/tf_dataset`,
+  # Re-execute the latest transform from history:
+  $ qri save --apply me/tf_dataset`,
 		Annotations: map[string]string{
 			"group": "dataset",
 		},

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -652,7 +652,7 @@ func (run *TestRunner) AddDatasetToRefstore(t *testing.T, refStr string, ds *dat
 	// No existing commit
 	emptyHeadRef := ""
 
-	if _, err = base.SaveDataset(ctx, r, r.Filesystem().DefaultWriteFS(), initID, emptyHeadRef, ds, base.SaveSwitches{}); err != nil {
+	if _, err = base.SaveDataset(ctx, r, r.Filesystem().DefaultWriteFS(), initID, emptyHeadRef, ds, nil, base.SaveSwitches{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/qri-io/qri/repo/gen"
 	reporef "github.com/qri-io/qri/repo/ref"
 	repotest "github.com/qri-io/qri/repo/test"
-	"github.com/qri-io/qri/transform/run"
+	tfrun "github.com/qri-io/qri/transform/run"
 	"github.com/qri-io/qri/transform/startf"
 	"github.com/spf13/cobra"
 )
@@ -131,7 +131,7 @@ func NewTestRunnerWithTempRegistry(t *testing.T, peerName, testName string) *Tes
 
 func useConsistentRunIDs() {
 	source := strings.NewReader(strings.Repeat("OmgZombies!?!?!", 200))
-	run.SetIDRand(source)
+	tfrun.SetIDRand(source)
 }
 
 func newTestRunnerFromRoot(root *repotest.TempRepo) *TestRunner {
@@ -192,7 +192,7 @@ func (run *TestRunner) Delete() {
 		os.RemoveAll(run.TmpDir)
 	}
 	// restore random RunID generator
-	run.SetIDRand(nil)
+	tfrun.SetIDRand(nil)
 	dsfs.Timestamp = run.DsfsTsFunc
 	logbook.NewTimestamp = run.LogbookTsFunc
 	StringerLocation = run.LocOrig

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/qri-io/qri/repo/gen"
 	reporef "github.com/qri-io/qri/repo/ref"
 	repotest "github.com/qri-io/qri/repo/test"
+	"github.com/qri-io/qri/transform/run"
 	"github.com/qri-io/qri/transform/startf"
 	"github.com/spf13/cobra"
 )
@@ -128,8 +129,14 @@ func NewTestRunnerWithTempRegistry(t *testing.T, peerName, testName string) *Tes
 	return runner
 }
 
+func useConsistentRunIDs() {
+	source := strings.NewReader(strings.Repeat("OmgZombies!?!?!", 200))
+	run.SetIDRand(source)
+}
+
 func newTestRunnerFromRoot(root *repotest.TempRepo) *TestRunner {
 	ctx, cancel := context.WithCancel(context.Background())
+	useConsistentRunIDs()
 
 	run := TestRunner{
 		RepoRoot:    root,
@@ -184,6 +191,8 @@ func (run *TestRunner) Delete() {
 	if run.TmpDir != "" {
 		os.RemoveAll(run.TmpDir)
 	}
+	// restore random RunID generator
+	run.SetIDRand(nil)
 	dsfs.Timestamp = run.DsfsTsFunc
 	logbook.NewTimestamp = run.LogbookTsFunc
 	StringerLocation = run.LocOrig

--- a/cmd/testdata/expect/TestSaveThenOverrideMetaAndTransformAndViz.json
+++ b/cmd/testdata/expect/TestSaveThenOverrideMetaAndTransformAndViz.json
@@ -5,18 +5,19 @@
       "id": "QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"
     },
     "message": "meta:\n\tupdated title\nviz added\ntransform added\nbody:\n\tadded row /",
-    "path": "/ipfs/QmaDUM2oKNv7w1jr7z67bDZDFfe7nB9LApp64mLaLQMNFr",
+    "path": "/ipfs/QmcAaxLKXPmMFmExS95iCjiXcNoec3BhTDC1xZK9em6vLS",
     "qri": "cm:0",
     "signature": "lkWFeHT2iFYBpTyrOUcFmepfNXsZw85i/znFQ5XTcUHDySPUIna5e7Ogj35VErhh8O/fR3s30WfsK7PZGHki29dPqk3narfL5WYWDV0iTxT0nuw+1ewnjFszvgXOuEo+1+XkX+2CsXpEuzltyvbQ2x1QNVVVaVnnRUYCosxc3fComk00+ET5SW2oZbHCmU2F8/IOPN+/sDyyfk/dvsRfKl/adoNSJ/LjvMdWyB44gRr+m54HfAo9+5raBde2HcDyoHU4Vne865x+SRbEehJZCIdNjRssGWx4Lahz8R681dpZxhmiWj0IWWK+sXFoilVy2ydzOkL8CyG1DQ4JSJpYjg==",
     "timestamp": "2001-01-01T01:02:01.000000001Z",
-    "title": "updated meta, viz, transform, and body"
+    "title": "updated meta, viz, transform, and body",
+    "runID": "4f6d675a-6f6d-4269-a573-213f213f214f"
   },
   "meta": {
     "path": "/ipfs/QmWWtJJLzCYWp4KEMb95aPQe7n98y3eyRmQTJvxwqyDXCv",
     "qri": "md:0",
     "title": "different title"
   },
-  "path": "/ipfs/Qmbqd8E9UpuF3qS76z2hvMdgEBSewD7ajGr1QTZfSyANgM",
+  "path": "/ipfs/Qmda7tyCpTY4brMbRXmo5RoxKikobY2EKr1ju6nDNkXZGe",
   "previousPath": "/ipfs/QmNeH3bPvUdir2vRH57TiiSmDKmsEPpdfV7bgqfUXZKa6v",
   "qri": "ds:0",
   "structure": {

--- a/cmd/testdata/expect/TestSaveThenOverrideTransform.json
+++ b/cmd/testdata/expect/TestSaveThenOverrideTransform.json
@@ -5,18 +5,19 @@
       "id": "QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"
     },
     "message": "transform added\nbody:\n\tadded row /",
-    "path": "/ipfs/QmRSa9PZGRzWZ41msdpAQPAkhAaE9AxEboTaNHhsd8a8wh",
+    "path": "/ipfs/QmYD8ThvQYcTd2U27fxC9jRfqFG1UxovYVry7Ln9tv2D6p",
     "qri": "cm:0",
     "signature": "YZE3hPvpEHDhqXC/yI/9I8kkXdyW9x++9mNT72PjI/T6yU6EIMbHPUYBqZLOLHVpk/DkUz/9Vpts+PfI1qqJVeEeu934rqQa0f62EOwD5jLHQY18TNW764PS2JKOVrpM+4CRiJBeZzY6o1l4/0rNgJgN2eBv9J5EI7ivYLqOBk1BGvx11pUiQBrXkJT1ls2iy10Fy866w/kHRoVFqMtYUAkpCGW9XmryYESeM1oBeDA622dCqveplmIj4zV++Nv16NMTYr/7w6gOejLlFJ840O9Sd9/mAtw6Clco7TLXIEfVFd9KuDkXTlOtIkwIa37pIQokIC9xvT/PF1pwZvrFaA==",
     "timestamp": "2001-01-01T01:02:01.000000001Z",
-    "title": "updated transform and body"
+    "title": "updated transform and body",
+    "runID": "4f6d675a-6f6d-4269-a573-213f213f214f"
   },
   "meta": {
     "path": "/ipfs/QmPTny3VHAB5BcP99r6xhK7SGnmDFjpC8cHXLCrHNn2tZB",
     "qri": "md:0",
     "title": "example movie data"
   },
-  "path": "/ipfs/Qma1g8HeemSxE4sy5HEumsGvjo1wTxHTyn4m2sUX1537mc",
+  "path": "/ipfs/QmPoD9rJ2E9NHD6agB9qovcCDh6UtP7ormLxPmUetgUaNq",
   "previousPath": "/ipfs/QmNeH3bPvUdir2vRH57TiiSmDKmsEPpdfV7bgqfUXZKa6v",
   "qri": "ds:0",
   "structure": {

--- a/dsref/spec/resolve.go
+++ b/dsref/spec/resolve.go
@@ -220,7 +220,7 @@ func GenerateExampleOplog(ctx context.Context, journal *logbook.Book, dsname, he
 		},
 		Path:         headPath,
 		PreviousPath: "",
-	})
+	}, nil)
 	if err != nil {
 		return "", nil, err
 	}

--- a/event/event.go
+++ b/event/event.go
@@ -164,6 +164,10 @@ func (b *bus) publish(ctx context.Context, typ Type, sessionID string, payload i
 		Payload:   payload,
 	}
 
+	if b.closed {
+		return e, ErrBusClosed
+	}
+
 	// TODO(dustmop): Add instrumentation, perhaps to ctx, to make logging / tracing
 	// a single event easier to do.
 

--- a/event/event.go
+++ b/event/event.go
@@ -164,10 +164,6 @@ func (b *bus) publish(ctx context.Context, typ Type, sessionID string, payload i
 		Payload:   payload,
 	}
 
-	if b.closed {
-		return e, ErrBusClosed
-	}
-
 	// TODO(dustmop): Add instrumentation, perhaps to ctx, to make logging / tracing
 	// a single event easier to do.
 

--- a/event/transform.go
+++ b/event/transform.go
@@ -9,13 +9,13 @@ const (
 	ETTransformStop = Type("tf:Stop")
 
 	// ETTransformStepStart signals a step is starting.
-	// Payload will be a StepDetail
+	// Payload will be a TransformStepLifecycle
 	ETTransformStepStart = Type("tf:StepStart")
 	// ETTransformStepStop signals a step has stopped.
-	// Payload will be a StepDetail
+	// Payload will be a TransformStepLifecycle
 	ETTransformStepStop = Type("tf:StepStop")
 	// ETTransformStepSkip signals a step was skipped.
-	// Payload will be a StepDetail
+	// Payload will be a TransformStepLifecycle
 	ETTransformStepSkip = Type("tf:StepSkip")
 
 	// ETTransformPrint is sent by print commands.

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -36,6 +36,7 @@ import (
 	"github.com/qri-io/qri/repo"
 	reporef "github.com/qri-io/qri/repo/ref"
 	"github.com/qri-io/qri/transform"
+	"github.com/qri-io/qri/transform/run"
 )
 
 // DatasetMethods encapsulates business logic for working with Datasets on Qri
@@ -835,7 +836,9 @@ func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Data
 		}
 	}
 
-	if !p.Force && p.Drop == "" &&
+	if !p.Force &&
+		!p.Apply &&
+		p.Drop == "" &&
 		ds.BodyPath == "" &&
 		ds.Body == nil &&
 		ds.BodyBytes == nil &&
@@ -852,15 +855,33 @@ func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Data
 		return nil, err
 	}
 
+	// runState holds the results of transform application. will be non-nil if a
+	// transform is applied while saving
+	var runState *run.State
+
 	// If applying a transform, execute its script before saving
 	if p.Apply {
 		if ds.Transform == nil {
-			return nil, fmt.Errorf("cannot apply while saving without a transform")
+			// if no transform component exists, load the latest transform component
+			// from history
+			if isNew {
+				return nil, fmt.Errorf("cannot apply while saving without a transform")
+			}
+
+			prevTransformDataset, err := base.LoadRevs(ctx, m.inst.qfs, ref, []*dsref.Rev{{Field: "tf", Gen: 1}})
+			if err != nil {
+				return nil, fmt.Errorf("loading transform component from history: %w", err)
+			}
+			ds.Transform = prevTransformDataset.Transform
 		}
+
 		str := m.inst.node.LocalStreams
 		scriptOut := p.ScriptOutput
 		secrets := p.Secrets
-
+		// allocate an ID for the transform, subscribe to print output & build up
+		// runState
+		runID := transform.NewRunID()
+		runState = run.NewState(runID)
 		// create a loader so transforms can call `load_dataset`
 		// TODO(b5) - add a ResolverMode save parameter and call m.inst.resolverForMode
 		// on the passed in mode string instead of just using the default resolver
@@ -868,9 +889,8 @@ func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Data
 		// string and control how transform functions
 		loader := NewParseResolveLoadFunc("", m.inst.defaultResolver(), m.inst)
 
-		// allocate an ID for the transform, for now just log the events it produces
-		runID := transform.NewRunID()
 		m.inst.bus.SubscribeID(func(ctx context.Context, e event.Event) error {
+			runState.AddTransformEvent(e)
 			if e.Type == event.ETTransformPrint {
 				if msg, ok := e.Payload.(event.TransformMessage); ok {
 					if p.ScriptOutput != nil {
@@ -886,8 +906,17 @@ func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Data
 		shouldWait := true
 		err := transform.Apply(ctx, ds, loader, runID, m.inst.bus, shouldWait, str, scriptOut, secrets)
 		if err != nil {
+			log.Errorw("transform run error", "err", err.Error())
+			runState.Message = err.Error()
+			if err := m.inst.logbook.WriteTransformRun(ctx, ref.InitID, runState); err != nil {
+				log.Debugw("writing errored transform run to logbook:", "err", err.Error())
+				return nil, err
+			}
+
 			return nil, err
 		}
+
+		ds.Commit.RunID = runID
 	}
 
 	if fsiPath != "" && p.Drop != "" {
@@ -911,7 +940,23 @@ func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Data
 	}
 	savedDs, err := base.SaveDataset(ctx, m.inst.repo, writeDest, ref.InitID, ref.Path, ds, switches)
 	if err != nil {
+		// datasets that are unchanged & have a runState record a record of no-changes
+		// to logbook
+		if errors.Is(err, dsfs.ErrNoChanges) && runState != nil {
+			runState.Status = run.RSUnchanged
+			runState.Message = err.Error()
+			if err := m.inst.logbook.WriteTransformRun(ctx, ref.InitID, runState); err != nil {
+				log.Debugw("writing unchanged transform run to logbook:", "err", err.Error())
+				return nil, err
+			}
+		}
+
 		log.Debugf("create ds error: %s\n", err.Error())
+		return nil, err
+	}
+
+	// Write the save to logbook
+	if err = m.inst.logbook.WriteVersionSave(ctx, ref.InitID, savedDs, runState); err != nil {
 		return nil, err
 	}
 

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -904,7 +904,7 @@ func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Data
 
 		// apply the transform
 		shouldWait := true
-		err := transform.Apply(ctx, ds, loader, runID, m.inst.bus, shouldWait, str, scriptOut, secrets)
+		err := m.inst.transform.Apply(ctx, ds, loader, runID, m.inst.bus, shouldWait, str, scriptOut, secrets)
 		if err != nil {
 			log.Errorw("transform run error", "err", err.Error())
 			runState.Message = err.Error()

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -737,7 +737,7 @@ func (p *SaveParams) SetNonZeroDefaults() {
 
 // Save adds a history entry, updating a dataset
 func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Dataset, error) {
-	log.Debugf("DatasetMethods.Save p=%v", p)
+	log.Debugw("DatasetMethods.Save", "params", p)
 	res := &dataset.Dataset{}
 
 	if m.inst.http != nil {
@@ -938,7 +938,7 @@ func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Data
 		NewName:             p.NewName,
 		Drop:                p.Drop,
 	}
-	savedDs, err := base.SaveDataset(ctx, m.inst.repo, writeDest, ref.InitID, ref.Path, ds, switches)
+	savedDs, err := base.SaveDataset(ctx, m.inst.repo, writeDest, ref.InitID, ref.Path, ds, runState, switches)
 	if err != nil {
 		// datasets that are unchanged & have a runState record a record of no-changes
 		// to logbook
@@ -952,11 +952,6 @@ func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Data
 		}
 
 		log.Debugf("create ds error: %s\n", err.Error())
-		return nil, err
-	}
-
-	// Write the save to logbook
-	if err = m.inst.logbook.WriteVersionSave(ctx, ref.InitID, savedDs, runState); err != nil {
 		return nil, err
 	}
 

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -165,7 +165,7 @@ func TestDatasetRequestsForceSave(t *testing.T) {
 		Force: true,
 	})
 	if err != nil {
-		t.Errorf("expected empty save with flag to not error. got: %s", err.Error())
+		t.Errorf("expected empty save with force flag to not error. got: %q", err.Error())
 	}
 }
 

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -39,6 +39,7 @@ import (
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/buildrepo"
 	"github.com/qri-io/qri/stats"
+	"github.com/qri-io/qri/transform"
 	"github.com/qri-io/qri/watchfs"
 )
 
@@ -369,14 +370,15 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		repoPath: repoPath,
 		cfg:      cfg,
 
-		qfs:      o.qfs,
-		repo:     o.repo,
-		node:     o.node,
-		streams:  o.Streams,
-		registry: o.regclient,
-		logbook:  o.logbook,
-		profiles: o.profiles,
-		bus:      event.NewBus(ctx),
+		qfs:       o.qfs,
+		repo:      o.repo,
+		node:      o.node,
+		streams:   o.Streams,
+		registry:  o.regclient,
+		logbook:   o.logbook,
+		profiles:  o.profiles,
+		bus:       event.NewBus(ctx),
+		transform: transform.NewService(ctx),
 	}
 	qri = inst
 
@@ -709,6 +711,7 @@ type Instance struct {
 	remoteClient    remote.Client
 	registry        *regclient.Client
 	stats           *stats.Service
+	transform       *transform.Service
 	logbook         *logbook.Book
 	dscache         *dscache.Dscache
 	bus             event.Bus

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -663,10 +663,11 @@ func NewInstanceFromConfigAndNodeAndBus(ctx context.Context, cfg *config.Config,
 		cancel: cancel,
 		doneCh: make(chan struct{}),
 
-		cfg:     cfg,
-		node:    node,
-		dscache: dc,
-		logbook: r.Logbook(),
+		cfg:       cfg,
+		node:      node,
+		dscache:   dc,
+		logbook:   r.Logbook(),
+		transform: transform.NewService(ctx),
 	}
 
 	inst.stats = stats.New(nil)

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -222,7 +222,7 @@ func saveDataset(ctx context.Context, r repo.Repo, ds *dataset.Dataset, sw base.
 	if err != nil {
 		return dsref.Ref{}, err
 	}
-	res, err := base.SaveDataset(ctx, r, r.Filesystem().DefaultWriteFS(), ref.InitID, ref.Path, ds, sw)
+	res, err := base.SaveDataset(ctx, r, r.Filesystem().DefaultWriteFS(), ref.InitID, ref.Path, ds, nil, sw)
 	if err != nil {
 		return dsref.Ref{}, err
 	}

--- a/lib/transform.go
+++ b/lib/transform.go
@@ -109,7 +109,7 @@ func (m *TransformMethods) Apply(ctx context.Context, p *ApplyParams) (*ApplyRes
 	}, runID)
 
 	scriptOut := p.ScriptOutput
-	err = transform.Apply(ctx, ds, loader, runID, m.inst.bus, p.Wait, str, scriptOut, p.Secrets)
+	err = m.inst.transform.Apply(ctx, ds, loader, runID, m.inst.bus, p.Wait, str, scriptOut, p.Secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/transform.go
+++ b/lib/transform.go
@@ -94,15 +94,17 @@ func (m *TransformMethods) Apply(ctx context.Context, p *ApplyParams) (*ApplyRes
 	// allocate an ID for the transform, for now just log the events it produces
 	runID := transform.NewRunID()
 	m.inst.bus.SubscribeID(func(ctx context.Context, e event.Event) error {
-		log.Debugw("apply transform event", "type", e.Type, "payload", e.Payload)
-		if e.Type == event.ETTransformPrint {
-			if msg, ok := e.Payload.(event.TransformMessage); ok {
-				if p.ScriptOutput != nil {
-					io.WriteString(p.ScriptOutput, msg.Msg)
-					io.WriteString(p.ScriptOutput, "\n")
+		go func() {
+			log.Debugw("apply transform event", "type", e.Type, "payload", e.Payload)
+			if e.Type == event.ETTransformPrint {
+				if msg, ok := e.Payload.(event.TransformMessage); ok {
+					if p.ScriptOutput != nil {
+						io.WriteString(p.ScriptOutput, msg.Msg)
+						io.WriteString(p.ScriptOutput, "\n")
+					}
 				}
 			}
-		}
+		}()
 		return nil
 	}, runID)
 

--- a/lib/transform_test.go
+++ b/lib/transform_test.go
@@ -18,7 +18,7 @@ func TestApplyTransform(t *testing.T) {
 		BodyPath: "testdata/cities_2/body.csv",
 	})
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// Apply a transformation

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -1193,6 +1193,12 @@ func branchToVersionInfos(blog *BranchLog, ref dsref.Ref, offset, limit int, col
 			// runs are only ever "init" op type
 			refs = append(refs, runItemFromOp(ref, op))
 		case PushModel:
+			// TODO(b5): added this to get remote.TestDatasetPullPushDeleteFeedsPreviewHTTP
+			// to not segfault. I don't think this is the right answer. Understand that
+			// test, bring the failure into a test in logbook, then implement the right fix
+			if len(refs) == 0 {
+				continue
+			}
 			switch op.Type {
 			case oplog.OpTypeInit:
 				for i := 1; i <= int(op.Size); i++ {

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -1132,6 +1132,7 @@ func runItemFromOp(ref dsref.Ref, op oplog.Op) dsref.VersionInfo {
 }
 
 func addCommitDetailsToRunItem(li dsref.VersionInfo, op oplog.Op) dsref.VersionInfo {
+	li.CommitTime = time.Unix(0, op.Timestamp)
 	li.CommitTitle = op.Note
 	li.BodySize = int(op.Size)
 	li.Path = op.Ref

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -1125,7 +1125,7 @@ func runItemFromOp(ref dsref.Ref, op oplog.Op) dsref.VersionInfo {
 		CommitTime:  time.Unix(0, op.Timestamp),
 		RunID:       op.Ref,
 		RunStatus:   op.Note,
-		RunDuration: int(op.Size),
+		RunDuration: int64(op.Size),
 		// TODO(B5): read run number, defaulting to -1 in the event of an error
 		// RunNumber: strconv.ParseInt(op.Name),
 	}

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -513,7 +513,7 @@ func (book *Book) WriteVersionSave(ctx context.Context, initID string, ds *datas
 		return ErrNoLogbook
 	}
 
-	log.Debugf("WriteVersionSave: %s", initID)
+	log.Debugw("WriteVersionSave", "initID", initID)
 	branchLog, err := book.branchLog(ctx, initID)
 	if err != nil {
 		return err
@@ -610,9 +610,12 @@ func (book *Book) appendTransformRun(blog *BranchLog, rs *run.State) int {
 		Ref:   rs.ID,
 		Name:  fmt.Sprintf("%d", rs.Number),
 
-		Timestamp: rs.StartTime.UnixNano(),
-		Size:      int64(rs.Duration),
-		Note:      string(rs.Status),
+		Size: int64(rs.Duration),
+		Note: string(rs.Status),
+	}
+
+	if rs.StartTime != nil {
+		op.Timestamp = rs.StartTime.UnixNano()
 	}
 
 	blog.Append(op)
@@ -871,10 +874,12 @@ func (book *Book) ResolveRef(ctx context.Context, ref *dsref.Ref) (string, error
 
 	var branchLog *BranchLog
 	if ref.Path == "" {
+		log.Debugw("finding branch log", "initID", initID)
 		branchLog, err = book.branchLog(ctx, initID)
 		if err != nil {
 			return "", err
 		}
+		log.Debugw("found branch log", "initID", initID, "size", branchLog.Size(), "latestSavePath", book.latestSavePath(branchLog.l))
 		ref.Path = book.latestSavePath(branchLog.l)
 	}
 

--- a/logbook/logbook_test.go
+++ b/logbook/logbook_test.go
@@ -84,7 +84,7 @@ func Example() {
 
 	// create a log record of the version of a dataset. In practice this'll be
 	// part of the overall save routine that created the above ds variable
-	if err := book.WriteVersionSave(ctx, initID, ds); err != nil {
+	if err := book.WriteVersionSave(ctx, initID, ds, nil); err != nil {
 		panic(err)
 	}
 
@@ -104,7 +104,7 @@ func Example() {
 	}
 
 	// once again, write to the log
-	if err := book.WriteVersionSave(ctx, initID, ds2); err != nil {
+	if err := book.WriteVersionSave(ctx, initID, ds2, nil); err != nil {
 		panic(err)
 	}
 
@@ -147,7 +147,7 @@ func Example() {
 	}
 
 	// once again, write to the log
-	if err := book.WriteVersionSave(ctx, initID, ds3); err != nil {
+	if err := book.WriteVersionSave(ctx, initID, ds3, nil); err != nil {
 		panic(err)
 	}
 
@@ -238,7 +238,7 @@ func TestNilCallable(t *testing.T) {
 	if err = book.WriteVersionDelete(ctx, initID, 0); err != logbook.ErrNoLogbook {
 		t.Errorf("expected '%s', got: %v", logbook.ErrNoLogbook, err)
 	}
-	if err = book.WriteVersionSave(ctx, initID, nil); err != logbook.ErrNoLogbook {
+	if err = book.WriteVersionSave(ctx, initID, nil, nil); err != logbook.ErrNoLogbook {
 		t.Errorf("expected '%s', got: %v", logbook.ErrNoLogbook, err)
 	}
 	if _, err = book.ResolveRef(ctx, nil); err != dsref.ErrRefNotFound {
@@ -426,7 +426,7 @@ func TestWritePermissions(t *testing.T) {
 		},
 		Path: "HashOfVersion1",
 	}
-	if err := tr.Book.WriteVersionSave(ctx, initID, ds); !errors.Is(err, logbook.ErrAccessDenied) {
+	if err := tr.Book.WriteVersionSave(ctx, initID, ds, nil); !errors.Is(err, logbook.ErrAccessDenied) {
 		t.Errorf("WriteVersionSave to an oplog the book author doesn't own must return a wrap of logbook.ErrAccessDenied")
 	}
 	if err := tr.Book.WriteVersionAmend(ctx, initID, ds); !errors.Is(err, logbook.ErrAccessDenied) {
@@ -468,7 +468,7 @@ func TestPushModel(t *testing.T) {
 			Title:     "initial commit",
 		},
 		Path: "HashOfVersion1",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +639,7 @@ func TestDatasetLogNaming(t *testing.T) {
 			Title:     "initial commit",
 		},
 		Path: "HashOfVersion1",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1052,7 +1052,7 @@ func (tr *testRunner) WriteWorldBankExample(t *testing.T) string {
 		PreviousPath: "",
 	}
 
-	if err := book.WriteVersionSave(tr.Ctx, initID, ds); err != nil {
+	if err := book.WriteVersionSave(tr.Ctx, initID, ds, nil); err != nil {
 		panic(err)
 	}
 
@@ -1064,7 +1064,7 @@ func (tr *testRunner) WriteWorldBankExample(t *testing.T) string {
 	ds.Path = "QmHashOfVersion2"
 	ds.PreviousPath = "QmHashOfVersion1"
 
-	if err := book.WriteVersionSave(tr.Ctx, initID, ds); err != nil {
+	if err := book.WriteVersionSave(tr.Ctx, initID, ds, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1104,7 +1104,7 @@ func (tr *testRunner) WriteMoreWorldBankCommits(t *testing.T, initID string) {
 		PreviousPath: "QmHashOfVersion3",
 	}
 
-	if err := book.WriteVersionSave(tr.Ctx, initID, ds); err != nil {
+	if err := book.WriteVersionSave(tr.Ctx, initID, ds, nil); err != nil {
 		panic(err)
 	}
 
@@ -1119,7 +1119,7 @@ func (tr *testRunner) WriteMoreWorldBankCommits(t *testing.T, initID string) {
 		PreviousPath: "QmHashOfVersion4",
 	}
 
-	if err := book.WriteVersionSave(tr.Ctx, initID, ds); err != nil {
+	if err := book.WriteVersionSave(tr.Ctx, initID, ds, nil); err != nil {
 		panic(err)
 	}
 }
@@ -1156,7 +1156,7 @@ func (tr *testRunner) WriteRenameExample(t *testing.T) {
 		PreviousPath: "",
 	}
 
-	if err := book.WriteVersionSave(tr.Ctx, initID, ds); err != nil {
+	if err := book.WriteVersionSave(tr.Ctx, initID, ds, nil); err != nil {
 		panic(err)
 	}
 
@@ -1165,7 +1165,7 @@ func (tr *testRunner) WriteRenameExample(t *testing.T) {
 	ds.Path = "QmHashOfVersion2"
 	ds.PreviousPath = "QmHashOfVersion1"
 
-	if err := book.WriteVersionSave(tr.Ctx, initID, ds); err != nil {
+	if err := book.WriteVersionSave(tr.Ctx, initID, ds, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1296,7 +1296,7 @@ func GenerateExampleOplog(ctx context.Context, t *testing.T, journal *logbook.Bo
 		},
 		Path:         headPath,
 		PreviousPath: "",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logbook/logsync/logsync_test.go
+++ b/logbook/logsync/logsync_test.go
@@ -488,14 +488,14 @@ func writeNasdaqLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref, er
 		PreviousPath: "",
 	}
 
-	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds, nil); err != nil {
 		return ref, err
 	}
 
 	ds.Path = "v1"
 	ds.PreviousPath = "v0"
 
-	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds, nil); err != nil {
 		return ref, err
 	}
 
@@ -529,21 +529,21 @@ func writeWorldBankLogs(ctx context.Context, book *logbook.Book) (ref dsref.Ref,
 		PreviousPath: "",
 	}
 
-	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds, nil); err != nil {
 		return ref, err
 	}
 
 	ds.Path = "/ipfs/QmVersion1"
 	ds.PreviousPath = "/ipfs/QmVesion0"
 
-	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds, nil); err != nil {
 		return ref, err
 	}
 
 	ds.Path = "/ipfs/QmVersion2"
 	ds.PreviousPath = "/ipfs/QmVersion1"
 
-	if err = book.WriteVersionSave(ctx, initID, ds); err != nil {
+	if err = book.WriteVersionSave(ctx, initID, ds, nil); err != nil {
 		return ref, err
 	}
 

--- a/logbook/temp_builder.go
+++ b/logbook/temp_builder.go
@@ -85,7 +85,7 @@ func (b *BookBuilder) Commit(ctx context.Context, t *testing.T, initID, title, i
 		Path:         ipfsHash,
 		PreviousPath: ref.Path,
 	}
-	if err := b.Book.WriteVersionSave(ctx, initID, &ds); err != nil {
+	if err := b.Book.WriteVersionSave(ctx, initID, &ds, nil); err != nil {
 		t.Fatal(err)
 	}
 	b.Dsrefs[ref.Name] = append(b.Dsrefs[ref.Name], ipfsHash)

--- a/logbook/types.go
+++ b/logbook/types.go
@@ -76,7 +76,7 @@ func newBranchLog(l *oplog.Log) *BranchLog {
 
 // Append adds an op to the BranchLog
 func (blog *BranchLog) Append(op oplog.Op) {
-	if op.Model != BranchModel && op.Model != CommitModel && op.Model != PushModel {
+	if op.Model != BranchModel && op.Model != CommitModel && op.Model != PushModel && op.Model != RunModel {
 		log.Errorf("cannot Append, incorrect model %d for BranchLog", op.Model)
 		return
 	}

--- a/remote/mock_client.go
+++ b/remote/mock_client.go
@@ -199,7 +199,7 @@ func (c *MockClient) createTheirDataset(ctx context.Context, ref *dsref.Ref) err
 	ref.Path = path
 
 	// Add a save operation to logbook
-	err = other.book.WriteVersionSave(ctx, ref.InitID, &ds)
+	err = other.book.WriteVersionSave(ctx, ref.InitID, &ds, nil)
 	if err != nil {
 		return err
 	}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -524,7 +524,7 @@ func saveDataset(ctx context.Context, r repo.Repo, peername string, ds *dataset.
 	if err != nil {
 		panic(err)
 	}
-	res, err := base.SaveDataset(ctx, r, r.Filesystem().DefaultWriteFS(), initID, headRef, ds, base.SaveSwitches{})
+	res, err := base.SaveDataset(ctx, r, r.Filesystem().DefaultWriteFS(), initID, headRef, ds, nil, base.SaveSwitches{})
 	if err != nil {
 		panic(err)
 	}

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -260,7 +260,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 			return ref, err
 		}
 	}
-	if err = r.Logbook().WriteVersionSave(ctx, initID, ds); err != nil && err != logbook.ErrNoLogbook {
+	if err = r.Logbook().WriteVersionSave(ctx, initID, ds, nil); err != nil && err != logbook.ErrNoLogbook {
 		return
 	}
 

--- a/transform/apply.go
+++ b/transform/apply.go
@@ -112,8 +112,8 @@ func Apply(
 		go func() {
 			for {
 				select {
-				case event := <-eventsCh:
-					pub.PublishID(ctx, event.Type, runID, event.Payload)
+				case e := <-eventsCh:
+					pub.PublishID(ctx, e.Type, runID, e.Payload)
 				case <-ctx.Done():
 					return
 				}
@@ -176,10 +176,10 @@ func Apply(
 
 			switch step.Syntax {
 			case SyntaxStarlark:
-				log.Debugw("runnning starlark step", "runID", runID, "category", step.Category, "name", step.Name, "scriptLen", scriptLen(step))
+				log.Debugw("running starlark transform step", "runID", runID, "category", step.Category, "name", step.Name, "scriptLen", scriptLen(step))
 				runErr = stepRunner.RunStep(ctx, target, step)
 				if runErr != nil {
-					log.Debugw("running transform step", "index", i, "err", runErr)
+					log.Debugw("error running starlark transform step", "runID", runID, "index", i, "err", runErr)
 					eventsCh <- event.Event{
 						Type: event.ETTransformError,
 						Payload: event.TransformMessage{

--- a/transform/apply.go
+++ b/transform/apply.go
@@ -176,7 +176,7 @@ func Apply(
 
 			switch step.Syntax {
 			case SyntaxStarlark:
-				log.Debugw("runnning starlark step", "step", step)
+				log.Debugw("runnning starlark step", "runID", runID, "category", step.Category, "name", step.Name, "scriptLen", scriptLen(step))
 				runErr = stepRunner.RunStep(ctx, target, step)
 				if runErr != nil {
 					log.Debugw("running transform step", "index", i, "err", runErr)
@@ -191,9 +191,9 @@ func Apply(
 				}
 			default:
 				if step.Syntax == SyntaxQri && step.Name == "save" {
-					log.Info("ignoring qri save step")
+					log.Infow("ignoring qri save step", "runID", runID)
 				} else {
-					log.Debugw("skipping unknown step", "syntax", step.Syntax)
+					log.Debugw("skipping unknown step", "runID", runID, "syntax", step.Syntax, "name", step.Name)
 					eventsCh <- event.Event{
 						Type: event.ETTransformError,
 						Payload: event.TransformMessage{
@@ -226,4 +226,13 @@ func Apply(
 
 	err = <-doneCh
 	return err
+}
+
+// scriptLen returns the length of the script string, -1 if the script is not
+// a string type
+func scriptLen(step *dataset.TransformStep) int {
+	if str, ok := step.Script.(string); ok {
+		return len(str)
+	}
+	return -1
 }

--- a/transform/apply.go
+++ b/transform/apply.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/google/uuid"
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
+	"github.com/qri-io/qri/transform/run"
 	"github.com/qri-io/qri/transform/startf"
 )
 
@@ -37,6 +37,10 @@ const (
 	// StatusSkipped is the canonical constant for "skipped" execution state
 	StatusSkipped = "skipped"
 )
+
+// NewRunID aliases the run identifier creation function to avoid requiring the
+// run package to invoke Apply
+var NewRunID = run.NewID
 
 // Apply applies the transform script to order to modify the changing dataset
 func Apply(
@@ -222,9 +226,4 @@ func Apply(
 
 	err = <-doneCh
 	return err
-}
-
-// NewRunID creates a run identifier
-func NewRunID() string {
-	return uuid.New().String()
 }

--- a/transform/apply_test.go
+++ b/transform/apply_test.go
@@ -94,7 +94,7 @@ func applyNoHistoryTransform(t *testing.T, tf *dataset.Transform) []event.Event 
 		return nil
 	}, runID)
 
-	if err := Apply(ctx, target, noHistoryLoader, runID, bus, false, streams, scriptOut, nil); err != nil {
+	if err := NewService(ctx).Apply(ctx, target, noHistoryLoader, runID, bus, false, streams, scriptOut, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/transform/run/run.go
+++ b/transform/run/run.go
@@ -3,6 +3,7 @@ package run
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/google/uuid"
@@ -12,6 +13,18 @@ import (
 // NewID creates a run identifier
 func NewID() string {
 	return uuid.New().String()
+}
+
+// SetIDRand sets the random reader that NewID uses as a source of random bytes
+// passing in nil will default to crypto.Rand. This can be used to make ID
+// generation deterministic for tests. eg:
+//    myString := "SomeRandomStringThatIsLong-SoYouCanCallItAsMuchAsNeeded..."
+//    run.SetIDRand(strings.NewReader(myString))
+//    a := NewID()
+//    run.SetIDRand(strings.NewReader(myString))
+//    b := NewID()
+func SetIDRand(r io.Reader) {
+	uuid.SetRand(r)
 }
 
 // Status enumerates all possible execution states of a transform script or

--- a/transform/run/run.go
+++ b/transform/run/run.go
@@ -1,0 +1,168 @@
+// Package run defines metadata about transform script execution
+package run
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/qri-io/qri/event"
+)
+
+// NewID creates a run identifier
+func NewID() string {
+	return uuid.New().String()
+}
+
+// Status enumerates all possible execution states of a transform script or
+// step within a script, in relation to the current time.
+// Scripts & steps that have completed are broken into categories based on exit
+// state
+type Status string
+
+const (
+	// RSWaiting indicates a script/step that has yet to start
+	RSWaiting = Status("waiting")
+	// RSRunning indicates a script/step is currently executing
+	RSRunning = Status("running")
+	// RSSucceeded indicates a script/step has completed without error
+	RSSucceeded = Status("succeeded")
+	// RSFailed indicates a script/step completed & exited when an unexpected error
+	// occured
+	RSFailed = Status("failed")
+	// RSUnchanged indicates a script completed but no changes were found
+	// since the last version of the script succeeded
+	RSUnchanged = Status("unchanged")
+	// RSSkipped indicates a script/step was not executed
+	RSSkipped = Status("skipped")
+)
+
+// State is a passable, cachable data structure that describes the execution of
+// a transform. State structs can act as a sink of transform events, collapsing
+// the state transition of multiple transform events into a single structure
+type State struct {
+	ID        string       `json:"id"`
+	Number    int          `json:"number"`
+	Status    Status       `json:"status"`
+	Message   string       `json:"message"`
+	StartTime *time.Time   `json:"startTime"`
+	StopTime  *time.Time   `json:"stopTime"`
+	Duration  int          `json:"duration"`
+	Steps     []*StepState `json:"steps"`
+}
+
+// NewState is a simple constructor to remind package consumers that state
+// structs must be initialized with an identifier to act as a sink of transform
+// events
+func NewState(id string) *State {
+	return &State{
+		ID: id,
+	}
+}
+
+// AddTransformEvent alters state based on a given event
+func (rs *State) AddTransformEvent(e event.Event) error {
+	if rs.ID != e.SessionID {
+		// silently ignore session ID mismatch
+		return nil
+	}
+
+	switch e.Type {
+	case event.ETTransformStart:
+		rs.Status = RSRunning
+		rs.StartTime = toTimePointer(e.Timestamp)
+		return nil
+	case event.ETTransformStop:
+		rs.StopTime = toTimePointer(e.Timestamp)
+		if tl, ok := e.Payload.(event.TransformLifecycle); ok {
+			rs.Status = Status(tl.Status)
+		}
+		if rs.StartTime != nil && rs.StopTime != nil {
+			rs.Duration = int(rs.StopTime.Sub(*rs.StartTime))
+		}
+		return nil
+	case event.ETTransformStepStart:
+		s, err := NewStepStateFromEvent(e)
+		if err != nil {
+			return err
+		}
+		s.Status = RSRunning
+		s.StartTime = toTimePointer(e.Timestamp)
+		rs.Steps = append(rs.Steps, s)
+		return nil
+	case event.ETTransformStepStop:
+		step, err := rs.lastStep()
+		if err != nil {
+			return err
+		}
+		step.StopTime = toTimePointer(e.Timestamp)
+		if tsl, ok := e.Payload.(event.TransformStepLifecycle); ok {
+			step.Status = Status(tsl.Status)
+		} else {
+			step.Status = RSFailed
+		}
+		if step.StartTime != nil && step.StopTime != nil {
+			step.Duration = int(step.StopTime.Sub(*step.StartTime))
+		}
+		return nil
+	case event.ETTransformStepSkip:
+		s, err := NewStepStateFromEvent(e)
+		if err != nil {
+			return err
+		}
+		s.Status = RSSkipped
+		rs.Steps = append(rs.Steps, s)
+		return nil
+	case event.ETTransformPrint,
+		event.ETTransformError,
+		event.ETTransformDatasetPreview:
+		return rs.appendStepOutputLog(e)
+	}
+	return fmt.Errorf("unexpected event type: %q", e.Type)
+}
+
+func (rs *State) lastStep() (*StepState, error) {
+	if len(rs.Steps) > 0 {
+		return rs.Steps[len(rs.Steps)-1], nil
+	}
+	return nil, fmt.Errorf("expected step to exist")
+}
+
+func (rs *State) appendStepOutputLog(e event.Event) error {
+	step, err := rs.lastStep()
+	if err != nil {
+		return err
+	}
+
+	step.Output = append(step.Output, e)
+	return nil
+}
+
+// StepState describes the execution of a transform step
+type StepState struct {
+	Name      string        `json:"name"`
+	Category  string        `json:"category"`
+	Status    Status        `json:"status"`
+	StartTime *time.Time    `json:"startTime"`
+	StopTime  *time.Time    `json:"stopTime"`
+	Duration  int           `json:"duration"`
+	Output    []event.Event `json:"output"`
+}
+
+// NewStepStateFromEvent constructs StepState from an event
+func NewStepStateFromEvent(e event.Event) (*StepState, error) {
+	if tsl, ok := e.Payload.(event.TransformStepLifecycle); ok {
+		return &StepState{
+			Name:     tsl.Name,
+			Category: tsl.Category,
+			Status:   Status(tsl.Status),
+		}, nil
+	}
+	return nil, fmt.Errorf("run step event data must be a transform step lifecycle struct")
+}
+
+func toTimePointer(unixnano int64) *time.Time {
+	// TODO (b5) - we're dropping nanosecond precision here :/
+	t := time.Unix(unixnano, 0)
+	return &t
+}

--- a/transform/run/run.go
+++ b/transform/run/run.go
@@ -162,7 +162,6 @@ func NewStepStateFromEvent(e event.Event) (*StepState, error) {
 }
 
 func toTimePointer(unixnano int64) *time.Time {
-	// TODO (b5) - we're dropping nanosecond precision here :/
-	t := time.Unix(unixnano, 0)
+	t := time.Unix(0, unixnano)
 	return &t
 }

--- a/transform/run/run_test.go
+++ b/transform/run/run_test.go
@@ -1,0 +1,116 @@
+package run
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/qri-io/qri/event"
+)
+
+func TestStateAddTransformEvent(t *testing.T) {
+	runID := NewID()
+	states := []struct {
+		e event.Event
+		r *State
+	}{
+		{
+			event.Event{Type: event.ETTransformStart, Timestamp: 1609460600090, SessionID: runID, Payload: event.TransformLifecycle{StepCount: 4, Status: "running"}},
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning},
+		},
+		{
+			event.Event{Type: event.ETTransformStepStart, Timestamp: 1609460700090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "setup"}},
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), Status: RSRunning},
+			}},
+		},
+		// {
+		//	event.Event{ Type: event.ETVersionPulled,           Timestamp: 1609460800090, SessionID: runID, Payload: {"refstring": "rico/presidents@QmFoo", "remote": "https://registy.qri.cloud" }},
+		//	&State{},
+		//	},
+		{
+			event.Event{Type: event.ETTransformStepStop, Timestamp: 1609460900090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "setup", Status: "succeeded"}},
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+			}},
+		},
+		{
+			event.Event{Type: event.ETTransformStepStart, Timestamp: 1609461000090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "download"}},
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), Status: RSRunning},
+			}},
+		},
+		{
+			event.Event{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), Status: RSRunning, Output: []event.Event{
+					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
+				}},
+			}},
+		},
+		// {
+		// 	event.Event{ Type: event.ETHttpRequestStart, Timestamp: 1609461200090, SessionID: runID, Payload: {"id": runID, "downloadSize": 230409, "method": "Gevent.ET", "url": "https://registy.qri.cloud" }},
+		// 	&State{},
+		// {
+		// {
+		// event.Event{ Type: event.ETHttpRequestStop, Timestamp: 1609461300090, SessionID: runID, Payload: {"size": 230409, "method": "Gevent.ET", "url": "https://registy.qri.cloud" }},
+		// &State{},
+		// },
+		{
+			event.Event{Type: event.ETTransformStepStop, Timestamp: 1609461400090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "download", Status: "succeeded"}},
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000000000000, Status: RSSucceeded, Output: []event.Event{
+					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
+				}},
+			}},
+		},
+		{
+			event.Event{Type: event.ETTransformStepStart, Timestamp: 1609461500090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "transform"}},
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000000000000, Status: RSSucceeded, Output: []event.Event{
+					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
+				}},
+				{Name: "transform", StartTime: toTimePointer(1609461500090), Status: RSRunning},
+			}},
+		},
+		{
+			event.Event{Type: event.ETTransformStepStop, Timestamp: 1609461600090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "transform", Status: "succeeded"}},
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000000000000, Status: RSSucceeded, Output: []event.Event{
+					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
+				}},
+				{Name: "transform", StartTime: toTimePointer(1609461500090), StopTime: toTimePointer(1609461600090), Duration: 100000000000000, Status: RSSucceeded},
+			}},
+		},
+		{
+			event.Event{Type: event.ETTransformStop, Timestamp: 1609461900090, SessionID: runID, Payload: event.TransformLifecycle{Status: "failed"}},
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), StopTime: toTimePointer(1609461900090), Duration: 1300000000000000, Status: RSFailed, Steps: []*StepState{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000000000000, Status: RSSucceeded, Output: []event.Event{
+					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
+				}},
+				{Name: "transform", StartTime: toTimePointer(1609461500090), StopTime: toTimePointer(1609461600090), Duration: 100000000000000, Status: RSSucceeded},
+			}},
+		},
+	}
+
+	for i, s := range states {
+		t.Run(fmt.Sprintf("after_event_%d", i), func(t *testing.T) {
+			got := NewState(runID)
+			for j := 0; j <= i; j++ {
+				if err := got.AddTransformEvent(states[j].e); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if diff := cmp.Diff(s.r, got); diff != "" {
+				t.Errorf("result mismatch. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/transform/run/run_test.go
+++ b/transform/run/run_test.go
@@ -2,11 +2,26 @@ package run
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/qri-io/qri/event"
 )
+
+func ExampleNewID() {
+	myString := "SomeRandomStringThatIsLong-SoYouCanCallItAsMuchAsNeeded..."
+	SetIDRand(strings.NewReader(myString))
+	a := NewID()
+	SetIDRand(strings.NewReader(myString))
+	b := NewID()
+
+	fmt.Printf("a:  %s\nb:  %s\neq: %t", a, b, a == b)
+	// Output:
+	// a:  536f6d65-5261-4e64-af6d-537472696e67
+	// b:  536f6d65-5261-4e64-af6d-537472696e67
+	// eq: true
+}
 
 func TestStateAddTransformEvent(t *testing.T) {
 	runID := NewID()
@@ -31,20 +46,20 @@ func TestStateAddTransformEvent(t *testing.T) {
 		{
 			event.Event{Type: event.ETTransformStepStop, Timestamp: 1609460900090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "setup", Status: "succeeded"}},
 			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
-				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000, Status: RSSucceeded},
 			}},
 		},
 		{
 			event.Event{Type: event.ETTransformStepStart, Timestamp: 1609461000090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "download"}},
 			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
-				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000, Status: RSSucceeded},
 				{Name: "download", StartTime: toTimePointer(1609461000090), Status: RSRunning},
 			}},
 		},
 		{
 			event.Event{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
 			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
-				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000, Status: RSSucceeded},
 				{Name: "download", StartTime: toTimePointer(1609461000090), Status: RSRunning, Output: []event.Event{
 					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
 				}},
@@ -61,8 +76,8 @@ func TestStateAddTransformEvent(t *testing.T) {
 		{
 			event.Event{Type: event.ETTransformStepStop, Timestamp: 1609461400090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "download", Status: "succeeded"}},
 			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
-				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
-				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000000000000, Status: RSSucceeded, Output: []event.Event{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000, Status: RSSucceeded, Output: []event.Event{
 					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
 				}},
 			}},
@@ -70,8 +85,8 @@ func TestStateAddTransformEvent(t *testing.T) {
 		{
 			event.Event{Type: event.ETTransformStepStart, Timestamp: 1609461500090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "transform"}},
 			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
-				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
-				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000000000000, Status: RSSucceeded, Output: []event.Event{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000, Status: RSSucceeded, Output: []event.Event{
 					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
 				}},
 				{Name: "transform", StartTime: toTimePointer(1609461500090), Status: RSRunning},
@@ -80,21 +95,21 @@ func TestStateAddTransformEvent(t *testing.T) {
 		{
 			event.Event{Type: event.ETTransformStepStop, Timestamp: 1609461600090, SessionID: runID, Payload: event.TransformStepLifecycle{Name: "transform", Status: "succeeded"}},
 			&State{ID: runID, StartTime: toTimePointer(1609460600090), Status: RSRunning, Steps: []*StepState{
-				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
-				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000000000000, Status: RSSucceeded, Output: []event.Event{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000, Status: RSSucceeded, Output: []event.Event{
 					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
 				}},
-				{Name: "transform", StartTime: toTimePointer(1609461500090), StopTime: toTimePointer(1609461600090), Duration: 100000000000000, Status: RSSucceeded},
+				{Name: "transform", StartTime: toTimePointer(1609461500090), StopTime: toTimePointer(1609461600090), Duration: 100000, Status: RSSucceeded},
 			}},
 		},
 		{
 			event.Event{Type: event.ETTransformStop, Timestamp: 1609461900090, SessionID: runID, Payload: event.TransformLifecycle{Status: "failed"}},
-			&State{ID: runID, StartTime: toTimePointer(1609460600090), StopTime: toTimePointer(1609461900090), Duration: 1300000000000000, Status: RSFailed, Steps: []*StepState{
-				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000000000000, Status: RSSucceeded},
-				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000000000000, Status: RSSucceeded, Output: []event.Event{
+			&State{ID: runID, StartTime: toTimePointer(1609460600090), StopTime: toTimePointer(1609461900090), Duration: 1300000, Status: RSFailed, Steps: []*StepState{
+				{Name: "setup", StartTime: toTimePointer(1609460700090), StopTime: toTimePointer(1609460900090), Duration: 200000, Status: RSSucceeded},
+				{Name: "download", StartTime: toTimePointer(1609461000090), StopTime: toTimePointer(1609461400090), Duration: 400000, Status: RSSucceeded, Output: []event.Event{
 					{Type: event.ETTransformPrint, Timestamp: 1609461100090, SessionID: runID, Payload: event.TransformMessage{Msg: "oh hai there"}},
 				}},
-				{Name: "transform", StartTime: toTimePointer(1609461500090), StopTime: toTimePointer(1609461600090), Duration: 100000000000000, Status: RSSucceeded},
+				{Name: "transform", StartTime: toTimePointer(1609461500090), StopTime: toTimePointer(1609461600090), Duration: 100000, Status: RSSucceeded},
 			}},
 		},
 	}


### PR DESCRIPTION
I've added lots of details to commit messages, please read commits while reviewing. I've kept this as a draft as it's not fully tested quite yet, but things are mostly working.

On save, transform components are recalled from history if no transform component is provided to save. This used to be accomplished with a "recall: tf" param, but I've kept it as a transform-specific feature this go-round. I think it ties in a little better with the new --apply semantics.

When saving with a trasnform we now build up a *run.State with the RunID event subscription. I'd initally experimented with designs that had runState built and returned within `transform.Apply`, but found it too easy to create a data race when transform.Apply's wait argument is false. In that case transform.Apply doesn't have a clear moment of when to return a run.State value without giving back a channel, or adding mutex locks & accessor methods to run.State. Seems
it's easier to just build run.State from an external event listener.

This commit introduces automation failure logging, but creates a new issue in the process: When a user "manually" invokes save with the apply flag and the transform fails, a record of that failure will be recorded, which might feel counter-intuitive. The problem here is we're not passing any details to save that lets us disambiguate automation-driven `save` calls from user-driven ones.


To smoke test **please make a backup of your logbook.qfb** repo file before running this branch. The only way to see the result of these changes is to:
1. Create at least one dataset version using the `--apply` flag.
2. Run `qri connect` & `curl http://localhost:2503/history/your/dataset | jq`. You should see fields like `RunID` and `RunDuration` in the JSON response.