### PR TITLE
fix(prove): Prove command updates local logbook as needed

### DIFF
--- a/lib/registry.go
+++ b/lib/registry.go
@@ -105,6 +105,10 @@ func (m RegistryClientMethods) ProveProfileKey(p *RegistryProfile, ok *bool) err
 	cfg := m.configFromProfile(p)
 	if profileID, ok := res["profileID"]; ok {
 		cfg.Profile.ID = profileID
+		if pid := profile.IDB58DecodeOrEmpty(profileID); pid != "" {
+			// Assign to profile struct as well
+			pro.ID = pid
+		}
 	} else {
 		return fmt.Errorf("prove: server response invalid, did not have profileID")
 	}

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"path/filepath"
 
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/logbook"
+	"github.com/qri-io/qri/logbook/oplog"
 	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/registry"
 )
@@ -58,6 +61,19 @@ func (m RegistryClientMethods) ProveProfileKey(p *RegistryProfile, ok *bool) err
 
 	ctx := context.Background()
 
+	// Check if the repository has any saved datasets. If so, calling prove is
+	// not allowed, because doing so would essentially throw away the old profile,
+	// making those references unreachable. In the future, this can be changed
+	// such that the old identity is given a different username, and is merged
+	// into the client's collection.
+	numRefs, err := m.inst.repo.RefCount()
+	if err != nil {
+		return err
+	}
+	if numRefs > 0 {
+		return fmt.Errorf("cannot prove with a non-empty repository")
+	}
+
 	// For signing the outgoing message
 	// TODO(arqu): this should take the profile PK instead of active PK once multi tenancy is supported
 	privKey := m.inst.repo.PrivateKey(ctx)
@@ -92,7 +108,33 @@ func (m RegistryClientMethods) ProveProfileKey(p *RegistryProfile, ok *bool) err
 	} else {
 		return fmt.Errorf("prove: server response invalid, did not have profileID")
 	}
-	// TODO(dustmop): Also get logbook
+
+	// If an existing user of this profileID pushed something, get the previous logbook data
+	// and write it to our repository. This enables push and pull to continue to work
+	if logbookBin, ok := res["logbookInit"]; ok && len(logbookBin) > 0 {
+		logbookBytes, err := base64.StdEncoding.DecodeString(logbookBin)
+		if err != nil {
+			return err
+		}
+		lg := &oplog.Log{}
+		if err := lg.UnmarshalFlatbufferBytes(logbookBytes); err != nil {
+			return err
+		}
+		err = m.inst.repo.Logbook().ReplaceAll(ctx, lg)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Otherwise, nothing was ever pushed. Create new logbook data using the
+		// profileID we got back.
+		logbookPath := filepath.Join(m.inst.repoPath, "logbook.qfb")
+		logbook, err := logbook.NewJournalOverwriteWithProfileID(privKey, p.Username, m.inst.bus,
+			m.inst.qfs, logbookPath, cfg.Profile.ID)
+		if err != nil {
+			return err
+		}
+		m.inst.logbook = logbook
+	}
 
 	// Save the modified config
 	return m.inst.ChangeConfig(cfg)

--- a/lib/registry_test.go
+++ b/lib/registry_test.go
@@ -1,0 +1,63 @@
+package lib
+
+import (
+	"context"
+	"testing"
+
+	testPeers "github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/profile"
+	"github.com/qri-io/qri/registry/regserver"
+	repotest "github.com/qri-io/qri/repo/test"
+)
+
+// Test that running prove sets the profileID for the user
+func TestProveProfileKey(t *testing.T) {
+	tr := newTestRunner(t)
+	defer tr.Delete()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reg, cleanup, err := regserver.NewTempRegistry(ctx, "temp_registry", "", repotest.NewTestCrypto())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	defer cancel()
+
+	// Create a mock registry, point our test runner to its URL
+	regClient, _ := regserver.NewMockServerRegistry(*reg)
+	tr.Instance.registry = regClient
+
+	// Get an example peer, and add it to the local profile store
+	info := testPeers.GetTestPeerInfo(2)
+	pro := &profile.Profile{
+		Peername: "test_peer",
+		PubKey:   info.PubKey,
+		PrivKey:  info.PrivKey,
+		ID:       profile.IDFromPeerID(info.PeerID),
+	}
+	repo := tr.Instance.Repo()
+	pstore := repo.Profiles()
+	err = pstore.SetOwner(pro)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Call the endpoint to prove our account
+	methods := NewRegistryClientMethods(tr.Instance)
+	p := RegistryProfile{
+		Username: pro.Peername,
+		Email:    "test_peer@qri.io",
+		Password: "hunter2",
+	}
+	ok := false
+	err = methods.ProveProfileKey(&p, &ok)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Peer 3 is used by the mock regserver, it is now used by this peer
+	expectProfileID := profile.IDFromPeerID(testPeers.GetTestPeerInfo(3).PeerID)
+	if pro.ID != expectProfileID {
+		t.Errorf("bad profileID for peer after prove. expect: %s, got: %s", expectProfileID, pro.ID)
+	}
+}

--- a/logbook/oplog/log.go
+++ b/logbook/oplog/log.go
@@ -91,6 +91,9 @@ type Logstore interface {
 	// get all generations of a log, using the given log as an outparam
 	// Descendants MUST only mutate Logs field of the passed-in log pointer
 	Descendants(ctx context.Context, l *Log) error
+
+	// ReplaceAll replaces the contents of the entire log
+	ReplaceAll(ctx context.Context, l *Log) error
 }
 
 // SparseAncestorsAllDescendantsLogstore is a an extension interface to
@@ -332,6 +335,13 @@ func (j *Journal) Descendants(ctx context.Context, l *Log) error {
 	}
 
 	l.Logs = got.Logs
+	return nil
+}
+
+// ReplaceAll replaces the entirety of the logs
+func (j *Journal) ReplaceAll(ctx context.Context, l *Log) error {
+	j.logs = []*Log{l}
+	j.id = l.Ops[0].Hash()
 	return nil
 }
 

--- a/registry/regserver/handlers/handlers.go
+++ b/registry/regserver/handlers/handlers.go
@@ -57,6 +57,7 @@ func NewRoutes(reg registry.Registry, opts ...func(o *RouteOptions)) *http.Serve
 	if ps := reg.Profiles; ps != nil {
 		mux.HandleFunc("/registry/profile", logReq(NewProfileHandler(ps)))
 		mux.HandleFunc("/registry/profiles", pro.ProtectMethods("POST")(logReq(NewProfilesHandler(ps))))
+		mux.HandleFunc("/registry/provekey", NewProveKeyHandler(ps))
 	}
 
 	if s := reg.Search; s != nil {

--- a/registry/regserver/handlers/profile.go
+++ b/registry/regserver/handlers/profile.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	apiutil "github.com/qri-io/qri/api/util"
+	testPeers "github.com/qri-io/qri/config/test"
 	"github.com/qri-io/qri/registry"
 )
 
@@ -116,5 +117,17 @@ func NewProfileHandler(profiles registry.Profiles) http.HandlerFunc {
 		}
 
 		apiutil.WriteResponse(w, p)
+	}
+}
+
+// NewProveKeyHandler creates a handler that implements provekey
+func NewProveKeyHandler(profiles registry.Profiles) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// TODO(dustmop): Lookup account referred to by the request,
+		// and retrieve appropriate data.
+		info := testPeers.GetTestPeerInfo(3)
+		res := map[string]string{}
+		res["profileID"] = info.EncodedPeerID
+		apiutil.WriteResponse(w, res)
 	}
 }


### PR DESCRIPTION
When a user runs `prove`, the response they get back contains the original profileID and logbook data. Assign that data to their profile.