### PR TITLE
refactor(dsref): replace ProfileID with InitID in refstring serialization

### DIFF
--- a/base/remove_test.go
+++ b/base/remove_test.go
@@ -165,12 +165,11 @@ func TestVerifyRefsRemove(t *testing.T) {
 	// we get the proper response:
 	s = verifyRefsRemoved(ctx, r.Filesystem(), refs, 2)
 	sExpected := dstest.Template(t, `
-ref "peer/cities@{{ .ProfileID }}{{ .Path1 }}" should NOT exist in the store, but does
-ref "peer/cities@{{ .ProfileID }}{{ .Path2 }}" should NOT exist in the store, but does`,
+ref "peer/cities@{{ .Path1 }}" should NOT exist in the store, but does
+ref "peer/cities@{{ .Path2 }}" should NOT exist in the store, but does`,
 		map[string]string{
-			"ProfileID": "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
-			"Path1":     "/mem/Qmdki7aFGzimPynhNigPF1GnRnWp9k4ryop91D7JkxZ3pW",
-			"Path2":     "/mem/QmdAcSMzPBhZw8ebxfDqBaHZYLFS2X5J5QoAaKGHdiKiwE",
+			"Path1": "/mem/Qmdki7aFGzimPynhNigPF1GnRnWp9k4ryop91D7JkxZ3pW",
+			"Path2": "/mem/QmdAcSMzPBhZw8ebxfDqBaHZYLFS2X5J5QoAaKGHdiKiwE",
 		},
 	)
 	if diff := cmp.Diff(sExpected, s); diff != "" {

--- a/dsref/parse_test.go
+++ b/dsref/parse_test.go
@@ -11,12 +11,13 @@ func TestParseFull(t *testing.T) {
 		expect      Ref
 	}{
 		{"human friendly", "abc/my_dataset", Ref{Username: "abc", Name: "my_dataset"}},
-		{"full reference", "abc/my_dataset@QmFirst/ipfs/QmSecond", Ref{Username: "abc", Name: "my_dataset", ProfileID: "QmFirst", Path: "/ipfs/QmSecond"}},
-		{"right hand side", "@QmFirst/ipfs/QmSecond", Ref{ProfileID: "QmFirst", Path: "/ipfs/QmSecond"}},
+		{"full reference", "abc/my_dataset@base32identifier/ipfs/QmSecond", Ref{Username: "abc", Name: "my_dataset", InitID: "base32identifier", Path: "/ipfs/QmSecond"}},
+		{"right hand side", "@base32identifier/ipfs/QmSecond", Ref{InitID: "base32identifier", Path: "/ipfs/QmSecond"}},
 		{"just path", "@/ipfs/QmSecond", Ref{Path: "/ipfs/QmSecond"}},
 		{"long name", "peer/some_name@/mem/QmXATayrFgsS3tpCi2ykfpNJ8uiCWT74dttnvJvVo1J7Rn", Ref{Username: "peer", Name: "some_name", Path: "/mem/QmXATayrFgsS3tpCi2ykfpNJ8uiCWT74dttnvJvVo1J7Rn"}},
 		{"name-has-dash", "abc/my-dataset", Ref{Username: "abc", Name: "my-dataset"}},
 		{"dash-in-username", "some-user/my_dataset", Ref{Username: "some-user", Name: "my_dataset"}},
+		{"legacy profileID", "@QmFirst/ipfs/QmSecond", Ref{ProfileID: "QmFirst", Path: "/ipfs/QmSecond"}},
 	}
 	for i, c := range goodCases {
 		ref, err := Parse(c.text)
@@ -25,7 +26,7 @@ func TestParseFull(t *testing.T) {
 			continue
 		}
 		if !ref.Equals(c.expect) {
-			t.Errorf("case %d %q mismatch: expect %s, got %s", i, c.description, c.expect, ref)
+			t.Errorf("case %d %q mismatch: expect %q, got %q", i, c.description, c.expect, ref)
 		}
 	}
 

--- a/dsref/ref.go
+++ b/dsref/ref.go
@@ -7,6 +7,9 @@ type Ref struct {
 	// Username of dataset owner
 	Username string `json:"username,omitempty"`
 	// ProfileID of dataset owner
+	// deprecated - avoid using this field, we're working towards removing it
+	// generally profile IDs should come from request scopes, or be fetched from
+	// stores of identity info (profile.Store)
 	ProfileID string `json:"profileID,omitempty"`
 	// Unique name reference for this dataset
 	Name string `json:"name,omitempty"`
@@ -32,7 +35,24 @@ func (r Ref) Human() string {
 // String implements the Stringer interface for Ref
 func (r Ref) String() (s string) {
 	s = r.Alias()
-	if r.ProfileID != "" || r.Path != "" {
+	if r.InitID != "" || r.Path != "" {
+		s += "@"
+	}
+	if r.InitID != "" {
+		s += r.InitID
+	}
+	if r.Path != "" {
+		s += r.Path
+	}
+	return s
+}
+
+// LegacyProfileIDString serializes a ref in the form
+//   Username/Name@ProfileID/Path
+// Deprecated - don't add callers, use String or raw ref fields instead
+func (r Ref) LegacyProfileIDString() (s string) {
+	s = r.Alias()
+	if r.InitID != "" || r.Path != "" {
 		s += "@"
 	}
 	if r.ProfileID != "" {

--- a/dsref/ref_test.go
+++ b/dsref/ref_test.go
@@ -17,7 +17,7 @@ func TestRefAlias(t *testing.T) {
 	for _, c := range cases {
 		got := c.in.Alias()
 		if c.expect != got {
-			t.Errorf("result mismatch. input:%#v \nwant: '%s'\ngot: '%s'", c.in, c.expect, got)
+			t.Errorf("result mismatch. input:%#v \nwant: %q\ngot: %q", c.in, c.expect, got)
 		}
 	}
 }
@@ -35,7 +35,7 @@ func TestRefHuman(t *testing.T) {
 	for _, c := range cases {
 		got := c.in.Human()
 		if c.expect != got {
-			t.Errorf("result mismatch. input:%#v \nwant: '%s'\ngot: '%s'", c.in, c.expect, got)
+			t.Errorf("result mismatch. input:%#v \nwant: %q\ngot: %q", c.in, c.expect, got)
 		}
 	}
 }
@@ -49,12 +49,33 @@ func TestRefString(t *testing.T) {
 		{Ref{Username: "a", Name: "b"}, "a/b"},
 		{Ref{Username: "a", Name: "b"}, "a/b"},
 		{Ref{Username: "a", Name: "b", Path: "/foo"}, "a/b@/foo"},
+		{Ref{Username: "a", Name: "b", InitID: "initid", Path: "/foo"}, "a/b@initid/foo"},
 	}
 
 	for _, c := range cases {
 		got := c.in.String()
 		if c.expect != got {
-			t.Errorf("result mismatch. input:%#v \nwant: '%s'\ngot: '%s'", c.in, c.expect, got)
+			t.Errorf("result mismatch. input:%#v \nwant: %q\ngot: %q", c.in, c.expect, got)
+		}
+	}
+}
+
+func TestRefLegacyProfileIDString(t *testing.T) {
+	cases := []struct {
+		in     Ref
+		expect string
+	}{
+		{Ref{}, ""},
+		{Ref{Username: "a", Name: "b"}, "a/b"},
+		{Ref{Username: "a", Name: "b"}, "a/b"},
+		{Ref{Username: "a", Name: "b", Path: "/foo"}, "a/b@/foo"},
+		{Ref{Username: "a", Name: "b", ProfileID: "ProfileID", Path: "/foo"}, "a/b@ProfileID/foo"},
+	}
+
+	for _, c := range cases {
+		got := c.in.LegacyProfileIDString()
+		if c.expect != got {
+			t.Errorf("result mismatch. input:%#v \nwant: %q\ngot: %q", c.in, c.expect, got)
 		}
 	}
 }

--- a/dsref/spec/resolve.go
+++ b/dsref/spec/resolve.go
@@ -124,7 +124,57 @@ func AssertResolverSpec(t *testing.T, r dsref.Resolver, putFunc PutRefFunc) {
 			t.Errorf("provided path result mismatch. (-want +got):\n%s", diff)
 		}
 
-		// TODO(b5) - need to add a test that confirms ResolveRef CANNOT return
+		// resolveMe = dsref.Ref{
+		// 	Username: username,
+		// 	Name:     dsname,
+		// 	InitID:   initID,
+		// }
+
+		// expectRef = dsref.Ref{
+		// 	Username:  username,
+		// 	Name:      dsname,
+		// 	ProfileID: pubKeyID,
+		// 	Path:      headPath,
+		// 	InitID:    initID,
+		// }
+
+		// _, err = r.ResolveRef(ctx, &resolveMe)
+		// if err != nil {
+		// 	t.Error(err)
+		// }
+		// if resolveMe.InitID != expectRef.InitID {
+		// 	t.Errorf("providing an InitID result mismatch. want: %q\ngot:  %q", expectRef.InitID, resolveMe.InitID)
+		// }
+		// if diff := cmp.Diff(expectRef, resolveMe); diff != "" {
+		// 	t.Errorf("provided InitID result mismatch. (-want +got):\n%s", diff)
+		// }
+
+		// // TODO(b5): not yet enforced by this test yet, but providing just an initID
+		// // MUST populate the alias (human side) of a reference.
+		// resolveMe = dsref.Ref{
+		// 	InitID: initID,
+		// }
+
+		// expectRef = dsref.Ref{
+		// 	Username:  username,
+		// 	Name:      dsname,
+		// 	ProfileID: pubKeyID,
+		// 	Path:      headPath,
+		// 	InitID:    initID,
+		// }
+
+		// _, err = r.ResolveRef(ctx, &resolveMe)
+		// if err != nil {
+		// 	t.Error(err)
+		// }
+		// if resolveMe.InitID != expectRef.InitID {
+		// 	t.Errorf("providing InitID-only result mismatch. want: %q\ngot:  %q", expectRef.InitID, resolveMe.InitID)
+		// }
+		// if diff := cmp.Diff(expectRef, resolveMe); diff != "" {
+		// 	t.Errorf("provided InitID-only result mismatch. (-want +got):\n%s", diff)
+		// }
+
+		// TODO(b5): need to add a test that confirms ResolveRef CANNOT return
 		// paths outside of logbook HEAD. Subsystems that store references to
 		// mutable paths (eg: FSI links) cannot be set as reference resolution
 	})

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -429,7 +429,7 @@ func PushToRegistry(t *testing.T, inst *Instance, refstr string) dsref.Ref {
 	}, &res)
 
 	if err != nil {
-		log.Fatalf("publishing dataset: %s", err)
+		t.Fatalf("publishing dataset: %s", err)
 	}
 
 	return res

--- a/logbook/logsync/logsync.go
+++ b/logbook/logsync/logsync.go
@@ -123,7 +123,7 @@ func (lsync *Logsync) NewPull(ref dsref.Ref, remoteAddr string) (*Pull, error) {
 	if lsync == nil {
 		return nil, ErrNoLogsync
 	}
-	log.Debugf("NewPull ref=%q remoteAddr=%q", ref, remoteAddr)
+	log.Debugw("NewPull", "ref", ref, "remoteAddr", remoteAddr)
 
 	rem, err := lsync.remoteClient(context.TODO(), remoteAddr)
 	if err != nil {
@@ -387,7 +387,7 @@ type Pull struct {
 
 // Do executes the pull
 func (p *Pull) Do(ctx context.Context) (*oplog.Log, error) {
-	log.Debugf("pull.Do ref=%q", p.ref)
+	log.Debugw("pull.Do", "ref", p.ref)
 	sender, r, err := p.remote.get(ctx, p.book.Author(), p.ref)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a backwards-compatible spec change to the way we parse dataset reference strings, specifically the concrete part of a ref (the bit after the `@`). The grammar change from this:
```
<concreteRef> = '@' [ <profileID> ] '/' <network> '/' <commitHash>
```
to this:
```
<concreteRef> = '@' [ <datasetID> | <profileID> ] '/' <network> '/' <commitHash>
```

The only change is replacing `profileID` with `datasetID`, where `datasetID` is a lowercase-base32 dataset identifier (initID). This change makes it possible to reference datasets by ID directly. For example:

    @jzk63pfkfefgwub7wvhl54s4inqr25ncwhmi7svahjjxzwuknrlq
    @jzk63pfkfefgwub7wvhl54s4inqr25ncwhmi7svahjjxzwuknrlq/ipfs/QmHaash

We can make this change backwards-compatible because dataset identifiers & profileIDs use different character sets. Replacing the profileID is the right decision, as the use of profileIDs in dsrefs has been inconsitent to date, and
will only get less useful as we transition toward additional collaborators on the same dataset.