### PR TITLE
remove profile methods from repo

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -81,8 +81,7 @@ func testConfigAndSetter() (cfg *config.Config, setCfg func(*config.Config) erro
 
 func newTestInstanceWithProfileFromNode(ctx context.Context, node *p2p.QriNode) *lib.Instance {
 	cfg := config.DefaultConfigForTesting()
-	pro, _ := node.Repo.Profile(ctx)
-	cfg.Profile, _ = pro.Encode()
+	cfg.Profile, _ = node.Repo.Profiles().Owner().Encode()
 	return lib.NewInstanceFromConfigAndNode(ctx, cfg, node)
 }
 

--- a/api/profile_test.go
+++ b/api/profile_test.go
@@ -85,8 +85,7 @@ func TestProfilePhotoHandler(t *testing.T) {
 	cfg := config.DefaultConfigForTesting()
 	// newTestNode uses a different profile. assign here so instance config.Profile
 	// node config.Profile match
-	pro, _ := node.Repo.Profile(ctx)
-	cfg.Profile, _ = pro.Encode()
+	cfg.Profile, _ = node.Repo.Profiles().Owner().Encode()
 
 	// TODO (b5) - hack until tests have better instance-generation primitives
 	inst := lib.NewInstanceFromConfigAndNode(ctx, cfg, node)
@@ -144,8 +143,7 @@ func TestProfilePosterHandler(t *testing.T) {
 	cfg := config.DefaultConfigForTesting()
 	// newTestNode uses a different profile. assign here so instance config.Profile
 	// node config.Profile match
-	pro, _ := node.Repo.Profile(ctx)
-	cfg.Profile, _ = pro.Encode()
+	cfg.Profile, _ = node.Repo.Profiles().Owner().Encode()
 
 	// TODO (b5) - hack until tests have better instance-generation primitives
 	inst := lib.NewInstanceFromConfigAndNode(ctx, cfg, node)

--- a/base/base_test.go
+++ b/base/base_test.go
@@ -96,11 +96,8 @@ func updateCitiesDataset(t *testing.T, r repo.Repo, title string) dsref.Ref {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	pro, err := r.Profile(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
 
+	pro := r.Profiles().Owner()
 	ref, err := repo.GetVersionInfoShim(r, dsref.Ref{Username: pro.Peername, Name: tc.Name})
 	if err != nil {
 		t.Fatal(err)

--- a/base/dataset_prepare_test.go
+++ b/base/dataset_prepare_test.go
@@ -23,11 +23,7 @@ func TestPrepareSaveRef(t *testing.T) {
 	r := newTestRepo(t)
 	ctx := context.Background()
 
-	pro, err := r.Profile(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	pro := r.Profiles().Owner()
 	book := r.Logbook()
 
 	book.WriteDatasetInit(ctx, "cities")
@@ -97,13 +93,9 @@ func TestPrepareSaveRef(t *testing.T) {
 
 func TestInferValues(t *testing.T) {
 	r := newTestRepo(t)
-	ctx := context.Background()
-	pro, err := r.Profile(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	pro := r.Profiles().Owner()
 	ds := &dataset.Dataset{}
-	if err = InferValues(pro, ds); err != nil {
+	if err := InferValues(pro, ds); err != nil {
 		t.Error(err)
 	}
 	expectAuthorID := `QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt`
@@ -168,11 +160,7 @@ func TestInferStructureSchema(t *testing.T) {
 
 func TestInferValuesDontOverwriteSchema(t *testing.T) {
 	r := newTestRepo(t)
-	ctx := context.Background()
-	pro, err := r.Profile(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	pro := r.Profiles().Owner()
 
 	ds := &dataset.Dataset{
 		Name: "animals",
@@ -193,7 +181,7 @@ func TestInferValuesDontOverwriteSchema(t *testing.T) {
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("animals.csv",
 		[]byte("Animal,Sound,Weight\ncat,meow,1.4\ndog,bark,3.7\n")))
-	if err = InferValues(pro, ds); err != nil {
+	if err := InferValues(pro, ds); err != nil {
 		t.Error(err)
 	}
 
@@ -213,13 +201,6 @@ func TestInferValuesDontOverwriteSchema(t *testing.T) {
 }
 
 func TestMaybeAddDefaultViz(t *testing.T) {
-	r := newTestRepo(t)
-	ctx := context.Background()
-	_, err := r.Profile(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	ds := &dataset.Dataset{
 		Name: "animals",
 		Structure: &dataset.Structure{

--- a/base/log.go
+++ b/base/log.go
@@ -66,7 +66,8 @@ func DatasetLog(ctx context.Context, r repo.Repo, ref dsref.Ref, limit, offset i
 	}
 
 	// add a history entry b/c we didn't have one, but repo didn't error
-	if pro, err := r.Profile(ctx); err == nil && ref.Username == pro.Peername {
+	pro := r.Profiles().Owner()
+	if ref.Username == pro.Peername {
 		go func() {
 			if err := constructDatasetLogFromHistory(context.Background(), r, ref); err != nil {
 				log.Errorf("constructDatasetLogFromHistory: %s", err)

--- a/base/log_test.go
+++ b/base/log_test.go
@@ -207,10 +207,7 @@ func TestConstructDatasetLogFromHistory(t *testing.T) {
 	ref := updateCitiesDataset(t, mr, "")
 
 	// add the logbook back
-	p, err := mr.Profile(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := mr.Profiles().Owner()
 	book, err := logbook.NewJournal(p.PrivKey, p.Peername, event.NilBus, mr.Filesystem(), "/mem/logbook.qfb")
 	if err != nil {
 		t.Fatal(err)

--- a/base/ref.go
+++ b/base/ref.go
@@ -15,11 +15,7 @@ import (
 // InLocalNamespace checks if a dataset ref is local, assumes the reference is
 // already resolved
 func InLocalNamespace(ctx context.Context, r repo.Repo, ref dsref.Ref) bool {
-	p, err := r.Profile(ctx)
-	if err != nil {
-		return false
-	}
-
+	p := r.Profiles().Owner()
 	return p.ID.String() == ref.ProfileID
 }
 

--- a/base/save.go
+++ b/base/save.go
@@ -8,7 +8,6 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dsref"
-	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/transform/run"
 )
@@ -31,10 +30,7 @@ func SaveDataset(
 	sw SaveSwitches,
 ) (ds *dataset.Dataset, err error) {
 	log.Debugf("SaveDataset initID=%q prevPath=%q", initID, prevPath)
-	var pro *profile.Profile
-	if pro, err = r.Profile(ctx); err != nil {
-		return nil, err
-	}
+	pro := r.Profiles().Owner()
 	if initID == "" {
 		return nil, fmt.Errorf("SaveDataset requires an initID")
 	}
@@ -124,16 +120,11 @@ func SaveDataset(
 func CreateDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, ds, dsPrev *dataset.Dataset, sw SaveSwitches) (res *dataset.Dataset, err error) {
 	log.Debugf("CreateDataset ds=%#v dsPrev=%#v", ds, dsPrev)
 	var (
-		pro     *profile.Profile
+		pro     = r.Profiles().Owner()
 		path    string
 		resBody qfs.File
 	)
 
-	pro, err = r.Profile(ctx)
-	if err != nil {
-		log.Debugf("getting repo profile: %s", err)
-		return
-	}
 	// TODO(dustmop): Remove the dependence on the ds having an assigned Name. It is only
 	// needed for updating the refstore. Either pass in the reference needed to update the refstore,
 	// or move the refstore update out of this function.

--- a/base/save.go
+++ b/base/save.go
@@ -141,7 +141,7 @@ func CreateDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, d
 		return
 	}
 
-	if path, err = dsfs.CreateDataset(ctx, r.Filesystem(), writeDest, r.Bus(), ds, dsPrev, r.PrivateKey(ctx), sw); err != nil {
+	if path, err = dsfs.CreateDataset(ctx, r.Filesystem(), writeDest, r.Bus(), ds, dsPrev, pro.PrivKey, sw); err != nil {
 		log.Debugf("dsfs.CreateDataset: %s", err)
 		return nil, err
 	}

--- a/cmd/test_runner_test.go
+++ b/cmd/test_runner_test.go
@@ -385,11 +385,7 @@ func (run *TestRunner) LookupVersionInfo(t *testing.T, refStr string) *dsref.Ver
 	// TODO(b5): me shortcut is handled by an instance, it'd be nice we had a
 	// function in the repo package that deduplicated this in both places
 	if dr.Username == "me" {
-		pro, err := r.Profile(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		dr.Username = pro.Peername
+		dr.Username = r.Profiles().Owner().Peername
 	}
 
 	if _, err := r.ResolveRef(ctx, &dr); err != nil {

--- a/fsi/watchfs/watchfs_test.go
+++ b/fsi/watchfs/watchfs_test.go
@@ -84,10 +84,7 @@ func TestWatchAllFSIPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pro, err := r.Profile(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	pro := r.Profiles().Owner()
 
 	ref, err := r.GetRef(reporef.DatasetRef{
 		Peername: pro.Peername,

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -420,7 +420,7 @@ func TestDatasetRequestsListP2p(t *testing.T) {
 				t.Errorf("error listing dataset: %s", err.Error())
 			}
 			// Get number from end of peername, use that to find dataset name.
-			profile, _ := node.Repo.Profile(ctx)
+			profile := node.Repo.Profiles().Owner()
 			num := profile.Peername[len(profile.Peername)-1:]
 			index, _ := strconv.ParseInt(num, 10, 32)
 			expect := datasets[index]
@@ -695,7 +695,7 @@ func TestDatasetRequestsGetP2p(t *testing.T) {
 		go func(node *p2p.QriNode) {
 			defer wg.Done()
 			// Get number from end of peername, use that to create dataset name.
-			profile, _ := node.Repo.Profile(ctx)
+			profile := node.Repo.Profiles().Owner()
 			num := profile.Peername[len(profile.Peername)-1:]
 			index, _ := strconv.ParseInt(num, 10, 32)
 			name := datasets[index]
@@ -1030,7 +1030,7 @@ func TestDatasetRequestsAddP2P(t *testing.T) {
 				defer wg.Done()
 
 				// Get ref to dataset that peer2 has.
-				profile, _ := p1.Repo.Profile(ctx)
+				profile := p1.Repo.Profiles().Owner()
 				num := profile.Peername[len(profile.Peername)-1:]
 				index, _ := strconv.ParseInt(num, 10, 32)
 				name := datasets[index]
@@ -1045,8 +1045,8 @@ func TestDatasetRequestsAddP2P(t *testing.T) {
 
 				_, err := dsm.Pull(ctx, p)
 				if err != nil {
-					pro1, _ := p0.Repo.Profile(ctx)
-					pro2, _ := p1.Repo.Profile(ctx)
+					pro1 := p0.Repo.Profiles().Owner()
+					pro2 := p1.Repo.Profiles().Owner()
 					t.Errorf("error adding dataset for %s from %s to %s: %s",
 						ref.Name, pro2.Peername, pro1.Peername, err.Error())
 				}

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -642,13 +642,7 @@ func NewInstanceFromConfigAndNodeAndBus(ctx context.Context, cfg *config.Config,
 	ctx, cancel := context.WithCancel(ctx)
 
 	r := node.Repo
-	// TODO(aqru): should be owner?
-	pro, err := r.Profile(ctx)
-	if err != nil {
-		cancel()
-		panic(err)
-	}
-
+	pro := r.Profiles().Owner()
 	fsint := fsi.NewFSI(r, bus)
 	dc := dscache.NewDscache(ctx, r.Filesystem(), bus, pro.Peername, "")
 
@@ -679,6 +673,7 @@ func NewInstanceFromConfigAndNodeAndBus(ctx context.Context, cfg *config.Config,
 		inst.qfs = r.Filesystem()
 	}
 
+	var err error
 	inst.remoteClient, err = remote.NewClient(ctx, node, inst.bus)
 	if err != nil {
 		cancel()

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -214,10 +214,7 @@ func addCitiesDataset(t *testing.T, node *p2p.QriNode) dsref.Ref {
 }
 
 func saveDataset(ctx context.Context, r repo.Repo, ds *dataset.Dataset, sw base.SaveSwitches) (dsref.Ref, error) {
-	pro, err := r.Profile(ctx)
-	if err != nil {
-		return dsref.Ref{}, err
-	}
+	pro := r.Profiles().Owner()
 	ref, _, err := base.PrepareSaveRef(ctx, pro, r.Logbook(), r.Logbook(), fmt.Sprintf("%s/%s", pro.Peername, ds.Name), "", false)
 	if err != nil {
 		return dsref.Ref{}, err

--- a/lib/load_test.go
+++ b/lib/load_test.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"context"
 	"testing"
 
 	"github.com/qri-io/dataset"
@@ -12,7 +11,6 @@ import (
 )
 
 func TestLoadDataset(t *testing.T) {
-	ctx := context.Background()
 	tr := newTestRunner(t)
 	defer tr.Delete()
 
@@ -30,7 +28,7 @@ func TestLoadDataset(t *testing.T) {
 			event.NilBus,
 			ds,
 			nil,
-			tr.Instance.repo.PrivateKey(ctx),
+			tr.Instance.repo.Profiles().Owner().PrivKey,
 			dsfs.SaveSwitches{},
 		)
 	})

--- a/lib/peers.go
+++ b/lib/peers.go
@@ -52,7 +52,9 @@ func (m *PeerMethods) List(p *PeerListParams, res *[]*config.ProfilePod) (err er
 		p.Limit = DefaultPageSize
 	}
 
-	*res, err = p2p.ListPeers(m.inst.node, p.Limit, p.Offset, !p.Cached)
+	// requesting user is hardcoded as node owner
+	u := m.inst.repo.Profiles().Owner()
+	*res, err = p2p.ListPeers(m.inst.node, u.ID, p.Offset, p.Limit, !p.Cached)
 	return err
 }
 

--- a/lib/profile.go
+++ b/lib/profile.go
@@ -88,12 +88,6 @@ func (m *ProfileMethods) getProfile(ctx context.Context, r repo.Repo, idStr, pee
 		}
 	}
 
-	// TODO - own profile should just be inside the profile store
-	profile, err := r.Owner()
-	if err == nil && profile.ID.String() == id.String() {
-		return profile, nil
-	}
-
 	return r.Profiles().GetProfile(id)
 }
 

--- a/lib/profile.go
+++ b/lib/profile.go
@@ -44,7 +44,7 @@ func (m *ProfileMethods) GetProfile(ctx context.Context, in *bool, res *config.P
 
 	// TODO - this is a carry-over from when GetProfile only supported getting
 	if res.ID == "" && res.Peername == "" {
-		pro, err = r.Profile(ctx)
+		pro = r.Profiles().Owner()
 	} else {
 		pro, err = m.getProfile(ctx, r, res.ID, res.Peername)
 	}
@@ -229,27 +229,25 @@ func (m *ProfileMethods) SetProfilePhoto(p *FileParams, res *config.ProfilePod) 
 	cfg.Set("profile.photo", path)
 	// TODO - resize photo for thumb
 	cfg.Set("profile.thumb", path)
-
-	pro, err := profile.NewProfile(cfg.Profile)
-	if err != nil {
+	if err := m.inst.ChangeConfig(cfg); err != nil {
 		return err
 	}
+
+	pro := r.Profiles().Owner()
+	pro.Photo = path
+	pro.Thumb = path
+
 	if err := r.Profiles().SetOwner(pro); err != nil {
 		return err
 	}
 
-	newPro, err := r.Profile(ctx)
-	if err != nil {
-		return fmt.Errorf("error getting newly set profile: %s", err)
-	}
-	pp, err := newPro.Encode()
+	pp, err := pro.Encode()
 	if err != nil {
 		return fmt.Errorf("error encoding new profile: %s", err)
 	}
 
 	*res = *pp
-
-	return m.inst.ChangeConfig(cfg)
+	return nil
 }
 
 // PosterPhoto fetches the byte slice of a given user's poster photo
@@ -313,32 +311,27 @@ func (m *ProfileMethods) SetPosterPhoto(p *FileParams, res *config.ProfilePod) e
 	path, err := r.Filesystem().DefaultWriteFS().Put(ctx, qfs.NewMemfileBytes("plz_just_encode", data))
 	if err != nil {
 		log.Debug(err.Error())
-
 		return fmt.Errorf("error saving photo: %s", err.Error())
 	}
 
 	res.Poster = path
 	cfg := m.inst.cfg.Copy()
 	cfg.Set("profile.poster", path)
-
-	pro, err := profile.NewProfile(cfg.Profile)
-	if err != nil {
+	if err := m.inst.ChangeConfig(cfg); err != nil {
 		return err
 	}
+
+	pro := r.Profiles().Owner()
+	pro.Poster = path
 	if err := r.Profiles().SetOwner(pro); err != nil {
 		return err
 	}
 
-	newPro, err := r.Profile(ctx)
-	if err != nil {
-		return fmt.Errorf("error getting newly set profile: %s", err)
-	}
-	pp, err := newPro.Encode()
+	pp, err := pro.Encode()
 	if err != nil {
 		return fmt.Errorf("error encoding new profile: %s", err)
 	}
 
 	*res = *pp
-
-	return m.inst.ChangeConfig(cfg)
+	return nil
 }

--- a/lib/profile_test.go
+++ b/lib/profile_test.go
@@ -222,11 +222,7 @@ func TestProfileRequestsSetPeername(t *testing.T) {
 
 	m := NewProfileMethods(inst)
 
-	pro, err := node.Repo.Profile(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	pro := node.Repo.Profiles().Owner()
 	pro.Peername = "keyboard_cat"
 	pp, err := pro.Encode()
 	if err != nil {

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -38,9 +38,9 @@ func (m RegistryClientMethods) CreateProfile(p *RegistryProfile, ok *bool) (err 
 		return checkRPCError(m.inst.rpc.Call("RegistryClientMethods.CreateProfile", p, ok))
 	}
 
-	ctx := context.TODO()
 	// TODO(arqu): this should take the profile PK instead of active PK once multi tenancy is supported
-	pro, err := m.inst.registry.CreateProfile(p, m.inst.repo.PrivateKey(ctx))
+	ownerPk := m.inst.repo.Profiles().Owner().PrivKey
+	pro, err := m.inst.registry.CreateProfile(p, ownerPk)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (m RegistryClientMethods) ProveProfileKey(p *RegistryProfile, ok *bool) err
 
 	// For signing the outgoing message
 	// TODO(arqu): this should take the profile PK instead of active PK once multi tenancy is supported
-	privKey := m.inst.repo.PrivateKey(ctx)
+	privKey := m.inst.repo.Profiles().Owner().PrivKey
 
 	// Get public key to send to server
 	pro := m.inst.repo.Profiles().Owner()

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -79,10 +79,7 @@ func (m RegistryClientMethods) ProveProfileKey(p *RegistryProfile, ok *bool) err
 	privKey := m.inst.repo.PrivateKey(ctx)
 
 	// Get public key to send to server
-	pro, err := m.inst.repo.Profile(ctx)
-	if err != nil {
-		return err
-	}
+	pro := m.inst.repo.Profiles().Owner()
 	pubkeybytes, err := pro.PubKey.Bytes()
 	if err != nil {
 		return err

--- a/p2p/list_peers.go
+++ b/p2p/list_peers.go
@@ -4,16 +4,14 @@ import (
 	"fmt"
 
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/profile"
 )
 
 // ListPeers lists Peers on the qri network
-func ListPeers(node *QriNode, limit, offset int, onlineOnly bool) ([]*config.ProfilePod, error) {
+// userID is the profile identifier of the user making the request
+func ListPeers(node *QriNode, userID profile.ID, offset, limit int, onlineOnly bool) ([]*config.ProfilePod, error) {
 
 	r := node.Repo
-	user, err := r.Owner()
-	if err != nil {
-		return nil, err
-	}
 
 	peers := make([]*config.ProfilePod, 0, limit)
 	connected := node.ConnectedQriProfiles()
@@ -42,7 +40,7 @@ func ListPeers(node *QriNode, limit, offset int, onlineOnly bool) ([]*config.Pro
 		if len(peers) >= limit {
 			break
 		}
-		if pro == nil || pro.ID == user.ID {
+		if pro == nil || pro.ID == userID {
 			continue
 		}
 

--- a/p2p/list_peers_test.go
+++ b/p2p/list_peers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	p2ptest "github.com/qri-io/qri/p2p/test"
+	"github.com/qri-io/qri/profile"
 )
 
 func TestListPeers(t *testing.T) {
@@ -19,7 +20,8 @@ func TestListPeers(t *testing.T) {
 		t.Fatalf("error connecting peers: %s", err.Error())
 	}
 
-	peers, err := ListPeers(testPeers[0].(*QriNode), 3, 2, false)
+	userID := profile.IDFromPeerID(testPeers[0].SimpleAddrInfo().ID)
+	peers, err := ListPeers(testPeers[0].(*QriNode), userID, 2, 3, false)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -122,7 +122,7 @@ func NewQriNode(r repo.Repo, p2pconf *config.P2P, pub event.Publisher, localReso
 		DisconnectedF: node.disconnected,
 	}
 
-	node.qis = NewQriProfileService(node.Repo, node.pub)
+	node.qis = NewQriProfileService(node.Repo.Profiles(), node.pub)
 	return node, nil
 }
 
@@ -209,12 +209,7 @@ func (n *QriNode) GoOnline(c context.Context) (err error) {
 		return err
 	}
 
-	p, err := n.Repo.Owner()
-	if err != nil {
-		log.Errorf("error getting repo profile: %s\n", err.Error())
-		cancel()
-		return err
-	}
+	p := n.Repo.Profiles().Owner()
 	p.PeerIDs = []peer.ID{n.host.ID()}
 
 	// update profile with our p2p addresses

--- a/p2p/p2p_deprecate.go
+++ b/p2p/p2p_deprecate.go
@@ -82,14 +82,11 @@ func (n *QriNode) handleProfile(ws *WrappedStream, msg Message) (hangup bool) {
 }
 
 func (n *QriNode) profileBytes() ([]byte, error) {
-	p, err := n.Repo.Owner()
-	if err != nil {
-		log.Debugf("error getting repo profile: %s\n", err.Error())
-		return nil, err
-	}
+	p := n.Repo.Profiles().Owner()
+
 	pod, err := p.Encode()
 	if err != nil {
-		log.Debugf("error encoding repo profile: %s\n", err.Error())
+		log.Debugf("error encoding profile.Owner profile: %s\n", err.Error())
 		return nil, err
 	}
 

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -78,10 +78,7 @@ func writeWorldBankPopulation(ctx context.Context, t *testing.T, r repo.Repo) re
 		t.Fatal(err)
 	}
 
-	pro, err := r.Owner()
-	if err != nil {
-		t.Fatal(err)
-	}
+	pro := r.Profiles().Owner()
 
 	return reporef.DatasetRef{
 		Peername:  pro.Peername,

--- a/p2p/test/testable_node_test.go
+++ b/p2p/test/testable_node_test.go
@@ -57,18 +57,13 @@ func (n *TestableNode) TestStreamHandler(s net.Stream) {
 // GoOnline assumes the TestNode is not online, it will set
 // the StreamHandler and updates our profile with the underlying peerIDs
 func (n *TestableNode) GoOnline(_ context.Context) error {
-	// use a separate context
-	ctx := context.Background()
 	// add multistream handler for qri protocol to the host
 	// for more info on multistreams check github.com/multformats/go-multistream
 	// Setting the StreamHandler with the TestQriProtocol will let other peers
 	// know that we can speak the TestQriProtocol
 	n.Host().SetStreamHandler(TestQriProtocolID, n.TestStreamHandler)
 
-	p, err := n.Repo.Profile(ctx)
-	if err != nil {
-		return fmt.Errorf("error getting repo profile: %s", err.Error())
-	}
+	p := n.Repo.Profiles().Owner()
 	p.PeerIDs = []peer.ID{n.host.ID()}
 
 	// update profile with our p2p addresses

--- a/remote/client.go
+++ b/remote/client.go
@@ -127,10 +127,7 @@ func NewClient(ctx context.Context, node *p2p.QriNode, pub event.Publisher) (c C
 		})
 	}
 
-	pro, err := node.Repo.Profile(ctx)
-	if err != nil {
-		log.Debug("cannot get profile from repo, need username for access control on the remote to function")
-	}
+	pro := node.Repo.Profiles().Owner()
 
 	cli := &client{
 		pk:      node.Repo.PrivateKey(ctx),

--- a/remote/client.go
+++ b/remote/client.go
@@ -130,7 +130,7 @@ func NewClient(ctx context.Context, node *p2p.QriNode, pub event.Publisher) (c C
 	pro := node.Repo.Profiles().Owner()
 
 	cli := &client{
-		pk:      node.Repo.PrivateKey(ctx),
+		pk:      node.Repo.Profiles().Owner().PrivKey,
 		profile: pro,
 		ds:      ds,
 		logsync: ls,
@@ -729,7 +729,7 @@ func addressType(remoteAddr string) string {
 }
 
 func (c *client) signHTTPRequest(ctx context.Context, req *http.Request) error {
-	pk := c.node.Repo.PrivateKey(ctx)
+	pk := c.node.Repo.Profiles().Owner().PrivKey
 	now := fmt.Sprintf("%d", nowFunc().In(time.UTC).Unix())
 
 	// TODO (b5) - we shouldn't be calculating profile IDs here

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -153,11 +153,6 @@ func (r *Repo) Profile(ctx context.Context) (*profile.Profile, error) {
 	return r.profiles.Active(ctx), nil
 }
 
-// Owner returns the owner profile for this repository
-func (r *Repo) Owner() (*profile.Profile, error) {
-	return r.profiles.Owner(), nil
-}
-
 // Logbook stores operation logs for coordinating state across peers
 func (r *Repo) Logbook() *logbook.Book {
 	return r.logbook

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -148,11 +148,6 @@ func (r *Repo) SetFilesystem(fs *muxfs.Mux) {
 	r.fsys = fs
 }
 
-// Profile gives this repo's peer profile
-func (r *Repo) Profile(ctx context.Context) (*profile.Profile, error) {
-	return r.profiles.Active(ctx), nil
-}
-
 // Logbook stores operation logs for coordinating state across peers
 func (r *Repo) Logbook() *logbook.Book {
 	return r.logbook

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	golog "github.com/ipfs/go-log"
-	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/qri-io/qfs/muxfs"
 	"github.com/qri-io/qri/dscache"
 	"github.com/qri-io/qri/dsref"
@@ -156,11 +155,6 @@ func (r *Repo) Logbook() *logbook.Book {
 // Dscache returns a dscache
 func (r *Repo) Dscache() *dscache.Dscache {
 	return r.dscache
-}
-
-// PrivateKey returns this repo's private key
-func (r *Repo) PrivateKey(ctx context.Context) crypto.PrivKey {
-	return r.profiles.Active(ctx).PrivKey
 }
 
 // Profiles returns this repo's Peers implementation

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -163,11 +163,6 @@ func (r *MemRepo) Profile(ctx context.Context) (*profile.Profile, error) {
 	return r.profiles.Active(ctx), nil
 }
 
-// Owner returns the owner profile for this repository
-func (r *MemRepo) Owner() (*profile.Profile, error) {
-	return r.profiles.Owner(), nil
-}
-
 // Profiles gives this repo's Peer interface implementation
 func (r *MemRepo) Profiles() profile.Store {
 	return r.profiles

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -158,11 +158,6 @@ func (r *MemRepo) RefCache() Refstore {
 	return r.refCache
 }
 
-// Profile returns the peer profile for this repository
-func (r *MemRepo) Profile(ctx context.Context) (*profile.Profile, error) {
-	return r.profiles.Active(ctx), nil
-}
-
 // Profiles gives this repo's Peer interface implementation
 func (r *MemRepo) Profiles() profile.Store {
 	return r.profiles

--- a/repo/mem_repo.go
+++ b/repo/mem_repo.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	crypto "github.com/libp2p/go-libp2p-core/crypto"
-
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/muxfs"
 	"github.com/qri-io/qri/auth/key"
@@ -146,11 +144,6 @@ func (r *MemRepo) SetLogbook(book *logbook.Book) {
 // SetFilesystem implements QFSSetter, currently used during lib contstruction
 func (r *MemRepo) SetFilesystem(fs *muxfs.Mux) {
 	r.filesystem = fs
-}
-
-// PrivateKey returns this repo's private key
-func (r *MemRepo) PrivateKey(ctx context.Context) crypto.PrivKey {
-	return r.profiles.Active(ctx).PrivKey
 }
 
 // RefCache gives access to the ephemeral Refstore

--- a/repo/refstore.go
+++ b/repo/refstore.go
@@ -163,10 +163,7 @@ func CanonicalizeProfile(ctx context.Context, r Repo, ref *reporef.DatasetRef) e
 		return nil
 	}
 
-	p, err := r.Profile(ctx)
-	if err != nil {
-		return err
-	}
+	p := r.Profiles().Owner()
 
 	// If this is a dataset ref that a peer of the user owns.
 	if ref.Peername == "me" || ref.Peername == p.Peername || ref.ProfileID == p.ID {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -84,8 +84,6 @@ type Repo interface {
 	// A repository must maintain profile information about the active profile of this dataset.
 	// The value returned by Profile() should represent the peer.
 	Profile(ctx context.Context) (*profile.Profile, error)
-	// A repository maintains the profile information of the owner
-	Owner() (*profile.Profile, error)
 	// PrivateKey hands over this repo's private key
 	PrivateKey(ctx context.Context) crypto.PrivKey
 	// A repository must maintain profile information about encountered peers.

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -4,11 +4,9 @@
 package repo
 
 import (
-	"context"
 	"fmt"
 
 	golog "github.com/ipfs/go-log"
-	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qfs/muxfs"
 	"github.com/qri-io/qri/dscache"
@@ -81,8 +79,6 @@ type Repo interface {
 	// Repos have a logbook for recording & storing operation logs
 	Logbook() *logbook.Book
 
-	// PrivateKey hands over this repo's private key
-	PrivateKey(ctx context.Context) crypto.PrivKey
 	// A repository must maintain profile information about encountered peers.
 	// Decsisions regarding retentaion of peers is left to the the implementation
 	Profiles() profile.Store

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -81,9 +81,6 @@ type Repo interface {
 	// Repos have a logbook for recording & storing operation logs
 	Logbook() *logbook.Book
 
-	// A repository must maintain profile information about the active profile of this dataset.
-	// The value returned by Profile() should represent the peer.
-	Profile(ctx context.Context) (*profile.Profile, error)
 	// PrivateKey hands over this repo's private key
 	PrivateKey(ctx context.Context) crypto.PrivKey
 	// A repository must maintain profile information about encountered peers.

--- a/repo/test/spec/test.go
+++ b/repo/test/spec/test.go
@@ -6,7 +6,6 @@
 package spec
 
 import (
-	"context"
 	"testing"
 
 	"github.com/qri-io/qri/repo"
@@ -23,7 +22,6 @@ type repoTestFunc func(t *testing.T, rm RepoMakerFunc)
 // RunRepoTests tests that this repo conforms to expected behaviors
 func RunRepoTests(t *testing.T, rmf RepoMakerFunc) {
 	tests := map[string]repoTestFunc{
-		"testProfile":             testProfile,
 		"testRefstoreInvalidRefs": testRefstoreInvalidRefs,
 		"testRefstoreRefs":        testRefstoreRefs,
 		"testRefstore":            testRefstoreMain,
@@ -35,24 +33,4 @@ func RunRepoTests(t *testing.T, rmf RepoMakerFunc) {
 			test(t, rmf)
 		})
 	}
-}
-
-func testProfile(t *testing.T, rmf RepoMakerFunc) {
-	r, cleanup := rmf(t)
-	defer cleanup()
-	ctx := context.Background()
-
-	p, err := r.Profile(ctx)
-	if err != nil {
-		t.Errorf("%s", string(p.ID))
-		t.Errorf("Unexpected Profile error: %s", err.Error())
-		return
-	}
-
-	err = r.Profiles().SetOwner(p)
-	if err != nil {
-		t.Errorf("Unexpected SetProfile error: %s", err.Error())
-		return
-	}
-
 }

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -189,7 +189,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 	var (
 		ctx = context.Background()
 		ds  = tc.Input
-		pro *profile.Profile
+		pro = r.Profiles().Owner()
 		// NOTE - struct fields need to be instantiated to make assign set to
 		// new pointer values
 		userSet = &dataset.Dataset{
@@ -201,12 +201,8 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 		}
 		path    string
 		resBody qfs.File
+		dsName  = ds.Name
 	)
-	pro, err = r.Profile(ctx)
-	if err != nil {
-		return
-	}
-	dsName := ds.Name
 
 	userSet.Assign(ds)
 

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -214,7 +214,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 
 	sw := dsfs.SaveSwitches{Pin: true, ShouldRender: true}
 	fs := r.Filesystem()
-	if path, err = dsfs.CreateDataset(ctx, fs, fs.DefaultWriteFS(), r.Bus(), ds, nil, r.PrivateKey(ctx), sw); err != nil {
+	if path, err = dsfs.CreateDataset(ctx, fs, fs.DefaultWriteFS(), r.Bus(), ds, nil, pro.PrivKey, sw); err != nil {
 		return
 	}
 	if ds.PreviousPath != "" && ds.PreviousPath != "/" {

--- a/sql/qds/datasource_test.go
+++ b/sql/qds/datasource_test.go
@@ -109,7 +109,7 @@ func (tr *testRunner) MustRun(t *testing.T, query string, cfg *octocfg.Config) s
 }
 
 func (tr *testRunner) loadDatasetFunc() dsref.ParseResolveLoad {
-	pro, _ := tr.repo.Profile(tr.ctx)
+	pro := tr.repo.Profiles().Owner()
 	loader := base.NewLocalDatasetLoader(tr.repo.Filesystem())
 	return newParseResolveLoadFunc(pro.Peername, tr.repo, loader)
 }


### PR DESCRIPTION
builds on #1647

centralize all repo access around the `Profiles()` method that returns a profile store