### PR TITLE
refactor(list): RPC > HTTP for raw refs

### DIFF
--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io/ioutil"
@@ -77,7 +78,7 @@ func TestHTTPClient(t *testing.T) {
 	httpClient.Address = sURL.Host
 	httpClient.Protocol = "http"
 
-	err = httpClient.CallRaw(ctx, lib.AEHome, nil, []byte{})
+	err = httpClient.CallRaw(ctx, lib.AEHome, nil, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -95,13 +95,14 @@ func (o *ListOptions) Complete(f Factory, args []string) (err error) {
 func (o *ListOptions) Run() (err error) {
 	// convert Page and PageSize to Limit and Offset
 	page := apiutil.NewPage(o.Page, o.PageSize)
+	ctx := context.TODO()
 
 	if o.Raw {
-		var text string
 		p := &lib.ListParams{
 			UseDscache: o.UseDscache,
 		}
-		if err = o.DatasetMethods.ListRawRefs(p, &text); err != nil {
+		text, err := o.DatasetMethods.ListRawRefs(ctx, p)
+		if err != nil {
 			return err
 		}
 		printSuccess(o.Out, text)
@@ -118,7 +119,6 @@ func (o *ListOptions) Run() (err error) {
 		EnsureFSIExists: true,
 		UseDscache:      o.UseDscache,
 	}
-	ctx := context.TODO()
 	infos, err := o.DatasetMethods.List(ctx, p)
 	if err != nil {
 		if errors.Is(err, lib.ErrListWarning) {

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -1248,8 +1248,8 @@ func TestListRawRefs(t *testing.T) {
 	inst := NewInstanceFromConfigAndNode(ctx, config.DefaultConfigForTesting(), node)
 	m := NewDatasetMethods(inst)
 
-	var text string
-	if err := m.ListRawRefs(&ListParams{}, &text); err != nil {
+	text, err := m.ListRawRefs(ctx, &ListParams{})
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/http.go
+++ b/lib/http.go
@@ -126,7 +126,11 @@ func (c HTTPClient) do(ctx context.Context, addr string, httpMethod string, mime
 		if res.StatusCode < 200 && res.StatusCode > 299 {
 			return fmt.Errorf("HTTPClient req error: %d - %q", res.StatusCode, body)
 		}
-		result = body
+		if buf, ok := result.(*bytes.Buffer); ok {
+			buf.Write(body)
+		} else {
+			return fmt.Errorf("HTTPClient raw interface is not a byte buffer")
+		}
 		return nil
 	}
 

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -36,8 +36,8 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	}
 
 	p := &ListParams{}
-	refs := ""
-	if err := NewDatasetMethods(tr.RegistryInst).ListRawRefs(p, &refs); err != nil {
+	refs, err := NewDatasetMethods(tr.RegistryInst).ListRawRefs(tr.Ctx, p)
+	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(refs)
@@ -69,7 +69,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 
 	// 7. hinshun logsyncs with the registry for world bank dataset, sees multiple versions
 	dsm := NewDatasetMethods(hinshun)
-	_, err := dsm.Pull(tr.Ctx, &PullParams{LogsOnly: true, Ref: ref.String()})
+	_, err = dsm.Pull(tr.Ctx, &PullParams{LogsOnly: true, Ref: ref.String()})
 	if err != nil {
 		t.Errorf("cloning logs: %s", err)
 	}

--- a/lib/params.go
+++ b/lib/params.go
@@ -44,8 +44,8 @@ type ListParams struct {
 	// UseDscache controls whether to build a dscache to use to list the references
 	UseDscache bool
 
-	// Proxy identifies whether a call has been proxied from another instance
-	Proxy bool
+	// Raw indicates whether to return a raw string representation of a dataset list
+	Raw bool
 }
 
 // SetNonZeroDefaults sets OrderBy to "created" if it's value is the empty string
@@ -58,6 +58,14 @@ func (p *ListParams) SetNonZeroDefaults() {
 // UnmarshalFromRequest implements a custom deserialization-from-HTTP request
 func (p *ListParams) UnmarshalFromRequest(r *http.Request) error {
 	lp := ListParamsFromRequest(r)
+	if p == nil {
+		p = &ListParams{}
+	}
+	if !p.Raw {
+		lp.Raw = r.FormValue("raw") == "true"
+	} else {
+		lp.Raw = p.Raw
+	}
 	*p = lp
 	return nil
 }


### PR DESCRIPTION
Merged listRawRefs into the list API and converted from RPC to HTTP along with some bug fixes.