### PR TITLE
lib.NewRequestHandler removes boilerplate from api package

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,17 +2,13 @@
 package api
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/gorilla/schema"
 	golog "github.com/ipfs/go-log"
 	apiutil "github.com/qri-io/qri/api/util"
 	"github.com/qri-io/qri/auth/token"
@@ -31,7 +27,6 @@ const (
 	DefaultTemplateHash = "/ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw"
 	// TemplateUpdateAddress is the URI for the template update
 	TemplateUpdateAddress = "/ipns/defaulttmpl.qri.io"
-	jsonContentType       = "application/json"
 )
 
 func init() {
@@ -254,64 +249,4 @@ func NewServerRoutes(s Server) *mux.Router {
 	m.Use(token.OAuthTokenMiddleware)
 
 	return m
-}
-
-// snoop reads from an io.ReadCloser and restores it so it can be read again
-func snoop(body *io.ReadCloser) (io.ReadCloser, error) {
-	if body != nil && *body != nil {
-		result, err := ioutil.ReadAll(*body)
-		(*body).Close()
-
-		if err != nil {
-			return nil, err
-		}
-		if len(result) == 0 {
-			return nil, io.EOF
-		}
-
-		*body = ioutil.NopCloser(bytes.NewReader(result))
-		return ioutil.NopCloser(bytes.NewReader(result)), nil
-	}
-	return nil, io.EOF
-}
-
-var decoder = schema.NewDecoder()
-
-// UnmarshalParams deserialzes a lib req params stuct pointer from an HTTP
-// request
-func UnmarshalParams(r *http.Request, p interface{}) error {
-	// TODO(arqu): once APIs have a strict mapping to Params this line
-	// should be removed and should error out on unknown keys
-	decoder.IgnoreUnknownKeys(true)
-	defer func() {
-		if defSetter, ok := p.(lib.NZDefaultSetter); ok {
-			defSetter.SetNonZeroDefaults()
-		}
-	}()
-
-	if r.Method == http.MethodPost || r.Method == http.MethodPut {
-
-		if r.Header.Get("Content-Type") == jsonContentType {
-			body, err := snoop(&r.Body)
-			if err != nil && err != io.EOF {
-				return err
-			}
-			// this avoids resolving on empty body requests
-			// and tries to handle it almost like a GET
-			if err != io.EOF {
-				if err := json.NewDecoder(body).Decode(p); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	if ru, ok := p.(lib.RequestUnmarshaller); ok {
-		return ru.UnmarshalFromRequest(r)
-	}
-
-	if err := r.ParseForm(); err != nil {
-		return err
-	}
-	return decoder.Decode(p, r.Form)
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -251,7 +251,6 @@ func TestServerReadOnlyRoutes(t *testing.T) {
 		{"POST", "/registry/profile/new", 403},
 		{"POST", "/registry/profile/prove", 403},
 		{"GET", "/checkout/", 403},
-		{"GET", "/status/", 403},
 		{"GET", "/init/", 403},
 
 		// active endpoints:

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -216,7 +216,7 @@ func extensionToMimeType(ext string) string {
 
 func (h *DatasetHandlers) listHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.ListParams{}
-	if err := UnmarshalParams(r, params); err != nil {
+	if err := lib.UnmarshalParams(r, params); err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
 	}
@@ -255,7 +255,7 @@ func (h *DatasetHandlers) listHandler(w http.ResponseWriter, r *http.Request) {
 func (h *DatasetHandlers) getHandler(w http.ResponseWriter, r *http.Request) {
 	params := lib.GetParams{}
 
-	err := UnmarshalParams(r, &params)
+	err := lib.UnmarshalParams(r, &params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -350,7 +350,7 @@ func (h *DatasetHandlers) replyWithGetResponse(w http.ResponseWriter, r *http.Re
 
 func (h *DatasetHandlers) diffHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.DiffParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -369,7 +369,7 @@ func (h *DatasetHandlers) diffHandler(w http.ResponseWriter, r *http.Request) {
 func (h *DatasetHandlers) changesHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.ChangeReportParams{}
 
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -420,7 +420,7 @@ func (h *DatasetHandlers) peerListHandler(w http.ResponseWriter, r *http.Request
 
 func (h *DatasetHandlers) pullHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.PullParams{}
-	if err := UnmarshalParams(r, params); err != nil {
+	if err := lib.UnmarshalParams(r, params); err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
 	}
@@ -442,7 +442,7 @@ func (h *DatasetHandlers) pullHandler(w http.ResponseWriter, r *http.Request) {
 
 func (h *DatasetHandlers) saveHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.SaveParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		log.Debugw("unmarshal dataset save error", "err", err)
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
@@ -475,7 +475,7 @@ func (h *DatasetHandlers) saveHandler(w http.ResponseWriter, r *http.Request) {
 
 func (h *DatasetHandlers) removeHandler(w http.ResponseWriter, r *http.Request) {
 	params := lib.RemoveParams{}
-	err := UnmarshalParams(r, &params)
+	err := lib.UnmarshalParams(r, &params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -508,7 +508,7 @@ func (h *DatasetHandlers) removeHandler(w http.ResponseWriter, r *http.Request) 
 
 func (h DatasetHandlers) validateHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.ValidateParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -526,7 +526,7 @@ func (h DatasetHandlers) validateHandler(w http.ResponseWriter, r *http.Request)
 
 func (h DatasetHandlers) renameHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.RenameParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -570,7 +570,7 @@ func (h DatasetHandlers) unpackHandler(w http.ResponseWriter, r *http.Request, p
 
 func (h DatasetHandlers) manifestHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.ManifestParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -588,7 +588,7 @@ func (h DatasetHandlers) manifestHandler(w http.ResponseWriter, r *http.Request)
 
 func (h DatasetHandlers) manifestMissingHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.ManifestMissingParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -606,7 +606,7 @@ func (h DatasetHandlers) manifestMissingHandler(w http.ResponseWriter, r *http.R
 
 func (h DatasetHandlers) dagInfoHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.DAGInfoParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return

--- a/api/datasets_test.go
+++ b/api/datasets_test.go
@@ -302,7 +302,7 @@ func TestParseGetParams(t *testing.T) {
 			}
 			setRefStringFromMuxVars(r)
 			args := &lib.GetParams{}
-			err := UnmarshalParams(r, args)
+			err := lib.UnmarshalParams(r, args)
 			if err != nil {
 				t.Error(err)
 				return
@@ -340,7 +340,7 @@ func TestParseGetParams(t *testing.T) {
 			}
 			setRefStringFromMuxVars(r)
 			args := &lib.GetParams{}
-			err := UnmarshalParams(r, args)
+			err := lib.UnmarshalParams(r, args)
 			if err == nil {
 				t.Errorf("case %d: expected error, but did not get one", i)
 				return
@@ -359,7 +359,7 @@ func TestParseGetParamsAcceptHeader(t *testing.T) {
 	r = mux.SetURLVars(r, map[string]string{"peername": "peer", "name": "my_ds"})
 	setRefStringFromMuxVars(r)
 	args := &lib.GetParams{}
-	err := UnmarshalParams(r, args)
+	err := lib.UnmarshalParams(r, args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,7 +380,7 @@ func TestParseGetParamsAcceptHeader(t *testing.T) {
 	r = mux.SetURLVars(r, map[string]string{"peername": "peer", "name": "my_ds"})
 	setRefStringFromMuxVars(r)
 	args = &lib.GetParams{}
-	err = UnmarshalParams(r, args)
+	err = lib.UnmarshalParams(r, args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +394,7 @@ func TestParseGetParamsAcceptHeader(t *testing.T) {
 	r = mux.SetURLVars(r, map[string]string{"peername": "peer", "name": "my_ds"})
 	setRefStringFromMuxVars(r)
 	args = &lib.GetParams{}
-	err = UnmarshalParams(r, args)
+	err = lib.UnmarshalParams(r, args)
 	if err == nil {
 		t.Error("expected to get an error, but did not get one")
 	}

--- a/api/fsi.go
+++ b/api/fsi.go
@@ -58,7 +58,7 @@ func (h *FSIHandlers) statusHandler(routePrefix string) http.HandlerFunc {
 			return
 		}
 
-		if err := UnmarshalParams(r, p); err != nil {
+		if err := lib.UnmarshalParams(r, p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
@@ -97,7 +97,7 @@ func (h *FSIHandlers) whatChangedHandler(routePrefix string) http.HandlerFunc {
 		method := "fsi.whatchanged"
 		p := h.inst.NewInputParam(method)
 
-		if err := UnmarshalParams(r, p); err != nil {
+		if err := lib.UnmarshalParams(r, p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
@@ -136,7 +136,7 @@ func (h *FSIHandlers) initHandler(routePrefix string) http.HandlerFunc {
 		method := "fsi.init"
 		p := h.inst.NewInputParam(method)
 
-		if err := UnmarshalParams(r, p); err != nil {
+		if err := lib.UnmarshalParams(r, p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
@@ -175,7 +175,7 @@ func (h *FSIHandlers) canInitDatasetWorkDirHandler(routePrefix string) http.Hand
 		method := "fsi.caninitdatasetworkdir"
 		p := h.inst.NewInputParam(method)
 
-		if err := UnmarshalParams(r, p); err != nil {
+		if err := lib.UnmarshalParams(r, p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
@@ -213,7 +213,7 @@ func (h *FSIHandlers) writeHandler(routePrefix string) http.HandlerFunc {
 		method := "fsi.write"
 		p := h.inst.NewInputParam(method)
 
-		// TODO(dustmop): Add this to UnmarshalParams for methods that can
+		// TODO(dustmop): Add this to lib.UnmarshalParams for methods that can
 		// receive a refstr in the URL, or annotate the param struct with
 		// a tag and marshal the url to that field
 		err := addDsRefFromURL(r, routePrefix)
@@ -222,7 +222,7 @@ func (h *FSIHandlers) writeHandler(routePrefix string) http.HandlerFunc {
 			return
 		}
 
-		if err := UnmarshalParams(r, p); err != nil {
+		if err := lib.UnmarshalParams(r, p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
@@ -260,7 +260,7 @@ func (h *FSIHandlers) createLinkHandler(routePrefix string) http.HandlerFunc {
 		method := "fsi.createlink"
 		p := h.inst.NewInputParam(method)
 
-		// TODO(dustmop): Add this to UnmarshalParams for methods that can
+		// TODO(dustmop): Add this to lib.UnmarshalParams for methods that can
 		// receive a refstr in the URL, or annotate the param struct with
 		// a tag and marshal the url to that field
 		err := addDsRefFromURL(r, routePrefix)
@@ -269,7 +269,7 @@ func (h *FSIHandlers) createLinkHandler(routePrefix string) http.HandlerFunc {
 			return
 		}
 
-		if err := UnmarshalParams(r, p); err != nil {
+		if err := lib.UnmarshalParams(r, p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
@@ -307,7 +307,7 @@ func (h *FSIHandlers) unlinkHandler(routePrefix string) http.HandlerFunc {
 		method := "fsi.unlink"
 		p := h.inst.NewInputParam(method)
 
-		// TODO(dustmop): Add this to UnmarshalParams for methods that can
+		// TODO(dustmop): Add this to lib.UnmarshalParams for methods that can
 		// receive a refstr in the URL, or annotate the param struct with
 		// a tag and marshal the url to that field
 		err := addDsRefFromURL(r, routePrefix)
@@ -316,7 +316,7 @@ func (h *FSIHandlers) unlinkHandler(routePrefix string) http.HandlerFunc {
 			return
 		}
 
-		if err := UnmarshalParams(r, p); err != nil {
+		if err := lib.UnmarshalParams(r, p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
@@ -354,7 +354,7 @@ func (h *FSIHandlers) checkoutHandler(routePrefix string) http.HandlerFunc {
 		method := "fsi.checkout"
 		p := h.inst.NewInputParam(method)
 
-		// TODO(dustmop): Add this to UnmarshalParams for methods that can
+		// TODO(dustmop): Add this to lib.UnmarshalParams for methods that can
 		// receive a refstr in the URL, or annotate the param struct with
 		// a tag and marshal the url to that field
 		err := addDsRefFromURL(r, routePrefix)
@@ -363,7 +363,7 @@ func (h *FSIHandlers) checkoutHandler(routePrefix string) http.HandlerFunc {
 			return
 		}
 
-		if err := UnmarshalParams(r, p); err != nil {
+		if err := lib.UnmarshalParams(r, p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
@@ -401,7 +401,7 @@ func (h *FSIHandlers) restoreHandler(routePrefix string) http.HandlerFunc {
 		method := "fsi.restore"
 		p := h.inst.NewInputParam(method)
 
-		// TODO(dustmop): Add this to UnmarshalParams for methods that can
+		// TODO(dustmop): Add this to lib.UnmarshalParams for methods that can
 		// receive a refstr in the URL, or annotate the param struct with
 		// a tag and marshal the url to that field
 		err := addDsRefFromURL(r, routePrefix)
@@ -410,7 +410,7 @@ func (h *FSIHandlers) restoreHandler(routePrefix string) http.HandlerFunc {
 			return
 		}
 
-		if err := UnmarshalParams(r, p); err != nil {
+		if err := lib.UnmarshalParams(r, p); err != nil {
 			util.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}

--- a/api/fsi.go
+++ b/api/fsi.go
@@ -25,54 +25,6 @@ func NewFSIHandlers(inst *lib.Instance, readOnly bool) FSIHandlers {
 	}
 }
 
-// StatusHandler is the endpoint for getting the status of a linked dataset
-func (h *FSIHandlers) StatusHandler(routePrefix string) http.HandlerFunc {
-	handleStatus := h.statusHandler(routePrefix)
-
-	return func(w http.ResponseWriter, r *http.Request) {
-		if h.ReadOnly {
-			readOnlyResponse(w, routePrefix)
-			return
-		}
-
-		switch r.Method {
-		case http.MethodGet, http.MethodPost:
-			handleStatus(w, r)
-		default:
-			util.NotFoundHandler(w, r)
-		}
-	}
-}
-
-func (h *FSIHandlers) statusHandler(routePrefix string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		method := "fsi.status"
-		p := h.inst.NewInputParam(method)
-
-		// TODO(dustmop): Add this to UnmarshalParams for methods that can
-		// receive a refstr in the URL, or annotate the param struct with
-		// a tag and marshal the url to that field
-		err := addDsRefFromURL(r, routePrefix)
-		if err != nil {
-			util.WriteErrResponse(w, http.StatusBadRequest, err)
-			return
-		}
-
-		if err := lib.UnmarshalParams(r, p); err != nil {
-			util.WriteErrResponse(w, http.StatusBadRequest, err)
-			return
-		}
-
-		res, _, err := h.inst.Dispatch(r.Context(), method, p)
-		if err != nil {
-			util.RespondWithError(w, err)
-			return
-		}
-		util.WriteResponse(w, res)
-		return
-	}
-}
-
 // WhatChangedHandler is the endpoint for showing what changed for a specific commit
 func (h *FSIHandlers) WhatChangedHandler(routePrefix string) http.HandlerFunc {
 	handleStatus := h.whatChangedHandler(routePrefix)

--- a/api/log.go
+++ b/api/log.go
@@ -65,7 +65,7 @@ func (h *LogHandlers) LogbookSummaryHandler(w http.ResponseWriter, r *http.Reque
 
 func (h *LogHandlers) logHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.LogParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -94,7 +94,7 @@ func (h *LogHandlers) logHandler(w http.ResponseWriter, r *http.Request) {
 
 func (h *LogHandlers) logbookHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.RefListParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -111,7 +111,7 @@ func (h *LogHandlers) logbookHandler(w http.ResponseWriter, r *http.Request) {
 
 func (h *LogHandlers) plainLogsHandler(w http.ResponseWriter, r *http.Request) {
 	params := &lib.PlainLogsParams{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
@@ -128,7 +128,7 @@ func (h *LogHandlers) plainLogsHandler(w http.ResponseWriter, r *http.Request) {
 
 func (h *LogHandlers) logbookSummaryHandler(w http.ResponseWriter, r *http.Request) {
 	params := &struct{}{}
-	err := UnmarshalParams(r, params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return

--- a/lib/api.go
+++ b/lib/api.go
@@ -107,7 +107,7 @@ const (
 	// fsi endpoints
 
 	// AEStatus returns the filesystem dataset status
-	AEStatus = APIEndpoint("/status/{path:.*}")
+	AEStatus = APIEndpoint("/status")
 	// AEWhatChanged returns what changed for a specific commit
 	AEWhatChanged = APIEndpoint("/whatchanged/{path:.*}")
 	// AEInit invokes a dataset initialization on the filesystem

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -36,6 +37,13 @@ func (inst *Instance) Filesys() *FSIMethods {
 type LinkParams struct {
 	Dir    string
 	Refstr string
+}
+
+// UnmarshalFromRequest implements a custom deserialization-from-HTTP request
+func (p *LinkParams) UnmarshalFromRequest(r *http.Request) error {
+	p.Refstr = r.FormValue("refstr")
+	p.Dir = r.FormValue("dir")
+	return nil
 }
 
 // FSIWriteParams encapsultes arguments for writing to an FSI-linked directory

--- a/lib/http.go
+++ b/lib/http.go
@@ -200,11 +200,11 @@ func (c HTTPClient) checkError(res *http.Response, body []byte, raw bool) error 
 
 // NewHTTPRequestHandler creates a JSON-API endpoint for a registered dispatch
 // method
-func NewHTTPRequestHandler(inst *Instance, method string, ae APIEndpoint) http.HandlerFunc {
+func NewHTTPRequestHandler(inst *Instance, libMethod string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		p := inst.NewInputParam(method)
+		p := inst.NewInputParam(libMethod)
 		if p == nil {
-			apiutil.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("no params for method %s", method))
+			apiutil.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("no params for method %s", libMethod))
 			return
 		}
 
@@ -214,7 +214,7 @@ func NewHTTPRequestHandler(inst *Instance, method string, ae APIEndpoint) http.H
 			return
 		}
 
-		res, cursor, err := inst.Dispatch(r.Context(), method, p)
+		res, cursor, err := inst.Dispatch(r.Context(), libMethod, p)
 		if err != nil {
 			apiutil.WriteErrResponse(w, http.StatusInternalServerError, err)
 			return

--- a/lib/http.go
+++ b/lib/http.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
+	"github.com/gorilla/schema"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 	apiutil "github.com/qri-io/qri/api/util"
@@ -19,6 +21,15 @@ import (
 var ErrUnsupportedRPC = errors.New("Warning: method is not suported over RPC")
 
 const jsonMimeType = "application/json"
+
+// decoder maps HTTP requests to input structs
+var decoder = schema.NewDecoder()
+
+func init() {
+	// TODO(arqu): once APIs have a strict mapping to Params this line
+	// should be removed and should error out on unknown keys
+	decoder.IgnoreUnknownKeys(true)
+}
 
 // HTTPClient implements the qri http client
 type HTTPClient struct {
@@ -185,4 +196,93 @@ func (c HTTPClient) checkError(res *http.Response, body []byte, raw bool) error 
 		return fmt.Errorf(string(body))
 	}
 	return nil
+}
+
+// NewHTTPRequestHandler creates a JSON-API endpoint for a registered dispatch
+// method
+func NewHTTPRequestHandler(inst *Instance, method string, ae APIEndpoint) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p := inst.NewInputParam(method)
+		if p == nil {
+			apiutil.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("no params for method %s", method))
+			return
+		}
+
+		if err := UnmarshalParams(r, p); err != nil {
+			log.Debugw("unmarshal request params", "err", err)
+			apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
+			return
+		}
+
+		res, cursor, err := inst.Dispatch(r.Context(), method, p)
+		if err != nil {
+			apiutil.WriteErrResponse(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		if cursor != nil {
+			apiutil.WritePageResponse(w, res, r, apiutil.PageFromRequest(r))
+			return
+		}
+
+		apiutil.WriteResponse(w, res)
+	}
+}
+
+// UnmarshalParams deserialzes a lib req params stuct pointer from an HTTP
+// request
+//
+// Deprecated: This is only exported for one-off handlers in the API package
+// can make use of it. Prefer refactoring to use NewHTTPRequestHandler instead.
+// once all callers in the api package are removed, unexport this function.
+func UnmarshalParams(r *http.Request, p interface{}) error {
+	defer func() {
+		if defSetter, ok := p.(NZDefaultSetter); ok {
+			defSetter.SetNonZeroDefaults()
+		}
+	}()
+
+	if r.Method == http.MethodPost || r.Method == http.MethodPut {
+		if r.Header.Get("Content-Type") == jsonMimeType {
+			body, err := snoop(&r.Body)
+			if err != nil && err != io.EOF {
+				return err
+			}
+			// this avoids resolving on empty body requests
+			// and tries to handle it almost like a GET
+			if err != io.EOF {
+				if err := json.NewDecoder(body).Decode(p); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if ru, ok := p.(RequestUnmarshaller); ok {
+		return ru.UnmarshalFromRequest(r)
+	}
+
+	if err := r.ParseForm(); err != nil {
+		return err
+	}
+	return decoder.Decode(p, r.Form)
+}
+
+// snoop reads from an io.ReadCloser and restores it so it can be read again
+func snoop(body *io.ReadCloser) (io.ReadCloser, error) {
+	if body != nil && *body != nil {
+		result, err := ioutil.ReadAll(*body)
+		(*body).Close()
+
+		if err != nil {
+			return nil, err
+		}
+		if len(result) == 0 {
+			return nil, io.EOF
+		}
+
+		*body = ioutil.NopCloser(bytes.NewReader(result))
+		return ioutil.NopCloser(bytes.NewReader(result)), nil
+	}
+	return nil, io.EOF
 }


### PR DESCRIPTION
building on ideas from #1650, this adds the first method where the HTTP handler is generated by package lib, but mapped to an endpoint by package api.

This PR is mainly to establish the patten & talk through repercussions. Right now this only works for formats where the response format is well known / singular.