### PR TITLE
refactor(changes): use `Dispatch` with `lib.ChangeReport` function

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -209,7 +209,7 @@ func NewServerRoutes(s Server) *mux.Router {
 	m.Handle(lib.AERename.String(), s.Middleware(dsh.RenameHandler))
 	handleRefRoute(m, lib.AEValidate, s.Middleware(dsh.ValidateHandler))
 	m.Handle(lib.AEDiff.String(), s.Middleware(dsh.DiffHandler))
-	m.Handle(lib.AEChanges.String(), s.Middleware(dsh.ChangesHandler))
+	m.Handle(lib.AEChanges.String(), s.Middleware(dsh.ChangesHandler(lib.AEChanges.NoTrailingSlash())))
 	m.Handle(lib.AEUnpack.String(), s.Middleware(dsh.UnpackHandler))
 	m.Handle(lib.AEManifest.String(), s.Middleware(dsh.ManifestHandler))
 	m.Handle(lib.AEManifestMissing.String(), s.Middleware(dsh.ManifestMissingHandler))

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -23,10 +23,6 @@ import (
 
 // DatasetHandlers wraps a requests struct to interface with http.HandlerFunc
 type DatasetHandlers struct {
-	// TODO (ramfox): start here
-	// should have a dsm for dataset methods
-	// and an inst
-	// future refactors should have handlers rely on inst for node and repo
 	lib.DatasetMethods
 	inst     *lib.Instance
 	remote   *lib.RemoteMethods

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -15,9 +15,7 @@ import (
 	"github.com/qri-io/qri/base/archive"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
-	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/profile"
-	"github.com/qri-io/qri/repo"
 	reporef "github.com/qri-io/qri/repo/ref"
 )
 
@@ -26,8 +24,6 @@ type DatasetHandlers struct {
 	lib.DatasetMethods
 	inst     *lib.Instance
 	remote   *lib.RemoteMethods
-	node     *p2p.QriNode
-	repo     repo.Repo
 	ReadOnly bool
 }
 
@@ -35,7 +31,7 @@ type DatasetHandlers struct {
 func NewDatasetHandlers(inst *lib.Instance, readOnly bool) *DatasetHandlers {
 	dsm := lib.NewDatasetMethods(inst)
 	rm := lib.NewRemoteMethods(inst)
-	h := DatasetHandlers{*dsm, inst, rm, inst.Node(), inst.Node().Repo, readOnly}
+	h := DatasetHandlers{*dsm, inst, rm, readOnly}
 	return &h
 }
 

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -23,7 +23,12 @@ import (
 
 // DatasetHandlers wraps a requests struct to interface with http.HandlerFunc
 type DatasetHandlers struct {
+	// TODO (ramfox): start here
+	// should have a dsm for dataset methods
+	// and an inst
+	// future refactors should have handlers rely on inst for node and repo
 	lib.DatasetMethods
+	inst     *lib.Instance
 	remote   *lib.RemoteMethods
 	node     *p2p.QriNode
 	repo     repo.Repo
@@ -34,7 +39,7 @@ type DatasetHandlers struct {
 func NewDatasetHandlers(inst *lib.Instance, readOnly bool) *DatasetHandlers {
 	dsm := lib.NewDatasetMethods(inst)
 	rm := lib.NewRemoteMethods(inst)
-	h := DatasetHandlers{*dsm, rm, inst.Node(), inst.Node().Repo, readOnly}
+	h := DatasetHandlers{*dsm, inst, rm, inst.Node(), inst.Node().Repo, readOnly}
 	return &h
 }
 
@@ -96,17 +101,22 @@ func (h *DatasetHandlers) DiffHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// ChangesHandler is a dataset single endpoint
-func (h *DatasetHandlers) ChangesHandler(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodPost, http.MethodGet:
+// ChangesHandler is the endpoint for showing the changes between two datasets
+func (h *DatasetHandlers) ChangesHandler(routePrefix string) http.HandlerFunc {
+	handleChanges := h.changesHandler(routePrefix)
+
+	return func(w http.ResponseWriter, r *http.Request) {
 		if h.ReadOnly {
-			readOnlyResponse(w, "/changereport")
+			readOnlyResponse(w, routePrefix)
 			return
 		}
-		h.changesHandler(w, r)
-	default:
-		util.NotFoundHandler(w, r)
+
+		switch r.Method {
+		default:
+			util.NotFoundHandler(w, r)
+		case http.MethodGet, http.MethodPost:
+			handleChanges(w, r)
+		}
 	}
 }
 
@@ -366,22 +376,24 @@ func (h *DatasetHandlers) diffHandler(w http.ResponseWriter, r *http.Request) {
 	util.WritePageResponse(w, res, r, util.Page{})
 }
 
-func (h *DatasetHandlers) changesHandler(w http.ResponseWriter, r *http.Request) {
-	params := &lib.ChangeReportParams{}
+func (h *DatasetHandlers) changesHandler(routePrefix string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		method := "dataset.changereport"
+		p := h.inst.NewInputParam(method)
 
-	err := lib.UnmarshalParams(r, params)
-	if err != nil {
-		util.WriteErrResponse(w, http.StatusBadRequest, err)
+		if err := lib.UnmarshalParams(r, p); err != nil {
+			util.WriteErrResponse(w, http.StatusBadRequest, err)
+			return
+		}
+
+		res, _, err := h.inst.Dispatch(r.Context(), method, p)
+		if err != nil {
+			util.RespondWithError(w, err)
+			return
+		}
+		util.WriteResponse(w, res)
 		return
 	}
-
-	res, err := h.ChangeReport(r.Context(), params)
-	if err != nil {
-		util.WriteErrResponse(w, http.StatusInternalServerError, fmt.Errorf("error generating change report: %s", err.Error()))
-		return
-	}
-
-	util.WritePageResponse(w, res, r, util.Page{})
 }
 
 func (h *DatasetHandlers) peerListHandler(w http.ResponseWriter, r *http.Request) {

--- a/api/datasets_test.go
+++ b/api/datasets_test.go
@@ -93,7 +93,7 @@ func TestDatasetHandlers(t *testing.T) {
 		// {"GET", "/?leftRef=peer/family_relationships&rightRef=peer/cities", nil, nil},
 		{"DELETE", "/", nil, nil},
 	}
-	runHandlerTestCases(t, "changes", h.ChangesHandler, changesCases, false)
+	runHandlerTestCases(t, "changes", h.ChangesHandler(""), changesCases, false)
 
 	removeCases := []handlerTestCase{
 		{"GET", "/", nil, nil},

--- a/changes/changes.go
+++ b/changes/changes.go
@@ -386,14 +386,18 @@ func (svc *service) columnStatsDelta(left, right interface{}, lCol, rCol *tabula
 // Report computes the change report of two sources
 // This takes some assumptions - we work only with tabular data, with header rows and functional structure.json
 func (svc *service) Report(ctx context.Context, leftRef, rightRef dsref.Ref, loadSource string) (*ChangeReportResponse, error) {
-	leftDs, err := svc.loader.LoadDataset(ctx, leftRef, loadSource)
+	rightDs, err := svc.loader.LoadDataset(ctx, rightRef, loadSource)
 	if err != nil {
 		return nil, err
 	}
-	if rightRef.Path == "" {
-		rightRef.Path = leftDs.PreviousPath
+	if leftRef.Path == "" {
+		if rightDs.PreviousPath == "" {
+			return nil, fmt.Errorf("dataset has only one version")
+		}
+		leftRef.Path = rightDs.PreviousPath
 	}
-	rightDs, err := svc.loader.LoadDataset(ctx, rightRef, loadSource)
+
+	leftDs, err := svc.loader.LoadDataset(ctx, leftRef, loadSource)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/changes.go
+++ b/lib/changes.go
@@ -26,7 +26,7 @@ func (m *DatasetMethods) ChangeReport(ctx context.Context, p *ChangeReportParams
 }
 
 // ChangeReport generates report of changes between two datasets
-func (*DatasetImpl) ChangeReport(scope scope, p *ChangeReportParams) (*ChangeReport, error) {
+func (datasetImpl) ChangeReport(scope scope, p *ChangeReportParams) (*ChangeReport, error) {
 	ctx := scope.Context()
 	reportSource := ""
 

--- a/lib/changes.go
+++ b/lib/changes.go
@@ -44,5 +44,5 @@ func (datasetImpl) ChangeReport(scope scope, p *ChangeReportParams) (*ChangeRepo
 		left = dsref.Ref{Username: right.Username, Name: right.Name}
 	}
 
-	return changes.New(scope.inst, scope.inst.stats).Report(ctx, left, right, reportSource)
+	return changes.New(scope.Loader(), scope.Stats()).Report(ctx, left, right, reportSource)
 }

--- a/lib/changes.go
+++ b/lib/changes.go
@@ -18,30 +18,31 @@ type ChangeReport = changes.ChangeReportResponse
 
 // ChangeReport resolves the requested datasets and tries to generate a change report
 func (m *DatasetMethods) ChangeReport(ctx context.Context, p *ChangeReportParams) (*ChangeReport, error) {
+	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "changereport"), p)
+	if res, ok := got.(*ChangeReport); ok {
+		return res, err
+	}
+	return nil, dispatchReturnError(got, err)
+}
+
+// ChangeReport generates report of changes between two datasets
+func (*DatasetImpl) ChangeReport(scope scope, p *ChangeReportParams) (*ChangeReport, error) {
+	ctx := scope.Context()
 	reportSource := ""
 
-	if m.inst.http != nil {
-		res := &ChangeReport{}
-		err := m.inst.http.Call(ctx, AEChanges, p, res)
-		if err != nil {
-			return nil, err
-		}
-		return res, nil
-	}
-
-	right, _, err := m.inst.ParseAndResolveRef(ctx, p.RightRefstr, reportSource)
+	right, _, err := scope.ParseAndResolveRef(ctx, p.RightRefstr, reportSource)
 	if err != nil {
 		return nil, err
 	}
 
 	var left dsref.Ref
 	if p.LeftRefstr != "" {
-		if left, _, err = m.inst.ParseAndResolveRef(ctx, p.LeftRefstr, reportSource); err != nil {
+		if left, _, err = scope.ParseAndResolveRef(ctx, p.LeftRefstr, reportSource); err != nil {
 			return nil, err
 		}
 	} else {
 		left = dsref.Ref{Username: right.Username, Name: right.Name}
 	}
 
-	return changes.New(m.inst, m.inst.stats).Report(ctx, left, right, reportSource)
+	return changes.New(scope.inst, scope.inst.stats).Report(ctx, left, right, reportSource)
 }

--- a/lib/changes_test.go
+++ b/lib/changes_test.go
@@ -1,0 +1,37 @@
+package lib
+
+import (
+	"context"
+	"testing"
+
+	testcfg "github.com/qri-io/qri/config/test"
+	"github.com/qri-io/qri/event"
+	"github.com/qri-io/qri/p2p"
+	testrepo "github.com/qri-io/qri/repo/test"
+)
+
+func TestChanges(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+
+	mr, err := testrepo.NewTestRepo()
+	if err != nil {
+		t.Fatalf("error allocating test repo: %s", err.Error())
+	}
+	node, err := p2p.NewQriNode(mr, testcfg.DefaultP2PForTesting(), event.NilBus, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
+
+	InitWorldBankDataset(ctx, t, inst)
+	commitref := Commit2WorldBank(ctx, t, inst)
+
+	// test ChangeReport with one param
+	p := &ChangeReportParams{
+		RightRefstr: commitref.Alias(),
+	}
+	if _, err := inst.Dataset().ChangeReport(ctx, p); err != nil {
+		t.Fatalf("change report error: %s", err)
+	}
+}

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -58,9 +58,6 @@ func (inst *Instance) Dataset() *DatasetMethods {
 // ErrListWarning is a warning that can occur while listing
 var ErrListWarning = base.ErrUnlistableReferences
 
-// CoreRequestsName implements the Requets interface
-func (DatasetMethods) CoreRequestsName() string { return "datasets" }
-
 // NewDatasetMethods creates a DatasetMethods pointer from a qri instance
 func NewDatasetMethods(inst *Instance) *DatasetMethods {
 	return &DatasetMethods{
@@ -1734,5 +1731,66 @@ func formFileDataset(r *http.Request, ds *dataset.Dataset) (err error) {
 	return
 }
 
-// DatasetImpl holds the method implementations for DatasetMethods
-type DatasetImpl struct{}
+// datasetImpl holds the method implementations for DatasetMethods
+type datasetImpl struct{}
+
+// List gets the reflist for either the local repo or a peer
+func (datasetImpl) List(scope scope, p *ListParams) ([]dsref.VersionInfo, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// ListRawRefs gets the list of raw references as string
+func (datasetImpl) ListRawRefs(scope scope, p *ListParams) (string, error) {
+	return "", fmt.Errorf("not yet implemented")
+}
+
+// Get retrieves datasets and components for a given reference.t
+func (datasetImpl) Get(scope scope, p *GetParams) (*GetResult, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// Save adds a history entry, updating a dataset
+func (datasetImpl) Save(scope scope, p *SaveParams) (*dataset.Dataset, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// Rename changes a user's given name for a dataset
+func (datasetImpl) Rename(scope scope, p *RenameParams) (*dsref.VersionInfo, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// Remove a dataset entirely or remove a certain number of revisions
+func (datasetImpl) Remove(scope scope, p *RemoveParams) (*RemoveResponse, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// Pull downloads and stores an existing dataset to a peer's repository via
+// a network connection
+func (datasetImpl) Pull(scope scope, p *PullParams) (*dataset.Dataset, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// Validate gives a dataset of errors and issues for a given dataset
+func (datasetImpl) Validate(scope scope, p *ValidateParams) (*ValidateResponse, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// Manifest generates a manifest for a dataset path
+func (datasetImpl) Manifest(scope scope, p *ManifestParams) (*dag.Manifest, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// ManifestMissing generates a manifest of blocks that are not present on this repo for a given manifes
+func (datasetImpl) ManifestMissing(scope scope, p *ManifestMissingParams) (*dag.Manifest, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// DAGInfo generates a dag.Info for a dataset path. If a label is given, DAGInfo will generate a sub-dag.Info at that label.
+func (datasetImpl) DAGInfo(scope scope, p *DAGInfoParams) (*dag.Info, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// Stats generates stats for a dataset
+func (datasetImpl) Stats(scope scope, p *StatsParams) (*dataset.Stats, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -45,6 +45,16 @@ type DatasetMethods struct {
 	inst *Instance
 }
 
+// Name returns the name of this method group
+func (m *DatasetMethods) Name() string {
+	return "dataset"
+}
+
+// Dataset returns the DatasetMethods that Instance has registered
+func (inst *Instance) Dataset() *DatasetMethods {
+	return &DatasetMethods{inst: inst}
+}
+
 // ErrListWarning is a warning that can occur while listing
 var ErrListWarning = base.ErrUnlistableReferences
 
@@ -1723,3 +1733,6 @@ func formFileDataset(r *http.Request, ds *dataset.Dataset) (err error) {
 
 	return
 }
+
+// DatasetImpl holds the method implementations for DatasetMethods
+type DatasetImpl struct{}

--- a/lib/diff.go
+++ b/lib/diff.go
@@ -352,3 +352,8 @@ func isFilePath(text string) bool {
 	}
 	return !dsref.IsRefString(text)
 }
+
+// Diff computes the diff of two source
+func (datasetImpl) Diff(scope scope, p *DiffParams) (*DiffResponse, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -180,7 +180,7 @@ func (inst *Instance) RegisterMethods() {
 	reg := make(map[string]callable)
 	inst.registerOne("fsi", inst.Filesys(), fsiImpl{}, reg)
 	inst.registerOne("access", inst.Access(), accessImpl{}, reg)
-	inst.registerOne("dataset", inst.Dataset(), DatasetImpl{}, reg)
+	inst.registerOne("dataset", inst.Dataset(), datasetImpl{}, reg)
 	inst.regMethods = &regMethodSet{reg: reg}
 }
 

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -180,6 +180,7 @@ func (inst *Instance) RegisterMethods() {
 	reg := make(map[string]callable)
 	inst.registerOne("fsi", inst.Filesys(), fsiImpl{}, reg)
 	inst.registerOne("access", inst.Access(), accessImpl{}, reg)
+	inst.registerOne("dataset", inst.Dataset(), DatasetImpl{}, reg)
 	inst.regMethods = &regMethodSet{reg: reg}
 }
 

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -66,7 +66,7 @@ type InitDatasetParams = fsi.InitParams
 // StatusItem is an alias for an fsi.StatusItem
 type StatusItem = fsi.StatusItem
 
-// CreateLink creates a connection between a working drirectory and a dataset history
+// CreateLink creates a connection between a working directory and a dataset history
 func (m *FSIMethods) CreateLink(ctx context.Context, p *LinkParams) (*dsref.VersionInfo, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "createlink"), p)
 	if res, ok := got.(*dsref.VersionInfo); ok {
@@ -168,7 +168,7 @@ func (m *FSIMethods) EnsureRef(ctx context.Context, p *LinkParams) (*dsref.Versi
 // fsiImpl holds the method implementations for FSI
 type fsiImpl struct{}
 
-// CreateLink creates a connection between a working drirectory and a dataset history
+// CreateLink creates a connection between a working directory and a dataset history
 func (fsiImpl) CreateLink(scope scope, p *LinkParams) (*dsref.VersionInfo, error) {
 	ctx := scope.Context()
 

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -11,6 +11,7 @@ import (
 	"github.com/qri-io/qri/fsi"
 	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/repo"
+	"github.com/qri-io/qri/stats"
 )
 
 // scope represents the lifetime of a method call, abstractly connected to the caller of
@@ -77,6 +78,16 @@ func (s *scope) Profiles() profile.Store {
 	return s.inst.profiles
 }
 
+// Loader returns the instance
+func (s *scope) Loader() *Instance {
+	return s.inst
+}
+
+// Stats returns the stats service
+func (s *scope) Stats() *stats.Service {
+	return s.inst.stats
+}
+
 // ParseAndResolveRef parses a reference and resolves it
 func (s *scope) ParseAndResolveRef(ctx context.Context, refStr, source string) (dsref.Ref, string, error) {
 	return s.inst.ParseAndResolveRef(ctx, refStr, source)
@@ -93,7 +104,7 @@ func (s *scope) LoadDataset(ctx context.Context, ref dsref.Ref, source string) (
 }
 
 // Loader returns the default dataset ref loader
-func (s *scope) Loader() dsref.ParseResolveLoad {
+func (s *scope) ParseResolveFunc() dsref.ParseResolveLoad {
 	return NewParseResolveLoadFunc("", s.inst.defaultResolver(), s.inst)
 }
 


### PR DESCRIPTION
Lays groundwork for other upcoming `DatasetMethods` method conversions by creating `datasetImpl` struct, `Name` method (needed to satisfy the `MethodSet` interface), and all corresponding `datasetImpl` methods

Fixes a bug in `changes` that occurred when only `rightRef` was present.