### PR TITLE
test(api): json file driven spec tests for API

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -19,6 +19,7 @@ import (
 	golog "github.com/ipfs/go-log"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
+	apispec "github.com/qri-io/qri/api/spec"
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/config"
 	testcfg "github.com/qri-io/qri/config/test"
@@ -32,6 +33,20 @@ import (
 
 func init() {
 	abide.SnapshotsDir = "testdata"
+}
+
+func TestApiSpec(t *testing.T) {
+	if err := confirmQriNotRunning(); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	tr := NewAPITestRunner(t)
+	defer tr.Delete()
+
+	ts := tr.MustTestServer(t)
+	defer ts.Close()
+
+	apispec.AssertHTTPAPISpec(t, ts.URL, "./spec")
 }
 
 func newTestRepo(t *testing.T) (r repo.Repo, teardown func()) {

--- a/api/spec/spec.go
+++ b/api/spec/spec.go
@@ -1,0 +1,159 @@
+package spec
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// AssertHTTPAPISpec runs a test suite of HTTP requests against the given base URL
+// to assert it conforms to the qri core API specification. Spec is defined in
+// the "open_api_3.yaml" file in the api package
+func AssertHTTPAPISpec(t *testing.T, baseURL, specPackagePath string) {
+	t.Helper()
+
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("invalid base url: %s", err)
+	}
+
+	testFiles := []string{
+		"testdata/working_directory.json",
+	}
+
+	for _, path := range testFiles {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			ts := mustLoadTestSuite(t, filepath.Join(specPackagePath, path))
+			for i, c := range ts {
+				if err := c.do(base); err != nil {
+					t.Errorf("case %d %s %s:\n%s", i, c.Method, c.Endpoint, err)
+				}
+			}
+		})
+	}
+}
+
+// TestCase is a single request-response round trip to the API with parameters
+// for constructing the request & expectations for assessing the response.
+type TestCase struct {
+	Endpoint string            // API endpoint to test
+	Method   string            // HTTP request method, defaults to "GET"
+	Headers  map[string]string // Request HTTP headers
+	Body     interface{}       // request body
+	Expect   *Response         // Assertions about the response
+}
+
+func (c *TestCase) do(u *url.URL) error {
+	if c.Method == "" {
+		c.Method = http.MethodGet
+	}
+
+	u.Path = c.Endpoint
+
+	body, err := c.reqBodyReader()
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(c.Method, u.String(), body)
+	if err != nil {
+		return err
+	}
+	for k, v := range c.Headers {
+		req.Header.Set(k, v)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if exp := c.Expect; exp != nil {
+		if exp.Code != 0 && exp.Code != res.StatusCode {
+			return fmt.Errorf("response status code mismatch. want: %d got: %d\nresponse body: %s", exp.Code, res.StatusCode, c.resBodyErrString(res))
+		}
+
+		for key, expVal := range exp.Headers {
+			got := res.Header.Get(key)
+			if expVal != got {
+				return fmt.Errorf("repsonse header %q mismatch.\nwant: %q\ngot:  %q", key, expVal, got)
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (c *TestCase) reqBodyReader() (io.Reader, error) {
+	switch b := c.Body.(type) {
+	case map[string]interface{}:
+		buf := &bytes.Buffer{}
+		if err := json.NewEncoder(buf).Encode(b); err != nil {
+			return nil, err
+		}
+		return buf, nil
+	case string:
+		return strings.NewReader(b), nil
+	case nil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unrecognized type for request body %T", c.Body)
+	}
+}
+
+func (c *TestCase) decodeResponseBody(res *http.Response) (body interface{}, contentType string, err error) {
+	defer res.Body.Close()
+	contentType = res.Header.Get("Content-Type")
+	switch contentType {
+	case "application/json":
+		err = json.NewDecoder(res.Body).Decode(&body)
+	default:
+		body, err = ioutil.ReadAll(res.Body)
+	}
+	return body, contentType, err
+}
+
+func (c *TestCase) resBodyErrString(res *http.Response) string {
+	bd, ct, err := c.decodeResponseBody(res)
+	if err != nil {
+		return err.Error()
+	}
+	if ct == "application/json" {
+		enc, _ := json.MarshalIndent(bd, "", "  ")
+		return string(enc)
+	}
+
+	if data, ok := bd.([]byte); ok {
+		return string(data)
+	}
+
+	return fmt.Sprintf("<unexpected response body. Content-Type: %q DataType: %T>", ct, bd)
+}
+
+type Response struct {
+	Code    int
+	Headers map[string]string
+}
+
+func mustLoadTestSuite(t *testing.T, filePath string) []*TestCase {
+	f, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("opening test suite file %q: %s", filePath, err)
+	}
+	defer f.Close()
+	suite := []*TestCase{}
+	if err := json.NewDecoder(f).Decode(&suite); err != nil {
+		t.Fatalf("deserializing test suite file %q: %s", filePath, err)
+	}
+
+	return suite
+}

--- a/api/spec/testdata/access.json
+++ b/api/spec/testdata/access.json
@@ -1,0 +1,16 @@
+[
+  {
+    "endpoint": "/access/token",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {},
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+]

--- a/api/spec/testdata/aggregate.json
+++ b/api/spec/testdata/aggregate.json
@@ -1,0 +1,78 @@
+[
+  {
+    "endpoint": "/list",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/list/me",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sql",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "query": "SELECT * FROM peer/movies"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/diff",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "leftPath": "peer/movies",
+      "rightPath": "peer/cities"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/changes",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "leftRef": "peer/movies",
+      "rightRef": "peer/cities"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+]

--- a/api/spec/testdata/automation.json
+++ b/api/spec/testdata/automation.json
@@ -1,0 +1,16 @@
+[
+  {
+    "endpoint": "/auto/apply",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {},
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+]

--- a/api/spec/testdata/dataset.json
+++ b/api/spec/testdata/dataset.json
@@ -1,0 +1,236 @@
+[
+  {
+    "endpoint": "/ds/componentstatus",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/get",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/log",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/rename",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "current": "me/test_wd",
+      "next": "me/test_wd_2"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/save",
+    "params": {
+      "new": "true"
+    },
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd",
+      "dataset": {
+        "meta": {
+          "title": "test working directory"
+        }
+      },
+      "bodypath":"http://127.0.0.1:55556/C2ImportFamRelSample.csv"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/pull",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/push",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/render",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/remove",
+    "params": {
+      "all": "true"
+    },
+    "method": "POST",
+    "body": {
+    	"ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/validatee",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/unpack",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/manifest",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/manifestmissing",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "manifest": {}
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/ds/daginfo",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+]

--- a/api/spec/testdata/misc.json
+++ b/api/spec/testdata/misc.json
@@ -1,0 +1,67 @@
+[
+  {
+    "endpoint": "/",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "text/plain; charset=utf-8"
+      }
+    }
+  },
+  {
+    "endpoint": "/health",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "text/plain; charset=utf-8"
+      }
+    }
+  },
+  {
+    "endpoint": "/qfs/ipfs/test_path",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "text/plain; charset=utf-8"
+      }
+    }
+  },
+  {
+    "endpoint": "/qfs/s3/test_path",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "text/plain; charset=utf-8"
+      }
+    }
+  },
+  {
+    "endpoint": "/webui",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "text/html; charset=utf-8"
+      }
+    }
+  }
+]

--- a/api/spec/testdata/peer.json
+++ b/api/spec/testdata/peer.json
@@ -1,0 +1,79 @@
+[
+  {
+    "endpoint": "/peer",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "peername": "peer"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/peer/remove",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "peername": "peer"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/peer/connect",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "peername": "peer"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/peer/disconnect",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "peername": "peer"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/peer/list",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+]

--- a/api/spec/testdata/profile.json
+++ b/api/spec/testdata/profile.json
@@ -1,0 +1,54 @@
+[
+  {
+    "endpoint": "/profile/list",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/profile/me",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/profile/me/photo",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "image/jpeg"
+      }
+    }
+  },
+  {
+    "endpoint": "/profile/me/poster",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "image/jpeg"
+      }
+    }
+  }
+]

--- a/api/spec/testdata/remote.json
+++ b/api/spec/testdata/remote.json
@@ -1,0 +1,73 @@
+[
+  {
+    "endpoint": "/remote/feeds",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/remote/preview",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "peer/movies"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/remote/registry/profile/new",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {},
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/remote/registry/profile/prove",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {},
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/remote/search",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {},
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+]

--- a/api/spec/testdata/sync.json
+++ b/api/spec/testdata/sync.json
@@ -1,0 +1,136 @@
+[
+  {
+    "endpoint": "/sync/dag",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sync/dag",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sync/dag",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {},
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sync/dag",
+    "method": "PUT",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {},
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sync/dag",
+    "method": "PATCH",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {},
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sync/logs",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sync/logs",
+    "method": "PUT",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {},
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sync/logs",
+    "method": "DELETE",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sync/resolve",
+    "method": "GET",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/sync/resolve",
+    "method": "DELETE",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+]

--- a/api/spec/testdata/working_directory.json
+++ b/api/spec/testdata/working_directory.json
@@ -1,20 +1,9 @@
 [
   {
-    "endpoint": "/save/me/test_wd",
-    "params": {
-      "new": "true"
-    },
+    "endpoint": "/wd/caninitworkdir",
     "method": "POST",
     "headers": {
       "Content-Type": "application/json"
-    },
-    "body": {
-      "dataset": {
-        "meta": {
-          "title": "test working directory"
-        }
-      },
-      "bodypath":"http://127.0.0.1:55556/C2ImportFamRelSample.csv"
     },
     "expect": {
       "code": 200,
@@ -24,12 +13,27 @@
     }
   },
   {
-    "endpoint": "/wd/init/me/test_wd",
-    "method": "POST"
+    "endpoint": "/wd/init",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
   },
   {
-    "endpoint": "/wd/status/me/test_wd",
-    "method": "GET",
+    "endpoint": "/wd/status",
+    "method": "POST",
+    "body": {
+      "ref": "me/test_wd"
+    },
     "expect": { 
       "code": 200,
       "headers": {
@@ -38,29 +42,36 @@
     }
   },
   {
-    "endpoint": "/wd/whatchanged/me/test_wd",
-    "method": "GET",
-    "expect": {
-      "code": 200,
-      "headers": {
-        "Content-Type": "application/json"
-      }
-    }
-  },
-  {
-    "endpoint": "/wd/restore/me/test_wd",
-    "method": "POST",
-    "expect": {
-      "code": 200,
-      "headers": {
-        "Content-Type": "application/json"
-      }
-    }
-  },
-  {
-    "endpoint": "/wd/write/me/test_wd",
+    "endpoint": "/wd/checkout",
     "method": "POST",
     "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/wd/restore",
+    "method": "POST",
+    "body": {
+      "ref": "me/test_wd"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/wd/write",
+    "method": "POST",
+    "body": {
+      "ref": "me/test_wd",
       "meta": {
         "title": "test working directory",
         "description": "with an added description!"
@@ -75,11 +86,25 @@
     }
   },
   {
-    "endpoint": "/remove/me/test_wd",
-    "params": {
-      "all": "true"
-    },
+    "endpoint": "/wd/createlink",
     "method": "POST",
+    "body": {
+      "ref": "me/test_wd",
+      "path": "some_path"
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/wd/unlink",
+    "method": "POST",
+    "body": {
+      "ref": "me/test_wd",
+    },
     "expect": {
       "code": 200,
       "headers": {

--- a/api/spec/testdata/working_directory.json
+++ b/api/spec/testdata/working_directory.json
@@ -1,15 +1,20 @@
 [
   {
     "endpoint": "/save/me/test_wd",
+    "params": {
+      "new": "true"
+    },
     "method": "POST",
     "headers": {
       "Content-Type": "application/json"
     },
     "body": {
-      "meta": {
-        "title": "test working directory"
+      "dataset": {
+        "meta": {
+          "title": "test working directory"
+        }
       },
-      "body": [[1,2,3],[4,5,6]]
+      "bodypath":"http://127.0.0.1:55556/C2ImportFamRelSample.csv"
     },
     "expect": {
       "code": 200,
@@ -70,7 +75,10 @@
     }
   },
   {
-    "endpoint": "/remove/me/test_wd?all=true",
+    "endpoint": "/remove/me/test_wd",
+    "params": {
+      "all": "true"
+    },
     "method": "POST",
     "expect": {
       "code": 200,

--- a/api/spec/testdata/working_directory.json
+++ b/api/spec/testdata/working_directory.json
@@ -1,0 +1,82 @@
+[
+  {
+    "endpoint": "/save/me/test_wd",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "meta": {
+        "title": "test working directory"
+      },
+      "body": [[1,2,3],[4,5,6]]
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/wd/init/me/test_wd",
+    "method": "POST"
+  },
+  {
+    "endpoint": "/wd/status/me/test_wd",
+    "method": "GET",
+    "expect": { 
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/wd/whatchanged/me/test_wd",
+    "method": "GET",
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/wd/restore/me/test_wd",
+    "method": "POST",
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/wd/write/me/test_wd",
+    "method": "POST",
+    "body": {
+      "meta": {
+        "title": "test working directory",
+        "description": "with an added description!"
+      },
+      "body": [[1,2,3],[4,5,6],[7,8,9]]
+    },
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "endpoint": "/remove/me/test_wd?all=true",
+    "method": "POST",
+    "expect": {
+      "code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+]

--- a/api/test_runner_test.go
+++ b/api/test_runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -92,4 +93,9 @@ func (r *APITestRunner) SaveDataset(ds *dataset.Dataset, bodyFilename string) {
 
 func (r *APITestRunner) NewRenderHandlers() *RenderHandlers {
 	return NewRenderHandlers(r.Inst)
+}
+
+func (r *APITestRunner) MustTestServer(t *testing.T) *httptest.Server {
+	s := New(r.Inst)
+	return httptest.NewServer(NewServerRoutes(s))
 }


### PR DESCRIPTION
meant as a compliment to #1697, specifically how we're going to test an updated API contract.

add framing & a spec test using JSON files for our HTTP api. I'm hoping we can use this to construct a portable set of tests that make our API more reliable. I expect these tests to evolve over time, but the main purpose is to have all test configuration done via JSON files with a higher signal-to-noise ratio. The spec test runs strictly via HTTP req/res.

I'd considered trying to do this via the open_api spec, which apparently has tooling for turning an OpenAPI doc into a set of contract tests, but after some research I think it's better to have these spec tests in conjunction, which can be ordered to create tests that amount to integrations via successive calls.

tests don't pass yet, just getting the framework in place