### PR TITLE
refactor(dataset): dataset methods rely on `Dispatch`, for both lib & api

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -469,10 +469,11 @@ func (h *DatasetHandlers) saveHandler(w http.ResponseWriter, r *http.Request) {
 	scriptOutput := &bytes.Buffer{}
 	params.ScriptOutput = scriptOutput
 
-	res, err := h.Save(r.Context(), params)
-	if err != nil {
+	got, _, err := h.inst.Dispatch(r.Context(), "dataset.save", params)
+	res, ok := got.(*dataset.Dataset)
+	if err != nil || !ok {
 		log.Debugw("save dataset error", "err", err)
-		util.WriteErrResponse(w, http.StatusInternalServerError, err)
+		util.RespondWithError(w, err)
 		return
 	}
 	// Don't leak paths across the API, it's possible they contain absolute paths or tmp dirs.

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -229,7 +229,14 @@ func (h *DatasetHandlers) listHandler(w http.ResponseWriter, r *http.Request) {
 	if params.Raw {
 		resRaw, err = h.ListRawRefs(r.Context(), params)
 	} else {
-		res, err = h.List(r.Context(), params)
+		method := "dataset.list"
+		got, _, err := h.inst.Dispatch(r.Context(), method, params)
+		ok := false
+		res, ok = got.([]dsref.VersionInfo)
+		if err != nil || !ok {
+			util.RespondWithError(w, err)
+			return
+		}
 	}
 
 	if err != nil {

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -227,10 +227,15 @@ func (h *DatasetHandlers) listHandler(w http.ResponseWriter, r *http.Request) {
 	res := []dsref.VersionInfo{}
 	var err error
 	if params.Raw {
-		resRaw, err = h.ListRawRefs(r.Context(), params)
+		got, _, err := h.inst.Dispatch(r.Context(), "dataset.listrawrefs", params)
+		ok := false
+		resRaw, ok = got.(string)
+		if err != nil || !ok {
+			util.RespondWithError(w, err)
+			return
+		}
 	} else {
-		method := "dataset.list"
-		got, _, err := h.inst.Dispatch(r.Context(), method, params)
+		got, _, err := h.inst.Dispatch(r.Context(), "dataset.list", params)
 		ok := false
 		res, ok = got.([]dsref.VersionInfo)
 		if err != nil || !ok {

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -267,20 +267,21 @@ func (h *DatasetHandlers) listHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *DatasetHandlers) getHandler(w http.ResponseWriter, r *http.Request) {
-	params := lib.GetParams{}
+	params := &lib.GetParams{}
 
-	err := lib.UnmarshalParams(r, &params)
+	err := lib.UnmarshalParams(r, params)
 	if err != nil {
 		util.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
 	}
 
-	result, err := h.Get(r.Context(), &params)
-	if err != nil {
+	got, _, err := h.inst.Dispatch(r.Context(), "dataset.get", params)
+	res, ok := got.(*lib.GetResult)
+	if err != nil || !ok {
 		util.RespondWithError(w, err)
 		return
 	}
-	h.replyWithGetResponse(w, r, &params, result)
+	h.replyWithGetResponse(w, r, params, res)
 }
 
 // inlineScriptsToBytes consumes all open script files for dataset components

--- a/api/fsi_test.go
+++ b/api/fsi_test.go
@@ -232,8 +232,6 @@ func TestFSIWrite(t *testing.T) {
 	// already exists.
 	_ = os.RemoveAll(workDir)
 
-	dsm := lib.NewDatasetMethods(inst)
-
 	// TODO(dustmop): Use a TestRunner here, and have it call SaveDataset instead.
 
 	// Save version 1
@@ -246,7 +244,7 @@ func TestFSIWrite(t *testing.T) {
 		},
 		BodyPath: "testdata/cities/data.csv",
 	}
-	_, err := dsm.Save(ctx, &saveParams)
+	_, err := inst.Dataset().Save(ctx, &saveParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,8 +335,6 @@ func TestCheckoutAndRestore(t *testing.T) {
 	// already exists.
 	_ = os.RemoveAll(workDir)
 
-	dsm := lib.NewDatasetMethods(inst)
-
 	// Save version 1
 	saveParams := lib.SaveParams{
 		Ref: "me/fsi_checkout_restore",
@@ -349,7 +345,7 @@ func TestCheckoutAndRestore(t *testing.T) {
 		},
 		BodyPath: "testdata/cities/data.csv",
 	}
-	res, err := dsm.Save(ctx, &saveParams)
+	res, err := inst.Dataset().Save(ctx, &saveParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +363,7 @@ func TestCheckoutAndRestore(t *testing.T) {
 			},
 		},
 	}
-	res, err = dsm.Save(ctx, &saveParams)
+	res, err = inst.Dataset().Save(ctx, &saveParams)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -27,7 +27,7 @@ func TestHistoryHandlers(t *testing.T) {
 		},
 		Private: false,
 	}
-	_, err := lib.NewDatasetMethods(inst).Save(ctx, p)
+	_, err := inst.Dataset().Save(ctx, p)
 	if err != nil {
 		t.Fatalf("error writing dataset update: %s", err.Error())
 	}

--- a/api/test_runner_test.go
+++ b/api/test_runner_test.go
@@ -79,13 +79,12 @@ func (r *APITestRunner) BuildDataset(dsName string) *dataset.Dataset {
 }
 
 func (r *APITestRunner) SaveDataset(ds *dataset.Dataset, bodyFilename string) {
-	dsm := lib.NewDatasetMethods(r.Inst)
 	saveParams := lib.SaveParams{
 		Ref:      fmt.Sprintf("peer/%s", ds.Name),
 		Dataset:  ds,
 		BodyPath: bodyFilename,
 	}
-	_, err := dsm.Save(r.Ctx, &saveParams)
+	_, err := r.Inst.Dataset().Save(r.Ctx, &saveParams)
 	if err != nil {
 		panic(err)
 	}

--- a/api/util/errors.go
+++ b/api/util/errors.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
 	golog "github.com/ipfs/go-log"
@@ -70,4 +72,10 @@ func RespondWithError(w http.ResponseWriter, err error) {
 	log.Errorf("%s: treating this as a 500 is a bug, see https://github.com/qri-io/qri/issues/959. The code path that generated this should return a known error type, which this function should map to a reasonable http status code", err)
 	WriteErrResponse(w, http.StatusInternalServerError, err)
 	return
+}
+
+// RespondWithDispatchTypeError(w http.ResponseWriter, got
+func RespondWithDispatchTypeError(w http.ResponseWriter, got interface{}) {
+	log.Errorf("type mismatch: %v of type %s", got, reflect.TypeOf(got))
+	WriteErrResponse(w, http.StatusInternalServerError, fmt.Errorf("type mismatch: %v of type %s", got, reflect.TypeOf(got)))
 }

--- a/api/util/errors.go
+++ b/api/util/errors.go
@@ -74,7 +74,7 @@ func RespondWithError(w http.ResponseWriter, err error) {
 	return
 }
 
-// RespondWithDispatchTypeError(w http.ResponseWriter, got
+// RespondWithDispatchTypeError writes an error describing a type mismatch error from using dispatch
 func RespondWithDispatchTypeError(w http.ResponseWriter, got interface{}) {
 	log.Errorf("type mismatch: %v of type %s", got, reflect.TypeOf(got))
 	WriteErrResponse(w, http.StatusInternalServerError, fmt.Errorf("type mismatch: %v of type %s", got, reflect.TypeOf(got)))

--- a/cmd/access.go
+++ b/cmd/access.go
@@ -60,8 +60,8 @@ type AccessOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *AccessOptions) Complete(f Factory, args []string) (err error) {
-	o.Instance = f.Instance()
-	return nil
+	o.Instance, err = f.Instance()
+	return
 }
 
 // CreateAccessToken constructs an access token suitable for making

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -61,7 +61,10 @@ type ApplyOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *ApplyOptions) Complete(f Factory, args []string) (err error) {
-	o.Instance = f.Instance()
+	o.Instance, err = f.Instance()
+	if err != nil {
+		return err
+	}
 	if o.Refs, err = GetCurrentRefSelect(f, args, -1, nil); err != nil {
 		// This error will be handled during validation
 		if err != repo.ErrEmptyRef {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -61,8 +61,7 @@ type ApplyOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *ApplyOptions) Complete(f Factory, args []string) (err error) {
-	o.Instance, err = f.Instance()
-	if err != nil {
+	if o.Instance, err = f.Instance(); err != nil {
 		return err
 	}
 	if o.Refs, err = GetCurrentRefSelect(f, args, -1, nil); err != nil {

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -49,15 +49,13 @@ type CheckoutOptions struct {
 
 // Complete configures the checkout command
 func (o *CheckoutOptions) Complete(f Factory, args []string) (err error) {
-	o.Instance = f.Instance()
-
-	if err != nil {
-		return err
+	if o.Instance, err = f.Instance(); err != nil {
+		return
 	}
 
 	o.Refs, err = GetCurrentRefSelect(f, args, 1, EnsureFSIAgrees(o.Instance))
 	if err != nil {
-		return err
+		return
 	}
 
 	if len(args) == 2 {
@@ -65,8 +63,7 @@ func (o *CheckoutOptions) Complete(f Factory, args []string) (err error) {
 	} else {
 		o.Dir = ""
 	}
-
-	return nil
+	return
 }
 
 // Run executes the `checkout` command

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -681,6 +681,5 @@ func TestSetupHappensBeforeOtherCommands(t *testing.T) {
 			err := fmt.Sprintf("expected error for command %v:\n %v\n but received error:\n %v", cmdText, expect, noRepoErr)
 			t.Fatal(err)
 		}
-
 	}
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -80,7 +80,9 @@ run on each terminal session.`,
 
 // CompleteConfig adds any missing configuration that can only be added just before calling GetConfig
 func (o *ConfigOptions) CompleteConfig(f Factory) (err error) {
-	o.inst = f.Instance()
+	if o.inst, err = f.Instance(); err != nil {
+		return
+	}
 
 	o.ProfileMethods, err = f.ProfileMethods()
 	return

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -138,10 +138,9 @@ type ConfigOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *ConfigOptions) Complete(f Factory) (err error) {
-	if err != nil {
+	if o.inst, err = f.Instance(); err != nil {
 		return
 	}
-	o.inst = f.Instance()
 
 	o.ProfileMethods, err = f.ProfileMethods()
 	return

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -67,18 +67,18 @@ func (o *ConnectOptions) Complete(f Factory, args []string) (err error) {
 				Anonymous: true,
 			}
 			if err = so.Complete(f, args); err != nil {
-				return err
+				return
 			}
 			if err = so.DoSetup(f); err != nil {
-				return err
+				return
 			}
 		} else if repoErr != nil {
-			return err
+			return
 		}
 	}
 
 	if err = f.Init(); err != nil {
-		return err
+		return
 	}
 
 	// This fails whenever `qri connect` runs but another instance of `qri connect` is already
@@ -94,7 +94,7 @@ func (o *ConnectOptions) Complete(f Factory, args []string) (err error) {
 		return fmt.Errorf("Cannot serve without a node (`qri connect` or Qri Desktop already running?)")
 	}
 
-	o.inst = f.Instance()
+	o.inst, err = f.Instance()
 	return
 }
 

--- a/cmd/dag.go
+++ b/cmd/dag.go
@@ -100,7 +100,7 @@ type DAGOptions struct {
 	File       string
 	Label      string
 
-	DatasetMethods *lib.DatasetMethods
+	inst *lib.Instance
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -112,7 +112,7 @@ func (o *DAGOptions) Complete(f Factory, args []string, parseLabel bool) (err er
 		}
 	}
 	o.Refs = args
-	o.DatasetMethods, err = f.DatasetMethods()
+	o.inst, err = f.Instance()
 	return
 }
 
@@ -121,7 +121,7 @@ func (o *DAGOptions) Get() (err error) {
 	ctx := context.TODO()
 	mf := &dag.Manifest{}
 	for _, refstr := range o.Refs {
-		if mf, err = o.DatasetMethods.Manifest(ctx, &lib.ManifestParams{Refstr: refstr}); err != nil {
+		if mf, err = o.inst.Dataset().Manifest(ctx, &lib.ManifestParams{Refstr: refstr}); err != nil {
 			return err
 		}
 
@@ -177,7 +177,7 @@ func (o *DAGOptions) Missing() error {
 		return err
 	}
 
-	mf, err := o.DatasetMethods.ManifestMissing(ctx, &lib.ManifestMissingParams{Manifest: in})
+	mf, err := o.inst.Dataset().ManifestMissing(ctx, &lib.ManifestMissingParams{Manifest: in})
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (o *DAGOptions) Info() (err error) {
 
 	for _, refstr := range o.Refs {
 		s := &lib.DAGInfoParams{RefStr: refstr, Label: o.Label}
-		info, err = o.DatasetMethods.DAGInfo(ctx, s)
+		info, err = o.inst.Dataset().DAGInfo(ctx, s)
 		if err != nil {
 			return err
 		}

--- a/cmd/dag_test.go
+++ b/cmd/dag_test.go
@@ -87,8 +87,8 @@ func TestDAGComplete(t *testing.T) {
 			continue
 		}
 
-		if opt.DatasetMethods == nil {
-			t.Errorf("case %d, opt.DatasetMethods not set.", i)
+		if opt.inst == nil {
+			t.Errorf("case %d, opt.inst not set.", i)
 		}
 
 		if opt.Label != c.label {
@@ -152,15 +152,15 @@ func TestDAGInfo(t *testing.T) {
 		//     },
 	}
 	for i, c := range cases {
-		dsm, err := f.DatasetMethods()
+		inst, err := f.Instance()
 		if err != nil {
-			t.Errorf("case %d, error creating dataset request: %s", i, err)
+			t.Errorf("case %d, error creating inst: %s", i, err)
 			continue
 		}
 
 		opt := c.opt
 		opt.IOStreams = run.Streams
-		opt.DatasetMethods = dsm
+		opt.inst = inst
 
 		err = opt.Info()
 		if (err == nil && c.err != "") || (err != nil && c.err != err.Error()) {

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -75,7 +75,7 @@ type DiffOptions struct {
 	Format   string
 	Summary  bool
 
-	DatasetMethods *lib.DatasetMethods
+	inst *lib.Instance
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -96,15 +96,12 @@ func (o *DiffOptions) Complete(f Factory, args []string) (err error) {
 		o.Selector = args[0]
 		args = args[1:]
 	}
-	o.DatasetMethods, err = f.DatasetMethods()
-	if err != nil {
-		return err
+	if o.inst, err = f.Instance(); err != nil {
+		return
 	}
 
-	if o.Refs, err = GetCurrentRefSelect(f, args, 2, nil); err != nil {
-		return err
-	}
-	return nil
+	o.Refs, err = GetCurrentRefSelect(f, args, 2, nil)
+	return
 }
 
 // Run executes the diff command
@@ -139,7 +136,7 @@ func (o *DiffOptions) Run() (err error) {
 	}
 
 	ctx := context.TODO()
-	res, err := o.DatasetMethods.Diff(ctx, p)
+	res, err := o.inst.Dataset().Diff(ctx, p)
 	if err != nil {
 		return err
 	}

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -45,8 +45,8 @@ func TestDiffComplete(t *testing.T) {
 			continue
 		}
 
-		if opt.DatasetMethods == nil {
-			t.Errorf("case %d, opt.DatasetMethods not set.", i)
+		if opt.inst == nil {
+			t.Errorf("case %d, opt.inst not set.", i)
 			run.IOReset()
 			continue
 		}
@@ -99,14 +99,14 @@ func TestDiffRun(t *testing.T) {
 
 	for _, c := range good {
 		t.Run(c.description, func(t *testing.T) {
-			dsm, err := f.DatasetMethods()
+			inst, err := f.Instance()
 			if err != nil {
-				t.Fatalf("case %s, error creating dataset request: %s", c.description, err)
+				t.Fatalf("case %s, error creating inst: %s", c.description, err)
 			}
 
 			opt := c.opt
 			opt.IOStreams = run.Streams
-			opt.DatasetMethods = dsm
+			opt.inst = inst
 
 			if err = opt.Run(); err != nil {
 				t.Fatalf("case %s unexpected error: %s", c.description, err)
@@ -131,16 +131,16 @@ func TestDiffRun(t *testing.T) {
 	}
 
 	for _, c := range bad {
-		dsm, err := f.DatasetMethods()
+		inst, err := f.Instance()
 		if err != nil {
-			t.Errorf("case %s, error creating dataset request: %s", c.err, err)
+			t.Errorf("case %s, error creating instance: %s", c.err, err)
 			continue
 		}
 
 		opt := c.opt
 		opt.Refs = NewListOfRefSelects([]string{})
 		opt.IOStreams = run.Streams
-		opt.DatasetMethods = dsm
+		opt.inst = inst
 
 		err = opt.Run()
 

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -15,7 +15,7 @@ import (
 // Factory is an interface for providing required structures to cobra commands
 // It's main implementation is QriOptions
 type Factory interface {
-	Instance() *lib.Instance
+	Instance() (*lib.Instance, error)
 	Config() (*config.Config, error)
 
 	// path to qri data directory
@@ -26,7 +26,6 @@ type Factory interface {
 	RPC() *rpc.Client
 	ConnectionNode() (*p2p.QriNode, error)
 
-	DatasetMethods() (*lib.DatasetMethods, error)
 	RemoteMethods() (*lib.RemoteMethods, error)
 	RegistryClientMethods() (*lib.RegistryClientMethods, error)
 	LogMethods() (*lib.LogMethods, error)

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -103,8 +103,8 @@ func (t TestFactory) Config() (*config.Config, error) {
 	return t.config, nil
 }
 
-func (t TestFactory) Instance() *lib.Instance {
-	return t.inst
+func (t TestFactory) Instance() (*lib.Instance, error) {
+	return t.inst, nil
 }
 
 // RepoPath returns the path to the qri directory from internal state
@@ -130,11 +130,6 @@ func (t TestFactory) ConnectionNode() (*p2p.QriNode, error) {
 // RPC returns from internal state
 func (t TestFactory) RPC() *rpc.Client {
 	return nil
-}
-
-// DatasetMethods generates a lib.DatasetMethods from internal state
-func (t TestFactory) DatasetMethods() (*lib.DatasetMethods, error) {
-	return lib.NewDatasetMethods(t.inst), nil
 }
 
 // RemoteRequests generates a lib.RemoteRequests from internal state

--- a/cmd/fsi.go
+++ b/cmd/fsi.go
@@ -67,18 +67,17 @@ type FSIOptions struct {
 // Complete adds any missing configuration that can only be added just before
 // calling Run
 func (o *FSIOptions) Complete(f Factory, args []string) (err error) {
-	o.Instance = f.Instance()
+	if o.Instance, err = f.Instance(); err != nil {
+		return
+	}
 
 	if len(args) > 1 {
 		o.Path = args[1]
 		args = args[:1]
 	}
 
-	if o.Refs, err = GetCurrentRefSelect(f, args, 1, EnsureFSIAgrees(o.Instance)); err != nil {
-		return err
-	}
-
-	return nil
+	o.Refs, err = GetCurrentRefSelect(f, args, 1, EnsureFSIAgrees(o.Instance))
+	return
 }
 
 // Link creates a FSI link

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -82,12 +82,12 @@ type GetOptions struct {
 	Offline bool
 	Remote  string
 
-	DatasetMethods *lib.DatasetMethods
+	inst *lib.Instance
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *GetOptions) Complete(f Factory, args []string) (err error) {
-	if o.DatasetMethods, err = f.DatasetMethods(); err != nil {
+	if o.inst, err = f.Instance(); err != nil {
 		return
 	}
 
@@ -122,7 +122,7 @@ func (o *GetOptions) Complete(f Factory, args []string) (err error) {
 		}
 	}
 
-	return nil
+	return
 }
 
 // Run executes the get command
@@ -170,7 +170,7 @@ func (o *GetOptions) Run() (err error) {
 		Remote:      o.Remote,
 	}
 	ctx := context.TODO()
-	res, err := o.DatasetMethods.Get(ctx, &p)
+	res, err := o.inst.Dataset().Get(ctx, &p)
 	if err != nil {
 		return err
 	}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -65,8 +65,8 @@ func TestGetComplete(t *testing.T) {
 			continue
 		}
 
-		if opt.DatasetMethods == nil {
-			t.Errorf("case %d, opt.DatasetRequests not set.", i)
+		if opt.inst == nil {
+			t.Errorf("case %d, opt.inst not set.", i)
 			run.IOReset()
 			continue
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -70,20 +70,18 @@ type InitOptions struct {
 	TargetDir string
 	// Experimental: Use dscache subsystem to store dataset references
 	UseDscache bool
-
-	DatasetMethods *lib.DatasetMethods
 }
 
 // Complete completes a dataset reference
 func (o *InitOptions) Complete(f Factory, args []string) (err error) {
-	if o.DatasetMethods, err = f.DatasetMethods(); err != nil {
-		return err
+	if o.Instance, err = f.Instance(); err != nil {
+		return
 	}
-	o.Instance = f.Instance()
+
 	if len(args) > 0 {
 		o.TargetDir = args[0]
 	}
-	return err
+	return
 }
 
 // Run executes the `init` command

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -79,7 +79,7 @@ type ListOptions struct {
 	Raw             bool
 	UseDscache      bool
 
-	DatasetMethods *lib.DatasetMethods
+	inst *lib.Instance
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -87,7 +87,7 @@ func (o *ListOptions) Complete(f Factory, args []string) (err error) {
 	if len(args) > 0 {
 		o.Term = args[0]
 	}
-	o.DatasetMethods, err = f.DatasetMethods()
+	o.inst, err = f.Instance()
 	return
 }
 
@@ -101,7 +101,7 @@ func (o *ListOptions) Run() (err error) {
 		p := &lib.ListParams{
 			UseDscache: o.UseDscache,
 		}
-		text, err := o.DatasetMethods.ListRawRefs(ctx, p)
+		text, err := o.inst.Dataset().ListRawRefs(ctx, p)
 		if err != nil {
 			return err
 		}
@@ -119,7 +119,7 @@ func (o *ListOptions) Run() (err error) {
 		EnsureFSIExists: true,
 		UseDscache:      o.UseDscache,
 	}
-	infos, err := o.DatasetMethods.List(ctx, p)
+	infos, err := o.inst.Dataset().List(ctx, p)
 	if err != nil {
 		if errors.Is(err, lib.ErrListWarning) {
 			printWarning(o.ErrOut, fmt.Sprintf("%s\n", err))

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -47,18 +47,17 @@ dataset version(s). By default pull fetches the latest version of a dataset.
 // PullOptions encapsulates state for the add command
 type PullOptions struct {
 	ioes.IOStreams
-	LinkDir        string
-	Remote         string
-	LogsOnly       bool
-	DatasetMethods *lib.DatasetMethods
+	LinkDir  string
+	Remote   string
+	LogsOnly bool
+
+	inst *lib.Instance
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *PullOptions) Complete(f Factory) (err error) {
-	if o.DatasetMethods, err = f.DatasetMethods(); err != nil {
-		return
-	}
-	return nil
+	o.inst, err = f.Instance()
+	return
 }
 
 // Run adds another peer's dataset to this user's repo
@@ -81,7 +80,7 @@ func (o *PullOptions) Run(args []string) error {
 			Remote:   o.Remote,
 		}
 
-		res, err := o.DatasetMethods.Pull(ctx, p)
+		res, err := o.inst.Dataset().Pull(ctx, p)
 		if err != nil {
 			return err
 		}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -50,17 +50,13 @@ type PushOptions struct {
 	Logs       bool
 	RemoteName string
 
-	DatasetMethods *lib.DatasetMethods
-	RemoteMethods  *lib.RemoteMethods
+	RemoteMethods *lib.RemoteMethods
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *PushOptions) Complete(f Factory, args []string) (err error) {
-	if o.DatasetMethods, err = f.DatasetMethods(); err != nil {
-		return err
-	}
 	if o.Refs, err = GetCurrentRefSelect(f, args, 1, nil); err != nil {
-		return err
+		return
 	}
 	o.RemoteMethods, err = f.RemoteMethods()
 	return

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -191,11 +191,11 @@ Run migration now?`
 }
 
 // Instance returns the instance this options is using
-func (o *QriOptions) Instance() *lib.Instance {
+func (o *QriOptions) Instance() (*lib.Instance, error) {
 	if err := o.Init(); err != nil {
-		return nil
+		return nil, err
 	}
-	return o.inst
+	return o.inst, nil
 }
 
 // RepoPath returns the path to the qri data directory
@@ -230,14 +230,6 @@ func (o *QriOptions) ConnectionNode() (*p2p.QriNode, error) {
 		return nil, fmt.Errorf("repo not available")
 	}
 	return o.inst.Node(), nil
-}
-
-// DatasetMethods generates a lib.DatasetMethods from internal state
-func (o *QriOptions) DatasetMethods() (*lib.DatasetMethods, error) {
-	if err := o.Init(); err != nil {
-		return nil, err
-	}
-	return lib.NewDatasetMethods(o.inst), nil
 }
 
 // RemoteMethods generates a lib.RemoteMethods from internal state

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -91,22 +91,23 @@ type RemoveOptions struct {
 	KeepFiles     bool
 	Force         bool
 
-	RemoteMethods  *lib.RemoteMethods
-	DatasetMethods *lib.DatasetMethods
+	RemoteMethods *lib.RemoteMethods
+	inst          *lib.Instance
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *RemoveOptions) Complete(f Factory, args []string) (err error) {
-	if o.DatasetMethods, err = f.DatasetMethods(); err != nil {
-		return err
+	if o.inst, err = f.Instance(); err != nil {
+		return
 	}
+
 	if o.RemoteMethods, err = f.RemoteMethods(); err != nil {
-		return err
+		return
 	}
 	if o.Refs, err = GetCurrentRefSelect(f, args, 1, nil); err != nil {
 		// This error will be handled during validation
 		if err != repo.ErrEmptyRef {
-			return err
+			return
 		}
 		err = nil
 	}
@@ -128,7 +129,7 @@ func (o *RemoveOptions) Complete(f Factory, args []string) (err error) {
 		}
 		o.Revision = revisions[0]
 	}
-	return err
+	return
 }
 
 // Validate checks that all user input is valid
@@ -155,7 +156,7 @@ func (o *RemoveOptions) Run() (err error) {
 	}
 
 	ctx := context.TODO()
-	res, err := o.DatasetMethods.Remove(ctx, &params)
+	res, err := o.inst.Dataset().Remove(ctx, &params)
 	if err != nil {
 		// TODO(b5): move this error handling down into lib
 		if errors.Is(err, dsref.ErrRefNotFound) {

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -44,8 +44,8 @@ func TestRemoveComplete(t *testing.T) {
 			continue
 		}
 
-		if opt.DatasetMethods == nil {
-			t.Errorf("case %d, opt.DatasetMethods not set.", i)
+		if opt.inst == nil {
+			t.Errorf("case %d, opt.inst not set.", i)
 			run.IOReset()
 			continue
 		}
@@ -113,17 +113,16 @@ func TestRemoveRun(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		dsm, err := f.DatasetMethods()
+		inst, err := f.Instance()
 		if err != nil {
-			t.Errorf("case %d, error creating dataset request: %s", i, err)
-			continue
+			t.Fatalf("case %d, error creating instance: %s", i, err)
 		}
 
 		opt := &RemoveOptions{
-			IOStreams:      run.Streams,
-			Refs:           NewListOfRefSelects(c.args),
-			Revision:       &dsref.Rev{Field: "ds", Gen: c.revision},
-			DatasetMethods: dsm,
+			IOStreams: run.Streams,
+			Refs:      NewListOfRefSelects(c.args),
+			Revision:  &dsref.Rev{Field: "ds", Gen: c.revision},
+			inst:      inst,
 		}
 
 		err = opt.Run()

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -49,7 +49,7 @@ type RenameOptions struct {
 	From string
 	To   string
 
-	DatasetMethods *lib.DatasetMethods
+	inst *lib.Instance
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -58,7 +58,7 @@ func (o *RenameOptions) Complete(f Factory, args []string) (err error) {
 		o.From = args[0]
 		o.To = args[1]
 	}
-	o.DatasetMethods, err = f.DatasetMethods()
+	o.inst, err = f.Instance()
 	return
 }
 
@@ -77,7 +77,7 @@ func (o *RenameOptions) Run() error {
 		Next:    o.To,
 	}
 	ctx := context.TODO()
-	res, err := o.DatasetMethods.Rename(ctx, p)
+	res, err := o.inst.Dataset().Rename(ctx, p)
 	if err != nil {
 		return err
 	}

--- a/cmd/rename_test.go
+++ b/cmd/rename_test.go
@@ -57,8 +57,8 @@ func TestRenameComplete(t *testing.T) {
 			continue
 		}
 
-		if opt.DatasetMethods == nil {
-			t.Errorf("case %d, opt.DatasetMethods not set.", i)
+		if opt.inst == nil {
+			t.Errorf("case %d, opt.inst not set.", i)
 			run.IOReset()
 			continue
 		}
@@ -129,17 +129,17 @@ func TestRenameRun(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		dsm, err := f.DatasetMethods()
+		inst, err := f.Instance()
 		if err != nil {
-			t.Errorf("case %d, error creating dataset request: %s", i, err)
+			t.Errorf("case %d, error creating instance: %s", i, err)
 			continue
 		}
 
 		opt := &RenameOptions{
-			IOStreams:      run.Streams,
-			From:           c.from,
-			To:             c.to,
-			DatasetMethods: dsm,
+			IOStreams: run.Streams,
+			From:      c.from,
+			To:        c.to,
+			inst:      inst,
 		}
 
 		err = opt.Run()

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -72,7 +72,9 @@ func (o *RestoreOptions) Complete(f Factory, args []string) (err error) {
 	o.Path = ""
 	o.ComponentName = ""
 
-	o.Instance = f.Instance()
+	if o.Instance, err = f.Instance(); err != nil {
+		return
+	}
 
 	// TODO(dlong): Add low-level utilities that parse strings like "peername/ds_name", and
 	// "/ipfs/QmFoo", "meta.description", etc and use those everywhere. Use real regexs so
@@ -114,10 +116,8 @@ func (o *RestoreOptions) Complete(f Factory, args []string) (err error) {
 		return fmt.Errorf("unknown argument \"%s\"", arg)
 	}
 
-	if o.Refs, err = GetCurrentRefSelect(f, dsRefList, 1, EnsureFSIAgrees(o.Instance)); err != nil {
-		return err
-	}
-	return nil
+	o.Refs, err = GetCurrentRefSelect(f, dsRefList, 1, EnsureFSIAgrees(o.Instance))
+	return
 }
 
 // Run executes the `restore` command

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -111,7 +111,7 @@ type SaveOptions struct {
 	NewName        bool
 	UseDscache     bool
 
-	DatasetMethods *lib.DatasetMethods
+	inst *lib.Instance
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
@@ -120,14 +120,14 @@ func (o *SaveOptions) Complete(f Factory, args []string) (err error) {
 		return fmt.Errorf("--dry-run has been removed, use `qri apply` command instead")
 	}
 
-	if o.DatasetMethods, err = f.DatasetMethods(); err != nil {
+	if o.inst, err = f.Instance(); err != nil {
 		return
 	}
 
 	if o.Refs, err = GetCurrentRefSelect(f, args, BadUpperCaseOkayWhenSavingExistingDataset, nil); err != nil {
 		// Not an error to use an empty reference, it will be inferred later on.
 		if err != repo.ErrEmptyRef {
-			return err
+			return
 		}
 	}
 
@@ -143,7 +143,6 @@ func (o *SaveOptions) Complete(f Factory, args []string) (err error) {
 	if err := qfs.AbsPath(&o.BodyPath); err != nil {
 		return fmt.Errorf("body file: %s", err)
 	}
-
 	return nil
 }
 
@@ -205,7 +204,7 @@ continue?`, true) {
 	}
 
 	ctx := context.TODO()
-	res, err := o.DatasetMethods.Save(ctx, p)
+	res, err := o.inst.Dataset().Save(ctx, p)
 	if err != nil {
 		return err
 	}

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -62,8 +62,8 @@ func TestSaveComplete(t *testing.T) {
 			continue
 		}
 
-		if opt.DatasetMethods == nil {
-			t.Errorf("case %d, opt.DatasetMethods not set.", i)
+		if opt.inst == nil {
+			t.Errorf("case %d, opt.inst not set.", i)
 			run.IOReset()
 			continue
 		}
@@ -144,9 +144,9 @@ func TestSaveRun(t *testing.T) {
 
 	for _, c := range cases {
 		run.IOReset()
-		dsm, err := f.DatasetMethods()
+		inst, err := f.Instance()
 		if err != nil {
-			t.Errorf("case \"%s\", error creating dataset request: %s", c.description, err)
+			t.Errorf("case \"%s\", error creating instance: %s", c.description, err)
 			continue
 		}
 
@@ -156,14 +156,14 @@ func TestSaveRun(t *testing.T) {
 		}
 
 		opt := &SaveOptions{
-			IOStreams:      run.Streams,
-			Refs:           NewExplicitRefSelect(c.ref),
-			FilePaths:      pathList,
-			BodyPath:       c.bodypath,
-			Title:          c.title,
-			Message:        c.message,
-			NoRender:       c.noRender,
-			DatasetMethods: dsm,
+			IOStreams: run.Streams,
+			Refs:      NewExplicitRefSelect(c.ref),
+			FilePaths: pathList,
+			BodyPath:  c.bodypath,
+			Title:     c.title,
+			Message:   c.message,
+			NoRender:  c.noRender,
+			inst:      inst,
 		}
 
 		err = opt.Run()

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -46,19 +46,15 @@ type StatsOptions struct {
 	Refs   *RefSelect
 	Pretty bool
 
-	DatasetMethods *lib.DatasetMethods
+	inst *lib.Instance
 }
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *StatsOptions) Complete(f Factory, args []string) (err error) {
-	if o.DatasetMethods, err = f.DatasetMethods(); err != nil {
+	if o.inst, err = f.Instance(); err != nil {
 		return
 	}
-
 	o.Refs, err = GetCurrentRefSelect(f, args, 1, nil)
-	if err != nil {
-		return err
-	}
 	return
 }
 
@@ -75,7 +71,7 @@ func (o *StatsOptions) Run() (err error) {
 	p := &lib.StatsParams{
 		Refstr: o.Refs.Ref(),
 	}
-	sa, err := o.DatasetMethods.Stats(ctx, p)
+	sa, err := o.inst.Dataset().Stats(ctx, p)
 	if err != nil {
 		return err
 	}

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -67,8 +67,8 @@ func TestStatsComplete(t *testing.T) {
 			continue
 		}
 
-		if opt.DatasetMethods == nil {
-			t.Errorf("%d. case %s, opt.DatasetMethods not set.", i, c.description)
+		if opt.inst == nil {
+			t.Errorf("%d. case %s, opt.inst not set.", i, c.description)
 			run.IOReset()
 			continue
 		}
@@ -88,7 +88,7 @@ func TestStatsRun(t *testing.T) {
 		t.Fatalf("error creating new test factory: %s", err)
 	}
 
-	dsm, err := f.DatasetMethods()
+	inst, err := f.Instance()
 	if err != nil {
 		t.Fatalf("error creating dataset request: %s", err)
 	}
@@ -105,9 +105,9 @@ func TestStatsRun(t *testing.T) {
 		run.IOReset()
 
 		opt := &StatsOptions{
-			IOStreams:      run.Streams,
-			Refs:           NewExplicitRefSelect(c.ref),
-			DatasetMethods: dsm,
+			IOStreams: run.Streams,
+			Refs:      NewExplicitRefSelect(c.ref),
+			inst:      inst,
 		}
 
 		if err = opt.Run(); err.Error() != c.err {
@@ -132,9 +132,9 @@ func TestStatsRun(t *testing.T) {
 		run.IOReset()
 
 		opt := &StatsOptions{
-			IOStreams:      run.Streams,
-			Refs:           NewExplicitRefSelect(c.ref),
-			DatasetMethods: dsm,
+			IOStreams: run.Streams,
+			Refs:      NewExplicitRefSelect(c.ref),
+			inst:      inst,
 		}
 
 		if err = opt.Run(); err != nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -63,7 +63,9 @@ type StatusOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *StatusOptions) Complete(f Factory, args []string) (err error) {
-	o.Instance = f.Instance()
+	if o.Instance, err = f.Instance(); err != nil {
+		return
+	}
 
 	// Cannot pass explicit reference, must be run in a working directory
 	if len(args) > 0 {
@@ -72,11 +74,7 @@ func (o *StatusOptions) Complete(f Factory, args []string) (err error) {
 	}
 
 	o.Refs, err = GetCurrentRefSelect(f, args, 0, EnsureFSIAgrees(o.Instance))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return
 }
 
 // ColumnPositionForMtime is the column position at which to display mod times, if requested

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -99,12 +99,12 @@ type ValidateOptions struct {
 	StructureFilepath string
 	Format            string
 
-	DatasetMethods *lib.DatasetMethods
+	inst *lib.Instance
 }
 
 // Complete adds any configuration that can only be added just before calling Run
 func (o *ValidateOptions) Complete(f Factory, args []string) (err error) {
-	if o.DatasetMethods, err = f.DatasetMethods(); err != nil {
+	if o.inst, err = f.Instance(); err != nil {
 		return
 	}
 
@@ -138,7 +138,7 @@ func (o *ValidateOptions) Run() (err error) {
 	}
 
 	ctx := context.TODO()
-	res, err := o.DatasetMethods.Validate(ctx, p)
+	res, err := o.inst.Dataset().Validate(ctx, p)
 	if err != nil {
 		return err
 	}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -56,8 +56,8 @@ func TestValidateComplete(t *testing.T) {
 				t.Errorf("case %d, opt.Refs not set correctly. Expected: %q, Got: %q", i, c.expect, opt.Refs.Ref())
 			}
 
-			if opt.DatasetMethods == nil {
-				t.Fatalf("case %d, opt.DatasetMethods not set.", i)
+			if opt.inst == nil {
+				t.Fatalf("case %d, opt.inst not set.", i)
 			}
 		})
 	}
@@ -77,9 +77,9 @@ func TestValidateRun(t *testing.T) {
 		return
 	}
 
-	dsm, err := f.DatasetMethods()
+	inst, err := f.Instance()
 	if err != nil {
-		t.Fatalf("error creating dataset request: %s", err)
+		t.Fatalf("error creating instance: %s", err)
 	}
 
 	bad := []struct {
@@ -113,7 +113,7 @@ func TestValidateRun(t *testing.T) {
 				SchemaFilepath:    c.schemaPath,
 				StructureFilepath: c.structurePath,
 				Format:            c.format,
-				DatasetMethods:    dsm,
+				inst:              inst,
 			}
 
 			err := opt.Run()
@@ -176,7 +176,7 @@ func TestValidateRun(t *testing.T) {
 				SchemaFilepath:    c.schemaPath,
 				StructureFilepath: c.structurePath,
 				Format:            c.format,
-				DatasetMethods:    dsm,
+				inst:              inst,
 			}
 
 			if err := opt.Run(); err != nil {

--- a/cmd/whatchanged.go
+++ b/cmd/whatchanged.go
@@ -43,9 +43,11 @@ type WhatChangedOptions struct {
 
 // Complete adds any missing configuration that can only be added just before calling Run
 func (o *WhatChangedOptions) Complete(f Factory, args []string) (err error) {
-	o.Instance = f.Instance()
+	if o.Instance, err = f.Instance(); err != nil {
+		return
+	}
 	o.Refs, err = GetCurrentRefSelect(f, args, 1, EnsureFSIAgrees(o.Instance))
-	return nil
+	return
 }
 
 // Run executes the whatchanged command

--- a/lib/config.go
+++ b/lib/config.go
@@ -198,7 +198,7 @@ func (configImpl) SetConfig(scope scope, update *config.Config) (*bool, error) {
 		return &res, fmt.Errorf("validating config: %w", err)
 	}
 
-	if err := scope.Loader().ChangeConfig(update); err != nil {
+	if err := scope.ChangeConfig(update); err != nil {
 		return &res, err
 	}
 	res = true

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -67,124 +67,11 @@ func NewDatasetMethods(inst *Instance) *DatasetMethods {
 
 // List gets the reflist for either the local repo or a peer
 func (m *DatasetMethods) List(ctx context.Context, p *ListParams) ([]dsref.VersionInfo, error) {
-	if m.inst.http != nil {
-		res := []dsref.VersionInfo{}
-		p.RPC = true
-		err := m.inst.http.Call(ctx, AEList, p, &res)
-		if err != nil {
-			return nil, err
-		}
-		return res, nil
+	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "list"), p)
+	if res, ok := got.([]dsref.VersionInfo); ok {
+		return res, err
 	}
-
-	// TODO(dustmop): When List is converted to use scope, get the ProfileID from
-	// the scope if the user is authorized to only view their own datasets, as opposed
-	// to the full collection that exists in this node's repository.
-	restrictPid := ""
-
-	// ensure valid limit value
-	if p.Limit <= 0 {
-		p.Limit = 25
-	}
-	// ensure valid offset value
-	if p.Offset < 0 {
-		p.Offset = 0
-	}
-
-	reqProfile := m.inst.repo.Profiles().Owner()
-	listProfile, err := getProfile(ctx, m.inst.Repo().Profiles(), reqProfile.ID.String(), p.Peername)
-	if err != nil {
-		return nil, err
-	}
-
-	// If the list operation leads to a warning, store it in this var
-	var listWarning error
-
-	var infos []dsref.VersionInfo
-	if p.UseDscache {
-		c := m.inst.dscache
-		if c.IsEmpty() {
-			log.Infof("building dscache from repo's logbook, profile, and dsref")
-			built, err := build.DscacheFromRepo(ctx, m.inst.repo)
-			if err != nil {
-				return nil, err
-			}
-			err = c.Assign(built)
-			if err != nil {
-				log.Error(err)
-			}
-		}
-		refs, err := c.ListRefs()
-		if err != nil {
-			return nil, err
-		}
-		// Filter references so that only with a matching name are returned
-		if p.Term != "" {
-			matched := make([]reporef.DatasetRef, len(refs))
-			count := 0
-			for _, ref := range refs {
-				if strings.Contains(ref.AliasString(), p.Term) {
-					matched[count] = ref
-					count++
-				}
-			}
-			refs = matched[:count]
-		}
-		// Filter references by skipping to the correct offset
-		if p.Offset > len(refs) {
-			refs = []reporef.DatasetRef{}
-		} else {
-			refs = refs[p.Offset:]
-		}
-		// Filter references by limiting how many are returned
-		if p.Limit < len(refs) {
-			refs = refs[:p.Limit]
-		}
-		// Convert old style DatasetRef list to VersionInfo list.
-		// TODO(dustmop): Remove this and convert lower-level functions to return []VersionInfo.
-		infos = make([]dsref.VersionInfo, len(refs))
-		for i, r := range refs {
-			infos[i] = reporef.ConvertToVersionInfo(&r)
-		}
-	} else if listProfile.Peername == "" || reqProfile.Peername == listProfile.Peername {
-		infos, err = base.ListDatasets(ctx, m.inst.repo, p.Term, restrictPid, p.Offset, p.Limit, p.RPC, p.Public, p.ShowNumVersions)
-		if errors.Is(err, ErrListWarning) {
-			listWarning = err
-			err = nil
-		}
-	} else {
-		return nil, fmt.Errorf("listing datasets on a peer is not implemented")
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	if p.EnsureFSIExists {
-		// For each reference with a linked fsi working directory, check that the folder exists
-		// and has a .qri-ref file. If it's missing, remove the link from the centralized repo.
-		// Doing this every list operation is a bit inefficient, so the behavior is opt-in.
-		for _, info := range infos {
-			if info.FSIPath != "" && !linkfile.ExistsInDir(info.FSIPath) {
-				info.FSIPath = ""
-				ref := reporef.RefFromVersionInfo(&info)
-				if ref.Path == "" {
-					if err = m.inst.repo.DeleteRef(ref); err != nil {
-						log.Debugf("cannot delete ref for %q, err: %s", ref, err)
-					}
-					continue
-				}
-				if err = m.inst.repo.PutRef(ref); err != nil {
-					log.Debugf("cannot put ref for %q, err: %s", ref, err)
-				}
-			}
-		}
-	}
-
-	if listWarning != nil {
-		return nil, listWarning
-	}
-
-	return infos, nil
+	return nil, dispatchReturnError(got, err)
 }
 
 // ListRawRefs gets the list of raw references as string
@@ -1737,7 +1624,114 @@ type datasetImpl struct{}
 
 // List gets the reflist for either the local repo or a peer
 func (datasetImpl) List(scope scope, p *ListParams) ([]dsref.VersionInfo, error) {
-	return nil, fmt.Errorf("not yet implemented")
+	// TODO(dustmop): When List is converted to use scope, get the ProfileID from
+	// the scope if the user is authorized to only view their own datasets, as opposed
+	// to the full collection that exists in this node's repository.
+	restrictPid := ""
+
+	// ensure valid limit value
+	if p.Limit <= 0 {
+		p.Limit = 25
+	}
+	// ensure valid offset value
+	if p.Offset < 0 {
+		p.Offset = 0
+	}
+
+	reqProfile := scope.Repo().Profiles().Owner()
+	listProfile, err := getProfile(scope.Context(), scope.Repo().Profiles(), reqProfile.ID.String(), p.Peername)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the list operation leads to a warning, store it in this var
+	var listWarning error
+
+	var infos []dsref.VersionInfo
+	if p.UseDscache {
+		c := scope.Dscache()
+		if c.IsEmpty() {
+			log.Infof("building dscache from repo's logbook, profile, and dsref")
+			built, err := build.DscacheFromRepo(scope.Context(), scope.Repo())
+			if err != nil {
+				return nil, err
+			}
+			err = c.Assign(built)
+			if err != nil {
+				log.Error(err)
+			}
+		}
+		refs, err := c.ListRefs()
+		if err != nil {
+			return nil, err
+		}
+		// Filter references so that only with a matching name are returned
+		if p.Term != "" {
+			matched := make([]reporef.DatasetRef, len(refs))
+			count := 0
+			for _, ref := range refs {
+				if strings.Contains(ref.AliasString(), p.Term) {
+					matched[count] = ref
+					count++
+				}
+			}
+			refs = matched[:count]
+		}
+		// Filter references by skipping to the correct offset
+		if p.Offset > len(refs) {
+			refs = []reporef.DatasetRef{}
+		} else {
+			refs = refs[p.Offset:]
+		}
+		// Filter references by limiting how many are returned
+		if p.Limit < len(refs) {
+			refs = refs[:p.Limit]
+		}
+		// Convert old style DatasetRef list to VersionInfo list.
+		// TODO(dustmop): Remove this and convert lower-level functions to return []VersionInfo.
+		infos = make([]dsref.VersionInfo, len(refs))
+		for i, r := range refs {
+			infos[i] = reporef.ConvertToVersionInfo(&r)
+		}
+	} else if listProfile.Peername == "" || reqProfile.Peername == listProfile.Peername {
+		infos, err = base.ListDatasets(scope.Context(), scope.Repo(), p.Term, restrictPid, p.Offset, p.Limit, p.RPC, p.Public, p.ShowNumVersions)
+		if errors.Is(err, ErrListWarning) {
+			listWarning = err
+			err = nil
+		}
+	} else {
+		return nil, fmt.Errorf("listing datasets on a peer is not implemented")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if p.EnsureFSIExists {
+		// For each reference with a linked fsi working directory, check that the folder exists
+		// and has a .qri-ref file. If it's missing, remove the link from the centralized repo.
+		// Doing this every list operation is a bit inefficient, so the behavior is opt-in.
+		for _, info := range infos {
+			if info.FSIPath != "" && !linkfile.ExistsInDir(info.FSIPath) {
+				info.FSIPath = ""
+				ref := reporef.RefFromVersionInfo(&info)
+				if ref.Path == "" {
+					if err = scope.Repo().DeleteRef(ref); err != nil {
+						log.Debugf("cannot delete ref for %q, err: %s", ref, err)
+					}
+					continue
+				}
+				if err = scope.Repo().PutRef(ref); err != nil {
+					log.Debugf("cannot put ref for %q, err: %s", ref, err)
+				}
+			}
+		}
+	}
+
+	if listWarning != nil {
+		return nil, listWarning
+	}
+
+	return infos, nil
 }
 
 // ListRawRefs gets the list of raw references as string

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -78,10 +78,9 @@ func TestDatasetRequestsSave(t *testing.T) {
 	}()
 
 	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
-	m := NewDatasetMethods(inst)
 
 	privateErrMsg := "option to make dataset private not yet implemented, refer to https://github.com/qri-io/qri/issues/291 for updates"
-	_, err = m.Save(ctx, &SaveParams{Private: true})
+	_, err = inst.Dataset().Save(ctx, &SaveParams{Private: true})
 	if err == nil {
 		t.Errorf("expected datset to error")
 	} else if err.Error() != privateErrMsg {
@@ -99,7 +98,7 @@ func TestDatasetRequestsSave(t *testing.T) {
 	}
 
 	for i, c := range good {
-		got, err := m.Save(ctx, &c.params)
+		got, err := inst.Dataset().Save(ctx, &c.params)
 		if err != nil {
 			t.Errorf("case %d: '%s' unexpected error: %s", i, c.description, err.Error())
 			continue
@@ -125,7 +124,7 @@ func TestDatasetRequestsSave(t *testing.T) {
 	}
 
 	for i, c := range bad {
-		_, err := m.Save(ctx, &c.params)
+		_, err := inst.Dataset().Save(ctx, &c.params)
 		if err == nil {
 			t.Errorf("case %d: '%s' returned no error", i, c.description)
 		}
@@ -153,14 +152,13 @@ func TestDatasetRequestsForceSave(t *testing.T) {
 	node := newTestQriNode(t)
 	ref := addCitiesDataset(t, node)
 	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
-	m := NewDatasetMethods(inst)
 
-	_, err := m.Save(ctx, &SaveParams{Ref: ref.Alias()})
+	_, err := inst.Dataset().Save(ctx, &SaveParams{Ref: ref.Alias()})
 	if err == nil {
 		t.Error("expected empty save without force flag to error")
 	}
 
-	_, err = m.Save(ctx, &SaveParams{
+	_, err = inst.Dataset().Save(ctx, &SaveParams{
 		Ref:   ref.Alias(),
 		Force: true,
 	})
@@ -182,11 +180,10 @@ func TestDatasetRequestsSaveZip(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
-	m := NewDatasetMethods(inst)
 
 	// TODO (b5): import.zip has a ref.txt file that specifies test_user/test_repo as the dataset name,
 	// save now requires a string reference. we need to pick a behaviour here & write a test that enforces it
-	res, err := m.Save(ctx, &SaveParams{Ref: "me/huh", FilePaths: []string{"testdata/import.zip"}})
+	res, err := inst.Dataset().Save(ctx, &SaveParams{Ref: "me/huh", FilePaths: []string{"testdata/import.zip"}})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -844,7 +841,6 @@ func TestDatasetRequestsRemove(t *testing.T) {
 	}
 
 	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
-	dsm := NewDatasetMethods(inst)
 	allRevs := &dsref.Rev{Field: "ds", Gen: -1}
 
 	// we need some fsi stuff to fully test remove
@@ -876,7 +872,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 	}
 
 	// add a commit to craigslist
-	_, err = dsm.Save(ctx, &SaveParams{Ref: "peer/craigslist", Dataset: &dataset.Dataset{Meta: &dataset.Meta{Title: "oh word"}}})
+	_, err = inst.Dataset().Save(ctx, &SaveParams{Ref: "peer/craigslist", Dataset: &dataset.Dataset{Meta: &dataset.Meta{Title: "oh word"}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -903,7 +899,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 	for i, c := range badCases {
 		t.Run(fmt.Sprintf("bad_case_%s", c.err), func(t *testing.T) {
-			_, err := dsm.Remove(ctx, &c.params)
+			_, err := inst.Dataset().Remove(ctx, &c.params)
 
 			if err == nil {
 				t.Errorf("case %d: expected error. got nil", i)
@@ -931,7 +927,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 	for _, c := range goodCases {
 		t.Run(fmt.Sprintf("good_case_%s", c.description), func(t *testing.T) {
-			res, err := dsm.Remove(ctx, &c.params)
+			res, err := inst.Dataset().Remove(ctx, &c.params)
 
 			if err != nil {
 				t.Errorf("unexpected error: %s", err)

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -551,10 +551,9 @@ func TestDatasetRequestsGet(t *testing.T) {
 			bodyToPrettyString(moviesBody[:3])},
 	}
 
-	dsm := NewDatasetMethods(inst)
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			got, err := dsm.Get(ctx, c.params)
+			got, err := inst.Dataset().Get(ctx, c.params)
 			if err != nil {
 				if err.Error() != c.expect {
 					t.Errorf("error mismatch: expected: %s, got: %s", c.expect, err)
@@ -597,11 +596,10 @@ func TestDatasetRequestsGetFSIPath(t *testing.T) {
 		t.Fatalf("error checking out dataset: %s", err)
 	}
 
-	dsm := NewDatasetMethods(inst)
 	getParams := &GetParams{
 		Refstr: "peer/movies",
 	}
-	got, err := dsm.Get(ctx, getParams)
+	got, err := inst.Dataset().Get(ctx, getParams)
 	if err != nil {
 		t.Fatalf("error getting fsi dataset: %s", err)
 	}
@@ -701,10 +699,9 @@ func TestDatasetRequestsGetP2p(t *testing.T) {
 			ref := reporef.DatasetRef{Peername: profile.Peername, Name: name}
 
 			inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
-			m := NewDatasetMethods(inst)
 			// TODO (b5) - we're using "JSON" here b/c the "craigslist" test dataset
 			// is tripping up the YAML serializer
-			got, err := m.Get(ctx, &GetParams{Refstr: fmt.Sprintf("%s/%s", profile.Peername, name), Format: "json"})
+			got, err := inst.Dataset().Get(ctx, &GetParams{Refstr: fmt.Sprintf("%s/%s", profile.Peername, name), Format: "json"})
 			if err != nil {
 				t.Errorf("error getting dataset for %q: %s", ref, err.Error())
 			}

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -1251,9 +1251,8 @@ func TestListRawRefs(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
-	m := NewDatasetMethods(inst)
 
-	text, err := m.ListRawRefs(ctx, &ListParams{})
+	text, err := inst.Dataset().ListRawRefs(ctx, &ListParams{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/diff_test.go
+++ b/lib/diff_test.go
@@ -11,7 +11,7 @@ func TestDatasetMethodsDiff(t *testing.T) {
 	tr := newTestRunner(t)
 	defer tr.Delete()
 
-	req := NewDatasetMethods(tr.Instance)
+	req := tr.Instance.Dataset()
 	jobsOnePath := tr.MustWriteTmpFile(t, "jobs_by_automation_1.csv", jobsByAutomationData1)
 	jobsTwoPath := tr.MustWriteTmpFile(t, "jobs_by_automation_2.csv", jobsByAutomationData2)
 

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -36,7 +36,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	}
 
 	p := &ListParams{}
-	refs, err := NewDatasetMethods(tr.RegistryInst).ListRawRefs(tr.Ctx, p)
+	refs, err := tr.RegistryInst.Dataset().ListRawRefs(tr.Ctx, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,8 +68,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	PushToRegistry(t, nasim, ref.Alias())
 
 	// 7. hinshun logsyncs with the registry for world bank dataset, sees multiple versions
-	dsm := NewDatasetMethods(hinshun)
-	_, err = dsm.Pull(tr.Ctx, &PullParams{LogsOnly: true, Ref: ref.String()})
+	_, err = hinshun.Dataset().Pull(tr.Ctx, &PullParams{LogsOnly: true, Ref: ref.String()})
 	if err != nil {
 		t.Errorf("cloning logs: %s", err)
 	}

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -164,7 +164,6 @@ func TestReferencePulling(t *testing.T) {
 
 	// create adnan
 	adnan := tr.InitAdnan(t)
-	dsm := NewDatasetMethods(adnan)
 
 	// run a transform script that relies on world_bank_population, which adnan's
 	// node should automatically pull to execute this script
@@ -187,7 +186,7 @@ def transform(ds, ctx):
 		},
 		Apply: true,
 	}
-	_, err = dsm.Save(tr.Ctx, saveParams)
+	_, err = adnan.Dataset().Save(tr.Ctx, saveParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +372,7 @@ func AssertLogsEqual(a, b *Instance, ref dsref.Ref) error {
 }
 
 func InitWorldBankDataset(ctx context.Context, t *testing.T, inst *Instance) dsref.Ref {
-	res, err := NewDatasetMethods(inst).Save(ctx, &SaveParams{
+	res, err := inst.Dataset().Save(ctx, &SaveParams{
 		Ref: "me/world_bank_population",
 		Dataset: &dataset.Dataset{
 			Meta: &dataset.Meta{
@@ -397,7 +396,7 @@ d,e,f,false,3`),
 }
 
 func Commit2WorldBank(ctx context.Context, t *testing.T, inst *Instance) dsref.Ref {
-	res, err := NewDatasetMethods(inst).Save(ctx, &SaveParams{
+	res, err := inst.Dataset().Save(ctx, &SaveParams{
 		Ref: "me/world_bank_population",
 		Dataset: &dataset.Dataset{
 			Meta: &dataset.Meta{

--- a/lib/render_test.go
+++ b/lib/render_test.go
@@ -125,7 +125,7 @@ func newRenderTestRunner(t *testing.T, testName string) *renderTestRunner {
 		panic(err)
 	}
 	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), r.Node)
-	r.DatasetReqs = NewDatasetMethods(inst)
+	r.DatasetReqs = inst.Dataset()
 	r.RenderMethods = NewRenderMethods(inst)
 
 	return &r

--- a/lib/rpc_test.go
+++ b/lib/rpc_test.go
@@ -30,7 +30,7 @@ func TestRPCRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = NewDatasetMethods(adnanInst).Get(tr.Ctx, &GetParams{
+	_, err = adnanInst.Dataset().Get(tr.Ctx, &GetParams{
 		Refstr: ref.String(),
 	})
 

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -15,7 +15,6 @@ import (
 	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/stats"
-	"github.com/qri-io/qri/transform"
 )
 
 // scope represents the lifetime of a method call, abstractly connected to the caller of
@@ -138,12 +137,13 @@ func (s *scope) Repo() repo.Repo {
 	return s.inst.repo
 }
 
+// ResolverForMode returns a resolver for a particular mode, options are:
+// "local", "network", "registry, "p2p", or "" for the default resolver
+func (s *scope) ResolverForMode(mode string) (dsref.Resolver, error) {
+	return s.inst.resolverForMode(mode)
+}
+
 // Stats returns the stats service
 func (s *scope) Stats() *stats.Service {
 	return s.inst.stats
-}
-
-// Transform returns the transform service
-func (s *scope) Transform() *transform.Service {
-	return s.inst.transform
 }

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -89,6 +89,11 @@ func (s *scope) Profiles() profile.Store {
 	return s.inst.profiles
 }
 
+// Repo returns the repo store
+func (s *scope) Repo() repo.Repo {
+	return s.inst.Repo()
+}
+
 // Loader returns the instance
 func (s *scope) Loader() *Instance {
 	return s.inst

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
 	"github.com/qri-io/qri/fsi"
+	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/stats"
@@ -91,7 +92,12 @@ func (s *scope) Profiles() profile.Store {
 
 // Repo returns the repo store
 func (s *scope) Repo() repo.Repo {
-	return s.inst.Repo()
+	return s.inst.repo
+}
+
+// Logbook returns the repo logbook
+func (s *scope) Logbook() *logbook.Book {
+	return s.inst.logbook
 }
 
 // Loader returns the instance

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -52,6 +52,11 @@ func (s *scope) Bus() event.Bus {
 	return s.inst.bus
 }
 
+// ChangeConfig implements the ConfigSetter interface
+func (s *scope) ChangeConfig(ctg *config.Config) error {
+	return s.inst.ChangeConfig(ctg)
+}
+
 // Config returns the config
 func (s *scope) Config() *config.Config {
 	return s.inst.cfg
@@ -93,7 +98,7 @@ func (s *scope) GetVersionInfoShim(ref dsref.Ref) (*dsref.VersionInfo, error) {
 }
 
 // Loader returns the instance
-func (s *scope) Loader() *Instance {
+func (s *scope) Loader() dsref.Loader {
 	return s.inst
 }
 

--- a/lib/test_runner_test.go
+++ b/lib/test_runner_test.go
@@ -153,12 +153,11 @@ func (tr *testRunner) MustSaveFromBody(t *testing.T, dsName, bodyFilename string
 	if !dsref.IsValidName(dsName) {
 		t.Fatalf("invalid dataset name: %q", dsName)
 	}
-	m := NewDatasetMethods(tr.Instance)
 	p := SaveParams{
 		Ref:      fmt.Sprintf("peer/%s", dsName),
 		BodyPath: bodyFilename,
 	}
-	res, err := m.Save(tr.Ctx, &p)
+	res, err := tr.Instance.Dataset().Save(tr.Ctx, &p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,8 +165,7 @@ func (tr *testRunner) MustSaveFromBody(t *testing.T, dsName, bodyFilename string
 }
 
 func (tr *testRunner) SaveWithParams(p *SaveParams) (dsref.Ref, error) {
-	m := NewDatasetMethods(tr.Instance)
-	res, err := m.Save(tr.Ctx, p)
+	res, err := tr.Instance.Dataset().Save(tr.Ctx, p)
 	if err != nil {
 		return dsref.Ref{}, err
 	}

--- a/lib/test_runner_test.go
+++ b/lib/test_runner_test.go
@@ -175,9 +175,8 @@ func (tr *testRunner) SaveWithParams(p *SaveParams) (dsref.Ref, error) {
 }
 
 func (tr *testRunner) MustGet(t *testing.T, refstr string) *dataset.Dataset {
-	m := NewDatasetMethods(tr.Instance)
 	p := GetParams{Refstr: refstr}
-	res, err := m.Get(tr.Ctx, &p)
+	res, err := tr.Instance.Dataset().Get(tr.Ctx, &p)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Refactors dataset functions to use `Dispatch` at both the lib and api level
This pr also removes all references (the cmd level) to `NewDatasetMethods` in favor of using  the new `inst.Dataset` accessor. 

* [x] list
* [x] get
* [x] save

continued in #1707 