### PR TITLE
refactor(remote): RPC > HTTP & API for remote

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -253,11 +253,13 @@ func NewServerRoutes(s Server) *mux.Router {
 	m.Handle(lib.AEDAGInfo.String(), s.Middleware(dsh.DAGInfoHandler))
 
 	remClientH := NewRemoteClientHandlers(s.Instance, cfg.API.ReadOnly)
-	m.Handle(lib.AEPush.String(), s.Middleware(remClientH.PushHandler))
+	routeParams = newrefRouteParams(lib.AEPush, false, false, http.MethodGet, http.MethodPost, http.MethodDelete)
+	handleRefRoute(m, routeParams, s.Middleware(remClientH.PushHandler))
 	routeParams = newrefRouteParams(lib.AEPull, false, false, http.MethodPost, http.MethodPut)
 	handleRefRoute(m, routeParams, s.Middleware(dsh.PullHandler))
 	m.Handle(lib.AEFeeds.String(), s.Middleware(remClientH.FeedsHandler))
-	m.Handle(lib.AEPreview.String(), s.Middleware(remClientH.DatasetPreviewHandler))
+	routeParams = newrefRouteParams(lib.AEPreview, false, false, http.MethodGet, http.MethodPost)
+	handleRefRoute(m, routeParams, s.Middleware(remClientH.DatasetPreviewHandler))
 
 	routeParams = newrefRouteParams(lib.AEStatus, false, false, http.MethodGet, http.MethodPost)
 	handleRefRoute(m, routeParams, s.Middleware(lib.NewHTTPRequestHandler(s.Instance, "fsi.status")))

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -517,11 +517,10 @@ func (h *DatasetHandlers) removeHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if params.Remote != "" {
-		res := &dsref.Ref{}
-		err := h.remote.Remove(&lib.PushParams{
-			Ref:        params.Ref,
-			RemoteName: params.Remote,
-		}, res)
+		res, err := h.remote.Remove(r.Context(), &lib.PushParams{
+			Ref:    params.Ref,
+			Remote: params.Remote,
+		})
 		if err != nil {
 			log.Error("deleting dataset from remote: %s", err.Error())
 			util.WriteErrResponse(w, http.StatusBadRequest, err)

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -69,12 +70,13 @@ func (o *PreviewOptions) Complete(f Factory, args []string) (err error) {
 // Run executes the publish command
 func (o *PreviewOptions) Run() error {
 	p := lib.PreviewParams{
-		Ref:        o.Refs.Ref(),
-		RemoteName: o.RemoteName,
+		Ref:    o.Refs.Ref(),
+		Remote: o.RemoteName,
 	}
 
-	res := &dataset.Dataset{}
-	if err := o.RemoteMethods.Preview(&p, res); err != nil {
+	ctx := context.TODO()
+	res, err := o.RemoteMethods.Preview(ctx, &p)
+	if err != nil {
 		return err
 	}
 	var preview string

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/qri-io/ioes"
-	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
 	"github.com/spf13/cobra"
 )
@@ -64,15 +65,15 @@ func (o *PushOptions) Complete(f Factory, args []string) (err error) {
 
 // Run executes the push command
 func (o *PushOptions) Run() error {
-	var res dsref.Ref
-
+	ctx := context.TODO()
 	for _, ref := range o.Refs.RefList() {
 		p := lib.PushParams{
-			Ref:        ref,
-			RemoteName: o.RemoteName,
+			Ref:    ref,
+			Remote: o.RemoteName,
 		}
 
-		if err := o.RemoteMethods.Push(&p, &res); err != nil {
+		res, err := o.RemoteMethods.Push(ctx, &p)
+		if err != nil {
 			return err
 		}
 		printInfo(o.Out, "pushed dataset %s", res)

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -185,11 +185,11 @@ func (o *RemoveOptions) Run() (err error) {
 
 // RemoveRemote runs the remove command as a network request to a remote
 func (o *RemoveOptions) RemoveRemote() error {
-	res := &dsref.Ref{}
-	err := o.RemoteMethods.Remove(&lib.PushParams{
-		Ref:        o.Refs.Ref(),
-		RemoteName: o.Remote,
-	}, res)
+	ctx := context.TODO()
+	res, err := o.RemoteMethods.Remove(ctx, &lib.PushParams{
+		Ref:    o.Refs.Ref(),
+		Remote: o.Remote,
+	})
 	if err != nil {
 		return fmt.Errorf("dataset not removed")
 	}

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -29,7 +29,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	ref := InitWorldBankDataset(tr.Ctx, t, nasim)
 
 	// - nasim publishes to the registry
-	PushToRegistry(t, nasim, ref.Alias())
+	PushToRegistry(tr.Ctx, t, nasim, ref.Alias())
 
 	if err := AssertLogsEqual(nasim, tr.RegistryInst, ref); err != nil {
 		t.Error(err)
@@ -52,7 +52,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	// - hunshun fetches a preview of nasim's dataset
 	// TODO (b5) - need to use the ref returned from search results
 	t.Log(ref.String())
-	Preview(t, hinshun, ref.String())
+	Preview(tr.Ctx, t, hinshun, ref.String())
 
 	// - hinshun pulls nasim's dataset
 	Pull(tr.Ctx, t, hinshun, ref.Alias())
@@ -65,7 +65,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	ref = Commit2WorldBank(tr.Ctx, t, nasim)
 
 	// 6. nasim re-publishes to the registry
-	PushToRegistry(t, nasim, ref.Alias())
+	PushToRegistry(tr.Ctx, t, nasim, ref.Alias())
 
 	// 7. hinshun logsyncs with the registry for world bank dataset, sees multiple versions
 	_, err = hinshun.Dataset().Pull(tr.Ctx, &PullParams{LogsOnly: true, Ref: ref.String()})
@@ -103,7 +103,7 @@ func TestAddCheckoutIntegration(t *testing.T) {
 
 	// - nasim creates a dataset, publishes to registry
 	ref := InitWorldBankDataset(tr.Ctx, t, nasim)
-	PushToRegistry(t, nasim, ref.Alias())
+	PushToRegistry(tr.Ctx, t, nasim, ref.Alias())
 
 	hinshun := tr.InitHinshun(t)
 	dsm := NewDatasetMethods(hinshun)
@@ -127,7 +127,7 @@ func TestReferencePulling(t *testing.T) {
 
 	// - nasim creates a dataset, publishes to registry
 	ref := InitWorldBankDataset(tr.Ctx, t, nasim)
-	PushToRegistry(t, nasim, ref.Alias())
+	PushToRegistry(tr.Ctx, t, nasim, ref.Alias())
 
 	// - nasim's local repo should reflect publication
 	logRes, err := NewLogMethods(nasim).Log(tr.Ctx, &LogParams{Ref: ref.Alias(), ListParams: ListParams{Limit: 1}})
@@ -416,17 +416,16 @@ g,g,i,true,4`),
 	return dsref.ConvertDatasetToVersionInfo(res).SimpleRef()
 }
 
-func PushToRegistry(t *testing.T, inst *Instance, refstr string) dsref.Ref {
-	res := dsref.Ref{}
-	err := NewRemoteMethods(inst).Push(&PushParams{
+func PushToRegistry(ctx context.Context, t *testing.T, inst *Instance, refstr string) dsref.Ref {
+	res, err := NewRemoteMethods(inst).Push(ctx, &PushParams{
 		Ref: refstr,
-	}, &res)
+	})
 
 	if err != nil {
 		t.Fatalf("publishing dataset: %s", err)
 	}
 
-	return res
+	return *res
 }
 
 func SearchFor(ctx context.Context, t *testing.T, inst *Instance, term string) []SearchResult {
@@ -447,14 +446,14 @@ func Pull(ctx context.Context, t *testing.T, inst *Instance, refstr string) *dat
 	return res
 }
 
-func Preview(t *testing.T, inst *Instance, refstr string) *dataset.Dataset {
+func Preview(ctx context.Context, t *testing.T, inst *Instance, refstr string) *dataset.Dataset {
 	t.Helper()
 	p := &PreviewParams{
-		Ref:        refstr,
-		RemoteName: "",
+		Ref:    refstr,
+		Remote: "",
 	}
-	res := &dataset.Dataset{}
-	if err := NewRemoteMethods(inst).Preview(p, res); err != nil {
+	res, err := NewRemoteMethods(inst).Preview(ctx, p)
+	if err != nil {
 		t.Fatal(err)
 	}
 	return res

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -187,7 +187,7 @@ func TestReceivers(t *testing.T) {
 	inst := &Instance{node: node, cfg: cfg}
 
 	reqs := Receivers(inst)
-	expect := 2
+	expect := 1
 	if len(reqs) != expect {
 		t.Errorf("unexpected number of receivers returned. expected: %d. got: %d\nhave you added/removed a receiver?", expect, len(reqs))
 		return

--- a/lib/remote.go
+++ b/lib/remote.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/base"
@@ -29,155 +30,170 @@ func NewRemoteMethods(inst *Instance) *RemoteMethods {
 // CoreRequestsName implements the Requests interface
 func (*RemoteMethods) CoreRequestsName() string { return "remote" }
 
+// FeedsParams provides arguments to the feeds method
+type FeedsParams struct {
+	Remote string
+}
+
 // Feeds returns a listing of datasets from a number of feeds like featured and
 // popular. Each feed is keyed by string in the response
-func (r *RemoteMethods) Feeds(remoteName *string, res *map[string][]dsref.VersionInfo) error {
-	if r.inst.rpc != nil {
-		return checkRPCError(r.inst.rpc.Call("RemoteMethods.Feeds", remoteName, res))
+func (r *RemoteMethods) Feeds(ctx context.Context, p *FeedsParams) (map[string][]dsref.VersionInfo, error) {
+	if r.inst.http != nil {
+		res := map[string][]dsref.VersionInfo{}
+		err := r.inst.http.Call(ctx, AEFeeds, p, &res)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
 	}
-	ctx := context.TODO()
 
-	addr, err := remote.Address(r.inst.GetConfig(), *remoteName)
+	addr, err := remote.Address(r.inst.GetConfig(), p.Remote)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	feed, err := r.inst.RemoteClient().Feeds(ctx, addr)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	*res = feed
-	return nil
+	return feed, nil
 }
 
 // PreviewParams provides arguments to the preview method
 type PreviewParams struct {
-	RemoteName string
-	Ref        string
+	Remote string
+	Ref    string
+}
+
+// UnmarshalFromRequest implements a custom deserialization-from-HTTP request
+func (p *PreviewParams) UnmarshalFromRequest(r *http.Request) error {
+	if p == nil {
+		p = &PreviewParams{}
+	}
+
+	params := *p
+	if params.Ref == "" {
+		params.Ref = r.FormValue("refstr")
+	}
+	if params.Remote == "" {
+		params.Remote = r.FormValue("remote")
+	}
+
+	*p = params
+	return nil
 }
 
 // Preview requests a dataset preview from a remote
-func (r *RemoteMethods) Preview(p *PreviewParams, res *dataset.Dataset) error {
-	if r.inst.rpc != nil {
-		return checkRPCError(r.inst.rpc.Call("RemoteMethods.Preview", p, res))
+func (r *RemoteMethods) Preview(ctx context.Context, p *PreviewParams) (*dataset.Dataset, error) {
+	if r.inst.http != nil {
+		res := &dataset.Dataset{}
+		err := r.inst.http.Call(ctx, AEPreview, p, res)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
 	}
-	ctx := context.TODO()
 
 	ref, err := dsref.Parse(p.Ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	addr, err := remote.Address(r.inst.GetConfig(), p.RemoteName)
+	addr, err := remote.Address(r.inst.GetConfig(), p.Remote)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	pre, err := r.inst.RemoteClient().PreviewDatasetVersion(ctx, ref, addr)
+	res, err := r.inst.RemoteClient().PreviewDatasetVersion(ctx, ref, addr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	*res = *pre
-	return nil
+	return res, nil
 }
 
 // PushParams encapsulates parmeters for dataset publication
 type PushParams struct {
-	Ref        string
-	RemoteName string
+	Ref    string `schema:"refstr" json:"refstr"`
+	Remote string
 	// All indicates all versions of a dataset and the dataset namespace should
 	// be either published or removed
 	All bool
 }
 
 // Push posts a dataset version to a remote
-func (r *RemoteMethods) Push(p *PushParams, res *dsref.Ref) error {
-	if r.inst.rpc != nil {
-		return checkRPCError(r.inst.rpc.Call("RemoteMethods.Push", p, res))
+func (r *RemoteMethods) Push(ctx context.Context, p *PushParams) (*dsref.Ref, error) {
+	if r.inst.http != nil {
+		res := &dsref.Ref{}
+		err := r.inst.http.Call(ctx, AEPush, p, res)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
 	}
-
-	// TODO (b5) - need contexts yo
-	ctx := context.TODO()
 
 	ref, _, err := r.inst.ParseAndResolveRef(ctx, p.Ref, "local")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	addr, err := remote.Address(r.inst.GetConfig(), p.RemoteName)
+	addr, err := remote.Address(r.inst.GetConfig(), p.Remote)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err = r.inst.RemoteClient().PushDataset(ctx, ref, addr); err != nil {
-		return err
+		return nil, err
 	}
 
 	datasetRef := reporef.RefFromDsref(ref)
 	datasetRef.Published = true
 	if err = base.SetPublishStatus(ctx, r.inst.node.Repo, ref, true); err != nil {
-		return err
+		return nil, err
 	}
 
-	*res = ref
-	return nil
-}
-
-// Pull fetches a dataset version & logbook data from a remote
-func (r *RemoteMethods) Pull(p *PushParams, res *dataset.Dataset) error {
-	if r.inst.rpc != nil {
-		return checkRPCError(r.inst.rpc.Call("RemoteMethods.Pull", p, res))
-	}
-
-	ref, err := dsref.Parse(p.Ref)
-	if err != nil {
-		return err
-	}
-
-	// TODO (b5) - need contexts yo
-	ctx := context.TODO()
-
-	ds, err := r.inst.RemoteClient().PullDataset(ctx, &ref, p.RemoteName)
-	*res = *ds
-	return err
+	return &ref, nil
 }
 
 // Remove asks a remote to remove a dataset
-func (r *RemoteMethods) Remove(p *PushParams, res *dsref.Ref) error {
-	if r.inst.rpc != nil {
-		return checkRPCError(r.inst.rpc.Call("RemoteMethods.Remove", p, res))
+func (r *RemoteMethods) Remove(ctx context.Context, p *PushParams) (*dsref.Ref, error) {
+	if r.inst.http != nil {
+		res := &dsref.Ref{}
+		qvars := map[string]string{
+			"refstr": p.Ref,
+			"remote": p.Remote,
+		}
+		err := r.inst.http.CallMethod(ctx, AEPush, http.MethodDelete, qvars, res)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
 	}
 
 	ref, err := dsref.ParseHumanFriendly(p.Ref)
 	if err != nil {
 		if err == dsref.ErrNotHumanFriendly {
-			return fmt.Errorf("can only remove entire dataset. run remove without a path")
+			return nil, fmt.Errorf("can only remove entire dataset. run remove without a path")
 		}
-		return err
+		return nil, err
 	}
-
-	// TODO (b5) - need contexts yo
-	ctx := context.TODO()
 
 	if _, err := r.inst.ResolveReference(ctx, &ref, "local"); err != nil {
-		return err
+		return nil, err
 	}
 
-	addr, err := remote.Address(r.inst.GetConfig(), p.RemoteName)
+	addr, err := remote.Address(r.inst.GetConfig(), p.Remote)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.inst.RemoteClient().RemoveDataset(ctx, ref, addr); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err = base.SetPublishStatus(ctx, r.inst.node.Repo, ref, false); err != nil {
-		return err
+		return nil, err
 	}
 
-	*res = ref
-	return nil
+	return &ref, nil
 }

--- a/lib/rpc.go
+++ b/lib/rpc.go
@@ -31,7 +31,6 @@ func init() {
 // API of lib methods
 func Receivers(inst *Instance) []Methods {
 	return []Methods{
-		NewRemoteMethods(inst),
 		NewPeerMethods(inst),
 	}
 }


### PR DESCRIPTION
Still have to manually test this before actually marking as done.
Another interesting bit is the modification to `lib/http.go` where it now encodes some query params if you pass in a `map[string]string` which was needed for the `DELETE` request on the `AEPush` endpoint

Part of https://github.com/qri-io/qri/issues/1675