### PR TITLE
feat(dispatch): Methods attributes to hold metadata about methodSets

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -30,7 +30,7 @@ type DatasetHandlers struct {
 // NewDatasetHandlers allocates a DatasetHandlers pointer
 func NewDatasetHandlers(inst *lib.Instance, readOnly bool) *DatasetHandlers {
 	rm := lib.NewRemoteMethods(inst)
-	h := DatasetHandlers{*inst.Dataset(), inst, rm, readOnly}
+	h := DatasetHandlers{inst.Dataset(), inst, rm, readOnly}
 	return &h
 }
 

--- a/cmd/ref_select.go
+++ b/cmd/ref_select.go
@@ -223,7 +223,7 @@ func EnsureFSIAgrees(inst *lib.Instance) *FSIRefLinkEnsurer {
 // EnsureFSIAgrees(*fsiMethods) when calling GetRefSelect, hopefully providing a bit of insight
 // about what this parameter is for.
 type FSIRefLinkEnsurer struct {
-	FSIMethods *lib.FSIMethods
+	FSIMethods lib.FSIMethods
 }
 
 // EnsureRef checks if the linkfile and repository agree on the dataset's working directory path.

--- a/lib/access.go
+++ b/lib/access.go
@@ -19,6 +19,13 @@ func (m AccessMethods) Name() string {
 	return "access"
 }
 
+// Attributes defines attributes for each method
+func (m AccessMethods) Attributes() map[string]AttributeSet {
+	return map[string]AttributeSet{
+		"createauthtoken": {APIEndpoint("/auth/createauthtoken"), "GET"},
+	}
+}
+
 // Access returns the authentication that Instance has registered
 func (inst *Instance) Access() AccessMethods {
 	return AccessMethods{d: inst}

--- a/lib/access.go
+++ b/lib/access.go
@@ -22,7 +22,7 @@ func (m AccessMethods) Name() string {
 // Attributes defines attributes for each method
 func (m AccessMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"createauthtoken": {APIEndpoint("/auth/createauthtoken"), "GET"},
+		"createauthtoken": {AECreateAuthToken, "GET"},
 	}
 }
 

--- a/lib/access.go
+++ b/lib/access.go
@@ -26,11 +26,6 @@ func (m AccessMethods) Attributes() map[string]AttributeSet {
 	}
 }
 
-// Access returns the authentication that Instance has registered
-func (inst *Instance) Access() AccessMethods {
-	return AccessMethods{d: inst}
-}
-
 // CreateAuthTokenParams are input parameters for Access().CreateAuthToken
 type CreateAuthTokenParams struct {
 	GranteeUsername  string

--- a/lib/api.go
+++ b/lib/api.go
@@ -136,6 +136,13 @@ const (
 	AEFSICreateLink = APIEndpoint("/fsi/createlink/{path:.*}")
 	// AEFSIUnlink removes the fsi link
 	AEFSIUnlink = APIEndpoint("/fsi/unlink/{path:.*}")
+	// AEEnsureRef ensures that the ref is fsi linked
+	AEEnsureRef = APIEndpoint("/fsi/ensureref/{path:.*}")
+
+	// auth endpoints
+
+	// AECreateAuthToken creates an auth token for a user
+	AECreateAuthToken = APIEndpoint("/auth/createauthtoken")
 
 	// other endpoints
 
@@ -162,6 +169,9 @@ const (
 	AEApply = APIEndpoint("/apply")
 	// AEWebUI serves the remote WebUI
 	AEWebUI = APIEndpoint("/webui")
+
+	// denyRPC if used will disable RPC calls for a method
+	denyRPC = APIEndpoint("")
 )
 
 // DsRefFromPath parses a path and returns a dsref.Ref

--- a/lib/changes.go
+++ b/lib/changes.go
@@ -17,7 +17,7 @@ type ChangeReportParams struct {
 type ChangeReport = changes.ChangeReportResponse
 
 // ChangeReport resolves the requested datasets and tries to generate a change report
-func (m *DatasetMethods) ChangeReport(ctx context.Context, p *ChangeReportParams) (*ChangeReport, error) {
+func (m DatasetMethods) ChangeReport(ctx context.Context, p *ChangeReportParams) (*ChangeReport, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "changereport"), p)
 	if res, ok := got.(*ChangeReport); ok {
 		return res, err

--- a/lib/config.go
+++ b/lib/config.go
@@ -17,12 +17,12 @@ type ConfigMethods struct {
 }
 
 // Name returns the name of this method group
-func (m *ConfigMethods) Name() string {
+func (m ConfigMethods) Name() string {
 	return "config"
 }
 
 // Attributes defines attributes for each method
-func (m *ConfigMethods) Attributes() map[string]AttributeSet {
+func (m ConfigMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
 		// config methods are not allowed over HTTP nor RPC
 		"getconfig":     {denyRPC, ""},
@@ -42,7 +42,7 @@ type GetConfigParams struct {
 
 // GetConfig returns the Config, or one of the specified fields of the Config,
 // as a slice of bytes the bytes can be formatted as json, concise json, or yaml
-func (m *ConfigMethods) GetConfig(ctx context.Context, p *GetConfigParams) ([]byte, error) {
+func (m ConfigMethods) GetConfig(ctx context.Context, p *GetConfigParams) ([]byte, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "getconfig"), p)
 	if res, ok := got.([]byte); ok {
 		return res, err
@@ -52,7 +52,7 @@ func (m *ConfigMethods) GetConfig(ctx context.Context, p *GetConfigParams) ([]by
 
 // GetConfigKeys returns the Config key fields, or sub keys of the specified
 // fields of the Config, as a slice of bytes to be used for auto completion
-func (m *ConfigMethods) GetConfigKeys(ctx context.Context, p *GetConfigParams) ([]byte, error) {
+func (m ConfigMethods) GetConfigKeys(ctx context.Context, p *GetConfigParams) ([]byte, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "getconfigkeys"), p)
 	if res, ok := got.([]byte); ok {
 		return res, err
@@ -61,7 +61,7 @@ func (m *ConfigMethods) GetConfigKeys(ctx context.Context, p *GetConfigParams) (
 }
 
 // SetConfig validates, updates and saves the config
-func (m *ConfigMethods) SetConfig(ctx context.Context, update *config.Config) (*bool, error) {
+func (m ConfigMethods) SetConfig(ctx context.Context, update *config.Config) (*bool, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "setconfig"), update)
 	if res, ok := got.(*bool); ok {
 		return res, err

--- a/lib/config.go
+++ b/lib/config.go
@@ -25,9 +25,9 @@ func (m *ConfigMethods) Name() string {
 func (m *ConfigMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
 		// config methods are not allowed over HTTP nor RPC
-		"getconfig":     {"", ""},
-		"getconfigkeys": {"", ""},
-		"setconfig":     {"", ""},
+		"getconfig":     {denyRPC, ""},
+		"getconfigkeys": {denyRPC, ""},
+		"setconfig":     {denyRPC, ""},
 	}
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -13,7 +13,7 @@ import (
 
 // ConfigMethods encapsulates changes to a qri configuration
 type ConfigMethods struct {
-	inst *Instance
+	d dispatcher
 }
 
 // Name returns the name of this method group
@@ -31,11 +31,6 @@ func (m *ConfigMethods) Attributes() map[string]AttributeSet {
 	}
 }
 
-// Config returns the `Config` that the instance has registered
-func (inst *Instance) Config() *ConfigMethods {
-	return &ConfigMethods{inst: inst}
-}
-
 // GetConfigParams are the params needed to format/specify the fields in bytes
 // returned from the GetConfig function
 type GetConfigParams struct {
@@ -48,7 +43,7 @@ type GetConfigParams struct {
 // GetConfig returns the Config, or one of the specified fields of the Config,
 // as a slice of bytes the bytes can be formatted as json, concise json, or yaml
 func (m *ConfigMethods) GetConfig(ctx context.Context, p *GetConfigParams) ([]byte, error) {
-	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "getconfig"), p)
+	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "getconfig"), p)
 	if res, ok := got.([]byte); ok {
 		return res, err
 	}
@@ -58,7 +53,7 @@ func (m *ConfigMethods) GetConfig(ctx context.Context, p *GetConfigParams) ([]by
 // GetConfigKeys returns the Config key fields, or sub keys of the specified
 // fields of the Config, as a slice of bytes to be used for auto completion
 func (m *ConfigMethods) GetConfigKeys(ctx context.Context, p *GetConfigParams) ([]byte, error) {
-	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "getconfigkeys"), p)
+	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "getconfigkeys"), p)
 	if res, ok := got.([]byte); ok {
 		return res, err
 	}
@@ -67,7 +62,7 @@ func (m *ConfigMethods) GetConfigKeys(ctx context.Context, p *GetConfigParams) (
 
 // SetConfig validates, updates and saves the config
 func (m *ConfigMethods) SetConfig(ctx context.Context, update *config.Config) (*bool, error) {
-	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "setconfig"), update)
+	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "setconfig"), update)
 	if res, ok := got.(*bool); ok {
 		return res, err
 	}

--- a/lib/config.go
+++ b/lib/config.go
@@ -21,6 +21,16 @@ func (m *ConfigMethods) Name() string {
 	return "config"
 }
 
+// Attributes defines attributes for each method
+func (m *ConfigMethods) Attributes() map[string]AttributeSet {
+	return map[string]AttributeSet{
+		// config methods are not allowed over HTTP nor RPC
+		"getconfig":     {"", ""},
+		"getconfigkeys": {"", ""},
+		"setconfig":     {"", ""},
+	}
+}
+
 // Config returns the `Config` that the instance has registered
 func (inst *Instance) Config() *ConfigMethods {
 	return &ConfigMethods{inst: inst}
@@ -38,10 +48,6 @@ type GetConfigParams struct {
 // GetConfig returns the Config, or one of the specified fields of the Config,
 // as a slice of bytes the bytes can be formatted as json, concise json, or yaml
 func (m *ConfigMethods) GetConfig(ctx context.Context, p *GetConfigParams) ([]byte, error) {
-	if m.inst.http != nil {
-		return nil, ErrUnsupportedRPC
-	}
-
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "getconfig"), p)
 	if res, ok := got.([]byte); ok {
 		return res, err
@@ -52,9 +58,6 @@ func (m *ConfigMethods) GetConfig(ctx context.Context, p *GetConfigParams) ([]by
 // GetConfigKeys returns the Config key fields, or sub keys of the specified
 // fields of the Config, as a slice of bytes to be used for auto completion
 func (m *ConfigMethods) GetConfigKeys(ctx context.Context, p *GetConfigParams) ([]byte, error) {
-	if m.inst.http != nil {
-		return nil, ErrUnsupportedRPC
-	}
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "getconfigkeys"), p)
 	if res, ok := got.([]byte); ok {
 		return res, err
@@ -64,11 +67,6 @@ func (m *ConfigMethods) GetConfigKeys(ctx context.Context, p *GetConfigParams) (
 
 // SetConfig validates, updates and saves the config
 func (m *ConfigMethods) SetConfig(ctx context.Context, update *config.Config) (*bool, error) {
-	if m.inst.http != nil {
-		res := false
-		return &res, ErrUnsupportedRPC
-	}
-
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "setconfig"), update)
 	if res, ok := got.(*bool); ok {
 		return res, err

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -42,6 +42,7 @@ import (
 
 // DatasetMethods encapsulates business logic for working with Datasets on Qri
 type DatasetMethods struct {
+	// TODO(dustmop): Once Dispatch is in use for Diff, change to "d dispatcher"
 	inst *Instance
 }
 
@@ -53,11 +54,11 @@ func (m *DatasetMethods) Name() string {
 // Attributes defines attributes for each method
 func (m *DatasetMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"changereport":    {"/changes", "POST"},
-		"daginfo":         {"/dag/info", "GET"},
-		"diff":            {"/diff", "GET"},
-		"get":             {"/get", "GET"},
-		"list":            {"/list", "GET"},
+		"changereport": {"/changes", "POST"},
+		"daginfo":      {"/dag/info", "GET"},
+		"diff":         {"/diff", "GET"},
+		"get":          {"/get", "GET"},
+		"list":         {"/list", "GET"},
 		// TODO(dustmop): Needs its own endpoint
 		"listrawrefs":     {"/list", "GET"},
 		"manifest":        {"/manifest", "GET"},
@@ -67,14 +68,9 @@ func (m *DatasetMethods) Attributes() map[string]AttributeSet {
 		"rename":          {"/rename", "POST"},
 		"save":            {"/save", "POST"},
 		// TODO(dustmop): Needs its own endpoint
-		"stats":           {"/get", "GET"},
-		"validate":        {"/validate", "GET"},
+		"stats":    {"/get", "GET"},
+		"validate": {"/validate", "GET"},
 	}
-}
-
-// Dataset returns the DatasetMethods the instance has registered
-func (inst *Instance) Dataset() *DatasetMethods {
-	return &DatasetMethods{inst: inst}
 }
 
 // ErrListWarning is a warning that can occur while listing

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -50,6 +50,28 @@ func (m *DatasetMethods) Name() string {
 	return "dataset"
 }
 
+// Attributes defines attributes for each method
+func (m *DatasetMethods) Attributes() map[string]AttributeSet {
+	return map[string]AttributeSet{
+		"changereport":    {"/changes", "POST"},
+		"daginfo":         {"/dag/info", "GET"},
+		"diff":            {"/diff", "GET"},
+		"get":             {"/get", "GET"},
+		"list":            {"/list", "GET"},
+		// TODO(dustmop): Needs its own endpoint
+		"listrawrefs":     {"/list", "GET"},
+		"manifest":        {"/manifest", "GET"},
+		"manifestmissing": {"/manifest/missing", "GET"},
+		"pull":            {"/pull", "POST"},
+		"remove":          {"/remove", "POST"},
+		"rename":          {"/rename", "POST"},
+		"save":            {"/save", "POST"},
+		// TODO(dustmop): Needs its own endpoint
+		"stats":           {"/get", "GET"},
+		"validate":        {"/validate", "GET"},
+	}
+}
+
 // Dataset returns the DatasetMethods the instance has registered
 func (inst *Instance) Dataset() *DatasetMethods {
 	return &DatasetMethods{inst: inst}

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -47,12 +47,12 @@ type DatasetMethods struct {
 }
 
 // Name returns the name of this method group
-func (m *DatasetMethods) Name() string {
+func (m DatasetMethods) Name() string {
 	return "dataset"
 }
 
 // Attributes defines attributes for each method
-func (m *DatasetMethods) Attributes() map[string]AttributeSet {
+func (m DatasetMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
 		"changereport": {AEChanges, "POST"},
 		"daginfo":      {AEDAGInfo, "GET"},
@@ -77,7 +77,7 @@ func (m *DatasetMethods) Attributes() map[string]AttributeSet {
 var ErrListWarning = base.ErrUnlistableReferences
 
 // List gets the reflist for either the local repo or a peer
-func (m *DatasetMethods) List(ctx context.Context, p *ListParams) ([]dsref.VersionInfo, error) {
+func (m DatasetMethods) List(ctx context.Context, p *ListParams) ([]dsref.VersionInfo, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "list"), p)
 	if res, ok := got.([]dsref.VersionInfo); ok {
 		return res, err
@@ -86,7 +86,7 @@ func (m *DatasetMethods) List(ctx context.Context, p *ListParams) ([]dsref.Versi
 }
 
 // ListRawRefs gets the list of raw references as string
-func (m *DatasetMethods) ListRawRefs(ctx context.Context, p *ListParams) (string, error) {
+func (m DatasetMethods) ListRawRefs(ctx context.Context, p *ListParams) (string, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "listrawrefs"), p)
 	if res, ok := got.(string); ok {
 		return res, err
@@ -249,7 +249,7 @@ type DataResponse struct {
 // a blank selector, will also fill the entire dataset at res.Data. If the selector is "body"
 // then res.Bytes is loaded with the body. If the selector is "stats", then res.Bytes is loaded
 // with the generated stats.
-func (m *DatasetMethods) Get(ctx context.Context, p *GetParams) (*GetResult, error) {
+func (m DatasetMethods) Get(ctx context.Context, p *GetParams) (*GetResult, error) {
 	// TODO(dustmop): Have Dispatch perform this AbsPath call automatically
 	if err := qfs.AbsPath(&p.Outfile); err != nil {
 		return nil, err
@@ -427,7 +427,7 @@ func (p *SaveParams) SetNonZeroDefaults() {
 }
 
 // Save adds a history entry, updating a dataset
-func (m *DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Dataset, error) {
+func (m DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Dataset, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "save"), p)
 	if res, ok := got.(*dataset.Dataset); ok {
 		return res, err
@@ -441,7 +441,7 @@ type RenameParams struct {
 }
 
 // Rename changes a user's given name for a dataset
-func (m *DatasetMethods) Rename(ctx context.Context, p *RenameParams) (*dsref.VersionInfo, error) {
+func (m DatasetMethods) Rename(ctx context.Context, p *RenameParams) (*dsref.VersionInfo, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "rename"), p)
 	if res, ok := got.(*dsref.VersionInfo); ok {
 		return res, err
@@ -503,7 +503,7 @@ func (p *RemoveParams) SetNonZeroDefaults() {
 var ErrCantRemoveDirectoryDirty = fmt.Errorf("cannot remove files while working directory is dirty")
 
 // Remove a dataset entirely or remove a certain number of revisions
-func (m *DatasetMethods) Remove(ctx context.Context, p *RemoveParams) (*RemoveResponse, error) {
+func (m DatasetMethods) Remove(ctx context.Context, p *RemoveParams) (*RemoveResponse, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "remove"), p)
 	if res, ok := got.(*RemoveResponse); ok {
 		return res, err
@@ -530,7 +530,7 @@ func (p *PullParams) UnmarshalFromRequest(r *http.Request) error {
 
 // Pull downloads and stores an existing dataset to a peer's repository via
 // a network connection
-func (m *DatasetMethods) Pull(ctx context.Context, p *PullParams) (*dataset.Dataset, error) {
+func (m DatasetMethods) Pull(ctx context.Context, p *PullParams) (*dataset.Dataset, error) {
 	if err := qfs.AbsPath(&p.LinkDir); err != nil {
 		return nil, err
 	}
@@ -567,7 +567,7 @@ type ValidateResponse struct {
 }
 
 // Validate gives a dataset of errors and issues for a given dataset
-func (m *DatasetMethods) Validate(ctx context.Context, p *ValidateParams) (*ValidateResponse, error) {
+func (m DatasetMethods) Validate(ctx context.Context, p *ValidateParams) (*ValidateResponse, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "validate"), p)
 	if res, ok := got.(*ValidateResponse); ok {
 		return res, err
@@ -581,7 +581,7 @@ type ManifestParams struct {
 }
 
 // Manifest generates a manifest for a dataset path
-func (m *DatasetMethods) Manifest(ctx context.Context, p *ManifestParams) (*dag.Manifest, error) {
+func (m DatasetMethods) Manifest(ctx context.Context, p *ManifestParams) (*dag.Manifest, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "manifest"), p)
 	if res, ok := got.(*dag.Manifest); ok {
 		return res, err
@@ -595,7 +595,7 @@ type ManifestMissingParams struct {
 }
 
 // ManifestMissing generates a manifest of blocks that are not present on this repo for a given manifest
-func (m *DatasetMethods) ManifestMissing(ctx context.Context, p *ManifestMissingParams) (*dag.Manifest, error) {
+func (m DatasetMethods) ManifestMissing(ctx context.Context, p *ManifestMissingParams) (*dag.Manifest, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "manifestmissing"), p)
 	if res, ok := got.(*dag.Manifest); ok {
 		return res, err
@@ -609,7 +609,7 @@ type DAGInfoParams struct {
 }
 
 // DAGInfo generates a dag.Info for a dataset path. If a label is given, DAGInfo will generate a sub-dag.Info at that label.
-func (m *DatasetMethods) DAGInfo(ctx context.Context, p *DAGInfoParams) (*dag.Info, error) {
+func (m DatasetMethods) DAGInfo(ctx context.Context, p *DAGInfoParams) (*dag.Info, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "daginfo"), p)
 	if res, ok := got.(*dag.Info); ok {
 		return res, err
@@ -627,7 +627,7 @@ type StatsParams struct {
 }
 
 // Stats generates stats for a dataset
-func (m *DatasetMethods) Stats(ctx context.Context, p *StatsParams) (*dataset.Stats, error) {
+func (m DatasetMethods) Stats(ctx context.Context, p *StatsParams) (*dataset.Stats, error) {
 	got, _, err := m.inst.Dispatch(ctx, dispatchMethodName(m, "stats"), p)
 	if res, ok := got.(*dataset.Stats); ok {
 		return res, err

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -54,22 +54,22 @@ func (m *DatasetMethods) Name() string {
 // Attributes defines attributes for each method
 func (m *DatasetMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"changereport": {"/changes", "POST"},
-		"daginfo":      {"/dag/info", "GET"},
-		"diff":         {"/diff", "GET"},
-		"get":          {"/get", "GET"},
-		"list":         {"/list", "GET"},
+		"changereport": {AEChanges, "POST"},
+		"daginfo":      {AEDAGInfo, "GET"},
+		"diff":         {AEDiff, "GET"},
+		"get":          {AEGet, "GET"},
+		"list":         {AEList, "GET"},
 		// TODO(dustmop): Needs its own endpoint
-		"listrawrefs":     {"/list", "GET"},
-		"manifest":        {"/manifest", "GET"},
-		"manifestmissing": {"/manifest/missing", "GET"},
-		"pull":            {"/pull", "POST"},
-		"remove":          {"/remove", "POST"},
-		"rename":          {"/rename", "POST"},
-		"save":            {"/save", "POST"},
+		"listrawrefs":     {AEList, "GET"},
+		"manifest":        {AEManifest, "GET"},
+		"manifestmissing": {AEManifestMissing, "GET"},
+		"pull":            {AEPull, "POST"},
+		"remove":          {AERemove, "POST"},
+		"rename":          {AERename, "POST"},
+		"save":            {AESave, "POST"},
 		// TODO(dustmop): Needs its own endpoint
-		"stats":    {"/get", "GET"},
-		"validate": {"/validate", "GET"},
+		"stats":    {AEGet, "GET"},
+		"validate": {AEValidate, "GET"},
 	}
 }
 

--- a/lib/diff.go
+++ b/lib/diff.go
@@ -106,7 +106,7 @@ const (
 )
 
 // Diff computes the diff of two sources
-func (m *DatasetMethods) Diff(ctx context.Context, p *DiffParams) (*DiffResponse, error) {
+func (m DatasetMethods) Diff(ctx context.Context, p *DiffParams) (*DiffResponse, error) {
 	// absolutize any local paths before a possible trip over RPC to another local process
 	if !dsref.IsRefString(p.LeftSide) {
 		if err := qfs.AbsPath(&p.LeftSide); err != nil {

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"time"
@@ -29,6 +30,14 @@ type Cursor interface{}
 // with the context.Context replaced by a scope.
 type MethodSet interface {
 	Name() string
+	Attributes() map[string]AttributeSet
+}
+
+// AttributeSet is extra information about each method, such as: http endpoint,
+// http verb, (TODO) permissions, and (TODO) other metadata
+type AttributeSet struct {
+	endpoint APIEndpoint
+	verb     string
 }
 
 // Dispatch is a system for handling calls to lib. Should only be called by top-level lib methods.
@@ -80,14 +89,14 @@ func (inst *Instance) Dispatch(ctx context.Context, method string, param interfa
 		}
 
 		if c, ok := inst.regMethods.lookup(method); ok {
-			// TODO(dustmop): This is always using the "POST" verb currently. We need some
-			// mechanism of tagging methods as being read-only and "GET"-able. Once that
-			// exists, use it here to lookup the verb that should be used to invoke the rpc.
+			if c.Endpoint == "" {
+				return nil, nil, ErrUnsupportedRPC
+			}
 			if c.OutType != nil {
 				out := reflect.New(c.OutType)
 				res = out.Interface()
 			}
-			err = inst.http.Call(ctx, methodEndpoint(method), param, res)
+			err = inst.http.CallMethod(ctx, c.Endpoint, c.Verb, param, res)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -193,6 +202,8 @@ type callable struct {
 	InType    reflect.Type
 	OutType   reflect.Type
 	RetCursor bool
+	Endpoint  APIEndpoint
+	Verb      string
 }
 
 // RegisterMethods iterates the methods provided by the lib API, and makes them visible to dispatch
@@ -210,6 +221,10 @@ func (inst *Instance) registerOne(ourName string, methods MethodSet, impl interf
 	implType := reflect.TypeOf(impl)
 	msetType := reflect.TypeOf(methods)
 	methodMap := inst.buildMethodMap(methods)
+	// Validate that the methodSet has the correct name
+	if methods.Name() != ourName {
+		regFail("registration wrong name, expect: %q, got: %q", ourName, methods.Name())
+	}
 	// Iterate methods on the implementation, register those that have the right signature
 	num := implType.NumMethod()
 	for k := 0; k < num; k++ {
@@ -222,31 +237,31 @@ func (inst *Instance) registerOne(ourName string, methods MethodSet, impl interf
 		// should have 1-3 output parametres: ([output value]?, [cursor]?, error)
 		f := i.Type
 		if f.NumIn() != 3 {
-			panic(fmt.Sprintf("%s: bad number of inputs: %d", funcName, f.NumIn()))
+			regFail("%s: bad number of inputs: %d", funcName, f.NumIn())
 		}
 		// First input must be the receiver
 		inType := f.In(0)
 		if inType != implType {
-			panic(fmt.Sprintf("%s: first input param should be impl, got %v", funcName, inType))
+			regFail("%s: first input param should be impl, got %v", funcName, inType)
 		}
 		// Second input must be a scope
 		inType = f.In(1)
 		if inType.Name() != "scope" {
-			panic(fmt.Sprintf("%s: second input param should be scope, got %v", funcName, inType))
+			regFail("%s: second input param should be scope, got %v", funcName, inType)
 		}
 		// Third input is a pointer to the input struct
 		inType = f.In(2)
 		if inType.Kind() != reflect.Ptr {
-			panic(fmt.Sprintf("%s: third input param must be a struct pointer, got %v", funcName, inType))
+			regFail("%s: third input param must be a struct pointer, got %v", funcName, inType)
 		}
 		inType = inType.Elem()
 		if inType.Kind() != reflect.Struct {
-			panic(fmt.Sprintf("%s: third input param must be a struct pointer, got %v", funcName, inType))
+			regFail("%s: third input param must be a struct pointer, got %v", funcName, inType)
 		}
 		// Validate the output values of the implementation
 		numOuts := f.NumOut()
 		if numOuts < 1 || numOuts > 3 {
-			panic(fmt.Sprintf("%s: bad number of outputs: %d", funcName, numOuts))
+			regFail("%s: bad number of outputs: %d", funcName, numOuts)
 		}
 		// Validate output values
 		var outType reflect.Type
@@ -259,14 +274,14 @@ func (inst *Instance) registerOne(ourName string, methods MethodSet, impl interf
 			// Second output must be a cursor
 			outCursorType := f.Out(1)
 			if outCursorType.Name() != "Cursor" {
-				panic(fmt.Sprintf("%s: second output val must be a cursor, got %v", funcName, outCursorType))
+				regFail("%s: second output val must be a cursor, got %v", funcName, outCursorType)
 			}
 			returnsCursor = true
 		}
 		// Last output must be an error
 		outErrType := f.Out(numOuts - 1)
 		if outErrType.Name() != "error" {
-			panic(fmt.Sprintf("%s: last output val should be error, got %v", funcName, outErrType))
+			regFail("%s: last output val should be error, got %v", funcName, outErrType)
 		}
 
 		// Validate the parameters to the method that matches the implementation
@@ -274,58 +289,78 @@ func (inst *Instance) registerOne(ourName string, methods MethodSet, impl interf
 		// should have 1-3 output parametres: ([output value: same as impl], [cursor], error)
 		m, ok := methodMap[i.Name]
 		if !ok {
-			panic(fmt.Sprintf("method %s not found on MethodSet", i.Name))
+			regFail("method %s not found on MethodSet", i.Name)
 		}
 		f = m.Type
 		if f.NumIn() != 3 {
-			panic(fmt.Sprintf("%s: bad number of inputs: %d", funcName, f.NumIn()))
+			regFail("%s: bad number of inputs: %d", funcName, f.NumIn())
 		}
 		// First input must be the receiver
 		mType := f.In(0)
 		if mType.Name() != msetType.Name() {
-			panic(fmt.Sprintf("%s: first input param should be impl, got %v", funcName, mType))
+			regFail("%s: first input param should be impl, got %v", funcName, mType)
 		}
 		// Second input must be a context
 		mType = f.In(1)
 		if mType.Name() != "Context" {
-			panic(fmt.Sprintf("%s: second input param should be context.Context, got %v", funcName, mType))
+			regFail("%s: second input param should be context.Context, got %v", funcName, mType)
 		}
 		// Third input is a pointer to the input struct
 		mType = f.In(2)
 		if mType.Kind() != reflect.Ptr {
-			panic(fmt.Sprintf("%s: third input param must be a pointer, got %v", funcName, mType))
+			regFail("%s: third input param must be a pointer, got %v", funcName, mType)
 		}
 		mType = mType.Elem()
 		if mType != inType {
-			panic(fmt.Sprintf("%s: third input param must match impl, expect %v, got %v", funcName, inType, mType))
+			regFail("%s: third input param must match impl, expect %v, got %v", funcName, inType, mType)
 		}
 		// Validate the output values of the implementation
 		msetNumOuts := f.NumOut()
 		if msetNumOuts < 1 || msetNumOuts > 3 {
-			panic(fmt.Sprintf("%s: bad number of outputs: %d", funcName, f.NumOut()))
+			regFail("%s: bad number of outputs: %d", funcName, f.NumOut())
 		}
 		// First output, if there's more than 1, matches the impl output
 		if msetNumOuts == 2 || msetNumOuts == 3 {
 			mType = f.Out(0)
 			if mType != outType {
-				panic(fmt.Sprintf("%s: first output val must match impl, expect %v, got %v", funcName, outType, mType))
+				regFail("%s: first output val must match impl, expect %v, got %v", funcName, outType, mType)
 			}
 		}
 		// Second output, if there are three, must be a cursor
 		if msetNumOuts == 3 {
 			mType = f.Out(1)
 			if mType.Name() != "Cursor" {
-				panic(fmt.Sprintf("%s: second output val must match a cursor, got %v", funcName, mType))
+				regFail("%s: second output val must match a cursor, got %v", funcName, mType)
 			}
 		}
 		// Last output must be an error
 		mType = f.Out(msetNumOuts - 1)
 		if mType.Name() != "error" {
-			panic(fmt.Sprintf("%s: last output val should be error, got %v", funcName, mType))
+			regFail("%s: last output val should be error, got %v", funcName, mType)
 		}
 
 		// Remove this method from the methodSetMap now that it has been processed
 		delete(methodMap, i.Name)
+
+		var endpoint APIEndpoint
+		var httpVerb string
+		// Additional attributes for the method are found in the Attributes
+		amap := methods.Attributes()
+		methodAttrs, ok := amap[lowerName]
+		if !ok {
+			regFail("not in Attributes: %s.%s", ourName, lowerName)
+		}
+		endpoint = methodAttrs.endpoint
+		httpVerb = methodAttrs.verb
+		// If both these are empty string, RPC is not allowed for this method
+		if endpoint != "" || httpVerb != "" {
+			if !strings.HasPrefix(string(endpoint), "/") {
+				regFail("%s: endpoint URL must start with /, got %q", lowerName, endpoint)
+			}
+			if httpVerb != http.MethodGet && httpVerb != http.MethodPost && httpVerb != http.MethodPut {
+				regFail("%s: unknown http verb, got %q", lowerName, httpVerb)
+			}
+		}
 
 		// Save the method to the registration table
 		reg[funcName] = callable{
@@ -334,15 +369,21 @@ func (inst *Instance) registerOne(ourName string, methods MethodSet, impl interf
 			InType:    inType,
 			OutType:   outType,
 			RetCursor: returnsCursor,
+			Endpoint:  endpoint,
+			Verb:      httpVerb,
 		}
 		log.Debugf("%d: registered %s(*%s) %v", k, funcName, inType, outType)
 	}
 
 	for k := range methodMap {
-		if k != "Name" {
-			panic(fmt.Sprintf("%s: did not find implementation for method %s", msetType, k))
+		if k != "Name" && k != "Attributes" {
+			regFail("%s: did not find implementation for method %s", msetType, k)
 		}
 	}
+}
+
+func regFail(fstr string, vals ...interface{}) {
+	panic(fmt.Sprintf(fstr, vals...))
 }
 
 func (inst *Instance) buildMethodMap(impl interface{}) map[string]reflect.Method {
@@ -359,31 +400,6 @@ func (inst *Instance) buildMethodMap(impl interface{}) map[string]reflect.Method
 func dispatchMethodName(m MethodSet, funcName string) string {
 	lowerName := strings.ToLower(funcName)
 	return fmt.Sprintf("%s.%s", m.Name(), lowerName)
-}
-
-// methodEndpoint returns a method name and returns the API endpoint for it
-func methodEndpoint(method string) APIEndpoint {
-	// TODO(dustmop): This is here temporarily. /fsi/write/ works differently than
-	// other methods; their http API endpoints are only their method name, for
-	// exmaple /status/. This should be replaced with an explicit mapping from
-	// method names to endpoints.
-	if method == "fsi.write" {
-		return "/fsi/write/"
-	}
-	if method == "fsi.createlink" {
-		return "/fsi/createlink/"
-	}
-	if method == "fsi.unlink" {
-		return "/fsi/unlink/"
-	}
-	if method == "dataset.list" {
-		return "/list"
-	}
-	pos := strings.Index(method, ".")
-	prefix := method[:pos]
-	_ = prefix
-	res := "/" + method[pos+1:] + "/"
-	return APIEndpoint(res)
 }
 
 func dispatchReturnError(got interface{}, err error) error {

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -28,6 +28,8 @@ type Cursor interface{}
 //           3: (output, Cursor, error)
 // The implementation should have the same input and output as the method, except
 // with the context.Context replaced by a scope.
+// No other functions are allowed to be defined, other that those that are going to
+// be registered (as described above) and those that are required by the interface.
 type MethodSet interface {
 	Name() string
 	Attributes() map[string]AttributeSet
@@ -35,6 +37,7 @@ type MethodSet interface {
 
 // AttributeSet is extra information about each method, such as: http endpoint,
 // http verb, (TODO) permissions, and (TODO) other metadata
+// Each method is required to have associated attributes in order to successfully register
 type AttributeSet struct {
 	endpoint APIEndpoint
 	verb     string

--- a/lib/dispatch_test.go
+++ b/lib/dispatch_test.go
@@ -341,10 +341,10 @@ func (m *fruitMethods) Name() string {
 
 func (m *fruitMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"apple": {"/apple", "GET"},
+		"apple":  {"/apple", "GET"},
 		"banana": {"/banana", "GET"},
 		"cherry": {"/cherry", "GET"},
-		"date": {"/date", "GET"},
+		"date":   {"/date", "GET"},
 		// entawak cannot be called over RPC
 		"entawak": {"", ""},
 	}

--- a/lib/dispatch_test.go
+++ b/lib/dispatch_test.go
@@ -243,8 +243,8 @@ func (m *animalMethods) Name() string {
 
 func (m *animalMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"cat": {"", ""},
-		"dog": {"", ""},
+		"cat": {denyRPC, ""},
+		"dog": {denyRPC, ""},
 	}
 }
 
@@ -346,7 +346,7 @@ func (m *fruitMethods) Attributes() map[string]AttributeSet {
 		"cherry": {"/cherry", "GET"},
 		"date":   {"/date", "GET"},
 		// entawak cannot be called over RPC
-		"entawak": {"", ""},
+		"entawak": {denyRPC, ""},
 	}
 }
 

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -28,6 +28,22 @@ func (m *FSIMethods) Name() string {
 	return "fsi"
 }
 
+// Attributes defines attributes for each method
+func (m *FSIMethods) Attributes() map[string]AttributeSet {
+	return map[string]AttributeSet{
+		"createlink":            {"/fsi/createlink", "POST"},
+		"unlink":                {"/fsi/unlink", "POST"},
+		"status":                {"/status", "GET"},
+		"whatchanged":           {"/whatchanged", "GET"},
+		"checkout":              {"/checkout", "POST"},
+		"write":                 {"/fsi/write", "POST"},
+		"restore":               {"/restore", "POST"},
+		"init":                  {"/init", "POST"},
+		"caninitdatasetworkdir": {"/caninitdatasetworkdir", "GET"},
+		"ensureref":             {"/ensureref", "POST"},
+	}
+}
+
 // Filesys returns the FSIMethods that Instance has registered
 func (inst *Instance) Filesys() *FSIMethods {
 	return &FSIMethods{d: inst}

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -44,11 +44,6 @@ func (m *FSIMethods) Attributes() map[string]AttributeSet {
 	}
 }
 
-// Filesys returns the FSIMethods that Instance has registered
-func (inst *Instance) Filesys() *FSIMethods {
-	return &FSIMethods{d: inst}
-}
-
 // LinkParams encapsulate parameters for linked datasets
 type LinkParams struct {
 	Dir    string

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -31,16 +31,16 @@ func (m *FSIMethods) Name() string {
 // Attributes defines attributes for each method
 func (m *FSIMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"createlink":            {"/fsi/createlink", "POST"},
-		"unlink":                {"/fsi/unlink", "POST"},
-		"status":                {"/status", "GET"},
-		"whatchanged":           {"/whatchanged", "GET"},
-		"checkout":              {"/checkout", "POST"},
-		"write":                 {"/fsi/write", "POST"},
-		"restore":               {"/restore", "POST"},
-		"init":                  {"/init", "POST"},
-		"caninitdatasetworkdir": {"/caninitdatasetworkdir", "GET"},
-		"ensureref":             {"/ensureref", "POST"},
+		"createlink":            {AEFSICreateLink, "POST"},
+		"unlink":                {AEFSIUnlink, "POST"},
+		"status":                {AEStatus, "GET"},
+		"whatchanged":           {AEWhatChanged, "GET"},
+		"checkout":              {AECheckout, "POST"},
+		"write":                 {AEFSIWrite, "POST"},
+		"restore":               {AERestore, "POST"},
+		"init":                  {AEInit, "POST"},
+		"caninitdatasetworkdir": {AECanInitDatasetWorkDir, "GET"},
+		"ensureref":             {AEEnsureRef, "POST"},
 	}
 }
 

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -24,12 +24,12 @@ type FSIMethods struct {
 }
 
 // Name returns the name of this method group
-func (m *FSIMethods) Name() string {
+func (m FSIMethods) Name() string {
 	return "fsi"
 }
 
 // Attributes defines attributes for each method
-func (m *FSIMethods) Attributes() map[string]AttributeSet {
+func (m FSIMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
 		"createlink":            {AEFSICreateLink, "POST"},
 		"unlink":                {AEFSIUnlink, "POST"},
@@ -78,7 +78,7 @@ type InitDatasetParams = fsi.InitParams
 type StatusItem = fsi.StatusItem
 
 // CreateLink creates a connection between a working directory and a dataset history
-func (m *FSIMethods) CreateLink(ctx context.Context, p *LinkParams) (*dsref.VersionInfo, error) {
+func (m FSIMethods) CreateLink(ctx context.Context, p *LinkParams) (*dsref.VersionInfo, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "createlink"), p)
 	if res, ok := got.(*dsref.VersionInfo); ok {
 		return res, err
@@ -89,7 +89,7 @@ func (m *FSIMethods) CreateLink(ctx context.Context, p *LinkParams) (*dsref.Vers
 // Unlink removes the connection between a working directory and a dataset. If given only a
 // directory, will remove the link file from that directory. If given only a reference,
 // will remove the fsi path from that reference, and remove the link file from that fsi path
-func (m *FSIMethods) Unlink(ctx context.Context, p *LinkParams) (string, error) {
+func (m FSIMethods) Unlink(ctx context.Context, p *LinkParams) (string, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "unlink"), p)
 	if res, ok := got.(string); ok {
 		return res, err
@@ -99,7 +99,7 @@ func (m *FSIMethods) Unlink(ctx context.Context, p *LinkParams) (string, error) 
 
 // Status checks for any modifications or errors in a linked directory against its previous
 // version in the repo. Must only be called if FSI is enabled for this dataset.
-func (m *FSIMethods) Status(ctx context.Context, p *LinkParams) ([]StatusItem, error) {
+func (m FSIMethods) Status(ctx context.Context, p *LinkParams) ([]StatusItem, error) {
 	// TODO(dustmop): Have Dispatch perform this AbsPath call automatically
 	if err := qfs.AbsPath(&p.Dir); err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func (m *FSIMethods) Status(ctx context.Context, p *LinkParams) ([]StatusItem, e
 
 // WhatChanged gets changes that happened at a particular version in the history of the given
 // dataset reference.
-func (m *FSIMethods) WhatChanged(ctx context.Context, p *LinkParams) ([]StatusItem, error) {
+func (m FSIMethods) WhatChanged(ctx context.Context, p *LinkParams) ([]StatusItem, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "whatchanged"), p)
 	if res, ok := got.([]StatusItem); ok {
 		return res, err
@@ -122,13 +122,13 @@ func (m *FSIMethods) WhatChanged(ctx context.Context, p *LinkParams) ([]StatusIt
 }
 
 // Checkout method writes a dataset to a directory as individual files.
-func (m *FSIMethods) Checkout(ctx context.Context, p *LinkParams) error {
+func (m FSIMethods) Checkout(ctx context.Context, p *LinkParams) error {
 	_, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "checkout"), p)
 	return err
 }
 
 // Write mutates a linked dataset on the filesystem
-func (m *FSIMethods) Write(ctx context.Context, p *FSIWriteParams) ([]StatusItem, error) {
+func (m FSIMethods) Write(ctx context.Context, p *FSIWriteParams) ([]StatusItem, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "write"), p)
 	if res, ok := got.([]StatusItem); ok {
 		return res, err
@@ -137,13 +137,13 @@ func (m *FSIMethods) Write(ctx context.Context, p *FSIWriteParams) ([]StatusItem
 }
 
 // Restore method restores a component or all of the component files of a dataset from the repo
-func (m *FSIMethods) Restore(ctx context.Context, p *RestoreParams) error {
+func (m FSIMethods) Restore(ctx context.Context, p *RestoreParams) error {
 	_, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "restore"), p)
 	return err
 }
 
 // Init initializes a new working directory for a linked dataset
-func (m *FSIMethods) Init(ctx context.Context, p *InitDatasetParams) (string, error) {
+func (m FSIMethods) Init(ctx context.Context, p *InitDatasetParams) (string, error) {
 	// TODO(dustmop): Have Dispatch perform these AbsPath calls automatically
 	if err := qfs.AbsPath(&p.TargetDir); err != nil {
 		return "", err
@@ -159,13 +159,13 @@ func (m *FSIMethods) Init(ctx context.Context, p *InitDatasetParams) (string, er
 }
 
 // CanInitDatasetWorkDir returns nil if the directory can init a dataset, or an error if not
-func (m *FSIMethods) CanInitDatasetWorkDir(ctx context.Context, p *InitDatasetParams) error {
+func (m FSIMethods) CanInitDatasetWorkDir(ctx context.Context, p *InitDatasetParams) error {
 	_, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "caninitdatasetworkdir"), p)
 	return err
 }
 
 // EnsureRef will modify the directory path in the repo for the given reference
-func (m *FSIMethods) EnsureRef(ctx context.Context, p *LinkParams) (*dsref.VersionInfo, error) {
+func (m FSIMethods) EnsureRef(ctx context.Context, p *LinkParams) (*dsref.VersionInfo, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "ensureref"), p)
 	if res, ok := got.(*dsref.VersionInfo); ok {
 		return res, err
@@ -174,7 +174,6 @@ func (m *FSIMethods) EnsureRef(ctx context.Context, p *LinkParams) (*dsref.Versi
 }
 
 // Implementations for FSI methods follow
-// TODO(dustmop): Perhaps consider moving these methods to /lib/impl/*.go
 
 // fsiImpl holds the method implementations for FSI
 type fsiImpl struct{}

--- a/lib/http.go
+++ b/lib/http.go
@@ -19,7 +19,7 @@ import (
 )
 
 // ErrUnsupportedRPC is an error for when running a method that is not supported via HTTP RPC
-var ErrUnsupportedRPC = errors.New("Warning: method is not suported over RPC")
+var ErrUnsupportedRPC = errors.New("method is not suported over RPC")
 
 const jsonMimeType = "application/json"
 

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -808,6 +808,31 @@ func (inst *Instance) Connect(ctx context.Context) (err error) {
 	return nil
 }
 
+// Access returns the AccessMethods that Instance has registered
+func (inst *Instance) Access() AccessMethods {
+	return AccessMethods{d: inst}
+}
+
+// Config returns the ConfigMethods that Instance has registered
+func (inst *Instance) Config() *ConfigMethods {
+	return &ConfigMethods{d: inst}
+}
+
+// Dataset returns the DatasetMethods that Instance has registered
+func (inst *Instance) Dataset() *DatasetMethods {
+	return &DatasetMethods{inst: inst}
+}
+
+// Filesys returns the FSIMethods that Instance has registered
+func (inst *Instance) Filesys() *FSIMethods {
+	return &FSIMethods{d: inst}
+}
+
+// Transform returns the TransformMethods that Instance has registered
+func (inst *Instance) Transform() *TransformMethods {
+	return &TransformMethods{d: inst}
+}
+
 // GetConfig provides methods for manipulating Qri configuration
 //
 // Deprecated: this method will be removed in a future release.

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -814,23 +814,23 @@ func (inst *Instance) Access() AccessMethods {
 }
 
 // Config returns the ConfigMethods that Instance has registered
-func (inst *Instance) Config() *ConfigMethods {
-	return &ConfigMethods{d: inst}
+func (inst *Instance) Config() ConfigMethods {
+	return ConfigMethods{d: inst}
 }
 
 // Dataset returns the DatasetMethods that Instance has registered
-func (inst *Instance) Dataset() *DatasetMethods {
-	return &DatasetMethods{inst: inst}
+func (inst *Instance) Dataset() DatasetMethods {
+	return DatasetMethods{inst: inst}
 }
 
 // Filesys returns the FSIMethods that Instance has registered
-func (inst *Instance) Filesys() *FSIMethods {
-	return &FSIMethods{d: inst}
+func (inst *Instance) Filesys() FSIMethods {
+	return FSIMethods{d: inst}
 }
 
 // Transform returns the TransformMethods that Instance has registered
-func (inst *Instance) Transform() *TransformMethods {
-	return &TransformMethods{d: inst}
+func (inst *Instance) Transform() TransformMethods {
+	return TransformMethods{d: inst}
 }
 
 // GetConfig provides methods for manipulating Qri configuration

--- a/lib/render_test.go
+++ b/lib/render_test.go
@@ -94,7 +94,7 @@ func TestRenderMethodsRender(t *testing.T) {
 type renderTestRunner struct {
 	Node          *p2p.QriNode
 	Repo          repo.Repo
-	DatasetReqs   *DatasetMethods
+	DatasetReqs   DatasetMethods
 	RenderMethods *RenderMethods
 	Context       context.Context
 	ContextDone   func()

--- a/lib/transform.go
+++ b/lib/transform.go
@@ -30,11 +30,6 @@ func (m *TransformMethods) Attributes() map[string]AttributeSet {
 	}
 }
 
-// Transform returns the TransformMethods that Instance has registered
-func (inst *Instance) Transform() *TransformMethods {
-	return &TransformMethods{d: inst}
-}
-
 // ApplyParams are parameters for the apply command
 type ApplyParams struct {
 	Refstr    string

--- a/lib/transform.go
+++ b/lib/transform.go
@@ -19,12 +19,12 @@ type TransformMethods struct {
 }
 
 // Name returns the name of this method group
-func (m *TransformMethods) Name() string {
+func (m TransformMethods) Name() string {
 	return "transform"
 }
 
 // Attributes defines attributes for each method
-func (m *TransformMethods) Attributes() map[string]AttributeSet {
+func (m TransformMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
 		"apply": {AEApply, "POST"},
 	}
@@ -57,7 +57,7 @@ type ApplyResult struct {
 }
 
 // Apply runs a transform script
-func (m *TransformMethods) Apply(ctx context.Context, p *ApplyParams) (*ApplyResult, error) {
+func (m TransformMethods) Apply(ctx context.Context, p *ApplyParams) (*ApplyResult, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "apply"), p)
 	if res, ok := got.(*ApplyResult); ok {
 		return res, err

--- a/lib/transform.go
+++ b/lib/transform.go
@@ -18,9 +18,16 @@ type TransformMethods struct {
 	d dispatcher
 }
 
-// Name returns the name of this method gropu
+// Name returns the name of this method group
 func (m *TransformMethods) Name() string {
 	return "transform"
+}
+
+// Attributes defines attributes for each method
+func (m *TransformMethods) Attributes() map[string]AttributeSet {
+	return map[string]AttributeSet{
+		"apply": {"/apply", "POST"},
+	}
 }
 
 // Transform returns the TransformMethods that Instance has registered

--- a/lib/transform.go
+++ b/lib/transform.go
@@ -26,7 +26,7 @@ func (m *TransformMethods) Name() string {
 // Attributes defines attributes for each method
 func (m *TransformMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"apply": {"/apply", "POST"},
+		"apply": {AEApply, "POST"},
 	}
 }
 


### PR DESCRIPTION
Originally prototyped by https://github.com/qri-io/qri/pull/1687, this change adds an "Attributes" method to each MethodSet. For now, this is only defining the HTTP endpoint and verb, but in the future can include things like permissions, data structures that need locking (logbook and profile store etc), and more.

We can then delete some of the earlier hacks put in place for Dispatch, such as methodEndpoint function.

For now, endpoints only allow a single HTTP verb. We may find we need to allow a list of verbs instead, but if so, need a way to determine which verb to use when calling a method over HTTP RPC.

Open question on which of these directions to go:
1) should the endpoint urls should remain in lib/api.go, with Attributes using the constants
2) should we keep the endpoint urls in Attributes, and remove them from lib/api.go
I'm leaning a bit towards (2), because it keeps the urls closer to their owner, but am not completely sure