### PR TITLE
refactor(sql): Dispatch for sql. Move resolver source to scope

### DIFF
--- a/api/testdata/api.snapshot
+++ b/api/testdata/api.snapshot
@@ -6246,12 +6246,12 @@ HTTP/1.1 200 OK
 Connection: close
 
 /* snapshot: TestSQLHandler sql case 0: POST /sql */
-HTTP/1.1 422 Unprocessable Entity
+HTTP/1.1 500 Internal Server Error
 Connection: close
 
 {
   "meta": {
-    "code": 422,
+    "code": 500,
     "error": "empty statement"
   }
 }

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -30,7 +30,6 @@ type Factory interface {
 	LogMethods() (*lib.LogMethods, error)
 	ProfileMethods() (*lib.ProfileMethods, error)
 	SearchMethods() (*lib.SearchMethods, error)
-	SQLMethods() (*lib.SQLMethods, error)
 	RenderMethods() (*lib.RenderMethods, error)
 }
 

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -157,11 +157,6 @@ func (t TestFactory) SearchMethods() (*lib.SearchMethods, error) {
 	return lib.NewSearchMethods(t.inst), nil
 }
 
-// SQLMethods generates a lib.SQLhMethods from internal state
-func (t TestFactory) SQLMethods() (*lib.SQLMethods, error) {
-	return lib.NewSQLMethods(t.inst), nil
-}
-
 // RenderMethods generates a lib.RenderMethods from internal state
 func (t TestFactory) RenderMethods() (*lib.RenderMethods, error) {
 	return lib.NewRenderMethods(t.inst), nil

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -167,10 +167,9 @@ func (o *GetOptions) Run() (err error) {
 		// outputting a zip. lib.Get will also check that we're outputting a zip, this check is
 		// repeated here for clarity.
 		GenFilename: o.Outfile == "" && stdoutIsTerminal() && o.Format == "zip",
-		Remote:      o.Remote,
 	}
 	ctx := context.TODO()
-	res, err := o.inst.Dataset().Get(ctx, &p)
+	res, err := o.inst.WithSource(o.Remote).Dataset().Get(ctx, &p)
 	if err != nil {
 		return err
 	}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -511,17 +511,24 @@ func TestGetRemoteDataset(t *testing.T) {
 
 	expect := "cannot use '--offline' and '--remote' flags together"
 	err := run.ExecCommand("qri get --remote=registry --offline other_peer/their_dataset")
+	if err == nil {
+		t.Fatal("expected to get an error, did not get one")
+	}
 	if expect != err.Error() {
 		t.Errorf("response mismatch\nwant: %q\n got: %q", expect, err)
 	}
 
 	expect = "reference not found"
 	err = run.ExecCommand("qri get --offline other_peer/their_dataset")
+	if err == nil {
+		t.Fatal("expected to get an error, did not get one")
+	}
 	if expect != err.Error() {
 		t.Errorf("response mismatch\nwant: %q\n got: %q", expect, err)
 	}
 
-	expect = dstest.Template(t, `bodyPath: {{ .bodyPath }}
+	expect = dstest.Template(t, `pulling other_peer/their_dataset from registry ...
+bodyPath: {{ .bodyPath }}
 commit:
   message: created dataset
   path: {{ .commitPath }}

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -80,7 +80,7 @@ func (o *PullOptions) Run(args []string) error {
 			Remote:   o.Remote,
 		}
 
-		res, err := o.inst.Dataset().Pull(ctx, p)
+		res, err := o.inst.WithSource("network").Dataset().Pull(ctx, p)
 		if err != nil {
 			return err
 		}

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -276,14 +276,6 @@ func (o *QriOptions) SearchMethods() (*lib.SearchMethods, error) {
 	return lib.NewSearchMethods(o.inst), nil
 }
 
-// SQLMethods generates a lib.SQLMethods from internal state
-func (o *QriOptions) SQLMethods() (*lib.SQLMethods, error) {
-	if err := o.Init(); err != nil {
-		return nil, err
-	}
-	return lib.NewSQLMethods(o.inst), nil
-}
-
 // RenderMethods generates a lib.RenderMethods from internal state
 func (o *QriOptions) RenderMethods() (*lib.RenderMethods, error) {
 	if err := o.Init(); err != nil {

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -1095,9 +1095,9 @@ func (datasetImpl) Save(scope scope, p *SaveParams) (*dataset.Dataset, error) {
 		p.Ref = fmt.Sprintf("me/%s", ds.Name)
 	}
 
-	resolver, err := scope.ResolverForMode("local")
+	resolver, err := scope.LocalResolver()
 	if err != nil {
-		log.Debugw("save construct resolver", "mode", "local", "err", err)
+		log.Debugw("save construct local resolver", "err", err)
 		return nil, err
 	}
 

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -1492,18 +1492,21 @@ func (datasetImpl) Remove(scope scope, p *RemoveParams) (*RemoveResponse, error)
 // a network connection
 func (datasetImpl) Pull(scope scope, p *PullParams) (*dataset.Dataset, error) {
 	res := &dataset.Dataset{}
+	// TODO(dustmop): source has moved to the scope, and passing it to ParseAndResolveRef
+	// does nothing. Remove it from here and from the third parameter of that func
 	source := p.Remote
 	if source == "" {
 		source = "network"
 	}
 
-	ref, source, err := scope.ParseAndResolveRef(scope.Context(), p.Ref, source)
+	ref, location, err := scope.ParseAndResolveRef(scope.Context(), p.Ref, source)
 	if err != nil {
 		log.Debugf("resolving reference: %s", err)
 		return nil, err
 	}
+	log.Infof("pulling dataset from location: %s", location)
 
-	ds, err := scope.RemoteClient().PullDataset(scope.Context(), &ref, source)
+	ds, err := scope.RemoteClient().PullDataset(scope.Context(), &ref, location)
 	if err != nil {
 		log.Debugf("pulling dataset: %s", err)
 		return nil, err

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -20,8 +20,6 @@ import (
 )
 
 func TestTwoActorRegistryIntegration(t *testing.T) {
-	t.Skip("TODO(dustmop): meaning of source changed, this needs to be fixed")
-
 	tr := NewNetworkIntegrationTestRunner(t, "integration_two_actor_registry")
 	defer tr.Cleanup()
 
@@ -70,7 +68,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 	PushToRegistry(tr.Ctx, t, nasim, ref.Alias())
 
 	// 7. hinshun logsyncs with the registry for world bank dataset, sees multiple versions
-	_, err = hinshun.Dataset().Pull(tr.Ctx, &PullParams{LogsOnly: true, Ref: ref.String()})
+	_, err = hinshun.WithSource("network").Dataset().Pull(tr.Ctx, &PullParams{LogsOnly: true, Ref: ref.String()})
 	if err != nil {
 		t.Errorf("cloning logs: %s", err)
 	}
@@ -437,7 +435,7 @@ func SearchFor(ctx context.Context, t *testing.T, inst *Instance, term string) [
 
 func Pull(ctx context.Context, t *testing.T, inst *Instance, refstr string) *dataset.Dataset {
 	t.Helper()
-	res, err := inst.Dataset().Pull(ctx, &PullParams{Ref: refstr})
+	res, err := inst.WithSource("network").Dataset().Pull(ctx, &PullParams{Ref: refstr})
 	if err != nil {
 		t.Fatalf("cloning dataset %s: %s", refstr, err)
 	}

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestTwoActorRegistryIntegration(t *testing.T) {
+	t.Skip("TODO(dustmop): meaning of source changed, this needs to be fixed")
+
 	tr := NewNetworkIntegrationTestRunner(t, "integration_two_actor_registry")
 	defer tr.Cleanup()
 
@@ -138,25 +140,23 @@ func TestReferencePulling(t *testing.T) {
 	}
 
 	hinshun := tr.InitHinshun(t)
-	sqlm := NewSQLMethods(hinshun)
 
 	// fetch this from the registry by default
 	p := &SQLQueryParams{
-		Query:        "SELECT * FROM nasim/world_bank_population a LIMIT 1",
-		OutputFormat: "json",
+		Query:  "SELECT * FROM nasim/world_bank_population a LIMIT 1",
+		Format: "json",
 	}
-	if _, err := sqlm.Exec(tr.Ctx, p); err != nil {
+	if _, err := hinshun.SQL().Exec(tr.Ctx, p); err != nil {
 		t.Fatal(err)
 	}
 
 	// re-run. dataset should now be local, and no longer require registry to
 	// resolve
 	p = &SQLQueryParams{
-		Query:        "SELECT * FROM nasim/world_bank_population a LIMIT 1 OFFSET 1",
-		OutputFormat: "json",
-		ResolverMode: "local",
+		Query:  "SELECT * FROM nasim/world_bank_population a LIMIT 1 OFFSET 1",
+		Format: "json",
 	}
-	if _, err = sqlm.Exec(tr.Ctx, p); err != nil {
+	if _, err = hinshun.WithSource("local").SQL().Exec(tr.Ctx, p); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -833,9 +833,38 @@ func (inst *Instance) Peer() PeerMethods {
 	return PeerMethods{d: inst}
 }
 
+// SQL returns the SQLMethods that Instance has registered
+func (inst *Instance) SQL() SQLMethods {
+	return SQLMethods{d: inst}
+}
+
 // Transform returns the TransformMethods that Instance has registered
 func (inst *Instance) Transform() TransformMethods {
 	return TransformMethods{d: inst}
+}
+
+// WithSource returns a wrapped instance that will resolve refs from the given source
+func (inst *Instance) WithSource(source string) *InstanceSourceWrap {
+	return &InstanceSourceWrap{
+		source: source,
+		inst:   inst,
+	}
+}
+
+// InstanceSourceWrap is a wrapped instance with an explicit resolver source added
+type InstanceSourceWrap struct {
+	source string
+	inst   *Instance
+}
+
+// Dataset returns the DatasetMethods that Instance has registered
+func (isw *InstanceSourceWrap) Dataset() DatasetMethods {
+	return DatasetMethods{d: isw}
+}
+
+// SQL returns the SQLMethods that Instance has registered
+func (isw *InstanceSourceWrap) SQL() SQLMethods {
+	return SQLMethods{d: isw}
 }
 
 // GetConfig provides methods for manipulating Qri configuration


### PR DESCRIPTION
Use the Dispatch pattern for sql methods.

Instead of source being a parameter that is passed down the callstack, until code calls LoadDataset or ParseAndResolveRef, attach source to the scope. This will let us remove the source from the interface, since the callsite of LoadDataset doesn't care about source, the concrete implementation of the Loader does. Clients of lib can configure the source just-in-time by using WithSource on the Instance.

Also, discovered that the --offline flag for sql was broken, so resolution would never be local-only. The cause was ParseResolveFunc always using the defaultResolver. This type of cleanup should make these sorts of bugs much harder to cause.

Finally, remove the ResolverForMode function from scope. Only lib.Save was using it, but in actually it only needs a localResolver, so it uses that instead now.