### PR TITLE
refactor(api): remove unneeded `DatasetHandlers`

### DIFF
--- a/lib/api.go
+++ b/lib/api.go
@@ -44,9 +44,6 @@ const (
 
 	// AEList lists all datasets in your collection
 	AEList = APIEndpoint("/list")
-	// AEPeerList lists all datasets in your
-	// collection for a particular peer
-	AEPeerList = APIEndpoint("/list/{peer}")
 	// AEDiff is an endpoint for generating dataset diffs
 	AEDiff = APIEndpoint("/diff")
 	// AEChanges is an endpoint for generating dataset change reports


### PR DESCRIPTION
`AESave`, `AEPull`, & `AERemove` endpoints are all handled using `NewHTTPRequestHandler`
`AEPeerList` & `PeerListHandler` is removed
Removes associated tests.

closes #1721 