### PR TITLE
fix(lib): Align input params across all lib methods

### DIFF
--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -21,7 +21,7 @@ func TestGetZip(t *testing.T) {
 	run.SaveDataset(ds, "testdata/cities/data.csv")
 
 	// Get a zip file binary over the API
-	gotStatusCode, gotBodyString := APICall("/get/peer/test_ds?format=zip", GetHandler(run.Inst, ""), map[string]string{"peername": "peer", "name": "test_ds"})
+	gotStatusCode, gotBodyString := APICall("/get/peer/test_ds?format=zip", GetHandler(run.Inst, ""), map[string]string{"username": "peer", "name": "test_ds"})
 	if gotStatusCode != 200 {
 		t.Fatalf("expected status code 200, got %d", gotStatusCode)
 	}
@@ -48,13 +48,13 @@ func TestDatasetGet(t *testing.T) {
 	}
 	run.SaveDataset(&ds, "testdata/cities/data.csv")
 
-	actualStatusCode, actualBody := APICall("/get/peer/test_ds", GetHandler(run.Inst, ""), map[string]string{"peername": "peer", "name": "test_ds"})
+	actualStatusCode, actualBody := APICall("/get/peer/test_ds", GetHandler(run.Inst, ""), map[string]string{"username": "peer", "name": "test_ds"})
 	assertStatusCode(t, "get dataset", actualStatusCode, 200)
 	got := datasetJSONResponse(t, actualBody)
 	dstest.CompareGoldenDatasetAndUpdateIfEnvVarSet(t, "testdata/expect/TestDatasetGet.test_ds.json", got)
 
 	// Get csv body using "body.csv" suffix
-	actualStatusCode, actualBody = APICall("/get/peer/test_ds/body.csv", GetHandler(run.Inst, ""), map[string]string{"peername": "peer", "name": "test_ds", "selector": "body.csv"})
+	actualStatusCode, actualBody = APICall("/get/peer/test_ds/body.csv", GetHandler(run.Inst, ""), map[string]string{"username": "peer", "name": "test_ds", "selector": "body.csv"})
 	expectBody := "city,pop,avg_age,in_usa\ntoronto,40000000,55.5,false\nnew york,8500000,44.4,true\nchicago,300000,44.4,true\nchatham,35000,65.25,true\nraleigh,250000,50.65,true\n"
 	assertStatusCode(t, "get body.csv using suffix", actualStatusCode, 200)
 	if diff := cmp.Diff(expectBody, actualBody); diff != "" {
@@ -62,27 +62,27 @@ func TestDatasetGet(t *testing.T) {
 	}
 
 	// Can get zip file
-	actualStatusCode, _ = APICall("/get/peer/test_ds?format=zip", GetHandler(run.Inst, ""), map[string]string{"peername": "peer", "name": "test_ds"})
+	actualStatusCode, _ = APICall("/get/peer/test_ds?format=zip", GetHandler(run.Inst, ""), map[string]string{"username": "peer", "name": "test_ds"})
 	assertStatusCode(t, "get zip file", actualStatusCode, 200)
 
 	// Can get a single component
-	actualStatusCode, _ = APICall("/get/peer/test_ds/meta", GetHandler(run.Inst, ""), map[string]string{"peername": "peer", "name": "test_ds", "selector": "meta"})
+	actualStatusCode, _ = APICall("/get/peer/test_ds/meta", GetHandler(run.Inst, ""), map[string]string{"username": "peer", "name": "test_ds", "selector": "meta"})
 	assertStatusCode(t, "get meta component", actualStatusCode, 200)
 
 	// Can get at an ipfs version
-	actualStatusCode, _ = APICall("/get/peer/test_ds/at/mem/QmeTvt83npHg4HoxL8bp8yz5bmG88hUVvRc5k9taW8uxTr", GetHandler(run.Inst, ""), map[string]string{"peername": "peer", "name": "test_ds", "fs": "mem", "hash": "QmeTvt83npHg4HoxL8bp8yz5bmG88hUVvRc5k9taW8uxTr"})
+	actualStatusCode, _ = APICall("/get/peer/test_ds/at/mem/QmeTvt83npHg4HoxL8bp8yz5bmG88hUVvRc5k9taW8uxTr", GetHandler(run.Inst, ""), map[string]string{"username": "peer", "name": "test_ds", "fs": "mem", "hash": "QmeTvt83npHg4HoxL8bp8yz5bmG88hUVvRc5k9taW8uxTr"})
 	assertStatusCode(t, "get at content-addressed version", actualStatusCode, 200)
 
 	// Error 404 if ipfs version doesn't exist
-	actualStatusCode, _ = APICall("/get/peer/test_ds/at/mem/QmissingEJUqFWNfdiPTPtxyba6wf86TmbQe1nifpZCRH6", GetHandler(run.Inst, ""), map[string]string{"peername": "peer", "name": "test_ds", "fs": "mem", "hash": "QmissingEJUqFWNfdiPTPtxyba6wf86TmbQe1nifpZCRH6"})
+	actualStatusCode, _ = APICall("/get/peer/test_ds/at/mem/QmissingEJUqFWNfdiPTPtxyba6wf86TmbQe1nifpZCRH6", GetHandler(run.Inst, ""), map[string]string{"username": "peer", "name": "test_ds", "fs": "mem", "hash": "QmissingEJUqFWNfdiPTPtxyba6wf86TmbQe1nifpZCRH6"})
 	assertStatusCode(t, "get missing content-addressed version", actualStatusCode, 404)
 
 	// Error 400 due to unknown component
-	actualStatusCode, _ = APICall("/get/peer/test_ds/dunno", GetHandler(run.Inst, ""), map[string]string{"peername": "peer", "name": "test_ds", "selector": "dunno"})
+	actualStatusCode, _ = APICall("/get/peer/test_ds/dunno", GetHandler(run.Inst, ""), map[string]string{"username": "peer", "name": "test_ds", "selector": "dunno"})
 	assertStatusCode(t, "unknown component", actualStatusCode, 400)
 
 	// Error 400 due to parse error of dsref
-	actualStatusCode, _ = APICall("/get/peer/test+ds", GetHandler(run.Inst, ""), map[string]string{"peername": "peer", "name": "test+ds"})
+	actualStatusCode, _ = APICall("/get/peer/test+ds", GetHandler(run.Inst, ""), map[string]string{"username": "peer", "name": "test+ds"})
 	assertStatusCode(t, "invalid dsref", actualStatusCode, 400)
 }
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -72,7 +72,7 @@ func muxVarsToQueryParamMiddleware(next http.Handler) http.Handler {
 		q := r.URL.Query()
 		for varName, val := range mux.Vars(r) {
 			if q.Get(varName) != "" {
-				util.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("unrecognized query param: %s", varName))
+				util.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("conflict in query param: %s = %s", varName, val))
 				return
 			}
 			q.Add(varName, val)
@@ -94,14 +94,14 @@ func refStringMiddleware(next http.Handler) http.Handler {
 func setRefStringFromMuxVars(r *http.Request) {
 	mvars := mux.Vars(r)
 	ref := dsref.Ref{
-		Username: mvars["peername"],
+		Username: mvars["username"],
 		Name:     mvars["name"],
 		Path:     muxVarsPath(mvars),
 	}
 
 	if refstr := ref.String(); refstr != "" {
 		q := r.URL.Query()
-		q.Add("refstr", refstr)
+		q.Add("ref", refstr)
 		r.URL.RawQuery = q.Encode()
 	}
 }
@@ -117,6 +117,6 @@ func muxVarsPath(mvars map[string]string) string {
 
 func stripServerSideQueryParams(r *http.Request) {
 	q := r.URL.Query()
-	q.Del("refstr")
+	q.Del("ref")
 	r.URL.RawQuery = q.Encode()
 }

--- a/api/params_test.go
+++ b/api/params_test.go
@@ -20,65 +20,65 @@ func TestUnmarshalGetParams(t *testing.T) {
 			"basic get",
 			"/get/peer/my_ds",
 			&lib.GetParams{
-				Refstr: "peer/my_ds",
+				Ref:    "peer/my_ds",
 				Format: "json",
 				All:    true,
 			},
-			map[string]string{"peername": "peer", "name": "my_ds"},
+			map[string]string{"username": "peer", "name": "my_ds"},
 		},
 		{
 			"meta component",
 			"/get/peer/my_ds/meta",
 			&lib.GetParams{
-				Refstr:   "peer/my_ds",
+				Ref:      "peer/my_ds",
 				Format:   "json",
 				Selector: "meta",
 				All:      true,
 			},
-			map[string]string{"peername": "peer", "name": "my_ds", "selector": "meta"},
+			map[string]string{"username": "peer", "name": "my_ds", "selector": "meta"},
 		},
 		{
 			"body component",
 			"/get/peer/my_ds/body",
 			&lib.GetParams{
-				Refstr:   "peer/my_ds",
+				Ref:      "peer/my_ds",
 				Format:   "json",
 				Selector: "body",
 				All:      true,
 			},
-			map[string]string{"peername": "peer", "name": "my_ds", "selector": "body"},
+			map[string]string{"username": "peer", "name": "my_ds", "selector": "body"},
 		},
 		{
 			"body.csv path suffix",
 			"/get/peer/my_ds/body.csv",
 			&lib.GetParams{
-				Refstr:   "peer/my_ds",
+				Ref:      "peer/my_ds",
 				Format:   "csv",
 				Selector: "body",
 				All:      true,
 			},
-			map[string]string{"peername": "peer", "name": "my_ds", "selector": "body.csv"},
+			map[string]string{"username": "peer", "name": "my_ds", "selector": "body.csv"},
 		},
 		{
 			"download body as csv",
 			"/get/peer/my_ds/body?format=csv",
 			&lib.GetParams{
-				Refstr:   "peer/my_ds",
+				Ref:      "peer/my_ds",
 				Format:   "csv",
 				Selector: "body",
 				All:      true,
 			},
-			map[string]string{"peername": "peer", "name": "my_ds", "selector": "body"},
+			map[string]string{"username": "peer", "name": "my_ds", "selector": "body"},
 		},
 		{
 			"zip format",
 			"/get/peer/my_ds?format=zip",
 			&lib.GetParams{
-				Refstr: "peer/my_ds",
+				Ref:    "peer/my_ds",
 				Format: "zip",
 				All:    true,
 			},
-			map[string]string{"peername": "peer", "name": "my_ds"},
+			map[string]string{"username": "peer", "name": "my_ds"},
 		},
 	}
 	for _, c := range cases {
@@ -110,13 +110,13 @@ func TestUnmarshalGetParams(t *testing.T) {
 			"get me",
 			"/get/me/my_ds",
 			`username "me" not allowed`,
-			map[string]string{"peername": "me", "name": "my_ds"},
+			map[string]string{"username": "me", "name": "my_ds"},
 		},
 		{
 			"bad parse",
 			"/get/peer/my+ds",
 			`unexpected character at position 7: '+'`,
-			map[string]string{"peername": "peer", "name": "my+ds"},
+			map[string]string{"username": "peer", "name": "my+ds"},
 		},
 	}
 	for i, c := range badCases {
@@ -143,7 +143,7 @@ func TestParseGetParamsAcceptHeader(t *testing.T) {
 	// Construct a request with "Accept: text/csv"
 	r, _ := http.NewRequest("GET", "/get/peer/my_ds", nil)
 	r.Header.Add("Accept", "text/csv")
-	r = mux.SetURLVars(r, map[string]string{"peername": "peer", "name": "my_ds"})
+	r = mux.SetURLVars(r, map[string]string{"username": "peer", "name": "my_ds"})
 	setRefStringFromMuxVars(r)
 	args := &lib.GetParams{}
 	err := UnmarshalParams(r, args)
@@ -151,7 +151,7 @@ func TestParseGetParamsAcceptHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectArgs := &lib.GetParams{
-		Refstr:   "peer/my_ds",
+		Ref:      "peer/my_ds",
 		Selector: "body",
 		Format:   "csv",
 		All:      true,
@@ -164,7 +164,7 @@ func TestParseGetParamsAcceptHeader(t *testing.T) {
 	// Construct a request with format=csv and "Accept: text/csv", which is ok
 	r, _ = http.NewRequest("GET", "/get/peer/my_ds?format=csv", nil)
 	r.Header.Add("Accept", "text/csv")
-	r = mux.SetURLVars(r, map[string]string{"peername": "peer", "name": "my_ds"})
+	r = mux.SetURLVars(r, map[string]string{"username": "peer", "name": "my_ds"})
 	setRefStringFromMuxVars(r)
 	args = &lib.GetParams{}
 	err = UnmarshalParams(r, args)
@@ -178,7 +178,7 @@ func TestParseGetParamsAcceptHeader(t *testing.T) {
 	// Construct a request with format=json and "Accept: text/csv", which is an error
 	r, _ = http.NewRequest("GET", "/get/peer/my_ds?format=json", nil)
 	r.Header.Add("Accept", "text/csv")
-	r = mux.SetURLVars(r, map[string]string{"peername": "peer", "name": "my_ds"})
+	r = mux.SetURLVars(r, map[string]string{"username": "peer", "name": "my_ds"})
 	setRefStringFromMuxVars(r)
 	args = &lib.GetParams{}
 	err = UnmarshalParams(r, args)

--- a/base/dataset.go
+++ b/base/dataset.go
@@ -157,7 +157,7 @@ func CloseDataset(ds *dataset.Dataset) (err error) {
 }
 
 // ListDatasets lists datasets from a repo
-func ListDatasets(ctx context.Context, r repo.Repo, term, profileID string, offset, limit int, RPC, publishedOnly, showVersions bool) ([]dsref.VersionInfo, error) {
+func ListDatasets(ctx context.Context, r repo.Repo, term, profileID string, offset, limit int, publishedOnly, showVersions bool) ([]dsref.VersionInfo, error) {
 	fs := r.Filesystem()
 	num, err := r.RefCount()
 	if err != nil {
@@ -228,9 +228,6 @@ func ListDatasets(ctx context.Context, r repo.Repo, term, profileID string, offs
 			ds.Peername = ref.Peername
 			ds.Name = ref.Name
 			ref.Dataset = ds
-			if RPC {
-				ref.Dataset.Structure.Schema = nil
-			}
 
 			if showVersions {
 				dsVersions, err := DatasetLog(ctx, r, reporef.ConvertToDsref(ref), 1000000, 0, false)

--- a/base/dataset_test.go
+++ b/base/dataset_test.go
@@ -16,7 +16,7 @@ func TestListDatasets(t *testing.T) {
 	ref := addCitiesDataset(t, r)
 
 	// Limit to one
-	res, err := ListDatasets(ctx, r, "", "", 0, 1, false, false, false)
+	res, err := ListDatasets(ctx, r, "", "", 0, 1, false, false)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -25,7 +25,7 @@ func TestListDatasets(t *testing.T) {
 	}
 
 	// Limit to published datasets
-	res, err = ListDatasets(ctx, r, "", "", 0, 1, false, true, false)
+	res, err = ListDatasets(ctx, r, "", "", 0, 1, true, false)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -39,7 +39,7 @@ func TestListDatasets(t *testing.T) {
 	}
 
 	// Limit to published datasets, after publishing cities
-	res, err = ListDatasets(ctx, r, "", "", 0, 1, false, true, false)
+	res, err = ListDatasets(ctx, r, "", "", 0, 1, true, false)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -49,7 +49,7 @@ func TestListDatasets(t *testing.T) {
 	}
 
 	// Limit to datasets with "city" in their name
-	res, err = ListDatasets(ctx, r, "city", "", 0, 1, false, false, false)
+	res, err = ListDatasets(ctx, r, "city", "", 0, 1, false, false)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -58,7 +58,7 @@ func TestListDatasets(t *testing.T) {
 	}
 
 	// Limit to datasets with "cit" in their name
-	res, err = ListDatasets(ctx, r, "cit", "", 0, 1, false, false, false)
+	res, err = ListDatasets(ctx, r, "cit", "", 0, 1, false, false)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -66,7 +66,7 @@ func TestListDatasets(t *testing.T) {
 		t.Error(`expected one dataset with \"cit\" in their name`)
 	}
 
-	res, err = ListDatasets(ctx, r, "", "", 0, -1, false, false, false)
+	res, err = ListDatasets(ctx, r, "", "", 0, -1, false, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -103,7 +103,7 @@ func (o *ApplyOptions) Run() error {
 	}
 
 	params := lib.ApplyParams{
-		Refstr:       o.Refs.Ref(),
+		Ref:          o.Refs.Ref(),
 		Transform:    &tf,
 		ScriptOutput: o.Out,
 		Wait:         true,

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -87,7 +87,7 @@ func (o *CheckoutOptions) Run() (err error) {
 		o.Dir = dsref.GenerateName(ref[pos+1:], "")
 	}
 
-	if err = inst.Filesys().Checkout(ctx, &lib.LinkParams{Dir: o.Dir, Refstr: ref}); err != nil {
+	if err = inst.Filesys().Checkout(ctx, &lib.LinkParams{Dir: o.Dir, Ref: ref}); err != nil {
 		return err
 	}
 	printSuccess(o.Out, "created and linked working directory %s for existing dataset", o.Dir)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -107,7 +108,7 @@ func GetWd() string {
 	return dir
 }
 
-func loadFileIfPath(path string) (file *os.File, err error) {
+func loadFileIfPath(path string) (data []byte, err error) {
 	if path == "" {
 		return nil, nil
 	}
@@ -117,7 +118,7 @@ func loadFileIfPath(path string) (file *os.File, err error) {
 		return nil, err
 	}
 
-	return os.Open(path)
+	return ioutil.ReadFile(path)
 }
 
 // parseSecrets turns a key,value sequence into a map[string]string

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -234,7 +234,7 @@ __qri_custom_func() {
 
 # flag completions
 
-__qri_get_peer_flag_suggestions()
+__qri_get_user_flag_suggestions()
 {
 	__qri_suggest_completion "$(__qri_parse_peers)"
 }

--- a/cmd/dag.go
+++ b/cmd/dag.go
@@ -120,8 +120,8 @@ func (o *DAGOptions) Complete(f Factory, args []string, parseLabel bool) (err er
 func (o *DAGOptions) Get() (err error) {
 	ctx := context.TODO()
 	mf := &dag.Manifest{}
-	for _, refstr := range o.Refs {
-		if mf, err = o.inst.Dataset().Manifest(ctx, &lib.ManifestParams{Refstr: refstr}); err != nil {
+	for _, ref := range o.Refs {
+		if mf, err = o.inst.Dataset().Manifest(ctx, &lib.ManifestParams{Ref: ref}); err != nil {
 			return err
 		}
 
@@ -214,8 +214,8 @@ func (o *DAGOptions) Info() (err error) {
 		return fmt.Errorf("dataset reference required")
 	}
 
-	for _, refstr := range o.Refs {
-		s := &lib.DAGInfoParams{RefStr: refstr, Label: o.Label}
+	for _, ref := range o.Refs {
+		s := &lib.DAGInfoParams{Ref: ref, Label: o.Label}
 		info, err = o.inst.Dataset().DAGInfo(ctx, s)
 		if err != nil {
 			return err
@@ -242,7 +242,7 @@ func (o *DAGOptions) Info() (err error) {
 			if o.Label != "" {
 				out += fmt.Sprintf("\nSubDAG at: %s", abbrFieldToFull(o.Label))
 			}
-			out += fmt.Sprintf("\nDAG for: %s\n", refstr)
+			out += fmt.Sprintf("\nDAG for: %s\n", ref)
 			if totalSize != 0 {
 				out += fmt.Sprintf("Total Size: %s\n", humanize.Bytes(totalSize))
 			}

--- a/cmd/fsi.go
+++ b/cmd/fsi.go
@@ -91,8 +91,8 @@ func (o *FSIOptions) Link() (err error) {
 	inst := o.Instance
 
 	p := &lib.LinkParams{
-		Dir:    o.Path,
-		Refstr: o.Refs.Ref(),
+		Dir: o.Path,
+		Ref: o.Refs.Ref(),
 	}
 	res, err := inst.Filesys().CreateLink(ctx, p)
 	if err != nil {
@@ -111,7 +111,7 @@ func (o *FSIOptions) Unlink(ctx context.Context) error {
 		printRefSelect(o.ErrOut, o.Refs)
 
 		p := &lib.LinkParams{
-			Refstr: ref,
+			Ref: ref,
 		}
 		res, err := inst.Filesys().Unlink(ctx, p)
 		if err != nil {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -155,7 +155,7 @@ func (o *GetOptions) Run() (err error) {
 	// convert Page and PageSize to Limit and Offset
 	page := apiutil.NewPage(o.Page, o.PageSize)
 	p := lib.GetParams{
-		Refstr:       o.Refs.Ref(),
+		Ref:          o.Refs.Ref(),
 		Selector:     o.Selector,
 		Format:       o.Format,
 		FormatConfig: fc,

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -421,6 +421,8 @@ func TestGetDatasetCheckedOut(t *testing.T) {
 }
 
 func TestGetDatasetUsingDscache(t *testing.T) {
+	t.Skip("TODO(dustmop): Need a way to enable Dscache without the Param field")
+
 	run := NewTestRunner(t, "test_peer_get", "get_dataset_head")
 	defer run.Delete()
 
@@ -459,6 +461,8 @@ func TestGetDatasetUsingDscache(t *testing.T) {
 }
 
 func TestGetDatasetCheckedOutUsingDscache(t *testing.T) {
+	t.Skip("TODO(dustmop): Need a way to enable Dscache without the Param field")
+
 	run := NewFSITestRunner(t, "test_peer_get", "get_dataset_checked_out_using_dscache")
 	defer run.Delete()
 
@@ -527,8 +531,7 @@ func TestGetRemoteDataset(t *testing.T) {
 		t.Errorf("response mismatch\nwant: %q\n got: %q", expect, err)
 	}
 
-	expect = dstest.Template(t, `pulling other_peer/their_dataset from registry ...
-bodyPath: {{ .bodyPath }}
+	expect = dstest.Template(t, `bodyPath: {{ .bodyPath }}
 commit:
   message: created dataset
   path: {{ .commitPath }}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -57,10 +57,9 @@ must have ` + "`qri connect`" + ` running in a separate terminal window.`,
 	cmd.Flags().IntVar(&o.Page, "page", 1, "page number results, default 1")
 	cmd.Flags().BoolVarP(&o.Public, "public", "p", false, "list only publically visible")
 	cmd.Flags().BoolVarP(&o.ShowNumVersions, "num-versions", "n", false, "show number of versions")
-	cmd.Flags().StringVar(&o.Peername, "peer", "", "peer whose datasets to list")
-	cmd.MarkFlagCustom("peer", "__qri_get_peer_flag_suggestions")
+	cmd.Flags().StringVar(&o.Username, "user", "", "user whose datasets to list")
+	cmd.MarkFlagCustom("user", "__qri_get_user_flag_suggestions")
 	cmd.Flags().BoolVarP(&o.Raw, "raw", "r", false, "to show raw references")
-	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "experimental: build and use dscache to list")
 
 	return cmd
 }
@@ -73,11 +72,10 @@ type ListOptions struct {
 	PageSize        int
 	Page            int
 	Term            string
-	Peername        string
+	Username        string
 	Public          bool
 	ShowNumVersions bool
 	Raw             bool
-	UseDscache      bool
 
 	inst *lib.Instance
 }
@@ -98,10 +96,7 @@ func (o *ListOptions) Run() (err error) {
 	ctx := context.TODO()
 
 	if o.Raw {
-		p := &lib.ListParams{
-			UseDscache: o.UseDscache,
-		}
-		text, err := o.inst.Collection().ListRawRefs(ctx, p)
+		text, err := o.inst.Collection().ListRawRefs(ctx, &lib.EmptyParams{})
 		if err != nil {
 			return err
 		}
@@ -111,13 +106,12 @@ func (o *ListOptions) Run() (err error) {
 
 	p := &lib.ListParams{
 		Term:            o.Term,
-		Peername:        o.Peername,
+		Username:        o.Username,
 		Limit:           page.Limit(),
 		Offset:          page.Offset(),
 		Public:          o.Public,
 		ShowNumVersions: o.ShowNumVersions,
 		EnsureFSIExists: true,
-		UseDscache:      o.UseDscache,
 	}
 	infos, err := o.inst.Collection().List(ctx, p)
 	if err != nil {
@@ -135,8 +129,8 @@ func (o *ListOptions) Run() (err error) {
 	}
 
 	if len(infos) == 0 {
-		pn := fmt.Sprintf("%s has", o.Peername)
-		if o.Peername == "" {
+		pn := fmt.Sprintf("%s has", o.Username)
+		if o.Username == "" {
 			pn = "you have"
 		}
 

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -40,7 +40,7 @@ for investigating a dataset before saving it locally.
 	}
 
 	cmd.Flags().StringVarP(&o.Format, "format", "", "pretty", "output format [pretty|json]")
-	cmd.Flags().StringVarP(&o.RemoteName, "remote", "", "", "name of remote to fetch preview from")
+	cmd.Flags().StringVarP(&o.Source, "source", "", "", "name of source to fetch preview from")
 
 	return cmd
 }
@@ -49,9 +49,9 @@ for investigating a dataset before saving it locally.
 type PreviewOptions struct {
 	ioes.IOStreams
 
-	Refs       *RefSelect
-	Format     string
-	RemoteName string
+	Refs   *RefSelect
+	Format string
+	Source string
 
 	inst *lib.Instance
 }
@@ -70,12 +70,11 @@ func (o *PreviewOptions) Complete(f Factory, args []string) (err error) {
 // Run executes the publish command
 func (o *PreviewOptions) Run() error {
 	p := lib.PreviewParams{
-		Ref:    o.Refs.Ref(),
-		Remote: o.RemoteName,
+		Ref: o.Refs.Ref(),
 	}
 
 	ctx := context.TODO()
-	res, err := o.inst.Remote().Preview(ctx, &p)
+	res, err := o.inst.WithSource(o.Source).Remote().Preview(ctx, &p)
 	if err != nil {
 		return err
 	}

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -37,7 +37,7 @@ dataset version(s). By default pull fetches the latest version of a dataset.
 	}
 
 	cmd.Flags().StringVar(&o.LinkDir, "link", "", "path to directory to link dataset to")
-	cmd.Flags().StringVar(&o.Remote, "remote", "", "location to pull from")
+	cmd.Flags().StringVar(&o.Source, "source", "network", "location to pull from")
 	cmd.MarkFlagFilename("link")
 	cmd.Flags().BoolVar(&o.LogsOnly, "logs-only", false, "only fetch logs, skipping HEAD data")
 
@@ -48,7 +48,7 @@ dataset version(s). By default pull fetches the latest version of a dataset.
 type PullOptions struct {
 	ioes.IOStreams
 	LinkDir  string
-	Remote   string
+	Source   string
 	LogsOnly bool
 
 	inst *lib.Instance
@@ -77,10 +77,9 @@ func (o *PullOptions) Run(args []string) error {
 			Ref:      arg,
 			LinkDir:  o.LinkDir,
 			LogsOnly: o.LogsOnly,
-			Remote:   o.Remote,
 		}
 
-		res, err := o.inst.WithSource("network").Dataset().Pull(ctx, p)
+		res, err := o.inst.WithSource(o.Source).Dataset().Pull(ctx, p)
 		if err != nil {
 			return err
 		}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -38,7 +38,7 @@ If no remote is specified, qri pushes to the registry.`,
 	}
 
 	cmd.Flags().BoolVarP(&o.Logs, "logs", "", false, "send only dataset history")
-	cmd.Flags().StringVarP(&o.RemoteName, "remote", "", "", "name of remote to push to")
+	cmd.Flags().StringVarP(&o.Remote, "remote", "", "", "name of remote to push to")
 
 	return cmd
 }
@@ -47,9 +47,9 @@ If no remote is specified, qri pushes to the registry.`,
 type PushOptions struct {
 	ioes.IOStreams
 
-	Refs       *RefSelect
-	Logs       bool
-	RemoteName string
+	Refs   *RefSelect
+	Logs   bool
+	Remote string
 
 	inst *lib.Instance
 }
@@ -71,10 +71,12 @@ func (o *PushOptions) Run() error {
 	for _, ref := range o.Refs.RefList() {
 		p := lib.PushParams{
 			Ref:    ref,
-			Remote: o.RemoteName,
+			Remote: o.Remote,
 		}
 
-		res, err := o.inst.Remote().Push(ctx, &p)
+		// Though push is pushing to a remote, it has to resolve datasets
+		// from your local collection.
+		res, err := o.inst.WithSource("local").Remote().Push(ctx, &p)
 		if err != nil {
 			return err
 		}

--- a/cmd/ref_select.go
+++ b/cmd/ref_select.go
@@ -233,7 +233,7 @@ func (e *FSIRefLinkEnsurer) EnsureRef(refs *RefSelect) error {
 	if e == nil {
 		return nil
 	}
-	p := lib.LinkParams{Dir: refs.Dir(), Refstr: refs.Ref()}
+	p := lib.LinkParams{Dir: refs.Dir(), Ref: refs.Ref()}
 	ctx := context.TODO()
 	_, err := e.FSIMethods.EnsureRef(ctx, &p)
 	return err

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -152,7 +152,7 @@ func (o *RemoveOptions) Run() (err error) {
 	}
 
 	ctx := context.TODO()
-	res, err := o.inst.Dataset().Remove(ctx, &params)
+	res, err := o.inst.WithSource("local").Dataset().Remove(ctx, &params)
 	if err != nil {
 		// TODO(b5): move this error handling down into lib
 		if errors.Is(err, dsref.ErrRefNotFound) {

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -79,7 +79,6 @@ different peer, the dataset gets renamed from ` + "`peers_name/dataset_name`" +
 	// TODO(dustmop): --no-render is deprecated, viz are being phased out, in favor of readme.
 	cmd.Flags().BoolVar(&o.NoRender, "no-render", false, "don't store a rendered version of the the visualization")
 	cmd.Flags().BoolVarP(&o.NewName, "new", "n", false, "save a new dataset only, using an available name")
-	cmd.Flags().BoolVarP(&o.UseDscache, "use-dscache", "", false, "experimental: build and use dscache if none exists")
 	cmd.Flags().StringVar(&o.Drop, "drop", "", "comma-separated list of components to remove")
 
 	return cmd
@@ -159,7 +158,6 @@ func (o *SaveOptions) Run() (err error) {
 
 		ShouldRender: !o.NoRender,
 		NewName:      o.NewName,
-		UseDscache:   o.UseDscache,
 	}
 
 	// Check if file ends in '.star'. If so, either Apply or NoApply is required.

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -177,6 +177,7 @@ func TestSaveRun(t *testing.T) {
 			t.Errorf("case '%s', did not get error, expected: '%s'", c.description, c.err)
 		}
 		if err != nil {
+			// Remove the current directory from path, to get consistent error messages
 			errGot := strings.Replace(err.Error(), pwd, "", -1)
 			if c.err != errGot {
 				t.Errorf("case '%s', mismatched error. Expected: '%s', Got: '%v'", c.description, c.err, errGot)
@@ -539,6 +540,8 @@ func TestSaveFilenameMeta(t *testing.T) {
 }
 
 func TestSaveDscacheFirstCommit(t *testing.T) {
+	t.Skip("TODO(dustmop): Need a way to enable Dscache without the Param field")
+
 	run := NewTestRunner(t, "test_peer_dscache_first", "qri_test_dscache_first")
 	defer run.Delete()
 
@@ -631,6 +634,8 @@ func TestSaveDscacheFirstCommit(t *testing.T) {
 }
 
 func TestSaveDscacheExistingDataset(t *testing.T) {
+	t.Skip("TODO(dustmop): Need a way to enable Dscache without the Param field")
+
 	run := NewTestRunner(t, "test_peer_save_dscache_existing_dataset", "qri_test_save_dscache_existing_dataset")
 	defer run.Delete()
 
@@ -716,6 +721,8 @@ func TestSaveDscacheExistingDataset(t *testing.T) {
 }
 
 func TestSaveDscacheThenRemoveAll(t *testing.T) {
+	t.Skip("TODO(dustmop): Need a way to enable Dscache without the Param field")
+
 	run := NewTestRunner(t, "test_peer_save_dscache_remove_all", "qri_test_save_dscache_remove_all")
 	defer run.Delete()
 
@@ -814,6 +821,8 @@ func TestSaveDscacheThenRemoveAll(t *testing.T) {
 }
 
 func TestSaveDscacheThenRemoveVersions(t *testing.T) {
+	t.Skip("TODO(dustmop): Need a way to enable Dscache without the Param field")
+
 	run := NewTestRunner(t, "test_peer_save_dscache_remove", "qri_test_save_dscache_remove")
 	defer run.Delete()
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -138,7 +138,7 @@ func (o *ValidateOptions) Run() (err error) {
 	}
 
 	ctx := context.TODO()
-	res, err := o.inst.Dataset().Validate(ctx, p)
+	res, err := o.inst.WithSource("local").Dataset().Validate(ctx, p)
 	if err != nil {
 		return err
 	}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -77,6 +78,13 @@ func TestValidateRun(t *testing.T) {
 		return
 	}
 
+	// Get the current directory, ending in a slash, to remove it from error messages
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pwd = pwd + "/"
+
 	inst, err := f.Instance()
 	if err != nil {
 		t.Fatalf("error creating instance: %s", err)
@@ -121,8 +129,10 @@ func TestValidateRun(t *testing.T) {
 				t.Errorf("expected error, got none")
 				return
 			}
-			if c.err != err.Error() {
-				t.Errorf("error mismatch.\nwant: %q\ngot:  %q", c.err, err.Error())
+			// Remove the current directory from path, to get consistent error messages
+			errGot := strings.Replace(err.Error(), pwd, "", -1)
+			if c.err != errGot {
+				t.Errorf("error mismatch.\nwant: %q\ngot:  %q", c.err, errGot)
 			}
 
 			if libErr, ok := err.(errors.Error); ok {

--- a/cmd/whatchanged.go
+++ b/cmd/whatchanged.go
@@ -57,7 +57,7 @@ func (o *WhatChangedOptions) Run() (err error) {
 	ctx := context.TODO()
 	inst := o.Instance
 
-	params := lib.LinkParams{Refstr: o.Refs.Ref()}
+	params := lib.LinkParams{Ref: o.Refs.Ref()}
 	res, err := inst.Dataset().ComponentStatus(ctx, &params)
 	if err != nil {
 		printErr(o.ErrOut, err)

--- a/lib/automation_test.go
+++ b/lib/automation_test.go
@@ -23,7 +23,7 @@ func TestApplyTransform(t *testing.T) {
 
 	// Apply a transformation
 	res, err := tr.ApplyWithParams(tr.Ctx, &ApplyParams{
-		Refstr: "me/cities_ds",
+		Ref: "me/cities_ds",
 		Transform: &dataset.Transform{
 			ScriptPath: "testdata/cities_2/add_city.star",
 		},

--- a/lib/changes.go
+++ b/lib/changes.go
@@ -9,8 +9,8 @@ import (
 
 // ChangeReportParams defines parameters for diffing two sources
 type ChangeReportParams struct {
-	LeftRefstr  string `schema:"leftRef" json:"leftRef"`
-	RightRefstr string `schema:"rightRef" json:"rightRef"`
+	LeftRef  string `schema:"leftRef" json:"leftRef"`
+	RightRef string `schema:"rightRef" json:"rightRef"`
 }
 
 // ChangeReport is a simple utility type declaration
@@ -28,21 +28,20 @@ func (m DiffMethods) Changes(ctx context.Context, p *ChangeReportParams) (*Chang
 // Changes generates report of changes between two datasets
 func (diffImpl) Changes(scope scope, p *ChangeReportParams) (*ChangeReport, error) {
 	ctx := scope.Context()
-	reportSource := ""
 
-	right, _, err := scope.ParseAndResolveRef(ctx, p.RightRefstr, reportSource)
+	right, location, err := scope.ParseAndResolveRef(ctx, p.RightRef)
 	if err != nil {
 		return nil, err
 	}
 
 	var left dsref.Ref
-	if p.LeftRefstr != "" {
-		if left, _, err = scope.ParseAndResolveRef(ctx, p.LeftRefstr, reportSource); err != nil {
+	if p.LeftRef != "" {
+		if left, _, err = scope.ParseAndResolveRef(ctx, p.LeftRef); err != nil {
 			return nil, err
 		}
 	} else {
 		left = dsref.Ref{Username: right.Username, Name: right.Name}
 	}
 
-	return changes.New(scope.Loader(), scope.Stats()).Report(ctx, left, right, reportSource)
+	return changes.New(scope.Loader(), scope.Stats()).Report(ctx, left, right, location)
 }

--- a/lib/changes_test.go
+++ b/lib/changes_test.go
@@ -29,7 +29,7 @@ func TestChanges(t *testing.T) {
 
 	// test ChangeReport with one param
 	p := &ChangeReportParams{
-		RightRefstr: commitref.Alias(),
+		RightRef: commitref.Alias(),
 	}
 	if _, err := inst.Diff().Changes(ctx, p); err != nil {
 		t.Fatalf("change report error: %s", err)

--- a/lib/collection_test.go
+++ b/lib/collection_test.go
@@ -76,7 +76,7 @@ func TestDatasetRequestsList(t *testing.T) {
 		{"list datasets - limit 2 offset 4", &ListParams{OrderBy: "", Limit: 2, Offset: 4}, []dsref.VersionInfo{sitemap}, ""},
 		{"list datasets - limit 2 offset 5", &ListParams{OrderBy: "", Limit: 2, Offset: 5}, []dsref.VersionInfo{}, ""},
 		{"list datasets - order by timestamp", &ListParams{OrderBy: "timestamp", Limit: 30, Offset: 0}, []dsref.VersionInfo{cities, counter, craigslist, movies, sitemap}, ""},
-		{"list datasets - peername 'me'", &ListParams{Peername: "me", OrderBy: "timestamp", Limit: 30, Offset: 0}, []dsref.VersionInfo{cities, counter, craigslist, movies, sitemap}, ""},
+		{"list datasets - username 'me'", &ListParams{Username: "me", OrderBy: "timestamp", Limit: 30, Offset: 0}, []dsref.VersionInfo{cities, counter, craigslist, movies, sitemap}, ""},
 		// TODO: re-enable {&ListParams{OrderBy: "name", Limit: 30, Offset: 0}, []*dsref.VersionInfo{cities, counter, movies}, ""},
 	}
 
@@ -109,7 +109,7 @@ func compareVersionInfoAsSimple(a, b dsref.VersionInfo) error {
 		return fmt.Errorf("PeerID mismatch. %s != %s", a.ProfileID, b.ProfileID)
 	}
 	if a.Username != b.Username {
-		return fmt.Errorf("Peername mismatch. %s != %s", a.Username, b.Username)
+		return fmt.Errorf("Username mismatch. %s != %s", a.Username, b.Username)
 	}
 	if a.Name != b.Name {
 		return fmt.Errorf("Name mismatch. %s != %s", a.Name, b.Name)
@@ -197,7 +197,7 @@ func TestListRawRefs(t *testing.T) {
 	}
 	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
 
-	text, err := inst.Collection().ListRawRefs(ctx, &ListParams{})
+	text, err := inst.Collection().ListRawRefs(ctx, &EmptyParams{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/datasets_test.go
+++ b/lib/datasets_test.go
@@ -318,78 +318,78 @@ func TestDatasetRequestsGet(t *testing.T) {
 		expect      string
 	}{
 		{"invalid peer name",
-			&GetParams{Refstr: "peer/ABC@abc"}, `"peer/ABC@abc" is not a valid dataset reference: unexpected character at position 8: '@'`},
+			&GetParams{Ref: "peer/ABC@abc"}, `"peer/ABC@abc" is not a valid dataset reference: unexpected character at position 8: '@'`},
 
 		{"peername without path",
-			&GetParams{Refstr: "peer/movies"},
+			&GetParams{Ref: "peer/movies"},
 			componentToString(setDatasetName(moviesDs, "peer/movies"), "yaml")},
 
 		{"peername with path",
-			&GetParams{Refstr: fmt.Sprintf("peer/movies@%s", ref.Path)},
+			&GetParams{Ref: fmt.Sprintf("peer/movies@%s", ref.Path)},
 			componentToString(setDatasetName(moviesDs, "peer/movies"), "yaml")},
 
 		{"peername as json format",
-			&GetParams{Refstr: "peer/movies", Format: "json"},
+			&GetParams{Ref: "peer/movies", Format: "json"},
 			componentToString(setDatasetName(moviesDs, "peer/movies"), "json")},
 
 		{"commit component",
-			&GetParams{Refstr: "peer/movies", Selector: "commit"},
+			&GetParams{Ref: "peer/movies", Selector: "commit"},
 			componentToString(moviesDs.Commit, "yaml")},
 
 		{"commit component as json format",
-			&GetParams{Refstr: "peer/movies", Selector: "commit", Format: "json"},
+			&GetParams{Ref: "peer/movies", Selector: "commit", Format: "json"},
 			componentToString(moviesDs.Commit, "json")},
 
 		{"title field of commit component",
-			&GetParams{Refstr: "peer/movies", Selector: "commit.title"}, "initial commit\n"},
+			&GetParams{Ref: "peer/movies", Selector: "commit.title"}, "initial commit\n"},
 
 		{"title field of commit component as json",
-			&GetParams{Refstr: "peer/movies", Selector: "commit.title", Format: "json"},
+			&GetParams{Ref: "peer/movies", Selector: "commit.title", Format: "json"},
 			"\"initial commit\""},
 
 		{"title field of commit component as yaml",
-			&GetParams{Refstr: "peer/movies", Selector: "commit.title", Format: "yaml"},
+			&GetParams{Ref: "peer/movies", Selector: "commit.title", Format: "yaml"},
 			"initial commit\n"},
 
 		{"title field of commit component as mispelled format",
-			&GetParams{Refstr: "peer/movies", Selector: "commit.title", Format: "jason"},
+			&GetParams{Ref: "peer/movies", Selector: "commit.title", Format: "jason"},
 			"unknown format: \"jason\""},
 
 		{"body as json",
-			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json"}, "[]"},
+			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json"}, "[]"},
 
 		{"dataset empty",
-			&GetParams{Refstr: "", Selector: "body", Format: "json"}, `"" is not a valid dataset reference: empty reference`},
+			&GetParams{Ref: "", Selector: "body", Format: "json"}, `"" is not a valid dataset reference: empty reference`},
 
 		{"body as csv",
-			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "csv"}, "title,duration\n"},
+			&GetParams{Ref: "peer/movies", Selector: "body", Format: "csv"}, "title,duration\n"},
 
 		{"body with limit and offfset",
-			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
 				Limit: 5, Offset: 0, All: false}, bodyToString(moviesBody[:5])},
 
 		{"body with invalid limit and offset",
-			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
 				Limit: -5, Offset: -100, All: false}, "invalid limit / offset settings"},
 
 		{"body with all flag ignores invalid limit and offset",
-			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
 				Limit: -5, Offset: -100, All: true}, bodyToString(moviesBody)},
 
 		{"body with all flag",
-			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
 				Limit: 0, Offset: 0, All: true}, bodyToString(moviesBody)},
 
 		{"body with limit and non-zero offset",
-			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
 				Limit: 2, Offset: 10, All: false}, bodyToString(moviesBody[10:12])},
 
 		{"head non-pretty json",
-			&GetParams{Refstr: "peer/movies", Format: "json", FormatConfig: nonprettyJSONConfig},
+			&GetParams{Ref: "peer/movies", Format: "json", FormatConfig: nonprettyJSONConfig},
 			componentToString(setDatasetName(moviesDs, "peer/movies"), "non-pretty json")},
 
 		{"body pretty json",
-			&GetParams{Refstr: "peer/movies", Selector: "body", Format: "json",
+			&GetParams{Ref: "peer/movies", Selector: "body", Format: "json",
 				FormatConfig: prettyJSONConfig, Limit: 3, Offset: 0, All: false},
 			bodyToPrettyString(moviesBody[:3])},
 	}
@@ -432,15 +432,15 @@ func TestDatasetRequestsGetFSIPath(t *testing.T) {
 	dsDir := filepath.Join(tempDir, "movies")
 	fsim := inst.Filesys()
 	p := &LinkParams{
-		Dir:    dsDir,
-		Refstr: "peer/movies",
+		Dir: dsDir,
+		Ref: "peer/movies",
 	}
 	if err := fsim.Checkout(ctx, p); err != nil {
 		t.Fatalf("error checking out dataset: %s", err)
 	}
 
 	getParams := &GetParams{
-		Refstr: "peer/movies",
+		Ref: "peer/movies",
 	}
 	got, err := inst.Dataset().Get(ctx, getParams)
 	if err != nil {
@@ -544,7 +544,7 @@ func TestDatasetRequestsGetP2p(t *testing.T) {
 			inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
 			// TODO (b5) - we're using "JSON" here b/c the "craigslist" test dataset
 			// is tripping up the YAML serializer
-			got, err := inst.Dataset().Get(ctx, &GetParams{Refstr: fmt.Sprintf("%s/%s", profile.Peername, name), Format: "json"})
+			got, err := inst.Dataset().Get(ctx, &GetParams{Ref: fmt.Sprintf("%s/%s", profile.Peername, name), Format: "json"})
 			if err != nil {
 				t.Errorf("error getting dataset for %q: %s", ref, err.Error())
 			}
@@ -709,8 +709,8 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 	// link cities dataset with a checkout
 	checkoutp := &LinkParams{
-		Dir:    filepath.Join(datasetsDir, "cities"),
-		Refstr: "me/cities",
+		Dir: filepath.Join(datasetsDir, "cities"),
+		Ref: "me/cities",
 	}
 	if err := fsim.Checkout(ctx, checkoutp); err != nil {
 		t.Fatal(err)
@@ -724,8 +724,8 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 	// link craigslist with a checkout
 	checkoutp = &LinkParams{
-		Dir:    filepath.Join(datasetsDir, "craigslist"),
-		Refstr: "me/craigslist",
+		Dir: filepath.Join(datasetsDir, "craigslist"),
+		Ref: "me/craigslist",
 	}
 	if err := fsim.Checkout(ctx, checkoutp); err != nil {
 		t.Fatal(err)
@@ -744,7 +744,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 	for i, c := range badCases {
 		t.Run(fmt.Sprintf("bad_case_%s", c.err), func(t *testing.T) {
-			_, err := inst.Dataset().Remove(ctx, &c.params)
+			_, err := inst.WithSource("local").Dataset().Remove(ctx, &c.params)
 
 			if err == nil {
 				t.Errorf("case %d: expected error. got nil", i)
@@ -772,7 +772,7 @@ func TestDatasetRequestsRemove(t *testing.T) {
 
 	for _, c := range goodCases {
 		t.Run(fmt.Sprintf("good_case_%s", c.description), func(t *testing.T) {
-			res, err := inst.Dataset().Remove(ctx, &c.params)
+			res, err := inst.WithSource("local").Dataset().Remove(ctx, &c.params)
 
 			if err != nil {
 				t.Errorf("unexpected error: %s", err)
@@ -953,7 +953,7 @@ Pirates of the Caribbean: At World's End ,foo
 
 	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
 	for i, c := range cases {
-		res, err := inst.Dataset().Validate(ctx, &c.p)
+		res, err := inst.WithSource("local").Dataset().Validate(ctx, &c.p)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch: expected: %s, got: %s", i, c.err, err.Error())
 			continue
@@ -988,7 +988,7 @@ func TestDatasetRequestsValidateFSI(t *testing.T) {
 	}
 
 	vp := &ValidateParams{Ref: refstr}
-	if _, err := tr.Instance.Dataset().Validate(ctx, vp); err != nil {
+	if _, err := tr.Instance.WithSource("local").Dataset().Validate(ctx, vp); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1007,7 +1007,6 @@ func TestDatasetRequestsStats(t *testing.T) {
 	}
 
 	inst := NewInstanceFromConfigAndNode(ctx, testcfg.DefaultConfigForTesting(), node)
-	m := inst.Dataset()
 
 	badCases := []struct {
 		description string
@@ -1019,7 +1018,7 @@ func TestDatasetRequestsStats(t *testing.T) {
 		{"dataset does not exist", "me/dataset_does_not_exist", "reference not found"},
 	}
 	for i, c := range badCases {
-		_, err = m.Get(ctx, &GetParams{Refstr: c.ref, Selector: "stats"})
+		_, err = inst.WithSource("local").Dataset().Get(ctx, &GetParams{Ref: c.ref, Selector: "stats"})
 		if c.expectedErr != err.Error() {
 			t.Errorf("%d. case %s: error mismatch, expected: %q, got: %q", i, c.description, c.expectedErr, err.Error())
 		}
@@ -1036,7 +1035,7 @@ func TestDatasetRequestsStats(t *testing.T) {
 		{"json: me/sitemap", "me/sitemap", []byte(`[{"count":10,"histogram":{"bins":[24515,24552,25028,25329,27827,28291,28337,30258,34042,40079,40080],"frequencies":[1,1,1,1,1,1,1,1,1,1]},"key":"contentLength","max":40079,"mean":28825.8,"median":28291,"min":24515,"type":"numeric"},{"count":10,"frequencies":{"text/html; charset=utf-8":10},"key":"contentSniff","maxLength":24,"minLength":24,"type":"string","unique":1},{"count":10,"frequencies":{"text/html; charset=utf-8":10},"key":"contentType","maxLength":24,"minLength":24,"type":"string","unique":1},{"count":10,"histogram":{"bins":[74291866,89911449,4055332831,4075146079,4077173686,4077286486,4077931202,4080164896,4080183198,4081577841,4081577842],"frequencies":[1,1,1,1,1,1,1,1,1,1]},"key":"duration","max":4081577841,"mean":3276899953.4,"median":4077286486,"min":74291866,"type":"numeric"},{"count":10,"frequencies":{"12200c610d5ec64231b2751e8ede38b4fd7d911360159fc5bba3e165f68c1ee4f169":1,"1220131c6c4233a75f1361045dcb45173c4d13eb94f08184edb45109975ce7d8b33a":1,"12203236442fb7b71bf1696b6071beb4abcc08bf318ade377daf352fdc846f14a292":1,"12203f978c899c51c0ee60a2f983ed76d2cd9351846e98efeb8f2f1d025e2e39dff8":1,"122055b62b100b92467d64d781e7f14a91e7ffac0869cb7ecc7fc38ad620d8c04ef5":1,"122066ace8ef380db026ef249b1a4cd2b35008c8901ab98994c56ab8022f099e7991":1,"12206c2e9e217a9efaa0506eba68a039513cd2ec8c7025c367b9b64256d462fb1660":1,"122075ddcf3989ef97e5f9d59ceb1b5b71d72bc32d8b76c181d7826b028792e202ab":1,"122093f53b43ac1e56bd091abacd6c1813eb249400ed0c98eba4e667916a4286ccf2":1,"1220e1975125bdbc7638bb16bd1a52e2115b6531511def6a0228ad1b671111a8066f":1},"key":"hash","maxLength":68,"minLength":68,"type":"string","unique":10},{"key":"links","type":"array","values":[{"count":10,"frequencies":{"http://cfpub.epa.gov/locator":1,"http://epa.gov/ace":1,"http://epa.gov/ace/ace-biomonitoring-lead":1,"http://epa.gov/careers":1,"http://epa.gov/environmental-topics":1,"http://epa.gov/environmental-topics/greener-living":1,"http://epa.gov/home/grants-and-other-funding-opportunities":1,"http://epa.gov/lead":1,"http://epa.gov/open":1,"http://usa.gov":1},"maxLength":58,"minLength":14,"unique":10},{"count":10,"frequencies":{"http://epa.gov/ace/ace-biomonitoring-mercury":1,"http://epa.gov/ace/ace-update-history":1,"http://epa.gov/contracts":1,"http://epa.gov/environmental-topics/air-topics":1,"http://epa.gov/environmental-topics/health-topics":1,"http://epa.gov/mold":1,"http://epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees":1,"http://epa.gov/planandbudget":1,"http://regulations.gov":1,"http://whitehouse.gov":1},"maxLength":115,"minLength":19,"unique":10},{"count":10,"frequencies":{"http://epa.gov/ace/ace-biomonitoring-cotinine":1,"http://epa.gov/ace/americas-children-and-environment-update-listserv":1,"http://epa.gov/bedbugs":1,"http://epa.gov/careers":1,"http://epa.gov/environmental-topics/land-waste-and-cleanup-topics":1,"http://epa.gov/home/forms/contact-epa":1,"http://epa.gov/home/grants-and-other-funding-opportunities":1,"http://epa.gov/newsroom/email-subscriptions":1,"http://epa.gov/pesticides":1,"http://epa.gov/privacy":1},"maxLength":68,"minLength":22,"unique":10},{"count":10,"frequencies":{"http://epa.gov/ace/ace-biomonitoring-perfluorochemicals-pfcs":1,"http://epa.gov/ace/basic-information-about-ace":1,"http://epa.gov/contracts":1,"http://epa.gov/environmental-topics/chemicals-and-toxics-topics":1,"http://epa.gov/home/epa-hotlines":1,"http://epa.gov/lead":1,"http://epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees":1,"http://epa.gov/privacy/privacy-and-security-notice":1,"http://epa.gov/radon":1,"http://usa.gov":1},"maxLength":115,"minLength":14,"unique":10},{"count":9,"frequencies":{"http://data.gov":1,"http://epa.gov/ace/ace-biomonitoring-polychlorinated-biphenyls-pcbs":1,"http://epa.gov/ace/key-findings-ace3-report":1,"http://epa.gov/environmental-topics/environmental-information-location":1,"http://epa.gov/environmental-topics/science-topics":1,"http://epa.gov/foia":1,"http://epa.gov/home/grants-and-other-funding-opportunities":1,"http://epa.gov/privacy":1,"http://whitehouse.gov":1},"maxLength":70,"minLength":15,"unique":9},{"count":9,"frequencies":{"http://epa.gov/ace/ace-biomonitoring-polybrominated-diphenyl-ethers-pbdes":1,"http://epa.gov/ace/ace-frequent-questions":1,"http://epa.gov/environmental-topics/greener-living":1,"http://epa.gov/environmental-topics/water-topics":1,"http://epa.gov/home/forms/contact-epa":1,"http://epa.gov/home/frequent-questions-specific-epa-programstopics":1,"http://epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees":1,"http://epa.gov/office-inspector-general/about-epas-office-inspector-general":1,"http://epa.gov/privacy/privacy-and-security-notice":1},"maxLength":115,"minLength":37,"unique":9},{"count":9,"frequencies":{"http://data.gov":1,"http://epa.gov/ace/ace-biomonitoring-phthalates":1,"http://epa.gov/ace/ace-environments-and-contaminants":1,"http://epa.gov/environmental-topics/health-topics":1,"http://epa.gov/environmental-topics/z-index":1,"http://epa.gov/home/epa-hotlines":1,"http://epa.gov/newsroom":1,"http://epa.gov/privacy":1,"http://facebook.com/EPA":1},"maxLength":52,"minLength":15,"unique":9},{"count":9,"frequencies":{"http://epa.gov/ace/ace-biomonitoring":1,"http://epa.gov/ace/ace-biomonitoring-bisphenol-bpa":1,"http://epa.gov/environmental-topics/land-waste-and-cleanup-topics":1,"http://epa.gov/foia":1,"http://epa.gov/laws-regulations":1,"http://epa.gov/office-inspector-general/about-epas-office-inspector-general":1,"http://epa.gov/open":1,"http://epa.gov/privacy/privacy-and-security-notice":1,"http://twitter.com/epa":1},"maxLength":75,"minLength":19,"unique":9},{"count":9,"frequencies":{"http://data.gov":1,"http://epa.gov/ace/ace-biomonitoring-perchlorate":1,"http://epa.gov/ace/ace-health":1,"http://epa.gov/home/frequent-questions-specific-epa-programstopics":1,"http://epa.gov/lead":1,"http://epa.gov/newsroom":1,"http://epa.gov/regulatory-information-sector":1,"http://regulations.gov":1,"http://youtube.com/user/USEPAgov":1},"maxLength":66,"minLength":15,"unique":9},{"count":7,"frequencies":{"http://epa.gov/ace/ace-supplementary-topics":1,"http://epa.gov/mold":1,"http://epa.gov/office-inspector-general/about-epas-office-inspector-general":1,"http://epa.gov/open":1,"http://epa.gov/regulatory-information-topic":1,"http://facebook.com/EPA":1,"http://flickr.com/photos/usepagov":1},"maxLength":75,"minLength":19,"unique":7},{"count":7,"frequencies":{"http://epa.gov/ace/americas-children-and-environment-third-edition":1,"http://epa.gov/compliance":1,"http://epa.gov/newsroom":1,"http://epa.gov/pesticides":1,"http://instagram.com/epagov":1,"http://regulations.gov":1,"http://twitter.com/epa":1},"maxLength":66,"minLength":22,"unique":7},{"count":6,"frequencies":{"http://epa.gov/ace/download-graphs-and-data":1,"http://epa.gov/enforcement":1,"http://epa.gov/newsroom/email-subscriptions":1,"http://epa.gov/open":1,"http://epa.gov/radon":1,"http://youtube.com/user/USEPAgov":1},"maxLength":43,"minLength":19,"unique":6},{"count":6,"frequencies":{"http://epa.gov/ace/americas-children-and-environment-third-edition-appendices":1,"http://epa.gov/environmental-topics/science-topics":1,"http://epa.gov/laws-regulations/laws-and-executive-orders":1,"http://flickr.com/photos/usepagov":1,"http://regulations.gov":1,"http://usa.gov":1},"maxLength":77,"minLength":14,"unique":6},{"count":6,"frequencies":{"http://epa.gov/ace/americas-children-and-environment-third-edition-references":1,"http://epa.gov/environmental-topics/water-topics":1,"http://epa.gov/laws-regulations/policy-guidance":1,"http://epa.gov/newsroom/email-subscriptions":1,"http://instagram.com/epagov":1,"http://whitehouse.gov":1},"maxLength":77,"minLength":21,"unique":6},{"count":4,"frequencies":{"http://epa.gov/home/forms/contact-epa":1,"http://epa.gov/laws-regulations/regulations":1,"http://instagram.com/epagov":1,"http://usa.gov":1},"maxLength":43,"minLength":14,"unique":4},{"count":3,"frequencies":{"http://epa.gov/aboutepa":1,"http://epa.gov/home/epa-hotlines":1,"http://whitehouse.gov":1},"maxLength":32,"minLength":21,"unique":3},{"count":3,"frequencies":{"http://epa.gov/aboutepa/epas-administrator":1,"http://epa.gov/foia":1,"http://epa.gov/home/forms/contact-epa":1},"maxLength":42,"minLength":19,"unique":3},{"count":3,"frequencies":{"http://epa.gov/aboutepa/current-epa-leadership":1,"http://epa.gov/home/epa-hotlines":1,"http://epa.gov/home/frequent-questions-specific-epa-programstopics":1},"maxLength":66,"minLength":32,"unique":3},{"count":3,"frequencies":{"http://epa.gov/aboutepa/epa-organization-chart":1,"http://epa.gov/foia":1,"http://facebook.com/EPA":1},"maxLength":46,"minLength":19,"unique":3},{"count":2,"frequencies":{"http://epa.gov/home/frequent-questions-specific-epa-programstopics":1,"http://twitter.com/epa":1},"maxLength":66,"minLength":22,"unique":2},{"count":2,"frequencies":{"http://facebook.com/EPA":1,"http://youtube.com/user/USEPAgov":1},"maxLength":32,"minLength":23,"unique":2},{"count":2,"frequencies":{"http://flickr.com/photos/usepagov":1,"http://twitter.com/epa":1},"maxLength":33,"minLength":22,"unique":2},{"count":2,"frequencies":{"http://instagram.com/epagov":1,"http://youtube.com/user/USEPAgov":1},"maxLength":32,"minLength":27,"unique":2},{"count":1,"frequencies":{"http://flickr.com/photos/usepagov":1},"maxLength":33,"minLength":33,"unique":1},{"count":1,"frequencies":{"http://instagram.com/epagov":1},"maxLength":27,"minLength":27,"unique":1}]},{"count":1,"frequencies":{"http://epa.gov/ace":1},"key":"redirectTo","maxLength":18,"minLength":18,"type":"string","unique":1},{"count":11,"histogram":{"bins":[200,301,302],"frequencies":[10,1]},"key":"status","max":301,"mean":209.1818181818182,"median":301,"min":200,"type":"numeric"},{"count":11,"frequencies":{"2018-03-28T09:18:45.235554272-04:00":1,"2018-03-28T09:25:13.540790419-04:00":1,"2018-03-28T09:25:14.862101674-04:00":1,"2018-03-28T09:25:14.945580151-04:00":1,"2018-03-28T09:25:16.428352736-04:00":1,"2018-03-28T09:25:17.625882413-04:00":1,"2018-03-28T09:25:18.940721061-04:00":1,"2018-03-28T09:25:19.026926128-04:00":1,"2018-03-28T09:25:23.023501668-04:00":1,"2018-03-28T10:16:52.269215284-04:00":1,"2018-03-28T13:48:21.498962156-04:00":1},"key":"timestamp","maxLength":35,"minLength":35,"type":"string","unique":11},{"count":10,"frequencies":{"ACE Biomonitoring | America's Children and the Environment (ACE) | US EPA":1,"America's Children and the Environment (ACE) | US EPA":1,"Contact Us about Section 508 Accessibility | Section 508: Accessibility | US EPA":1,"Frequent Questions about Section 508 | Section 508: Accessibility | US EPA":1,"Learn About Section 508 | Section 508: Accessibility | US EPA":1,"Section 508 Resources | Section 508: Accessibility | US EPA":1,"Section 508 Standards Resources | Section 508: Accessibility | US EPA":1,"Section 508 Standards | Section 508: Accessibility | US EPA":1,"Think 508 First! Section 508 Quick Reference Guide | Section 508: Accessibility | US EPA":1,"What is Section 508? | Section 508: Accessibility | US EPA":1},"key":"title","maxLength":88,"minLength":53,"type":"string","unique":10},{"count":11,"frequencies":{"http://epa.gov/accessibility/forms/contact-us-about-section-508-accessibility":1,"http://epa.gov/accessibility/frequent-questions-about-section-508":1,"http://epa.gov/accessibility/learn-about-section-508":1,"http://epa.gov/accessibility/section-508-resources":1,"http://epa.gov/accessibility/section-508-standards":1,"http://epa.gov/accessibility/section-508-standards-resources":1,"http://epa.gov/accessibility/think-508-first-section-508-quick-reference-guide":1,"http://epa.gov/accessibility/what-section-508":1,"http://epa.gov/ace":1,"http://epa.gov/ace%20":1,"http://epa.gov/ace/ace-biomonitoring":1},"key":"url","maxLength":78,"minLength":18,"type":"string","unique":11}]`)},
 	}
 	for i, c := range goodCases {
-		res, err := m.Get(ctx, &GetParams{Refstr: c.ref, Selector: "stats"})
+		res, err := inst.WithSource("local").Dataset().Get(ctx, &GetParams{Ref: c.ref, Selector: "stats"})
 		if err != nil {
 			t.Errorf("%d. case %s: unexpected error: '%s'", i, c.description, err.Error())
 			continue

--- a/lib/diff.go
+++ b/lib/diff.go
@@ -53,8 +53,6 @@ type DiffParams struct {
 
 	// Which component or part of a dataset to compare
 	Selector string
-
-	Remote string
 }
 
 // diffMode determinse

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -43,22 +43,22 @@ func (m FSIMethods) Attributes() map[string]AttributeSet {
 
 // LinkParams encapsulate parameters for linked datasets
 type LinkParams struct {
-	Dir    string `qri:"fspath"`
-	Refstr string `json:"refstr"`
+	Dir string `qri:"fspath"`
+	Ref string
 }
 
 // FSIWriteParams encapsultes arguments for writing to an FSI-linked directory
 type FSIWriteParams struct {
-	Refstr string
-	Ds     *dataset.Dataset
+	Ref     string
+	Dataset *dataset.Dataset
 }
 
 // RestoreParams provides parameters to the restore method.
 type RestoreParams struct {
-	Dir       string `qri:"fspath"`
-	Refstr    string
-	Path      string
-	Component string
+	Dir      string `qri:"fspath"`
+	Ref      string
+	Version  string
+	Selector string
 }
 
 // InitDatasetParams proxies parameters to initialization
@@ -151,7 +151,7 @@ type fsiImpl struct{}
 func (fsiImpl) CreateLink(scope scope, p *LinkParams) (*dsref.VersionInfo, error) {
 	ctx := scope.Context()
 
-	ref, _, err := scope.ParseAndResolveRef(ctx, p.Refstr, "local")
+	ref, _, err := scope.ParseAndResolveRef(ctx, p.Ref)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (fsiImpl) CreateLink(scope scope, p *LinkParams) (*dsref.VersionInfo, error
 func (fsiImpl) Unlink(scope scope, p *LinkParams) (string, error) {
 	ctx := scope.Context()
 
-	if p.Dir != "" && p.Refstr != "" {
+	if p.Dir != "" && p.Ref != "" {
 		return "", fmt.Errorf("Unlink should be called with either Dir or Ref, not both")
 	}
 
@@ -173,7 +173,7 @@ func (fsiImpl) Unlink(scope scope, p *LinkParams) (string, error) {
 	if p.Dir == "" {
 		// If only ref provided, canonicalize it to get its ref
 		var err error
-		ref, _, err = scope.ParseAndResolveRef(ctx, p.Refstr, "local")
+		ref, _, err = scope.ParseAndResolveRef(ctx, p.Ref)
 		if err != nil {
 			return "", err
 		}
@@ -201,8 +201,8 @@ func (fsiImpl) Unlink(scope scope, p *LinkParams) (string, error) {
 func (fsiImpl) Status(scope scope, p *LinkParams) ([]StatusItem, error) {
 	ctx := scope.Context()
 
-	if p.Dir == "" && p.Refstr == "" {
-		return nil, fmt.Errorf("either Dir or Refstr required for status")
+	if p.Dir == "" && p.Ref == "" {
+		return nil, fmt.Errorf("either Dir or Ref required for status")
 	}
 
 	// If the directory is given, get the status of the linked dataset
@@ -211,7 +211,7 @@ func (fsiImpl) Status(scope scope, p *LinkParams) ([]StatusItem, error) {
 	}
 
 	// Otherwise, get the file system path by looking up the ref
-	ref, err := dsref.ParseHumanFriendly(p.Refstr)
+	ref, err := dsref.ParseHumanFriendly(p.Ref)
 	if err != nil {
 		return nil, err
 	}
@@ -240,12 +240,12 @@ func (fsiImpl) Checkout(scope scope, p *LinkParams) error {
 	}
 
 	// Handle the ref to checkout
-	ref, source, err := scope.ParseAndResolveRef(ctx, p.Refstr, "")
+	ref, location, err := scope.ParseAndResolveRef(ctx, p.Ref)
 	if err != nil {
 		return err
 	}
 
-	if source != "" {
+	if location != "" {
 		return fmt.Errorf("auto-adding on checkout is not yet supported, please run `qri add %q` first", ref.Human())
 	}
 
@@ -275,7 +275,7 @@ func (fsiImpl) Checkout(scope scope, p *LinkParams) error {
 		log.Debugf("Checkout, fsi.CreateLink failed, error: %s", ref)
 		return err
 	}
-	log.Debugf("Checkout created link for %q <-> %q", p.Dir, p.Refstr)
+	log.Debugf("Checkout created link for %q <-> %q", p.Dir, p.Ref)
 
 	// Write components of the dataset to the working directory.
 	err = fsi.WriteComponents(ds, p.Dir, scope.Filesystem())
@@ -292,11 +292,11 @@ func (fsiImpl) Checkout(scope scope, p *LinkParams) error {
 func (fsiImpl) Write(scope scope, p *FSIWriteParams) ([]StatusItem, error) {
 	ctx := scope.Context()
 
-	if p.Ds == nil {
+	if p.Dataset == nil {
 		return nil, fmt.Errorf("dataset is required")
 	}
 
-	ref, _, err := scope.ParseAndResolveRef(ctx, p.Refstr, "local")
+	ref, _, err := scope.ParseAndResolveRef(ctx, p.Ref)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ func (fsiImpl) Write(scope scope, p *FSIWriteParams) ([]StatusItem, error) {
 	}
 
 	// Write components of the dataset to the working directory
-	err = fsi.WriteComponents(p.Ds, vi.FSIPath, scope.Filesystem())
+	err = fsi.WriteComponents(p.Dataset, vi.FSIPath, scope.Filesystem())
 	if err != nil {
 		return nil, err
 	}
@@ -324,13 +324,13 @@ func (fsiImpl) Write(scope scope, p *FSIWriteParams) ([]StatusItem, error) {
 func (fsiImpl) Restore(scope scope, p *RestoreParams) error {
 	ctx := scope.Context()
 
-	ref, _, err := scope.ParseAndResolveRef(ctx, p.Refstr, "local")
+	ref, _, err := scope.ParseAndResolveRef(ctx, p.Ref)
 	if err != nil {
 		return err
 	}
 
-	if p.Path != "" {
-		ref.Path = p.Path
+	if p.Version != "" {
+		ref.Path = p.Version
 	}
 
 	if p.Dir == "" {
@@ -374,7 +374,7 @@ func (fsiImpl) Restore(scope scope, p *RestoreParams) error {
 	}
 
 	for _, compName := range component.AllSubcomponentNames() {
-		if p.Component == "" || p.Component == compName {
+		if p.Selector == "" || p.Selector == compName {
 			if repoContainer.Base().GetSubcomponent(compName) == nil {
 				fsi.DeleteComponent(diskContainer, compName, p.Dir)
 			} else {
@@ -406,7 +406,7 @@ func (fsiImpl) CanInitDatasetWorkDir(scope scope, p *InitDatasetParams) error {
 func (fsiImpl) EnsureRef(scope scope, p *LinkParams) (*dsref.VersionInfo, error) {
 	ctx := scope.Context()
 
-	ref, err := dsref.Parse(p.Refstr)
+	ref, err := dsref.Parse(p.Ref)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/fsi_test.go
+++ b/lib/fsi_test.go
@@ -56,8 +56,8 @@ func TestFSIMethodsWrite(t *testing.T) {
 
 	// link cities dataset with a checkout
 	checkoutp := &LinkParams{
-		Dir:    filepath.Join(datasetsDir, "cities"),
-		Refstr: "me/cities",
+		Dir: filepath.Join(datasetsDir, "cities"),
+		Ref: "me/cities",
 	}
 	if err := methods.Checkout(ctx, checkoutp); err != nil {
 		t.Fatal(err)
@@ -65,8 +65,8 @@ func TestFSIMethodsWrite(t *testing.T) {
 
 	// link craigslist with a checkout
 	checkoutp = &LinkParams{
-		Dir:    filepath.Join(datasetsDir, "craigslist"),
-		Refstr: "me/craigslist",
+		Dir: filepath.Join(datasetsDir, "craigslist"),
+		Ref: "me/craigslist",
 	}
 	if err := methods.Checkout(ctx, checkoutp); err != nil {
 		t.Fatal(err)
@@ -76,12 +76,12 @@ func TestFSIMethodsWrite(t *testing.T) {
 		err    string
 		params FSIWriteParams
 	}{
-		{"dataset is required", FSIWriteParams{Refstr: "abc/movies"}},
-		{`"" is not a valid dataset reference: empty reference`, FSIWriteParams{Refstr: "", Ds: &dataset.Dataset{}}},
-		{`"abc/ABC" is not a valid dataset reference: dataset name may not contain any upper-case letters`, FSIWriteParams{Refstr: "abc/ABC", Ds: &dataset.Dataset{}}},
-		{`"👋" is not a valid dataset reference: unexpected character at position 0: 'ð'`, FSIWriteParams{Refstr: "👋", Ds: &dataset.Dataset{}}},
-		{"reference not found", FSIWriteParams{Refstr: "abc/movies", Ds: &dataset.Dataset{}}},
-		{"dataset is not linked to the filesystem", FSIWriteParams{Refstr: "peer/movies", Ds: &dataset.Dataset{}}},
+		{"dataset is required", FSIWriteParams{Ref: "abc/movies"}},
+		{`"" is not a valid dataset reference: empty reference`, FSIWriteParams{Ref: "", Dataset: &dataset.Dataset{}}},
+		{`"abc/ABC" is not a valid dataset reference: dataset name may not contain any upper-case letters`, FSIWriteParams{Ref: "abc/ABC", Dataset: &dataset.Dataset{}}},
+		{`"👋" is not a valid dataset reference: unexpected character at position 0: 'ð'`, FSIWriteParams{Ref: "👋", Dataset: &dataset.Dataset{}}},
+		{"reference not found", FSIWriteParams{Ref: "abc/movies", Dataset: &dataset.Dataset{}}},
+		{"dataset is not linked to the filesystem", FSIWriteParams{Ref: "peer/movies", Dataset: &dataset.Dataset{}}},
 	}
 
 	for _, c := range badCases {
@@ -102,7 +102,7 @@ func TestFSIMethodsWrite(t *testing.T) {
 		res         []StatusItem
 	}{
 		{"update cities structure",
-			FSIWriteParams{Refstr: "me/cities", Ds: &dataset.Dataset{Structure: &dataset.Structure{Format: "json"}}},
+			FSIWriteParams{Ref: "me/cities", Dataset: &dataset.Dataset{Structure: &dataset.Structure{Format: "json"}}},
 			[]StatusItem{
 				{Component: "meta", Type: "unmodified"},
 				{Component: "structure", Type: "modified"},
@@ -111,11 +111,11 @@ func TestFSIMethodsWrite(t *testing.T) {
 		},
 		// TODO (b5) - doesn't work yet
 		// {"overwrite craigslist body",
-		// 	FSIWriteParams{Ref: "me/craigslist", Ds: &dataset.Dataset{Body: []interface{}{[]interface{}{"foo", "bar", "baz"}}}},
+		// 	FSIWriteParams{Ref: "me/craigslist", Dataset: &dataset.Dataset{Body: []interface{}{[]interface{}{"foo", "bar", "baz"}}}},
 		// 	[]StatusItem{},
 		// },
 		{"set title for no history dataset",
-			FSIWriteParams{Refstr: noHistoryName, Ds: &dataset.Dataset{Meta: &dataset.Meta{Title: "Changed Title"}}},
+			FSIWriteParams{Ref: noHistoryName, Dataset: &dataset.Dataset{Meta: &dataset.Meta{Title: "Changed Title"}}},
 			[]StatusItem{
 				{Component: "meta", Type: "add"},
 				{Component: "structure", Type: "add"},
@@ -170,14 +170,15 @@ func TestCheckoutInvalidDirs(t *testing.T) {
 
 // Test that FSI checkout modifies dscache if it exists
 func TestDscacheCheckout(t *testing.T) {
+	t.Skip("TODO(dustmop): Need a way to enable Dscache without the Param field")
+
 	run := newTestRunner(t)
 	defer run.Delete()
 
 	// Save a dataset with one version.
 	_, err := run.SaveWithParams(&SaveParams{
-		Ref:        "me/cities_ds",
-		BodyPath:   "testdata/cities_2/body.csv",
-		UseDscache: true,
+		Ref:      "me/cities_ds",
+		BodyPath: "testdata/cities_2/body.csv",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -219,14 +220,15 @@ func TestDscacheCheckout(t *testing.T) {
 
 // Test that FSI init modifies dscache if it exists
 func TestDscacheInit(t *testing.T) {
+	t.Skip("TODO(dustmop): Need a way to enable Dscache without the Param field")
+
 	run := newTestRunner(t)
 	defer run.Delete()
 
 	// Save a dataset with one version.
 	_, err := run.SaveWithParams(&SaveParams{
-		Ref:        "me/cities_ds",
-		BodyPath:   "testdata/cities_2/body.csv",
-		UseDscache: true,
+		Ref:      "me/cities_ds",
+		BodyPath: "testdata/cities_2/body.csv",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/lib/http.go
+++ b/lib/http.go
@@ -226,7 +226,9 @@ func NewHTTPRequestHandler(inst *Instance, libMethod string) http.HandlerFunc {
 			apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
 			return
 		}
-		res, cursor, err := inst.Dispatch(r.Context(), libMethod, p)
+
+		source := SourceFromRequest(r)
+		res, cursor, err := inst.WithSource(source).Dispatch(r.Context(), libMethod, p)
 		if err != nil {
 			log.Debugw("http request: dispatch", "err", err)
 			apiutil.RespondWithError(w, err)
@@ -240,6 +242,11 @@ func NewHTTPRequestHandler(inst *Instance, libMethod string) http.HandlerFunc {
 
 		apiutil.WriteResponse(w, res)
 	}
+}
+
+// SourceFromRequest retrieves from the http request the source for resolving refs
+func SourceFromRequest(r *http.Request) string {
+	return r.Header.Get("SourceResolver")
 }
 
 // DecodeParams decodes a json body into params

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -35,8 +35,7 @@ func TestTwoActorRegistryIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
-	p := &ListParams{}
-	refs, err := tr.RegistryInst.Collection().ListRawRefs(tr.Ctx, p)
+	refs, err := tr.RegistryInst.Collection().ListRawRefs(tr.Ctx, &EmptyParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +107,7 @@ func TestAddCheckoutIntegration(t *testing.T) {
 	hinshun := tr.InitHinshun(t)
 
 	checkoutPath := filepath.Join(tr.hinshunRepo.RootPath, "wbp")
-	_, err := hinshun.Dataset().Pull(tr.Ctx, &PullParams{
+	_, err := hinshun.WithSource("network").Dataset().Pull(tr.Ctx, &PullParams{
 		Ref:     ref.String(),
 		LinkDir: checkoutPath,
 	})
@@ -413,7 +412,7 @@ g,g,i,true,4`),
 }
 
 func PushToRegistry(ctx context.Context, t *testing.T, inst *Instance, refstr string) dsref.Ref {
-	res, err := inst.Remote().Push(ctx, &PushParams{
+	res, err := inst.WithSource("local").Remote().Push(ctx, &PushParams{
 		Ref: refstr,
 	})
 
@@ -442,11 +441,10 @@ func Pull(ctx context.Context, t *testing.T, inst *Instance, refstr string) *dat
 	return res
 }
 
-func Preview(ctx context.Context, t *testing.T, inst *Instance, refstr string) *dataset.Dataset {
+func Preview(ctx context.Context, t *testing.T, inst *Instance, ref string) *dataset.Dataset {
 	t.Helper()
 	p := &PreviewParams{
-		Ref:    refstr,
-		Remote: "",
+		Ref: ref,
 	}
 	res, err := inst.Remote().Preview(ctx, p)
 	if err != nil {

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -887,6 +887,12 @@ func (inst *Instance) WithSource(source string) *InstanceSourceWrap {
 }
 
 // InstanceSourceWrap is a wrapped instance with an explicit resolver source added
+// TODO(dustmop): This struct is a temporary solution. The better approach is to
+// make it easy to copy the Instance cheaply. All of Instance's "heavy" state, such
+// as the Bus, and Logbook, should live on a shared object, while values that can
+// be overwritten should live as separate fields. Then `WithSource` can be replaced
+// with a method that constructs a new Instance that points to the original shared
+// object, with other fields assigned as needed.
 type InstanceSourceWrap struct {
 	source string
 	inst   *Instance
@@ -895,6 +901,16 @@ type InstanceSourceWrap struct {
 // Dataset returns the DatasetMethods that Instance has registered
 func (isw *InstanceSourceWrap) Dataset() DatasetMethods {
 	return DatasetMethods{d: isw}
+}
+
+// Log returns the LogMethods that Instance has registered
+func (isw *InstanceSourceWrap) Log() LogMethods {
+	return LogMethods{d: isw}
+}
+
+// Remote returns the RemoteMethods that Instance has registered
+func (isw *InstanceSourceWrap) Remote() RemoteMethods {
+	return RemoteMethods{d: isw}
 }
 
 // SQL returns the SQLMethods that Instance has registered

--- a/lib/load.go
+++ b/lib/load.go
@@ -38,7 +38,9 @@ func (inst *Instance) LoadDataset(ctx context.Context, ref dsref.Ref, source str
 	}
 
 	msg := fmt.Sprintf("pulling %s from %s ...\n", ref.Human(), source)
-	inst.streams.Out.Write([]byte(msg))
+	if inst.streams.Out != nil {
+		inst.streams.Out.Write([]byte(msg))
+	}
 
 	// TODO (b5) - it'd be nice to us the returned dataset here, skipping the
 	// loadLocalDataset call entirely. For that to work dsfs.LoadDataset &

--- a/lib/log.go
+++ b/lib/log.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/base/dsfs"
@@ -36,9 +35,8 @@ func (m LogMethods) Attributes() map[string]AttributeSet {
 type HistoryParams struct {
 	ListParams
 	// Reference to data to fetch history for
-	Ref    string
-	Pull   bool
-	Source string
+	Ref  string
+	Pull bool
 }
 
 // History returns the history of changes for a given dataset
@@ -111,26 +109,17 @@ func (logImpl) History(scope scope, params *HistoryParams) ([]dsref.VersionInfo,
 		params.Offset = 0
 	}
 
-	if params.Pull {
-		switch params.Source {
-		case "":
-			params.Source = "network"
-		case "local":
-			return nil, fmt.Errorf("cannot pull with only local source")
-		}
-	}
-
-	ref, source, err := scope.ParseAndResolveRef(scope.Context(), params.Ref, params.Source)
+	ref, location, err := scope.ParseAndResolveRef(scope.Context(), params.Ref)
 	if err != nil {
 		return nil, err
 	}
 
-	if source == "" {
+	if location == "" {
 		// local resolution
 		return base.DatasetLog(scope.Context(), scope.Repo(), ref, params.Limit, params.Offset, true)
 	}
 
-	logs, err := scope.RemoteClient().FetchLogs(scope.Context(), ref, source)
+	logs, err := scope.RemoteClient().FetchLogs(scope.Context(), ref, location)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +165,7 @@ func (logImpl) Log(scope scope, p *RefListParams) ([]LogEntry, error) {
 	res := []LogEntry{}
 	var err error
 
-	ref, _, err := scope.ParseAndResolveRef(scope.Context(), p.Ref, "local")
+	ref, _, err := scope.ParseAndResolveRef(scope.Context(), p.Ref)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/params.go
+++ b/lib/params.go
@@ -14,6 +14,10 @@ import (
 // Limit param is provided to a paginated method
 const DefaultPageSize = 100
 
+// EmptyParams is for methods that don't need any input
+type EmptyParams struct {
+}
+
 // NZDefaultSetter modifies zero values to non-zero defaults when called
 type NZDefaultSetter interface {
 	SetNonZeroDefaults()
@@ -25,13 +29,10 @@ type NZDefaultSetter interface {
 type ListParams struct {
 	ProfileID profile.ID `json:"-"`
 	Term      string
-	Peername  string
+	Username  string
 	OrderBy   string
 	Limit     int
 	Offset    int
-	// RPC is a horrible hack while we work to replace the net/rpc package
-	// TODO - remove this
-	RPC bool
 	// Public only applies to listing datasets, shows only datasets that are
 	// set to visible
 	Public bool
@@ -39,11 +40,6 @@ type ListParams struct {
 	ShowNumVersions bool
 	// EnsureFSIExists controls whether to ensure references in the repo have correct FSIPaths
 	EnsureFSIExists bool
-	// UseDscache controls whether to build a dscache to use to list the references
-	UseDscache bool
-
-	// Raw indicates whether to return a raw string representation of a dataset list
-	Raw bool
 }
 
 // SetNonZeroDefaults sets OrderBy to "created" if it's value is the empty string

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -124,13 +124,12 @@ func (s *scope) Node() *p2p.QriNode {
 
 // ParseAndResolveRef parses a reference and resolves it
 // TODO(dustmop): Remove last input parameter from callers
-func (s *scope) ParseAndResolveRef(ctx context.Context, refStr, _ string) (dsref.Ref, string, error) {
+func (s *scope) ParseAndResolveRef(ctx context.Context, refStr string) (dsref.Ref, string, error) {
 	return s.inst.ParseAndResolveRef(ctx, refStr, s.source)
 }
 
 // ParseAndResolveRefWithWorkingDir parses a reference and resolves it with FSI info attached
-// TODO(dustmop): Remove last input parameter from callers
-func (s *scope) ParseAndResolveRefWithWorkingDir(ctx context.Context, refstr, _ string) (dsref.Ref, string, error) {
+func (s *scope) ParseAndResolveRefWithWorkingDir(ctx context.Context, refstr string) (dsref.Ref, string, error) {
 	return s.inst.ParseAndResolveRefWithWorkingDir(ctx, refstr, s.source)
 }
 
@@ -184,7 +183,19 @@ func (s *scope) SetLogbook(l *logbook.Book) {
 	s.inst.logbook = l
 }
 
+// SourceName is the name of the configured source for reference resolution
+func (s *scope) SourceName() string {
+	return s.source
+}
+
 // Stats returns the stats service
 func (s *scope) Stats() *stats.Service {
 	return s.inst.stats
+}
+
+// UseDscache returns whether dscache should be generated
+// TODO(dustmop): Add a config option or environment variable to experimentally
+// enable the dscache
+func (s *scope) UseDscache() bool {
+	return false
 }

--- a/lib/test_runner_test.go
+++ b/lib/test_runner_test.go
@@ -181,8 +181,8 @@ func (tr *testRunner) SaveWithParams(p *SaveParams) (dsref.Ref, error) {
 	return dsref.ConvertDatasetToVersionInfo(res).SimpleRef(), nil
 }
 
-func (tr *testRunner) MustGet(t *testing.T, refstr string) *dataset.Dataset {
-	p := GetParams{Refstr: refstr}
+func (tr *testRunner) MustGet(t *testing.T, ref string) *dataset.Dataset {
+	p := GetParams{Ref: ref}
 	res, err := tr.Instance.Dataset().Get(tr.Ctx, &p)
 	if err != nil {
 		t.Fatal(err)
@@ -255,8 +255,8 @@ func (tr *testRunner) Checkout(refstr, dir string) error {
 	ctx := tr.Ctx
 	m := tr.Instance.Filesys()
 	p := LinkParams{
-		Refstr: refstr,
-		Dir:    dir,
+		Ref: refstr,
+		Dir: dir,
 	}
 	return m.Checkout(ctx, &p)
 }

--- a/p2p/datasets.go
+++ b/p2p/datasets.go
@@ -83,7 +83,7 @@ func (n *QriNode) handleDatasetsList(ws *WrappedStream, msg Message) (hangup boo
 			dlp.Limit = listMax
 		}
 
-		refs, err := base.ListDatasets(context.TODO(), n.Repo, dlp.Term, "", dlp.Offset, dlp.Limit, false, true, false)
+		refs, err := base.ListDatasets(context.TODO(), n.Repo, dlp.Term, "", dlp.Offset, dlp.Limit, true, false)
 		if err != nil {
 			log.Error(err)
 			return

--- a/registry/regserver/mock.go
+++ b/registry/regserver/mock.go
@@ -107,7 +107,7 @@ type MockRepoSearch struct {
 // Search implements the registry.Searchable interface
 func (ss MockRepoSearch) Search(p registry.SearchParams) ([]*dataset.Dataset, error) {
 	ctx := context.Background()
-	infos, err := base.ListDatasets(ctx, ss.Repo, p.Q, "", 0, 1000, false, true, false)
+	infos, err := base.ListDatasets(ctx, ss.Repo, p.Q, "", 0, 1000, true, false)
 	if err != nil {
 		return nil, err
 	}

--- a/remote/browse.go
+++ b/remote/browse.go
@@ -59,7 +59,7 @@ func (rf RepoFeeds) Feed(ctx context.Context, userID, name string, offset, limit
 	if name != "recent" {
 		return nil, fmt.Errorf("unknown feed name '%s'", name)
 	}
-	return base.ListDatasets(ctx, rf.Repo, "", "", offset, limit, false, true, false)
+	return base.ListDatasets(ctx, rf.Repo, "", "", offset, limit, true, false)
 }
 
 // Previews is an interface for generating constant-size summaries of dataset

--- a/remote/registry/regserver/mock.go
+++ b/remote/registry/regserver/mock.go
@@ -107,7 +107,7 @@ type MockRepoSearch struct {
 // Search implements the registry.Searchable interface
 func (ss MockRepoSearch) Search(p registry.SearchParams) ([]*dataset.Dataset, error) {
 	ctx := context.Background()
-	infos, err := base.ListDatasets(ctx, ss.Repo, p.Q, "", 0, 1000, false, true, false)
+	infos, err := base.ListDatasets(ctx, ss.Repo, p.Q, "", 0, 1000, true, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Modify names of all input param structs that are used for lib methods. This includes things like:

* Refstr -> Ref
* Component -> Selector
* Peername -> Username (except for p2p)
* Source moving to the scope (Remote remains for remote `pull` and `remove`)
* a few other small changes

Some outstanding work renames: the All flag from Get should be removed, but doing so will break functionality (such as /body.csv on the API) until Cursors exist. Also, there's some dscache specific tests that are being skipped, as I think we should be using some other mechanism to enable dscache instead of a field on the input params, such as an environmental variable or an option in the config file. Finally, ListParams need some additional work to combine them into a common struct.