### PR TITLE
fix(dispatch): Add default source resolver to Attributes

### DIFF
--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -78,14 +78,14 @@ func TestHTTPClient(t *testing.T) {
 	httpClient.Address = sURL.Host
 	httpClient.Protocol = "http"
 
-	err = httpClient.CallRaw(ctx, lib.AEHome, nil, &bytes.Buffer{})
+	err = httpClient.CallRaw(ctx, lib.AEHome, "", nil, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
 	res := []dsref.VersionInfo{}
 	p := lib.ListParams{}
-	err = httpClient.CallMethod(ctx, lib.AEList, http.MethodPost, p, &res)
+	err = httpClient.CallMethod(ctx, lib.AEList, http.MethodPost, "", p, &res)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -37,7 +37,7 @@ dataset version(s). By default pull fetches the latest version of a dataset.
 	}
 
 	cmd.Flags().StringVar(&o.LinkDir, "link", "", "path to directory to link dataset to")
-	cmd.Flags().StringVar(&o.Source, "source", "network", "location to pull from")
+	cmd.Flags().StringVar(&o.Source, "source", "", "location to pull from")
 	cmd.MarkFlagFilename("link")
 	cmd.Flags().BoolVar(&o.LogsOnly, "logs-only", false, "only fetch logs, skipping HEAD data")
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -152,7 +152,7 @@ func (o *RemoveOptions) Run() (err error) {
 	}
 
 	ctx := context.TODO()
-	res, err := o.inst.WithSource("local").Dataset().Remove(ctx, &params)
+	res, err := o.inst.Dataset().Remove(ctx, &params)
 	if err != nil {
 		// TODO(b5): move this error handling down into lib
 		if errors.Is(err, dsref.ErrRefNotFound) {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -138,7 +138,7 @@ func (o *ValidateOptions) Run() (err error) {
 	}
 
 	ctx := context.TODO()
-	res, err := o.inst.WithSource("local").Dataset().Validate(ctx, p)
+	res, err := o.inst.Dataset().Validate(ctx, p)
 	if err != nil {
 		return err
 	}

--- a/lib/access.go
+++ b/lib/access.go
@@ -22,7 +22,7 @@ func (m AccessMethods) Name() string {
 // Attributes defines attributes for each method
 func (m AccessMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"createauthtoken": {AECreateAuthToken, "GET"},
+		"createauthtoken": {AECreateAuthToken, "GET", "local"},
 	}
 }
 

--- a/lib/access.go
+++ b/lib/access.go
@@ -22,7 +22,7 @@ func (m AccessMethods) Name() string {
 // Attributes defines attributes for each method
 func (m AccessMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"createauthtoken": {AECreateAuthToken, "GET", "local"},
+		"createauthtoken": {endpoint: AECreateAuthToken, httpVerb: "GET", defaultSource: "local"},
 	}
 }
 

--- a/lib/automation.go
+++ b/lib/automation.go
@@ -26,7 +26,7 @@ func (m AutomationMethods) Name() string {
 // Attributes defines attributes for each method
 func (m AutomationMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"apply": {AEApply, "POST"},
+		"apply": {AEApply, "POST", ""},
 	}
 }
 

--- a/lib/automation.go
+++ b/lib/automation.go
@@ -26,7 +26,7 @@ func (m AutomationMethods) Name() string {
 // Attributes defines attributes for each method
 func (m AutomationMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"apply": {AEApply, "POST", ""},
+		"apply": {endpoint: AEApply, httpVerb: "POST"},
 	}
 }
 

--- a/lib/collection.go
+++ b/lib/collection.go
@@ -27,8 +27,8 @@ func (m CollectionMethods) Name() string {
 // Attributes defines attributes for each method
 func (m CollectionMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"list":        {AEList, "POST", ""},
-		"listrawrefs": {denyRPC, "", ""},
+		"list":        {endpoint: AEList, httpVerb: "POST"},
+		"listrawrefs": {endpoint: denyRPC},
 	}
 }
 

--- a/lib/collection.go
+++ b/lib/collection.go
@@ -27,8 +27,8 @@ func (m CollectionMethods) Name() string {
 // Attributes defines attributes for each method
 func (m CollectionMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"list":        {AEList, "POST"},
-		"listrawrefs": {denyRPC, ""},
+		"list":        {AEList, "POST", ""},
+		"listrawrefs": {denyRPC, "", ""},
 	}
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -25,9 +25,9 @@ func (m ConfigMethods) Name() string {
 func (m ConfigMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
 		// config methods are not allowed over HTTP nor RPC
-		"getconfig":     {denyRPC, "", ""},
-		"getconfigkeys": {denyRPC, "", ""},
-		"setconfig":     {denyRPC, "", ""},
+		"getconfig":     {endpoint: denyRPC},
+		"getconfigkeys": {endpoint: denyRPC},
+		"setconfig":     {endpoint: denyRPC},
 	}
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -25,9 +25,9 @@ func (m ConfigMethods) Name() string {
 func (m ConfigMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
 		// config methods are not allowed over HTTP nor RPC
-		"getconfig":     {denyRPC, ""},
-		"getconfigkeys": {denyRPC, ""},
-		"setconfig":     {denyRPC, ""},
+		"getconfig":     {denyRPC, "", ""},
+		"getconfigkeys": {denyRPC, "", ""},
+		"setconfig":     {denyRPC, "", ""},
 	}
 }
 

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -50,20 +50,20 @@ func (m DatasetMethods) Name() string {
 // Attributes defines attributes for each method
 func (m DatasetMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"componentstatus": {AEComponentStatus, "POST"},
-		"get":             {AEGet, "GET"},
+		"componentstatus": {AEComponentStatus, "POST", ""},
+		"get":             {AEGet, "GET", ""},
 		// "log":             {AELog, "POST"},
-		"rename": {AERename, "POST"},
-		"save":   {AESave, "POST"},
-		"pull":   {AEPull, "POST"},
+		"rename": {AERename, "POST", ""},
+		"save":   {AESave, "POST", ""},
+		"pull":   {AEPull, "POST", "network"},
 		// "push":            {AEPush, "POST"},
-		"render":   {AERender, "POST"},
-		"remove":   {AERemove, "POST"},
-		"validate": {AEValidate, "POST"},
+		"render":   {AERender, "POST", ""},
+		"remove":   {AERemove, "POST", "local"},
+		"validate": {AEValidate, "POST", ""},
 		// "unpack":          {AEUnpack, "POST"},
-		"manifest":        {AEManifest, "POST"},
-		"manifestmissing": {AEManifestMissing, "POST"},
-		"daginfo":         {AEDAGInfo, "POST"},
+		"manifest":        {AEManifest, "POST", ""},
+		"manifestmissing": {AEManifestMissing, "POST", ""},
+		"daginfo":         {AEDAGInfo, "POST", ""},
 	}
 }
 
@@ -1310,9 +1310,6 @@ func (datasetImpl) Validate(scope scope, p *ValidateParams) (*ValidateResponse, 
 
 	if p.Ref == "" && (p.BodyFilename == "" || schemaFlagType == "") {
 		return nil, qrierr.New(ErrBadArgs, "please provide a dataset name, or a supply the --body and --schema or --structure flags")
-	}
-	if scope.SourceName() != "local" {
-		return nil, fmt.Errorf("validate requires 'local' source")
 	}
 
 	fsiPath := ""

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -50,20 +50,20 @@ func (m DatasetMethods) Name() string {
 // Attributes defines attributes for each method
 func (m DatasetMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"componentstatus": {AEComponentStatus, "POST", ""},
-		"get":             {AEGet, "GET", ""},
-		// "log":             {AELog, "POST"},
-		"rename": {AERename, "POST", ""},
-		"save":   {AESave, "POST", ""},
-		"pull":   {AEPull, "POST", "network"},
-		// "push":            {AEPush, "POST"},
-		"render":   {AERender, "POST", ""},
-		"remove":   {AERemove, "POST", "local"},
-		"validate": {AEValidate, "POST", ""},
-		// "unpack":          {AEUnpack, "POST"},
-		"manifest":        {AEManifest, "POST", ""},
-		"manifestmissing": {AEManifestMissing, "POST", ""},
-		"daginfo":         {AEDAGInfo, "POST", ""},
+		"componentstatus": {endpoint: AEComponentStatus, httpVerb: "POST"},
+		"get":             {endpoint: AEGet, httpVerb: "GET"},
+		// "log":             {endpoint: AELog, httpVerb: "POST"},
+		"rename": {endpoint: AERename, httpVerb: "POST", defaultSource: "local"},
+		"save":   {endpoint: AESave, httpVerb: "POST"},
+		"pull":   {endpoint: AEPull, httpVerb: "POST", defaultSource: "network"},
+		// "push":    {endpoint: AEPush, httpVerb: "POST", defaultSource: "local"},
+		"render":   {endpoint: AERender, httpVerb: "POST"},
+		"remove":   {endpoint: AERemove, httpVerb: "POST", defaultSource: "local"},
+		"validate": {endpoint: AEValidate, httpVerb: "POST", defaultSource: "local"},
+		// "unpack":          {endpoint: AEUnpack, httpVerb: "POST"},
+		"manifest":        {endpoint: AEManifest, httpVerb: "POST"},
+		"manifestmissing": {endpoint: AEManifestMissing, httpVerb: "POST"},
+		"daginfo":         {endpoint: AEDAGInfo, httpVerb: "POST"},
 	}
 }
 

--- a/lib/diff.go
+++ b/lib/diff.go
@@ -26,8 +26,8 @@ func (m DiffMethods) Name() string {
 // Attributes defines attributes for each method
 func (m DiffMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"changes": {AEChanges, "POST"},
-		"diff":    {AEDiff, "POST"},
+		"changes": {AEChanges, "POST", ""},
+		"diff":    {AEDiff, "POST", ""},
 	}
 }
 

--- a/lib/diff.go
+++ b/lib/diff.go
@@ -26,8 +26,8 @@ func (m DiffMethods) Name() string {
 // Attributes defines attributes for each method
 func (m DiffMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"changes": {AEChanges, "POST", ""},
-		"diff":    {AEDiff, "POST", ""},
+		"changes": {endpoint: AEChanges, httpVerb: "POST"},
+		"diff":    {endpoint: AEDiff, httpVerb: "POST"},
 	}
 }
 

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -48,7 +48,9 @@ type MethodSet interface {
 // Each method is required to have associated attributes in order to successfully register
 type AttributeSet struct {
 	endpoint APIEndpoint
-	verb     string
+	httpVerb string
+	// the default source used for resolving references
+	defaultSource string
 }
 
 // Dispatch is a system for handling calls to lib. Should only be called by top-level lib methods.
@@ -144,6 +146,11 @@ func (inst *Instance) dispatchMethodCall(ctx context.Context, method string, par
 
 	// Look up the method for the given signifier
 	if c, ok := inst.regMethods.lookup(method); ok {
+		// If this method has a default source and no override exists, use that
+		// default instead
+		if source == "" {
+			source = c.Source
+		}
 		// Construct the isolated scope for this call
 		// TODO(dustmop): Add user authentication, profile, identity, etc
 		// TODO(dustmop): Also determine if the method is read-only vs read-write,
@@ -237,12 +244,14 @@ type callable struct {
 	RetCursor bool
 	Endpoint  APIEndpoint
 	Verb      string
+	Source    string
 }
 
 // RegisterMethods iterates the methods provided by the lib API, and makes them visible to dispatch
 func (inst *Instance) RegisterMethods() {
 	reg := make(map[string]callable)
 	inst.registerOne("access", inst.Access(), accessImpl{}, reg)
+	inst.registerOne("automation", inst.Automation(), automationImpl{}, reg)
 	inst.registerOne("collection", inst.Collection(), collectionImpl{}, reg)
 	inst.registerOne("config", inst.Config(), configImpl{}, reg)
 	inst.registerOne("dataset", inst.Dataset(), datasetImpl{}, reg)
@@ -255,7 +264,6 @@ func (inst *Instance) RegisterMethods() {
 	inst.registerOne("remote", inst.Remote(), remoteImpl{}, reg)
 	inst.registerOne("search", inst.Search(), searchImpl{}, reg)
 	inst.registerOne("sql", inst.SQL(), sqlImpl{}, reg)
-	inst.registerOne("automation", inst.Automation(), automationImpl{}, reg)
 	inst.regMethods = &regMethodSet{reg: reg}
 }
 
@@ -384,25 +392,13 @@ func (inst *Instance) registerOne(ourName string, methods MethodSet, impl interf
 		// Remove this method from the methodSetMap now that it has been processed
 		delete(methodMap, i.Name)
 
-		var endpoint APIEndpoint
-		var httpVerb string
 		// Additional attributes for the method are found in the Attributes
 		amap := methods.Attributes()
 		methodAttrs, ok := amap[lowerName]
 		if !ok {
 			regFail("not in Attributes: %s.%s", ourName, lowerName)
 		}
-		endpoint = methodAttrs.endpoint
-		httpVerb = methodAttrs.verb
-		// If both these are empty string, RPC is not allowed for this method
-		if endpoint != "" || httpVerb != "" {
-			if !strings.HasPrefix(string(endpoint), "/") {
-				regFail("%s: endpoint URL must start with /, got %q", lowerName, endpoint)
-			}
-			if httpVerb != http.MethodGet && httpVerb != http.MethodPost && httpVerb != http.MethodPut {
-				regFail("%s: unknown http verb, got %q", lowerName, httpVerb)
-			}
-		}
+		validateMethodAttrs(lowerName, methodAttrs)
 
 		// Save the method to the registration table
 		reg[funcName] = callable{
@@ -411,8 +407,9 @@ func (inst *Instance) registerOne(ourName string, methods MethodSet, impl interf
 			InType:    inType,
 			OutType:   outType,
 			RetCursor: returnsCursor,
-			Endpoint:  endpoint,
-			Verb:      httpVerb,
+			Endpoint:  methodAttrs.endpoint,
+			Verb:      methodAttrs.httpVerb,
+			Source:    methodAttrs.defaultSource,
 		}
 		log.Debugf("%d: registered %s(*%s) %v", k, funcName, inType, outType)
 	}
@@ -426,6 +423,30 @@ func (inst *Instance) registerOne(ourName string, methods MethodSet, impl interf
 
 func regFail(fstr string, vals ...interface{}) {
 	panic(fmt.Sprintf(fstr, vals...))
+}
+
+func validateMethodAttrs(methodName string, attrs AttributeSet) {
+	// If endpoint and verb are not set, then RPC is denied, nothing to validate
+	// TODO(dustmop): Technically this is denying all HTTP, not just RPC. Consider
+	// separating HTTP and RPC denial
+	if attrs.endpoint == "" && attrs.httpVerb == "" {
+		return
+	}
+	if !strings.HasPrefix(string(attrs.endpoint), "/") {
+		regFail("%s: endpoint URL must start with /, got %q", methodName, attrs.endpoint)
+	}
+	if !stringOneOf(attrs.httpVerb, []string{http.MethodGet, http.MethodPost, http.MethodPut}) {
+		regFail("%s: unknown http verb, got %q", methodName, attrs.httpVerb)
+	}
+}
+
+func stringOneOf(needle string, haystack []string) bool {
+	for _, each := range haystack {
+		if needle == each {
+			return true
+		}
+	}
+	return false
 }
 
 func (inst *Instance) buildMethodMap(impl interface{}) map[string]reflect.Method {

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -122,13 +122,12 @@ func (inst *Instance) dispatchMethodCall(ctx context.Context, method string, par
 				out := reflect.New(c.OutType)
 				res = out.Interface()
 			}
-			// TODO(dustmop): Send the source across the RPC, using an HTTP header
 			// TODO(ramfox): dispatch is still unable to give enough details to the url
 			// (because it doesn't know how or what param information to put into the url or query)
 			// for it to reliably use GET. All POSTs w/ content type application json work, however.
 			// we may want to just flat out say that as an RPC layer, dispatch will only ever use
 			// json POST to communicate.
-			err = inst.http.CallMethod(ctx, c.Endpoint, "POST", param, res)
+			err = inst.http.CallMethod(ctx, c.Endpoint, "POST", source, param, res)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/lib/dispatch_test.go
+++ b/lib/dispatch_test.go
@@ -308,8 +308,8 @@ func (m *animalMethods) Name() string {
 
 func (m *animalMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"cat": {denyRPC, "", ""},
-		"dog": {denyRPC, "", ""},
+		"cat": {endpoint: denyRPC},
+		"dog": {endpoint: denyRPC},
 	}
 }
 
@@ -406,12 +406,12 @@ func (m *fruitMethods) Name() string {
 
 func (m *fruitMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"apple":  {"/apple", "GET", ""},
-		"banana": {"/banana", "GET", ""},
-		"cherry": {"/cherry", "GET", ""},
-		"date":   {"/date", "GET", ""},
+		"apple":  {endpoint: "/apple", httpVerb: "GET"},
+		"banana": {endpoint: "/banana", httpVerb: "GET"},
+		"cherry": {endpoint: "/cherry", httpVerb: "GET"},
+		"date":   {endpoint: "/date", httpVerb: "GET"},
 		// entawak cannot be called over RPC
-		"entawak": {denyRPC, "", ""},
+		"entawak": {endpoint: denyRPC},
 	}
 }
 
@@ -489,8 +489,8 @@ func (m *getSrcMethods) Name() string {
 
 func (m *getSrcMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"one": {"/one", "GET", ""},
-		"two": {"/two", "GET", "network"},
+		"one": {endpoint: "/one", httpVerb: "GET"},
+		"two": {endpoint: "/two", httpVerb: "GET", defaultSource: "network"},
 	}
 }
 

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -29,15 +29,15 @@ func (m FSIMethods) Name() string {
 // Attributes defines attributes for each method
 func (m FSIMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"status":                {AEStatus, "POST", ""},
-		"caninitdatasetworkdir": {AECanInitDatasetWorkDir, "POST", ""},
-		"init":                  {AEInit, "POST", ""},
-		"checkout":              {AECheckout, "POST", ""},
-		"ensureref":             {AEEnsureRef, "POST", ""},
-		"restore":               {AERestore, "POST", ""},
-		"write":                 {AEFSIWrite, "POST", ""},
-		"createlink":            {AEFSICreateLink, "POST", ""},
-		"unlink":                {AEFSIUnlink, "POST", ""},
+		"status":                {endpoint: AEStatus, httpVerb: "POST"},
+		"caninitdatasetworkdir": {endpoint: AECanInitDatasetWorkDir, httpVerb: "POST"},
+		"init":                  {endpoint: AEInit, httpVerb: "POST"},
+		"checkout":              {endpoint: AECheckout, httpVerb: "POST"},
+		"ensureref":             {endpoint: AEEnsureRef, httpVerb: "POST"},
+		"restore":               {endpoint: AERestore, httpVerb: "POST"},
+		"write":                 {endpoint: AEFSIWrite, httpVerb: "POST"},
+		"createlink":            {endpoint: AEFSICreateLink, httpVerb: "POST"},
+		"unlink":                {endpoint: AEFSIUnlink, httpVerb: "POST"},
 	}
 }
 

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -29,15 +29,15 @@ func (m FSIMethods) Name() string {
 // Attributes defines attributes for each method
 func (m FSIMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"status":                {AEStatus, "POST"},
-		"caninitdatasetworkdir": {AECanInitDatasetWorkDir, "POST"},
-		"init":                  {AEInit, "POST"},
-		"checkout":              {AECheckout, "POST"},
-		"ensureref":             {AEEnsureRef, "POST"},
-		"restore":               {AERestore, "POST"},
-		"write":                 {AEFSIWrite, "POST"},
-		"createlink":            {AEFSICreateLink, "POST"},
-		"unlink":                {AEFSIUnlink, "POST"},
+		"status":                {AEStatus, "POST", ""},
+		"caninitdatasetworkdir": {AECanInitDatasetWorkDir, "POST", ""},
+		"init":                  {AEInit, "POST", ""},
+		"checkout":              {AECheckout, "POST", ""},
+		"ensureref":             {AEEnsureRef, "POST", ""},
+		"restore":               {AERestore, "POST", ""},
+		"write":                 {AEFSIWrite, "POST", ""},
+		"createlink":            {AEFSICreateLink, "POST", ""},
+		"unlink":                {AEFSIUnlink, "POST", ""},
 	}
 }
 

--- a/lib/http.go
+++ b/lib/http.go
@@ -21,6 +21,7 @@ import (
 var ErrUnsupportedRPC = errors.New("method is not suported over RPC")
 
 const jsonMimeType = "application/json"
+const sourceResolver = "SourceResolver"
 
 // HTTPClient implements the qri http client
 type HTTPClient struct {
@@ -70,35 +71,35 @@ func NewHTTPClientWithProtocol(multiaddr string, protocol string) (*HTTPClient, 
 }
 
 // Call calls API endpoint and passes on parameters, context info
-func (c HTTPClient) Call(ctx context.Context, apiEndpoint APIEndpoint, params interface{}, result interface{}) error {
-	return c.CallMethod(ctx, apiEndpoint, http.MethodPost, params, result)
+func (c HTTPClient) Call(ctx context.Context, apiEndpoint APIEndpoint, source string, params interface{}, result interface{}) error {
+	return c.CallMethod(ctx, apiEndpoint, http.MethodPost, source, params, result)
 }
 
 // CallMethod calls API endpoint and passes on parameters, context info and specific HTTP Method
-func (c HTTPClient) CallMethod(ctx context.Context, apiEndpoint APIEndpoint, httpMethod string, params interface{}, result interface{}) error {
+func (c HTTPClient) CallMethod(ctx context.Context, apiEndpoint APIEndpoint, httpMethod string, source string, params interface{}, result interface{}) error {
 	// TODO(arqu): work out mimeType configuration/override per API endpoint
 	mimeType := jsonMimeType
 	addr := fmt.Sprintf("%s://%s%s", c.Protocol, c.Address, apiEndpoint)
 
-	return c.do(ctx, addr, httpMethod, mimeType, params, result, false)
+	return c.do(ctx, addr, httpMethod, mimeType, source, params, result, false)
 }
 
 // CallRaw calls API endpoint and passes on parameters, context info and returns the []byte result
-func (c HTTPClient) CallRaw(ctx context.Context, apiEndpoint APIEndpoint, params interface{}, result interface{}) error {
-	return c.CallMethodRaw(ctx, apiEndpoint, http.MethodPost, params, result)
+func (c HTTPClient) CallRaw(ctx context.Context, apiEndpoint APIEndpoint, source string, params interface{}, result interface{}) error {
+	return c.CallMethodRaw(ctx, apiEndpoint, http.MethodPost, source, params, result)
 }
 
 // CallMethodRaw calls API endpoint and passes on parameters, context info, specific HTTP Method and returns the []byte result
-func (c HTTPClient) CallMethodRaw(ctx context.Context, apiEndpoint APIEndpoint, httpMethod string, params interface{}, result interface{}) error {
+func (c HTTPClient) CallMethodRaw(ctx context.Context, apiEndpoint APIEndpoint, httpMethod string, source string, params interface{}, result interface{}) error {
 	// TODO(arqu): work out mimeType configuration/override per API endpoint
 	mimeType := jsonMimeType
 	addr := fmt.Sprintf("%s://%s%s", c.Protocol, c.Address, apiEndpoint)
 	// TODO(arqu): inject context values into headers
 
-	return c.do(ctx, addr, httpMethod, mimeType, params, result, true)
+	return c.do(ctx, addr, httpMethod, mimeType, source, params, result, true)
 }
 
-func (c HTTPClient) do(ctx context.Context, addr string, httpMethod string, mimeType string, params interface{}, result interface{}, raw bool) error {
+func (c HTTPClient) do(ctx context.Context, addr string, httpMethod string, mimeType string, source string, params interface{}, result interface{}, raw bool) error {
 	var req *http.Request
 	var err error
 
@@ -133,6 +134,10 @@ func (c HTTPClient) do(ctx context.Context, addr string, httpMethod string, mime
 
 	req.Header.Set("Content-Type", mimeType)
 	req.Header.Set("Accept", mimeType)
+
+	if source != "" {
+		req.Header.Set(sourceResolver, source)
+	}
 
 	req, added := token.AddContextTokenToRequest(ctx, req)
 	if !added {
@@ -246,7 +251,7 @@ func NewHTTPRequestHandler(inst *Instance, libMethod string) http.HandlerFunc {
 
 // SourceFromRequest retrieves from the http request the source for resolving refs
 func SourceFromRequest(r *http.Request) string {
-	return r.Header.Get("SourceResolver")
+	return r.Header.Get(sourceResolver)
 }
 
 // DecodeParams decodes a json body into params

--- a/lib/log.go
+++ b/lib/log.go
@@ -24,10 +24,10 @@ func (m LogMethods) Name() string {
 // Attributes defines attributes for each method
 func (m LogMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"history":        {AEHistory, "POST", ""},
-		"log":            {AELog, "POST", ""},
-		"rawlogbook":     {denyRPC, "", ""},
-		"logbooksummary": {denyRPC, "", ""},
+		"history":        {endpoint: AEHistory, httpVerb: "POST"},
+		"log":            {endpoint: AELog, httpVerb: "POST"},
+		"rawlogbook":     {endpoint: denyRPC},
+		"logbooksummary": {endpoint: denyRPC},
 	}
 }
 

--- a/lib/log.go
+++ b/lib/log.go
@@ -24,10 +24,10 @@ func (m LogMethods) Name() string {
 // Attributes defines attributes for each method
 func (m LogMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"history":        {AEHistory, "POST"},
-		"log":            {AELog, "POST"},
-		"rawlogbook":     {denyRPC, ""},
-		"logbooksummary": {denyRPC, ""},
+		"history":        {AEHistory, "POST", ""},
+		"log":            {AELog, "POST", ""},
+		"rawlogbook":     {denyRPC, "", ""},
+		"logbooksummary": {denyRPC, "", ""},
 	}
 }
 

--- a/lib/peers.go
+++ b/lib/peers.go
@@ -26,12 +26,12 @@ func (m PeerMethods) Name() string { return "peer" }
 // Attributes defines attributes for each method
 func (m PeerMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"list":                 {AEPeers, "POST", ""},
-		"info":                 {AEPeer, "POST", ""},
-		"connect":              {AEConnect, "POST", ""},
-		"disconnect":           {AEDisconnect, "POST", ""},
-		"connections":          {AEConnections, "POST", ""},
-		"connectedqriprofiles": {AEConnectedQriProfiles, "POST", ""},
+		"list":                 {endpoint: AEPeers, httpVerb: "POST"},
+		"info":                 {endpoint: AEPeer, httpVerb: "POST"},
+		"connect":              {endpoint: AEConnect, httpVerb: "POST"},
+		"disconnect":           {endpoint: AEDisconnect, httpVerb: "POST"},
+		"connections":          {endpoint: AEConnections, httpVerb: "POST"},
+		"connectedqriprofiles": {endpoint: AEConnectedQriProfiles, httpVerb: "POST"},
 	}
 }
 

--- a/lib/peers.go
+++ b/lib/peers.go
@@ -26,12 +26,12 @@ func (m PeerMethods) Name() string { return "peer" }
 // Attributes defines attributes for each method
 func (m PeerMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"list":                 {AEPeers, "POST"},
-		"info":                 {AEPeer, "POST"},
-		"connect":              {AEConnect, "POST"},
-		"disconnect":           {AEDisconnect, "POST"},
-		"connections":          {AEConnections, "POST"},
-		"connectedqriprofiles": {AEConnectedQriProfiles, "POST"},
+		"list":                 {AEPeers, "POST", ""},
+		"info":                 {AEPeer, "POST", ""},
+		"connect":              {AEConnect, "POST", ""},
+		"disconnect":           {AEDisconnect, "POST", ""},
+		"connections":          {AEConnections, "POST", ""},
+		"connectedqriprofiles": {AEConnectedQriProfiles, "POST", ""},
 	}
 }
 

--- a/lib/profile.go
+++ b/lib/profile.go
@@ -29,10 +29,10 @@ func (m ProfileMethods) Name() string {
 // Attributes defines attributes for each method
 func (m ProfileMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"getprofile":      {denyRPC, ""},
-		"setprofile":      {denyRPC, ""},
-		"setprofilephoto": {denyRPC, ""},
-		"setposterphoto":  {denyRPC, ""},
+		"getprofile":      {denyRPC, "", ""},
+		"setprofile":      {denyRPC, "", ""},
+		"setprofilephoto": {denyRPC, "", ""},
+		"setposterphoto":  {denyRPC, "", ""},
 	}
 }
 

--- a/lib/profile.go
+++ b/lib/profile.go
@@ -29,10 +29,10 @@ func (m ProfileMethods) Name() string {
 // Attributes defines attributes for each method
 func (m ProfileMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"getprofile":      {denyRPC, "", ""},
-		"setprofile":      {denyRPC, "", ""},
-		"setprofilephoto": {denyRPC, "", ""},
-		"setposterphoto":  {denyRPC, "", ""},
+		"getprofile":      {endpoint: denyRPC},
+		"setprofile":      {endpoint: denyRPC},
+		"setprofilephoto": {endpoint: denyRPC},
+		"setposterphoto":  {endpoint: denyRPC},
 	}
 }
 

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -27,8 +27,8 @@ func (m RegistryClientMethods) Name() string {
 // Attributes defines attributes for each method
 func (m RegistryClientMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"createprofile":   {denyRPC, ""},
-		"proveprofilekey": {denyRPC, ""},
+		"createprofile":   {denyRPC, "", ""},
+		"proveprofilekey": {denyRPC, "", ""},
 	}
 }
 

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -27,8 +27,8 @@ func (m RegistryClientMethods) Name() string {
 // Attributes defines attributes for each method
 func (m RegistryClientMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"createprofile":   {denyRPC, "", ""},
-		"proveprofilekey": {denyRPC, "", ""},
+		"createprofile":   {endpoint: denyRPC},
+		"proveprofilekey": {endpoint: denyRPC},
 	}
 }
 

--- a/lib/remote.go
+++ b/lib/remote.go
@@ -27,10 +27,10 @@ func (m RemoteMethods) Name() string {
 // Attributes defines attributes for each method
 func (m RemoteMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"feeds":   {AEFeeds, "POST", ""},
-		"preview": {AEPreview, "POST", ""},
-		"push":    {AEPush, "POST", "local"},
-		"remove":  {AERemoteRemove, "POST", "network"},
+		"feeds":   {endpoint: AEFeeds, httpVerb: "POST"},
+		"preview": {endpoint: AEPreview, httpVerb: "POST"},
+		"push":    {endpoint: AEPush, httpVerb: "POST", defaultSource: "local"},
+		"remove":  {endpoint: AERemoteRemove, httpVerb: "POST", defaultSource: "network"},
 	}
 }
 

--- a/lib/remote.go
+++ b/lib/remote.go
@@ -27,10 +27,10 @@ func (m RemoteMethods) Name() string {
 // Attributes defines attributes for each method
 func (m RemoteMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"feeds":   {AEFeeds, "POST"},
-		"preview": {AEPreview, "POST"},
-		"push":    {AEPush, "POST"},
-		"remove":  {AERemoteRemove, "POST"},
+		"feeds":   {AEFeeds, "POST", ""},
+		"preview": {AEPreview, "POST", ""},
+		"push":    {AEPush, "POST", "local"},
+		"remove":  {AERemoteRemove, "POST", "network"},
 	}
 }
 

--- a/lib/search.go
+++ b/lib/search.go
@@ -21,7 +21,7 @@ func (m SearchMethods) Name() string {
 // Attributes defines attributes for each method
 func (m SearchMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"search": {AESearch, "POST"},
+		"search": {AESearch, "POST", ""},
 	}
 }
 

--- a/lib/search.go
+++ b/lib/search.go
@@ -21,7 +21,7 @@ func (m SearchMethods) Name() string {
 // Attributes defines attributes for each method
 func (m SearchMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"search": {AESearch, "POST", ""},
+		"search": {endpoint: AESearch, httpVerb: "POST"},
 	}
 }
 

--- a/lib/sql.go
+++ b/lib/sql.go
@@ -18,7 +18,7 @@ func (m SQLMethods) Name() string { return "sql" }
 // Attributes defines attributes for each method
 func (m SQLMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"exec": {AESQL, "POST"},
+		"exec": {AESQL, "POST", ""},
 	}
 }
 

--- a/lib/sql.go
+++ b/lib/sql.go
@@ -18,7 +18,7 @@ func (m SQLMethods) Name() string { return "sql" }
 // Attributes defines attributes for each method
 func (m SQLMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"exec": {AESQL, "POST", ""},
+		"exec": {endpoint: AESQL, httpVerb: "POST"},
 	}
 }
 


### PR DESCRIPTION
Attributes has a field for the default source for the method. This lets us remove the WithSource calls throughout the cmd package, and makes tests more readable.