### PR TITLE
docs(api): add non lib routes to spec

### DIFF
--- a/docs/api_doc_template.yaml
+++ b/docs/api_doc_template.yaml
@@ -11,14 +11,37 @@ paths:
       operationId: '{{ .MethodSet }}.{{ .MethodName }}'
       tags:
       - {{ .MethodSet }}
+      {{- if eq .HTTPVerb "get" }}
+      {{- if eq .Params.Name "pathParams" }}
+{{ if .Params.Fields }}      parameters: {{end}}
+{{- range .Params.Fields }}
+      - name: '{{ .Name }}'
+        in: path
+        required: true
+        schema:
+          type: string
+{{ end -}}
+      {{ end }}
+      {{ end -}}
       {{- if eq .HTTPVerb "post" }}
       {{- if ne .Params.Name "" }}
+      {{- if not .Params.IsBinary }}
       requestBody:
         required: true
         content:
           application/json:
             schema:
               '$ref': '#/components/schemas/{{ .Params.Name }}'
+      {{ end }}
+      {{- if .Params.IsBinary }}
+      requestBody:
+        required: true
+        content:
+          {{ .Params.Name }}:
+            schema:
+              type: string
+              format: binary
+      {{ end }}
       {{ end -}}
       {{ end }}
       responses:

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/getkin/kin-openapi v0.55.0
 	github.com/iancoleman/orderedmap v0.2.0
 	github.com/qri-io/ioes v0.1.1
-	github.com/qri-io/qri v0.9.13
+	github.com/qri-io/qri v0.9.14-0.20210428083546-967b708545a5
 	github.com/spf13/cobra v1.1.3
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1159,6 +1159,8 @@ github.com/qri-io/jsonschema v0.2.0 h1:is8lirh3HYwTkC0e+4jL/vWEHwzPLojnl4FWkUoeE
 github.com/qri-io/jsonschema v0.2.0/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANPBaaqW+VrI=
 github.com/qri-io/qfs v0.5.1-0.20201119141805-fb13393b2d1f h1:Oj2N/HRGMcs2NDZWl1K5gFsTifrxQVVE0KyFyUGgn8M=
 github.com/qri-io/qfs v0.5.1-0.20201119141805-fb13393b2d1f/go.mod h1:SU+DUq8+BfHNod1SXzmD8FrNLgPt42aKyQuO3fnFEQI=
+github.com/qri-io/qri v0.9.14-0.20210428083546-967b708545a5 h1:fb+C7wKQOFypiS/dAb9TQArphwWf/DsCNndIQ2kb/f0=
+github.com/qri-io/qri v0.9.14-0.20210428083546-967b708545a5/go.mod h1:FYXfoIUhkzj9lioSsIg5Y+03r5EW7B0UM5txyldsb94=
 github.com/qri-io/starlib v0.4.2 h1:ZGzmzT9fOqdluezcwhAZAbTn/v6kMg1tC6ALVjQPhpQ=
 github.com/qri-io/starlib v0.4.2/go.mod h1:2xlZ9r2UV4LF4G9mpYPBWo7CtXtdW0h1RoGIkZ8elOE=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=

--- a/lib/api.go
+++ b/lib/api.go
@@ -84,7 +84,7 @@ const (
 	// AEValidate is an endpoint for validating datasets
 	AEValidate = APIEndpoint("/ds/validate")
 	// AEUnpack unpacks a zip file and sends it back
-	AEUnpack = APIEndpoint("/ds/unpack/{path:.*}")
+	AEUnpack = APIEndpoint("/ds/unpack")
 	// AEManifest generates a manifest for a dataset path
 	AEManifest = APIEndpoint("/ds/manifest")
 	// AEManifestMissing generates a manifest of blocks that are not present on this repo for a given manifest

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -51,7 +51,7 @@ func (m DatasetMethods) Name() string {
 func (m DatasetMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
 		"componentstatus": {Endpoint: AEComponentStatus, HTTPVerb: "POST"},
-		"get":             {Endpoint: AEGet, HTTPVerb: "GET"},
+		"get":             {Endpoint: AEGet, HTTPVerb: "POST"},
 		"getcsv":          {Endpoint: DenyHTTP}, // getcsv is not part of the json api, but is handled in a separate `GetBodyCSVHandler` function
 		"getzip":          {Endpoint: DenyHTTP}, // getzip is not part of the json api, but is handled is a separate `GetHandler` function
 		"activity":        {Endpoint: AEActivity, HTTPVerb: "POST"},


### PR DESCRIPTION
Closes: https://github.com/qri-io/qri/issues/575

~~Still missing: `get` routes~~