### PR TITLE
refactor(lib, api): move sugar endpoints out of `lib` into `api`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -215,19 +215,19 @@ func NewServerRoutes(s Server) *mux.Router {
 	var routeParams refRouteParams
 
 	// misc endpoints
-	m.Handle(lib.AEHome.String(), s.NoLogMiddleware(s.HomeHandler))
-	m.Handle(lib.AEHealth.String(), s.NoLogMiddleware(HealthCheckHandler))
-	m.Handle(lib.AEIPFS.String(), s.Middleware(s.HandleIPFSPath))
+	m.Handle(AEHome.String(), s.NoLogMiddleware(s.HomeHandler))
+	m.Handle(AEHealth.String(), s.NoLogMiddleware(HealthCheckHandler))
+	m.Handle(AEIPFS.String(), s.Middleware(s.HandleIPFSPath))
 	if !cfg.API.DisableWebui {
-		m.Handle(lib.AEWebUI.String(), s.Middleware(WebuiHandler))
+		m.Handle(AEWebUI.String(), s.Middleware(WebuiHandler))
 	}
 
 	// non POST/json dataset endpoints
-	m.Handle(bodyCSVRouteFullRef, s.Middleware(GetBodyCSVHandler(s.Instance))).Methods(http.MethodGet)
-	m.Handle(bodyCSVRouteShortRef, s.Middleware(GetBodyCSVHandler(s.Instance))).Methods(http.MethodGet)
+	m.Handle(AEGetCSVFullRef.String(), s.Middleware(GetBodyCSVHandler(s.Instance))).Methods(http.MethodGet)
+	m.Handle(AEGetCSVShortRef.String(), s.Middleware(GetBodyCSVHandler(s.Instance))).Methods(http.MethodGet)
 	routeParams = newrefRouteParams(lib.AEGet, false, true, http.MethodGet)
 	handleRefRoute(m, routeParams, s.Middleware(GetHandler(s.Instance, lib.AEGet.String())))
-	m.Handle(lib.AEUnpack.String(), s.Middleware(UnpackHandler(lib.AEUnpack.NoTrailingSlash())))
+	m.Handle(AEUnpack.String(), s.Middleware(UnpackHandler(AEUnpack.NoTrailingSlash())))
 
 	// sync/protocol endpoints
 	if cfg.Remote != nil && cfg.Remote.Enabled {

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"github.com/qri-io/qri/lib"
+)
+
+const (
+	// base endpoints
+
+	// AEHome is the / endpoint
+	AEHome = lib.APIEndpoint("/")
+	// AEHealth is the service health check endpoint
+	AEHealth = lib.APIEndpoint("/health")
+	// AEIPFS is the IPFS endpoint
+	AEIPFS = lib.APIEndpoint("/qfs/ipfs/{path:.*}")
+	// AEWebUI serves the remote WebUI
+	AEWebUI = lib.APIEndpoint("/webui")
+
+	// dataset endpoints
+
+	// AEGetCSVFullRef is the route used to get a body as a csv, that can also handle a specific hash
+	AEGetCSVFullRef = lib.APIEndpoint("/ds/get/{username}/{name}/at/{fs}/{hash}/body.csv")
+	// AEGetCSVShortRef is the route used to get a body as a csv
+	AEGetCSVShortRef = lib.APIEndpoint("/ds/get/{username}/{name}/body.csv")
+	// AEUnpack unpacks a zip file and sends it back
+	AEUnpack = lib.APIEndpoint("/ds/unpack")
+)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -11,13 +11,6 @@ import (
 	"github.com/qri-io/qri/lib"
 )
 
-var (
-	// bodyCSVRouteFullRef is the route used to get a body as a csv, that can also handle a specific hash
-	bodyCSVRouteFullRef = fmt.Sprintf("%s/{username}/{name}/at/{fs}/{hash}/body.csv", lib.AEGet.NoTrailingSlash())
-	// bodyCSVRouteShortRef is the route used to get a body as a csv
-	bodyCSVRouteShortRef = fmt.Sprintf("%s/{username}/{name}/body.csv", lib.AEGet.NoTrailingSlash())
-)
-
 // GetBodyCSVHandler is a handler for returning the body as a csv file
 // Examples:
 // curl http://localhost:2503/ds/get/b5/world_bank_population/body.csv

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -78,7 +78,7 @@ func TestHTTPClient(t *testing.T) {
 	httpClient.Address = sURL.Host
 	httpClient.Protocol = "http"
 
-	err = httpClient.CallRaw(ctx, lib.AEHome, "", nil, &bytes.Buffer{})
+	err = httpClient.CallRaw(ctx, AEHome, "", nil, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/lib/api.go
+++ b/lib/api.go
@@ -29,17 +29,6 @@ func (ae APIEndpoint) WithSuffix(suffix string) APIEndpoint {
 }
 
 const (
-	// base endpoints
-
-	// AEHome is the / endpoint
-	AEHome = APIEndpoint("/")
-	// AEHealth is the service health check endpoint
-	AEHealth = APIEndpoint("/health")
-	// AEIPFS is the IPFS endpoint
-	AEIPFS = APIEndpoint("/qfs/ipfs/{path:.*}")
-	// AEWebUI serves the remote WebUI
-	AEWebUI = APIEndpoint("/webui")
-
 	// aggregate endpoints
 
 	// AEList lists all datasets in your collection
@@ -83,8 +72,6 @@ const (
 	AERemove = APIEndpoint("/ds/remove")
 	// AEValidate is an endpoint for validating datasets
 	AEValidate = APIEndpoint("/ds/validate")
-	// AEUnpack unpacks a zip file and sends it back
-	AEUnpack = APIEndpoint("/ds/unpack")
 	// AEManifest generates a manifest for a dataset path
 	AEManifest = APIEndpoint("/ds/manifest")
 	// AEManifestMissing generates a manifest of blocks that are not present on this repo for a given manifest


### PR DESCRIPTION
The `lib` package was defining endpoints that don't have any relation to
methods defined in lib. These endpoints have been moved into `api/endpoints.go`:

```
AEHome
AEHealth
AEIPFs
AEWebUI
AEUnpack
```

closes #1776 