### PR TITLE
fix(routes): skip over endpoints that are DenyHTTP

### DIFF
--- a/lib/routes.go
+++ b/lib/routes.go
@@ -13,6 +13,9 @@ func (inst *Instance) GiveAPIServer(middleware func(handler http.HandlerFunc) ht
 		if arrayContainsString(ignoreMethods, methodName) {
 			continue
 		}
+		if call.Endpoint == DenyHTTP {
+			continue
+		}
 		handler := middleware(NewHTTPRequestHandler(inst, methodName))
 		// All endpoints use POST verb
 		httpVerb := http.MethodPost


### PR DESCRIPTION
Closes: https://github.com/qri-io/qri/issues/1775

@dustmop noticed that writing the issue was more work than this commit. Sorry.