### PR TITLE
fix(remote): update handlers with gorilla mux

### DIFF
--- a/remote/registry/regserver/handlers/handlers.go
+++ b/remote/registry/regserver/handlers/handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/qri-io/qri/remote/registry"
 	"github.com/sirupsen/logrus"
 )
@@ -37,7 +38,7 @@ func AddProtector(p MethodProtector) func(o *RouteOptions) {
 }
 
 // NewRoutes allocates server handlers along standard routes
-func NewRoutes(reg registry.Registry, opts ...func(o *RouteOptions)) *http.ServeMux {
+func NewRoutes(reg registry.Registry, opts ...func(o *RouteOptions)) *mux.Router {
 	o := &RouteOptions{
 		Protector: NoopProtector(0),
 	}
@@ -46,25 +47,25 @@ func NewRoutes(reg registry.Registry, opts ...func(o *RouteOptions)) *http.Serve
 	}
 
 	pro := o.Protector
-	mux := http.NewServeMux()
-	mux.HandleFunc("/health", HealthCheckHandler)
+	m := mux.NewRouter()
+	m.HandleFunc("/health", HealthCheckHandler)
 
 	if rem := reg.Remote; rem != nil {
 		// add any "/remote" routes this remote provides
-		rem.AddDefaultRoutes(mux)
+		rem.AddDefaultRoutes(m)
 	}
 
 	if ps := reg.Profiles; ps != nil {
-		mux.HandleFunc("/registry/profile", logReq(NewProfileHandler(ps)))
-		mux.HandleFunc("/registry/profiles", pro.ProtectMethods("POST")(logReq(NewProfilesHandler(ps))))
-		mux.HandleFunc("/registry/provekey", NewProveKeyHandler(ps))
+		m.HandleFunc("/registry/profile", logReq(NewProfileHandler(ps)))
+		m.HandleFunc("/registry/profiles", pro.ProtectMethods("POST")(logReq(NewProfilesHandler(ps))))
+		m.HandleFunc("/registry/provekey", NewProveKeyHandler(ps))
 	}
 
 	if s := reg.Search; s != nil {
-		mux.HandleFunc("/registry/search", logReq(NewSearchHandler(s)))
+		m.HandleFunc("/registry/search", logReq(NewSearchHandler(s)))
 	}
 
-	return mux
+	return m
 }
 
 func logReq(h http.HandlerFunc) http.HandlerFunc {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gorilla/mux"
 	golog "github.com/ipfs/go-log"
 	"github.com/qri-io/dag"
 	"github.com/qri-io/dag/dsync"
@@ -557,18 +558,18 @@ func (r *Remote) logPreCheckHook(name string, action string, h Hook) logsync.Hoo
 }
 
 // AddDefaultRoutes attaches routes a remote client will expect to an HTTP muxer
-func (r *Remote) AddDefaultRoutes(mux *http.ServeMux) {
-	mux.Handle("/remote/dsync", r.DsyncHTTPHandler())
-	mux.Handle("/remote/logsync", r.LogsyncHTTPHandler())
-	mux.Handle("/remote/refs", r.RefsHTTPHandler())
+func (r *Remote) AddDefaultRoutes(m *mux.Router) {
+	m.Handle("/remote/dsync", r.DsyncHTTPHandler())
+	m.Handle("/remote/logsync", r.LogsyncHTTPHandler())
+	m.Handle("/remote/refs", r.RefsHTTPHandler())
 
 	if fs := r.Feeds; fs != nil {
-		mux.Handle("/remote/feeds", r.FeedsHTTPHandler())
-		mux.Handle("/remote/feeds/", r.FeedHTTPHandler("/remote/feeds/"))
+		m.Handle("/remote/feeds", r.FeedsHTTPHandler())
+		m.Handle("/remote/feeds/{path:.*}", r.FeedHTTPHandler("/remote/feeds/"))
 	}
 	if ps := r.Previews; ps != nil {
-		mux.Handle("/remote/dataset/preview/", r.PreviewHTTPHandler("/remote/dataset/preview/"))
-		mux.Handle("/remote/dataset/component/", r.ComponentHTTPHandler("/remote/dataset/component/"))
+		m.Handle("/remote/dataset/preview/{path:.*}", r.PreviewHTTPHandler("/remote/dataset/preview/"))
+		m.Handle("/remote/dataset/component/{path:.*}", r.ComponentHTTPHandler("/remote/dataset/component/"))
 	}
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gorilla/mux"
 	core "github.com/ipfs/go-ipfs/core"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qfs"
@@ -445,9 +445,9 @@ func (tr *testRunner) NodeARemote(t *testing.T, opts ...OptionsFunc) *Remote {
 }
 
 func (tr *testRunner) RemoteTestServer(rem *Remote) *httptest.Server {
-	mux := http.NewServeMux()
-	rem.AddDefaultRoutes(mux)
-	return httptest.NewServer(mux)
+	m := mux.NewRouter()
+	rem.AddDefaultRoutes(m)
+	return httptest.NewServer(m)
 }
 
 func (tr *testRunner) NodeBClient(t *testing.T) Client {


### PR DESCRIPTION
Updating remaining routes to `gorilla.mux` and bringing it in line with the rest. 