### PR TITLE
local collection migrates from repo, updates via event bus subscriptions

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -250,7 +250,7 @@ func (s *localSet) saveProfileCollection(pid profile.ID) error {
 
 	data, err := json.Marshal(items)
 	if err != nil {
-		return fmt.Errorf("serializing user colletion: %w", err)
+		return fmt.Errorf("serializing user collection: %w", err)
 	}
 
 	path := filepath.Join(s.basePath, fmt.Sprintf("%s.json", pid.String()))

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -16,10 +16,16 @@ import (
 	profiletest "github.com/qri-io/qri/profile/test"
 )
 
+var constructor = func(ctx context.Context, bus event.Bus) (collection.Set, error) {
+	return collection.NewLocalSet(ctx, bus, "")
+}
+
 func TestLocalCollection(t *testing.T) {
-	spec.AssertWritableCollectionSpec(t, func(ctx context.Context, bus event.Bus) (collection.Set, error) {
-		return collection.NewLocalSet(ctx, bus, "")
-	})
+	spec.AssertWritableCollectionSpec(t, constructor)
+}
+
+func TestLocalCollectionEvents(t *testing.T) {
+	spec.AssertCollectionEventSpec(t, constructor)
 }
 
 func TestCollectionPersistence(t *testing.T) {

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -25,7 +25,7 @@ func TestLocalCollection(t *testing.T) {
 }
 
 func TestLocalCollectionEvents(t *testing.T) {
-	spec.AssertCollectionEventSpec(t, constructor)
+	spec.AssertCollectionEventListenerSpec(t, constructor)
 }
 
 func TestCollectionPersistence(t *testing.T) {

--- a/collection/migrate.go
+++ b/collection/migrate.go
@@ -8,7 +8,9 @@ import (
 	"github.com/qri-io/qri/repo"
 )
 
-func MigrateRepoStoreToLocalCollection(ctx context.Context, bus event.Bus, repoDir string, r repo.Repo) (Set, error) {
+// MigrateRepoStoreToLocalCollectionSet constructs a local collection.Set from
+// legacy repo data
+func MigrateRepoStoreToLocalCollectionSet(ctx context.Context, bus event.Bus, repoDir string, r repo.Repo) (Set, error) {
 	datasets, err := repo.ListVersionInfoShim(r, 0, 1000000)
 	if err != nil {
 		return nil, err

--- a/collection/migrate.go
+++ b/collection/migrate.go
@@ -1,0 +1,37 @@
+package collection
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qri-io/qri/event"
+	"github.com/qri-io/qri/repo"
+)
+
+func MigrateRepoStoreToLocalCollection(ctx context.Context, bus event.Bus, repoDir string, r repo.Repo) (Set, error) {
+	datasets, err := repo.ListVersionInfoShim(r, 0, 1000000)
+	if err != nil {
+		return nil, err
+	}
+
+	book := r.Logbook()
+	for i, vi := range datasets {
+		ref := vi.SimpleRef()
+		if _, err := book.ResolveRef(ctx, &ref); err != nil {
+			return nil, fmt.Errorf("resolving dataset initID: %w", err)
+		}
+		datasets[i].InitID = ref.InitID
+	}
+
+	s, err := NewLocalSet(ctx, bus, repoDir)
+	if err != nil {
+		return nil, err
+	}
+
+	ws := s.(WritableSet)
+	if err = ws.Put(ctx, r.Profiles().Owner().ID, datasets...); err != nil {
+		return nil, err
+	}
+
+	return ws, nil
+}

--- a/collection/migrate_test.go
+++ b/collection/migrate_test.go
@@ -1,0 +1,48 @@
+package collection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/qri-io/qri/base/params"
+	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/event"
+	"github.com/qri-io/qri/repo"
+	repotest "github.com/qri-io/qri/repo/test"
+)
+
+func TestMigrateRepoStoreToLocalCollection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r, err := repotest.NewTestRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect, err := repo.ListVersionInfoShim(r, 0, 100000)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(expect) == 0 {
+		t.Fatalf("test repo has no datasets")
+	}
+
+	set, err := MigrateRepoStoreToLocalCollection(ctx, event.NilBus, "", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := set.List(ctx, r.Profiles().Owner().ID, params.ListAll)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if diff := cmp.Diff(expect, got, cmpopts.IgnoreFields(dsref.VersionInfo{}, "InitID")); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+
+}

--- a/collection/migrate_test.go
+++ b/collection/migrate_test.go
@@ -13,7 +13,7 @@ import (
 	repotest "github.com/qri-io/qri/repo/test"
 )
 
-func TestMigrateRepoStoreToLocalCollection(t *testing.T) {
+func TestMigrateRepoStoreToLocalCollectionSet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -31,7 +31,7 @@ func TestMigrateRepoStoreToLocalCollection(t *testing.T) {
 		t.Fatalf("test repo has no datasets")
 	}
 
-	set, err := MigrateRepoStoreToLocalCollection(ctx, event.NilBus, "", r)
+	set, err := MigrateRepoStoreToLocalCollectionSet(ctx, event.NilBus, "", r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/collection/spec/collection.go
+++ b/collection/spec/collection.go
@@ -198,9 +198,10 @@ func AssertWritableCollectionSpec(t *testing.T, constructor Constructor) {
 	})
 }
 
-// AssertCollectionEventSpec defines expected behaviours for collections
-// use events to update state
-func AssertCollectionEventSpec(t *testing.T, constructor Constructor) {
+// AssertCollectionEventListenerSpec defines expected behaviours for collections
+// that use event subscriptions to update state.
+// Event Listener specs are optional.
+func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	bus := event.NewBus(ctx)

--- a/collection/spec/collection.go
+++ b/collection/spec/collection.go
@@ -290,6 +290,14 @@ func AssertCollectionEventSpec(t *testing.T, constructor Constructor) {
 		}
 		assertCollectionList(ctx, t, kermit, params.ListAll, c, expect)
 
+		mustPublish(ctx, t, bus, event.ETDatasetDeleteAll, event.DsChange{
+			InitID:     muppetNamesInitID,
+			PrettyName: muppetNamesName2,
+		})
+
+		expect = []dsref.VersionInfo{}
+		assertCollectionList(ctx, t, kermit, params.ListAll, c, expect)
+
 		// TODO (b5): create a second dataset, use different timestamps for both,
 		// assert default ordering of datasets
 	})


### PR DESCRIPTION
fleshing out a local collection implementation using lessons learned from #1804. This PR adds an unused-but-tested migration function, and clarifies that specs for event subscriptions must be optional.