### PR TITLE
fix(api): don't error when running connect with disabled p2p

### DIFF
--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -71,7 +71,7 @@ func TestFetchCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := remoteInst.Connect(ctx); err != nil {
+	if err := remoteInst.ConnectP2P(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -772,10 +772,17 @@ type Instance struct {
 	releasers sync.WaitGroup
 }
 
-// Connect takes an instance online
-func (inst *Instance) Connect(ctx context.Context) (err error) {
+// ErrP2PDisabled error indicates p2p connectivity is disabled by configuration
+var ErrP2PDisabled = fmt.Errorf("peer-2-peer networking is disabled")
+
+// ConnectP2P connects an instance's peer-2-peer node
+func (inst *Instance) ConnectP2P(ctx context.Context) (err error) {
+	if inst.cfg.P2P == nil || !inst.cfg.P2P.Enabled {
+		return ErrP2PDisabled
+	}
+
 	if err = inst.node.GoOnline(ctx); err != nil {
-		log.Debugf("taking node online: %s", err.Error())
+		log.Debugw("connecting instance p2p node", "err", err.Error())
 		return
 	}
 


### PR DESCRIPTION
I'm in a place with really spotty internet, and need to work on qri frontend without blowing up the router. This change makes it possible to run qri connect with p2p features disabled. I've renamed lib.Instance.Connect -> lib.Instance.ConnectP2P to clarify that it's really just about p2p connections, and defined a canonical error for trying to connect with disabled p2p via configuration.

Output when running connect without p2p doesn't make allusions to the d.web, and skips listing libp2p addresses (because there are none).