### PR TITLE
refactor(connect): re-work connection detail printout for qri connect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 default: build
 
-QRI_VERSION?="0.10.0"
+QRI_VERSION?="0.10.1-dev"
 
 BUILD_FLAGS?=CGO_ENABLED=0
 PKG=$(shell go list ./version)

--- a/api/api.go
+++ b/api/api.go
@@ -54,6 +54,8 @@ func (s Server) Serve(ctx context.Context) (err error) {
 	node := s.Node()
 	cfg := s.GetConfig()
 
+	node.LocalStreams.Print(fmt.Sprintf("qri version v%s\nconnecting...\n", APIVersion))
+
 	ws, err := lib.NewWebsocketHandler(ctx, s.Instance)
 	if err != nil {
 		return err
@@ -73,11 +75,9 @@ func (s Server) Serve(ctx context.Context) (err error) {
 		Handler: s.Mux,
 	}
 
-	info := "\n"
-	if p2pConnected {
-		info += "📡  Success! You are now connected to the d.web. Here's your connection details:\n"
-	} else {
-		info += "Running a qri node with no d.web connection"
+	info := "qri is ready."
+	if !p2pConnected {
+		info += "running with no p2p connection"
 	}
 	info += cfg.SummaryString()
 	if p2pConnected {
@@ -86,8 +86,7 @@ func (s Server) Serve(ctx context.Context) (err error) {
 			info = fmt.Sprintf("%s\n  %s", info, a.String())
 		}
 	}
-	info += fmt.Sprintf("\nYou are running Qri v%s", APIVersion)
-	info += "\n\n"
+	info += "\n"
 
 	node.LocalStreams.Print(info)
 

--- a/config/config.go
+++ b/config/config.go
@@ -88,13 +88,6 @@ func (cfg Config) SummaryString() (summary string) {
 
 	if cfg.API != nil && cfg.API.Enabled {
 		summary += fmt.Sprintf("API address:\t%s\n", cfg.API.Address)
-		if cfg.API.WebsocketAddress != "" {
-			summary += fmt.Sprintf("Websocket address:\t%s\n", cfg.API.WebsocketAddress)
-		}
-	}
-
-	if cfg.RPC != nil && cfg.RPC.Enabled {
-		summary += fmt.Sprintf("RPC address:\t%s\n", cfg.RPC.Address)
 	}
 
 	return summary


### PR DESCRIPTION
Small tweaks to improve connection UX from the command line.

Remove websockt & RPC values, which are no longer in use. Stagger printout while initial ports are being acquired. Print version number first.