### PR TITLE
fix(search): use consistent naming and output format for search

### DIFF
--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -220,29 +220,33 @@ func TestSearchRun(t *testing.T) {
 
 var mockResponse = []byte(`{"data":[
 	{
-		"commit": {
-			"qri": "cm:0",
-			"timestamp": "2019-08-31T12:07:56.212858Z",
-			"title": "change to 10"
-		},
-		"meta": {
-			"keywords": [
-				"joke"
-			],
-			"qri": "md:0",
-			"title": "this is a d"
-		},
-		"name": "nuun",
-		"path": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
-		"peername": "nuun",
-		"qri": "ds:0",
-		"structure": {
-			"entries": 3,
-			"format": "csv",
-			"length": 36,
-			"qri": "st:0"
-		}
-	}
+      "type": "dataset",
+      "id": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
+      "value": {
+        "commit": {
+          "qri": "cm:0",
+          "timestamp": "2019-08-31T12:07:56.212858Z",
+          "title": "change to 10"
+        },
+        "meta": {
+          "keywords": [
+            "joke"
+          ],
+          "qri": "md:0",
+          "title": "this is a d"
+        },
+        "name": "nuun",
+        "path": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
+        "peername": "nuun",
+        "qri": "ds:0",
+        "structure": {
+          "entries": 3,
+          "format": "csv",
+          "length": 36,
+          "qri": "st:0"
+        }
+      }
+    }
 ],"meta":{"code":200}}`)
 
 var textSearchResponse = `showing 1 results for 'test'
@@ -255,10 +259,10 @@ var textSearchResponse = `showing 1 results for 'test'
 
 var jsonSearchResponse = `[
   {
-    "Type": "dataset",
-    "ID": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
-    "URL": "",
-    "Value": {
+    "type": "dataset",
+    "id": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
+    "url": "",
+    "value": {
       "commit": {
         "qri": "cm:0",
         "timestamp": "2019-08-31T12:07:56.212858Z",

--- a/lib/api.go
+++ b/lib/api.go
@@ -115,7 +115,7 @@ const (
 	// user on the registry
 	AERegistryProve = APIEndpoint("/remote/registry/profile/prove")
 	// AESearch returns a list of dataset search results
-	AESearch = APIEndpoint("/remote/search")
+	AESearch = APIEndpoint("/registry/search")
 
 	// fsi endpoints
 

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -442,7 +442,7 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 	// if logAll is enabled, turn on debug level logging for all qri packages. Packages need to
 	// be explicitly enumerated here
 	if o.logAll {
-		allPackages := []string{"qriapi", "qrip2p", "base", "changes", "cmd", "config", "dsref", "dsfs", "friendly", "fsi", "lib", "logbook", "profile", "repo", "sql", "token"}
+		allPackages := []string{"qriapi", "qrip2p", "base", "changes", "cmd", "config", "dsref", "dsfs", "friendly", "fsi", "lib", "logbook", "profile", "repo", "registry", "sql", "token"}
 		for _, name := range allPackages {
 			golog.SetLogLevel(name, "debug")
 		}

--- a/lib/search.go
+++ b/lib/search.go
@@ -34,9 +34,10 @@ type SearchParams struct {
 
 // SearchResult struct
 type SearchResult struct {
-	Type, ID string
-	URL      string
-	Value    *dataset.Dataset
+	Type  string           `json:"type"`
+	ID    string           `json:"id"`
+	URL   string           `json:"url"`
+	Value *dataset.Dataset `json:"value"`
 }
 
 // Search queries for items on qri related to given parameters

--- a/registry/regclient/client.go
+++ b/registry/regclient/client.go
@@ -4,6 +4,8 @@ package regclient
 import (
 	"errors"
 	"net/http"
+
+	golog "github.com/ipfs/go-log"
 )
 
 var (
@@ -19,6 +21,8 @@ var (
 	// HTTPClient is hoisted here in case you'd like to use a different client instance
 	// by default we just use http.DefaultClient
 	HTTPClient = http.DefaultClient
+
+	log = golog.Logger("registry")
 )
 
 // Client wraps a registry configuration with methods for interacting

--- a/registry/regclient/search.go
+++ b/registry/regclient/search.go
@@ -106,7 +106,9 @@ func (c Client) doJSONSearchReq(method string, s *registry.SearchParams) (result
 	}
 	// add response to an envelope
 	env := struct {
-		Data []*dataset.Dataset
+		Data []struct {
+			Value *dataset.Dataset
+		}
 		Meta struct {
 			Error  string
 			Status string
@@ -121,5 +123,14 @@ func (c Client) doJSONSearchReq(method string, s *registry.SearchParams) (result
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("error %d: %s", res.StatusCode, env.Meta.Error)
 	}
-	return env.Data, nil
+
+	datasets := []*dataset.Dataset{}
+	for _, d := range env.Data {
+		if d.Value != nil {
+			datasets = append(datasets, d.Value)
+		} else {
+			log.Errorf("failed parsing dataset response")
+		}
+	}
+	return datasets, nil
 }


### PR DESCRIPTION
Aligning the search response format and registry response parsing.