### PR TITLE
feat(feature_flags): added support for basic feature flag management

### DIFF
--- a/config/feature/flag.go
+++ b/config/feature/flag.go
@@ -1,0 +1,22 @@
+package feature
+
+import ()
+
+// ID is a string identifier for a workflow
+type ID string
+
+// Flag represents a feature and its state
+type Flag struct {
+	ID     ID   `json:"id"`
+	Active bool `json:"active"`
+}
+
+var (
+	// DefaultFlags represent the base state and system defined feature flags
+	DefaultFlags = map[ID]*Flag{
+		"BASE": &Flag{
+			ID:     "BASE",
+			Active: true,
+		},
+	}
+)

--- a/config/feature/store.go
+++ b/config/feature/store.go
@@ -1,0 +1,234 @@
+package feature
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/gofrs/flock"
+	"github.com/qri-io/qri/config"
+)
+
+// Store manages & stores feature flags
+type Store interface {
+	Lister
+	// Get fetches a Flag from the Store using the ID
+	Get(ctx context.Context, fid ID) (*Flag, error)
+	// Put updates the flag user settings
+	Put(ctx context.Context, f *Flag) (*Flag, error)
+}
+
+// A Lister lists entries from a feature flag store
+type Lister interface {
+	// List lists the Flags in the Store
+	List(ctx context.Context) ([]*Flag, error)
+}
+
+// NewStore constructs a feature.Store backed by memory or local file
+func NewStore(cfg *config.Config) (Store, error) {
+	if cfg.Repo == nil {
+		return NewMemStore(), nil
+	}
+
+	switch cfg.Repo.Type {
+	case "fs":
+		// Don't create a localstore with the empty path, this will use the current directory
+		if cfg.Path() == "" {
+			return nil, fmt.Errorf("new feature.LocalStore requires non-empty path")
+		}
+		return NewLocalStore(filepath.Join(filepath.Dir(cfg.Path()), "feature_flags.json"))
+	case "mem":
+		return NewMemStore(), nil
+	default:
+		return nil, fmt.Errorf("unknown repo type: %s", cfg.Repo.Type)
+	}
+}
+
+// MemStore is an in memory representation of a Store
+type MemStore struct {
+	sync.Mutex
+	flags     map[ID]*Flag
+	overrides map[ID]*Flag
+}
+
+var _ Store = (*MemStore)(nil)
+
+// NewMemStore returns a MemStore
+func NewMemStore() *MemStore {
+	return &MemStore{
+		flags:     DefaultFlags,
+		overrides: map[ID]*Flag{},
+	}
+}
+
+// List lists the Flags in the Store
+func (s *MemStore) List(ctx context.Context) ([]*Flag, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	flagMap := map[ID]*Flag{}
+	for _, f := range s.flags {
+		flagMap[f.ID] = f
+	}
+	for _, f := range s.overrides {
+		flagMap[f.ID] = f
+	}
+	flags := []*Flag{}
+	for _, f := range flagMap {
+		flags = append(flags, f)
+	}
+	return flags, nil
+}
+
+// Get fetches a Flag from the Store using the ID
+func (s *MemStore) Get(ctx context.Context, fid ID) (*Flag, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if flag, ok := s.overrides[fid]; ok {
+		return flag, nil
+	}
+	if flag, ok := s.flags[fid]; ok {
+		return flag, nil
+	}
+	return &Flag{
+		ID:     fid,
+		Active: false,
+	}, nil
+}
+
+// Put updates the flag user settings
+func (s *MemStore) Put(ctx context.Context, f *Flag) (*Flag, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.overrides[f.ID] = f
+	return f, nil
+}
+
+// LocalStore is a file backed representation of a Store
+type LocalStore struct {
+	sync.Mutex
+	flags     map[ID]*Flag
+	overrides map[ID]*Flag
+	filename  string
+	flock     *flock.Flock
+}
+
+var _ Store = (*LocalStore)(nil)
+
+// NewLocalStore returns a LocalStore
+func NewLocalStore(filename string) (*LocalStore, error) {
+	store := &LocalStore{
+		flags:     DefaultFlags,
+		overrides: map[ID]*Flag{},
+		filename:  filename,
+		flock:     flock.New(fmt.Sprintf("%s.lock", filename)),
+	}
+	err := store.load()
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// List lists the Flags in the Store
+func (s *LocalStore) List(ctx context.Context) ([]*Flag, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	flagMap := map[ID]*Flag{}
+	for _, f := range s.flags {
+		flagMap[f.ID] = f
+	}
+	for _, f := range s.overrides {
+		flagMap[f.ID] = f
+	}
+	flags := []*Flag{}
+	for _, f := range flagMap {
+		flags = append(flags, f)
+	}
+	return flags, nil
+}
+
+// Get fetches a Flag from the Store using the ID
+func (s *LocalStore) Get(ctx context.Context, fid ID) (*Flag, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if flag, ok := s.overrides[fid]; ok {
+		return flag, nil
+	}
+	if flag, ok := s.flags[fid]; ok {
+		return flag, nil
+	}
+	return &Flag{
+		ID:     fid,
+		Active: false,
+	}, nil
+}
+
+// Put updates the flag user settings
+func (s *LocalStore) Put(ctx context.Context, f *Flag) (*Flag, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.overrides[f.ID] = f
+	err := s.save()
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (s *LocalStore) load() error {
+	if err := s.flock.Lock(); err != nil {
+		return err
+	}
+	defer func() {
+		s.flock.Unlock()
+	}()
+
+	flags := []*Flag{}
+
+	data, err := ioutil.ReadFile(s.filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// on missing flag store we just continue normally
+			return nil
+		}
+		return fmt.Errorf("error loading flags: %s", err.Error())
+	}
+
+	if err := json.Unmarshal(data, &flags); err != nil {
+		return fmt.Errorf("error parsing flags: %s", err.Error())
+	}
+
+	for _, f := range flags {
+		s.overrides[f.ID] = f
+	}
+	return nil
+}
+
+func (s *LocalStore) save() error {
+	flags := []*Flag{}
+	for _, f := range s.overrides {
+		flags = append(flags, f)
+	}
+	data, err := json.Marshal(flags)
+	if err != nil {
+		return err
+	}
+
+	if err := s.flock.Lock(); err != nil {
+		return err
+	}
+	defer func() {
+		s.flock.Unlock()
+	}()
+	return ioutil.WriteFile(s.filename, data, 0644)
+}

--- a/config/feature/store_test.go
+++ b/config/feature/store_test.go
@@ -1,0 +1,77 @@
+package feature
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalStore(t *testing.T) {
+	path, err := ioutil.TempDir("", "flags")
+	if err != nil {
+		t.Fatalf("error creating tmp directory: %s", err.Error())
+	}
+	t.Logf("store: %s", path)
+
+	ffs, err := NewLocalStore(filepath.Join(path, "feature_flag_test.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	flagList, err := ffs.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lenFlagList := len(flagList)
+	if lenFlagList != len(DefaultFlags) {
+		t.Errorf("expected same length of returned feature flags as default: %d got %d", len(flagList), len(DefaultFlags))
+	}
+
+	flag, err := ffs.Get(ctx, "BASE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flag.ID != DefaultFlags["BASE"].ID || flag.Active != DefaultFlags["BASE"].Active {
+		t.Errorf("Get didn't return the expected values")
+	}
+
+	ffs.Put(ctx, &Flag{
+		ID:     "BASE",
+		Active: false,
+	})
+	flag, err = ffs.Get(ctx, "BASE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flag.Active {
+		t.Errorf("flag remained active after turning off")
+	}
+
+	ffs.Put(ctx, &Flag{
+		ID:     "NEW_BASE",
+		Active: true,
+	})
+	_, err = ffs.Get(ctx, "NEW_BASE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	flagList, err = ffs.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(flagList) != lenFlagList+1 {
+		t.Errorf("expected flag list to grow with new flag added")
+	}
+
+	flag, err = ffs.Get(ctx, "UNKNOWN_FLAG")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flag.Active {
+		t.Errorf("expected unknown flags to always return false")
+	}
+}

--- a/lib/api.go
+++ b/lib/api.go
@@ -153,6 +153,12 @@ const (
 	AEConnections = APIEndpoint("/connections")
 	// AEConnectedQriProfiles lists qri profile connections
 	AEConnectedQriProfiles = APIEndpoint("/connections/qri")
+	// AEListFlags lists qri feature flags
+	AEListFlags = APIEndpoint("/config/flags")
+	// AEGetFlag return a qri feature flag
+	AEGetFlag = APIEndpoint("/config/flag")
+	// AESetFlag updates a qri feature flag
+	AESetFlag = APIEndpoint("/config/flag/set")
 
 	// DenyHTTP will disable HTTP access to a method
 	DenyHTTP = APIEndpoint("")

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -279,6 +279,7 @@ func (inst *Instance) RegisterMethods() {
 	inst.registerOne("automation", inst.Automation(), automationImpl{}, reg)
 	inst.registerOne("collection", inst.Collection(), collectionImpl{}, reg)
 	inst.registerOne("config", inst.Config(), configImpl{}, reg)
+	inst.registerOne("feature", inst.FeatureFlags(), featureFlagsImpl{}, reg)
 	inst.registerOne("dataset", inst.Dataset(), datasetImpl{}, reg)
 	inst.registerOne("diff", inst.Diff(), diffImpl{}, reg)
 	inst.registerOne("fsi", inst.Filesys(), fsiImpl{}, reg)

--- a/lib/feature_flags.go
+++ b/lib/feature_flags.go
@@ -1,0 +1,72 @@
+package lib
+
+import (
+	"context"
+
+	"github.com/qri-io/qri/config/feature"
+)
+
+// FeatureFlagMethods encapsulates business logic for managing
+// feature flags
+type FeatureFlagMethods struct {
+	d dispatcher
+}
+
+// Name returns the name of this method group
+func (m FeatureFlagMethods) Name() string {
+	return "feature"
+}
+
+// Attributes defines attributes for each method
+func (m FeatureFlagMethods) Attributes() map[string]AttributeSet {
+	return map[string]AttributeSet{
+		"list": {Endpoint: AEListFlags, HTTPVerb: "POST"},
+		"get":  {Endpoint: AEGetFlag, HTTPVerb: "POST"},
+		"put":  {Endpoint: AESetFlag, HTTPVerb: "POST"},
+	}
+}
+
+// List returns a list of all the feature flags
+func (m FeatureFlagMethods) List(ctx context.Context, p *EmptyParams) ([]*feature.Flag, error) {
+	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "list"), p)
+	if res, ok := got.([]*feature.Flag); ok {
+		return res, err
+	}
+	return nil, dispatchReturnError(got, err)
+}
+
+// Get returns a feature flag based on the feature.ID in params
+func (m FeatureFlagMethods) Get(ctx context.Context, p *feature.Flag) (*feature.Flag, error) {
+	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "get"), p)
+	if res, ok := got.(*feature.Flag); ok {
+		return res, err
+	}
+	return nil, dispatchReturnError(got, err)
+}
+
+// Put updates a feature flag based on the feature.ID and active status in params
+func (m FeatureFlagMethods) Put(ctx context.Context, p *feature.Flag) (*feature.Flag, error) {
+	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "put"), p)
+	if res, ok := got.(*feature.Flag); ok {
+		return res, err
+	}
+	return nil, dispatchReturnError(got, err)
+}
+
+// featureFlagsImpl holds the method implementations for FeatureFlagMethods
+type featureFlagsImpl struct{}
+
+// List returns a list of all the feature flags
+func (m featureFlagsImpl) List(scope scope, p *EmptyParams) ([]*feature.Flag, error) {
+	return scope.FeatureFlags().List(scope.Context())
+}
+
+// Get returns a feature flag based on the feature.ID in params
+func (m featureFlagsImpl) Get(scope scope, p *feature.Flag) (*feature.Flag, error) {
+	return scope.FeatureFlags().Get(scope.Context(), p.ID)
+}
+
+// Put updates a feature flag based on the feature.ID and active status in params
+func (m featureFlagsImpl) Put(scope scope, p *feature.Flag) (*feature.Flag, error) {
+	return scope.FeatureFlags().Put(scope.Context(), p)
+}

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -6,6 +6,7 @@ import (
 	"github.com/qri-io/qfs/muxfs"
 	"github.com/qri-io/qri/collection"
 	"github.com/qri-io/qri/config"
+	"github.com/qri-io/qri/config/feature"
 	"github.com/qri-io/qri/dscache"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
@@ -66,6 +67,11 @@ func (s *scope) ChangeConfig(ctg *config.Config) error {
 // Config returns the config
 func (s *scope) Config() *config.Config {
 	return s.inst.cfg
+}
+
+// FeatureFlags returns the instance FeatureFlags Store
+func (s *scope) FeatureFlags() feature.Store {
+	return s.inst.featureFlags
 }
 
 // Context returns the context for this scope. Though this pattern is usually discouraged,


### PR DESCRIPTION
Adding feature flags management to qri core. Cloud should reuse this with a different store backing it, and frontend should source flags from the `/config/flags` endpoint.