### PR TITLE
Support docs examples from source comments, add json struct tags to lib input parameters

### DIFF
--- a/docs/api_doc_template.yaml
+++ b/docs/api_doc_template.yaml
@@ -3,11 +3,19 @@ info:
   title: Qri API
   description: Qri API used to communicate with a Qri node.
   version: {{ .QriVersion }}
+tags:
+{{- range .MethodSets }}
+{{- if gt .MethodCount 0}}
+- name: {{ .Name }}
+  description: "{{ .Doc }}"
+{{ end -}}
+{{ end -}}
 paths:
 {{- range .LibMethods }}
 {{- if .Endpoint }}
   '{{ .Endpoint }}':
     {{ .HTTPVerb }}:
+{{ if .Doc }}      description: {{ .Doc }}{{end}}
       operationId: '{{ .MethodSet }}.{{ .MethodName }}'
       tags:
       - {{ .MethodSet }}
@@ -112,6 +120,7 @@ components:
 {{ if .TypeIsCommon }}          type: {{ .Type }}{{ end }}
 {{ if not .TypeIsCommon }}          type: object{{ end }}
 {{ if ne .Doc "" }}          description: "{{ .Doc }}"{{ end }}
+{{ if ne .Example "" }}          example: "{{ .Example }}"{{ end }}
 {{- end }}
 {{- end }}
 ### Response Schemas

--- a/docs/api_docs.go
+++ b/docs/api_docs.go
@@ -522,6 +522,12 @@ func parseFieldComment(f *ast.Field) (description, example string) {
 		return strs[0], ""
 	case 2:
 		example = strings.TrimSpace(strs[1])
+
+		if !strings.HasPrefix(example, "e.g.") {
+			fmt.Printf("example must start with 'e.g.', got %q\ncomment:\n%s\n", example, f.Doc.Text())
+			return strs[0], ""
+		}
+
 		example = strings.TrimPrefix(example, "e.g.")
 		example = strings.TrimSpace(example)
 		example = strings.Trim(example, `"`)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -43,7 +43,10 @@ func main() {
 	ctx := context.Background()
 
 	if httpAddr != "" {
-		serveDocs(ctx, httpAddr)
+		if err := serveDocs(ctx, httpAddr); err != nil {
+			panic(err)
+		}
+		return
 	}
 
 	// generate markdown filenames

--- a/lib/access.go
+++ b/lib/access.go
@@ -28,9 +28,12 @@ func (m AccessMethods) Attributes() map[string]AttributeSet {
 
 // CreateAuthTokenParams are input parameters for Access().CreateAuthToken
 type CreateAuthTokenParams struct {
-	GranteeUsername  string
-	GranteeProfileID string
-	TTL              time.Duration
+	// username to grant auth; e.g. "keyboard_cat"
+	GranteeUsername string `json:"granteeUsername"`
+	// profile Identifier to grant token for; e.g. "QmemJQrK7PTQvD3n8gmo9JhyaByyLmETiNR1Y8wS7hv4sP"
+	GranteeProfileID string `json:"granteeProfileID"`
+	// lifespan of token in nanoseconds; e.g. 2000000000000
+	TTL time.Duration `json:"ttl"`
 }
 
 // SetNonZeroDefaults uses default token time-to-live if one isn't set

--- a/lib/automation.go
+++ b/lib/automation.go
@@ -32,10 +32,10 @@ func (m AutomationMethods) Attributes() map[string]AttributeSet {
 
 // ApplyParams are parameters for the apply command
 type ApplyParams struct {
-	Ref       string
-	Transform *dataset.Transform
-	Secrets   map[string]string
-	Wait      bool
+	Ref       string             `json:"ref"`
+	Transform *dataset.Transform `json:"transform"`
+	Secrets   map[string]string  `json:"secrets"`
+	Wait      bool               `json:"wait"`
 	// TODO(arqu): substitute with websockets when working over the wire
 	ScriptOutput io.Writer `json:"-"`
 }

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -224,9 +224,9 @@ func scriptFileSelection(ds *dataset.Dataset, selector string) (qfs.File, bool) 
 // ActivityParams defines parameters for the Activity method
 type ActivityParams struct {
 	ListParams
-	// Reference to data to fetch history for; eg b5/world_bank_population
+	// Reference to data to fetch history for; e.g. "b5/world_bank_population"
 	Ref string `json:"ref"`
-	// if true, pull any datasets that aren't stored locally; eg false
+	// if true, pull any datasets that aren't stored locally; e.g. false
 	Pull bool `json:"pull"`
 }
 
@@ -368,7 +368,7 @@ func (m DatasetMethods) Pull(ctx context.Context, p *PullParams) (*dataset.Datas
 
 // PushParams encapsulates parmeters for dataset publication
 type PushParams struct {
-	Ref    string `json:"ref" schema:"ref" `
+	Ref    string `json:"ref" schema:"ref"`
 	Remote string `json:"remote"`
 	// All indicates all versions of a dataset and the dataset namespace should
 	// be either published or removed
@@ -588,7 +588,7 @@ type RenderParams struct {
 	Dataset *dataset.Dataset `json:"dataset"`
 	// Optional template override
 	Template []byte `json:"template"`
-	// If true,
+	// TODO (b5): investigate if this field is still in use
 	UseFSI bool `json:"useFSI"`
 	// Output format. defaults to "html"
 	Format string `json:"format"`

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -224,9 +224,10 @@ func scriptFileSelection(ds *dataset.Dataset, selector string) (qfs.File, bool) 
 // ActivityParams defines parameters for the Activity method
 type ActivityParams struct {
 	ListParams
-	// Reference to data to fetch history for
-	Ref  string
-	Pull bool
+	// Reference to data to fetch history for; eg b5/world_bank_population
+	Ref string `json:"ref"`
+	// if true, pull any datasets that aren't stored locally; eg false
+	Pull bool `json:"pull"`
 }
 
 // Activity returns the activity and changes for a given dataset
@@ -244,18 +245,18 @@ type SaveParams struct {
 	// supplied by dataset
 	Dataset *dataset.Dataset
 
-	// dataset reference string, the name to save to
-	Ref string
-	// commit title, defaults to a generated string based on diff
-	Title string
-	// commit message, defaults to blank
+	// dataset reference string, the name to save to; e.g. "b5/world_bank_population"
+	Ref string `json:"ref"`
+	// commit title, defaults to a generated string based on diff; e.g. "update dataset meta"
+	Title string `json:"title"`
+	// commit message, defaults to blank; e.g. "reaname title & fill in supported langages"
 	Message string
 	// path to body data
-	BodyPath string `qri:"fspath"`
+	BodyPath string `json:"bodyPath" qri:"fspath"`
 	// absolute path or URL to the list of dataset files or components to load
-	FilePaths []string `qri:"fspath"`
-	// secrets for transform execution
-	Secrets map[string]string
+	FilePaths []string `json:"filePaths" qri:"fspath"`
+	// secrets for transform execution. Should be a set of key: value pairs
+	Secrets map[string]string `json:"secrets"`
 	// optional writer to have transform script record standard output to
 	// note: this won't work over RPC, only on local calls
 	ScriptOutput io.Writer `json:"-"`
@@ -264,23 +265,23 @@ type SaveParams struct {
 	// and return events on the bus that provide the progress of the save operation
 
 	// Apply runs a transform script to create the next version to save
-	Apply bool
+	Apply bool `json:"apply"`
 	// Replace writes the entire given dataset as a new snapshot instead of
 	// applying save params as augmentations to the existing history
-	Replace bool
+	Replace bool `json:"replace"`
 	// option to make dataset private. private data is not currently implimented,
 	// see https://github.com/qri-io/qri/issues/291 for updates
-	Private bool
+	Private bool `json:"private"`
 	// if true, convert body to the format of the previous version, if applicable
-	ConvertFormatToPrev bool
+	ConvertFormatToPrev bool `json:"convertFormatToPrev"`
 	// comma separated list of component names to delete before saving
-	Drop string
+	Drop string `json:"drop"`
 	// force a new commit, even if no changes are detected
-	Force bool
+	Force bool `json:"force"`
 	// save a rendered version of the template along with the dataset
-	ShouldRender bool
+	ShouldRender bool `json:"shouldRender"`
 	// new dataset only, don't create a commit on an existing dataset, name will be unused
-	NewName bool
+	NewName bool `json:"newName"`
 }
 
 // SetNonZeroDefaults sets basic save path params to defaults
@@ -299,7 +300,8 @@ func (m DatasetMethods) Save(ctx context.Context, p *SaveParams) (*dataset.Datas
 
 // RenameParams defines parameters for Dataset renaming
 type RenameParams struct {
-	Current, Next string
+	Current string `json:"current"`
+	Next    string `json:"next"`
 }
 
 // Rename changes a user's given name for a dataset
@@ -313,18 +315,18 @@ func (m DatasetMethods) Rename(ctx context.Context, p *RenameParams) (*dsref.Ver
 
 // RemoveParams defines parameters for remove command
 type RemoveParams struct {
-	Ref       string
-	Revision  *dsref.Rev
-	KeepFiles bool
-	Force     bool
+	Ref       string     `json:"ref"`
+	Revision  *dsref.Rev `json:"revision"`
+	KeepFiles bool       `json:"keepFiles"`
+	Force     bool       `json:"force"`
 }
 
 // RemoveResponse gives the results of a remove
 type RemoveResponse struct {
-	Ref        string
-	NumDeleted int
-	Message    string
-	Unlinked   bool
+	Ref        string `json:"ref"`
+	NumDeleted int    `json:"numDeleted"`
+	Message    string `json:"message"`
+	Unlinked   bool   `json:"unlinked"`
 }
 
 // SetNonZeroDefaults assigns default values
@@ -348,9 +350,10 @@ func (m DatasetMethods) Remove(ctx context.Context, p *RemoveParams) (*RemoveRes
 
 // PullParams encapsulates parameters to the add command
 type PullParams struct {
-	Ref      string
-	LinkDir  string `qri:"fspath"`
-	LogsOnly bool   // only fetch logbook data
+	Ref     string `json:"ref"`
+	LinkDir string `json:"linkDir" qri:"fspath"`
+	// only fetch logbook data
+	LogsOnly bool `json:"logsOnly"`
 }
 
 // Pull downloads and stores an existing dataset to a peer's repository via
@@ -365,11 +368,11 @@ func (m DatasetMethods) Pull(ctx context.Context, p *PullParams) (*dataset.Datas
 
 // PushParams encapsulates parmeters for dataset publication
 type PushParams struct {
-	Ref    string `schema:"ref" json:"ref"`
-	Remote string
+	Ref    string `json:"ref" schema:"ref" `
+	Remote string `json:"remote"`
 	// All indicates all versions of a dataset and the dataset namespace should
 	// be either published or removed
-	All bool
+	All bool `json:"all"`
 }
 
 // Push posts a dataset version to a remote
@@ -383,18 +386,18 @@ func (m DatasetMethods) Push(ctx context.Context, p *PushParams) (*dsref.Ref, er
 
 // ValidateParams defines parameters for dataset data validation
 type ValidateParams struct {
-	Ref               string
-	BodyFilename      string `qri:"fspath"`
-	SchemaFilename    string `qri:"fspath"`
-	StructureFilename string `qri:"fspath"`
+	Ref               string `json:"ref"`
+	BodyFilename      string `json:"bodyFilename" qri:"fspath"`
+	SchemaFilename    string `json:"schemaFilename" qri:"fspath"`
+	StructureFilename string `json:"structureFilename" qri:"fspath"`
 }
 
 // ValidateResponse is the result of running validate against a dataset
 type ValidateResponse struct {
 	// Structure used to perform validation
-	Structure *dataset.Structure
+	Structure *dataset.Structure `json:"structure"`
 	// Validation Errors
-	Errors []jsonschema.KeyError
+	Errors []jsonschema.KeyError `json:"errors"`
 }
 
 // Validate gives a dataset of errors and issues for a given dataset
@@ -408,7 +411,7 @@ func (m DatasetMethods) Validate(ctx context.Context, p *ValidateParams) (*Valid
 
 // ManifestParams encapsulates parameters to the manifest command
 type ManifestParams struct {
-	Ref string
+	Ref string `json:"ref"`
 }
 
 // Manifest generates a manifest for a dataset path
@@ -422,7 +425,7 @@ func (m DatasetMethods) Manifest(ctx context.Context, p *ManifestParams) (*dag.M
 
 // ManifestMissingParams encapsulates parameters to the missing manifest command
 type ManifestMissingParams struct {
-	Manifest *dag.Manifest
+	Manifest *dag.Manifest `json:"manifest"`
 }
 
 // ManifestMissing generates a manifest of blocks that are not present on this repo for a given manifest
@@ -436,8 +439,8 @@ func (m DatasetMethods) ManifestMissing(ctx context.Context, p *ManifestMissingP
 
 // DAGInfoParams defines parameters for the DAGInfo method
 type DAGInfoParams struct {
-	Ref   string
-	Label string
+	Ref   string `json:"ref"`
+	Label string `json:"label"`
 }
 
 // DAGInfo generates a dag.Info for a dataset path. If a label is given, DAGInfo will generate a sub-dag.Info at that label.
@@ -582,13 +585,13 @@ type RenderParams struct {
 	Ref string `json:"ref"`
 	// Optionally pass an entire dataset in for rendering, if providing a dataset,
 	// the Ref field must be empty
-	Dataset *dataset.Dataset
+	Dataset *dataset.Dataset `json:"dataset"`
 	// Optional template override
-	Template []byte
+	Template []byte `json:"template"`
 	// If true,
-	UseFSI bool
+	UseFSI bool `json:"useFSI"`
 	// Output format. defaults to "html"
-	Format string
+	Format string `json:"format"`
 	// Selector
 	Selector string `json:"selector"`
 }

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -43,22 +43,22 @@ func (m FSIMethods) Attributes() map[string]AttributeSet {
 
 // LinkParams encapsulate parameters for linked datasets
 type LinkParams struct {
-	Dir string `qri:"fspath"`
-	Ref string
+	Dir string `json:"dir" qri:"fspath"`
+	Ref string `json:"ref"`
 }
 
 // FSIWriteParams encapsultes arguments for writing to an FSI-linked directory
 type FSIWriteParams struct {
-	Ref     string
-	Dataset *dataset.Dataset
+	Ref     string           `json:"ref"`
+	Dataset *dataset.Dataset `json:"dataset"`
 }
 
 // RestoreParams provides parameters to the restore method.
 type RestoreParams struct {
-	Dir      string `qri:"fspath"`
-	Ref      string
-	Version  string
-	Selector string
+	Dir      string `json:"dir" qri:"fspath"`
+	Ref      string `json:"ref"`
+	Version  string `json:"version"`
+	Selector string `json:"selector"`
 }
 
 // InitDatasetParams proxies parameters to initialization

--- a/lib/params.go
+++ b/lib/params.go
@@ -28,18 +28,18 @@ type NZDefaultSetter interface {
 // TODO - rename this to PageParams.
 type ListParams struct {
 	ProfileID profile.ID `json:"-"`
-	Term      string
-	Username  string
-	OrderBy   string
-	Limit     int
-	Offset    int
+	Term      string     `json:"term"`
+	Username  string     `json:"username"`
+	OrderBy   string     `json:"orderBy"`
+	Limit     int        `json:"limit"`
+	Offset    int        `json:"offset"`
 	// Public only applies to listing datasets, shows only datasets that are
 	// set to visible
-	Public bool
+	Public bool `json:"public"`
 	// ShowNumVersions only applies to listing datasets
-	ShowNumVersions bool
+	ShowNumVersions bool `json:"showNumVersions"`
 	// EnsureFSIExists controls whether to ensure references in the repo have correct FSIPaths
-	EnsureFSIExists bool
+	EnsureFSIExists bool `json:"ensureFSIExists"`
 }
 
 // SetNonZeroDefaults sets OrderBy to "created" if it's value is the empty string

--- a/lib/peers.go
+++ b/lib/peers.go
@@ -37,10 +37,11 @@ func (m PeerMethods) Attributes() map[string]AttributeSet {
 
 // PeerListParams defines parameters for the List method
 type PeerListParams struct {
-	Limit, Offset int
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
 	// Cached == true will return offline peers from the repo
 	// as well as online peers, default is to list connected peers only
-	Cached bool
+	Cached bool `json:"cached"`
 }
 
 // List lists Peers on the qri network
@@ -54,10 +55,10 @@ func (m PeerMethods) List(ctx context.Context, p *PeerListParams) ([]*config.Pro
 
 // PeerInfoParams defines parameters for the Info method
 type PeerInfoParams struct {
-	Peername  string
-	ProfileID string
+	Peername  string `json:"peername"`
+	ProfileID string `json:"profileID"`
 	// Verbose adds network details from the p2p Peerstore
-	Verbose bool
+	Verbose bool `json:"verbose"`
 }
 
 // Info shows peer profile details
@@ -86,8 +87,8 @@ func (m PeerMethods) Disconnect(ctx context.Context, p *ConnectParamsPod) error 
 
 // ConnectionsParams defines parameters for the Connections method
 type ConnectionsParams struct {
-	Limit  int
-	Offset int
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
 }
 
 // Connections lists PeerID's we're currently connected to. If running
@@ -112,10 +113,10 @@ func (m PeerMethods) ConnectedQriProfiles(ctx context.Context, p *ConnectionsPar
 // ConnectParamsPod defines parameters for defining a connection
 // to a peer as plain-old-data
 type ConnectParamsPod struct {
-	Peername  string
-	ProfileID string
-	NetworkID string
-	Multiaddr string
+	Peername  string `json:"peername"`
+	ProfileID string `json:"profileID"`
+	NetworkID string `json:"networkID"`
+	Multiaddr string `json:"multiaddr"`
 }
 
 // NewConnectParamsPod attempts to turn a string into peer connection parameters

--- a/lib/profile.go
+++ b/lib/profile.go
@@ -51,7 +51,7 @@ func (m ProfileMethods) GetProfile(ctx context.Context, p *ProfileParams) (*conf
 // SetProfileParams defines parameters for setting parts of a profile
 // Cannot use this to set private keys, your peername, or peer id
 type SetProfileParams struct {
-	Pro *config.ProfilePod
+	Pro *config.ProfilePod `json:"pro"`
 }
 
 // SetProfile stores changes to the active peer's editable profile
@@ -69,9 +69,9 @@ type FileParams struct {
 	// url to download data from. either Url or Data is required
 	// Url      string
 	// Filename of data file. extension is used for filetype detection
-	Filename string `qri:"fspath"`
+	Filename string `json:"filename" qri:"fspath"`
 	// Data is the file as slice of bytes
-	Data []byte
+	Data []byte `json:"data"`
 }
 
 // SetProfilePhoto changes the active peer's profile image

--- a/lib/remote.go
+++ b/lib/remote.go
@@ -44,7 +44,7 @@ func (m RemoteMethods) Feeds(ctx context.Context, p *EmptyParams) (map[string][]
 
 // PreviewParams provides arguments to the preview method
 type PreviewParams struct {
-	Ref string
+	Ref string `json:"ref"`
 }
 
 // Preview requests a dataset preview from a remote

--- a/lib/sql.go
+++ b/lib/sql.go
@@ -24,8 +24,8 @@ func (m SQLMethods) Attributes() map[string]AttributeSet {
 
 // SQLQueryParams defines paremeters for running a SQL query
 type SQLQueryParams struct {
-	Query  string
-	Format string
+	Query  string `json:"query"`
+	Format string `json:"format"`
 }
 
 // SetNonZeroDefaults sets format to "json" if it's value is an empty string


### PR DESCRIPTION
see docs by navigating to project root & running `make serve-api-docs`, then load `http://localhost:2502` in a browser.

after this PR, comments in the lib package have two new rules:
* comments can have at most one semicolon, which separates comments into `[description];[example]` sections
* a single example value is now supported when prefixed with 'e.g.', example values should match their syntax type (string examples should be "quoted", boolean examples should be true, numeric should be 2.145)

note that _only_ `e.g.` will work to create an example, not `eg.`, which I continually mistype

I also put these new changes to immediate use, annotating a slew of input structs with JSON tags to clean up their documentation & narrow field name case sensitivity