### PR TITLE
feat(resolver): resolving a reference w an initID completes the ref

### DIFF
--- a/base/dataset_prepare.go
+++ b/base/dataset_prepare.go
@@ -117,11 +117,10 @@ func PrepareSaveRef(
 // use. Generated names start with _2, implying the "_1" file is the original
 // no-suffix name.
 func GenerateAvailableName(ctx context.Context, pro *profile.Profile, resolver dsref.Resolver, prefix string) string {
-	lookup := &dsref.Ref{Username: pro.Peername, Name: prefix}
 	counter := 1
 	for {
 		counter++
-		lookup.Name = fmt.Sprintf("%s_%d", prefix, counter)
+		lookup := &dsref.Ref{Username: pro.Peername, Name: fmt.Sprintf("%s_%d", prefix, counter)}
 		if _, err := resolver.ResolveRef(ctx, lookup); errors.Is(err, dsref.ErrRefNotFound) {
 			return lookup.Name
 		}

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -410,62 +410,76 @@ func TestSaveInferName(t *testing.T) {
 	}
 
 	// Save again, get an error because the inferred name already exists.
-	err := run.ExecCommand("qri save --body testdata/movies/body_four.json")
-	expectErr := `inferred dataset name already exists. To add a new commit to this dataset, run save again with the dataset reference "test_peer_save_infer_name/body_four". To create a new dataset, use --new flag`
-	if err == nil {
-		t.Errorf("error expected, did not get one")
-	}
-	if diff := cmp.Diff(expectErr, errorMessage(err)); diff != "" {
-		t.Errorf("result mismatch (-want +got):%s\n", diff)
-	}
+	t.Run("second_save_name_error", func(t *testing.T) {
+		err := run.ExecCommand("qri save --body testdata/movies/body_four.json")
+		expectErr := `inferred dataset name already exists. To add a new commit to this dataset, run save again with the dataset reference "test_peer_save_infer_name/body_four". To create a new dataset, use --new flag`
+		if err == nil {
+			t.Errorf("error expected, did not get one")
+		}
+		if diff := cmp.Diff(expectErr, errorMessage(err)); diff != "" {
+			t.Errorf("result mismatch (-want +got):%s\n", diff)
+		}
+	})
 
 	// Save but ensure a new dataset is created.
-	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/body_four.json --new")
-	actual = parseDatasetRefFromOutput(output)
-	expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/body_four_2@{{ .path2 }}\n", tmplData)
-	if diff := cmp.Diff(expect, actual); diff != "" {
-		t.Errorf("result mismatch (-want +got):%s\n", diff)
-	}
+	t.Run("save_expect_new", func(t *testing.T) {
+		output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/body_four.json --new")
+		actual = parseDatasetRefFromOutput(output)
+		expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/body_four_2@{{ .path2 }}\n", tmplData)
+		if diff := cmp.Diff(expect, actual); diff != "" {
+			t.Errorf("result mismatch (-want +got):%s\n", diff)
+		}
+	})
 
 	// Save once again.
-	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/body_four.json --new")
-	actual = parseDatasetRefFromOutput(output)
-	expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/body_four_3@{{ .path3 }}\n", tmplData)
-	if diff := cmp.Diff(expect, actual); diff != "" {
-		t.Errorf("result mismatch (-want +got):%s\n", diff)
-	}
+	t.Run("save_expect_new_again", func(t *testing.T) {
+		output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/body_four.json --new")
+		actual = parseDatasetRefFromOutput(output)
+		expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/body_four_3@{{ .path3 }}\n", tmplData)
+		if diff := cmp.Diff(expect, actual); diff != "" {
+			t.Errorf("result mismatch (-want +got):%s\n", diff)
+		}
+	})
 
 	// Save a dataset whose body filename starts with a number
-	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/2018_winners.csv")
-	actual = parseDatasetRefFromOutput(output)
-	expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/dataset_2018_winners@{{ .path4 }}\n", tmplData)
-	if diff := cmp.Diff(expect, actual); diff != "" {
-		t.Errorf("result mismatch (-want +got):%s\n", diff)
-	}
+	t.Run("save_body_file_starts_with_number", func(t *testing.T) {
+		output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/2018_winners.csv")
+		actual = parseDatasetRefFromOutput(output)
+		expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/dataset_2018_winners@{{ .path4 }}\n", tmplData)
+		if diff := cmp.Diff(expect, actual); diff != "" {
+			t.Errorf("result mismatch (-want +got):%s\n", diff)
+		}
+	})
 
 	// Save a dataset whose body filename is non-alphabetic
-	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/2015-09-16--2016-09-30.csv")
-	actual = parseDatasetRefFromOutput(output)
-	expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/dataset_2015-09-16--2016-09-30@{{ .path5 }}\n", tmplData)
-	if diff := cmp.Diff(expect, actual); diff != "" {
-		t.Errorf("result mismatch (-want +got):%s\n", diff)
-	}
+	t.Run("save_non_alpha_name", func(t *testing.T) {
+		output = run.MustExecCombinedOutErr(t, "qri save --body testdata/2015-09-16--2016-09-30.csv")
+		actual = parseDatasetRefFromOutput(output)
+		expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/dataset_2015-09-16--2016-09-30@{{ .path5 }}\n", tmplData)
+		if diff := cmp.Diff(expect, actual); diff != "" {
+			t.Errorf("result mismatch (-want +got):%s\n", diff)
+		}
+	})
 
 	// Save using a CamelCased body filename
-	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/TenMoviesAndLengths.csv")
-	actual = parseDatasetRefFromOutput(output)
-	expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/ten_movies_and_lengths@{{ .path6 }}\nthis dataset has 1 validation errors\n", tmplData)
-	if diff := cmp.Diff(expect, actual); diff != "" {
-		t.Errorf("result mismatch (-want +got):%s\n", diff)
-	}
+	t.Run("save_camel_case_body", func(t *testing.T) {
+		output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/TenMoviesAndLengths.csv")
+		actual = parseDatasetRefFromOutput(output)
+		expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/ten_movies_and_lengths@{{ .path6 }}\nthis dataset has 1 validation errors\n", tmplData)
+		if diff := cmp.Diff(expect, actual); diff != "" {
+			t.Errorf("result mismatch (-want +got):%s\n", diff)
+		}
+	})
 
 	// Save using a body filename that contains unicode
-	output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/pira\u00f1a_data.csv")
-	actual = parseDatasetRefFromOutput(output)
-	expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/pirana_data@{{ .path7 }}\n", tmplData)
-	if diff := cmp.Diff(expect, actual); diff != "" {
-		t.Errorf("result mismatch (-want +got):%s\n", diff)
-	}
+	t.Run("save_with_unicode_body", func(t *testing.T) {
+		output = run.MustExecCombinedOutErr(t, "qri save --body testdata/movies/pira\u00f1a_data.csv")
+		actual = parseDatasetRefFromOutput(output)
+		expect = dstest.Template(t, "dataset saved: test_peer_save_infer_name/pirana_data@{{ .path7 }}\n", tmplData)
+		if diff := cmp.Diff(expect, actual); diff != "" {
+			t.Errorf("result mismatch (-want +got):%s\n", diff)
+		}
+	})
 }
 
 func TestSaveFilenameUsedForCommitMessage(t *testing.T) {

--- a/dsref/mem_resolver.go
+++ b/dsref/mem_resolver.go
@@ -48,6 +48,10 @@ func (m *MemResolver) ResolveRef(ctx context.Context, ref *Ref) (string, error) 
 		return "", ErrRefNotFound
 	}
 
+	if ref.InitID != "" {
+		return m.completeRef(ctx, ref)
+	}
+
 	id := m.RefMap[ref.Alias()]
 	resolved, ok := m.IDMap[id]
 	if !ok {
@@ -60,5 +64,18 @@ func (m *MemResolver) ResolveRef(ctx context.Context, ref *Ref) (string, error) 
 		ref.Path = resolved.Path
 	}
 
+	return "", nil
+}
+
+func (m *MemResolver) completeRef(ctx context.Context, ref *Ref) (string, error) {
+	info, ok := m.IDMap[ref.InitID]
+	if !ok {
+		return "", ErrRefNotFound
+	}
+
+	ref.ProfileID = info.ProfileID
+	ref.Path = info.Path
+	ref.Username = info.Username
+	ref.Name = info.Name
 	return "", nil
 }

--- a/dsref/spec/resolve.go
+++ b/dsref/spec/resolve.go
@@ -150,30 +150,44 @@ func AssertResolverSpec(t *testing.T, r dsref.Resolver, putFunc PutRefFunc) {
 		// 	t.Errorf("provided InitID result mismatch. (-want +got):\n%s", diff)
 		// }
 
-		// // TODO(b5): not yet enforced by this test yet, but providing just an initID
-		// // MUST populate the alias (human side) of a reference.
-		// resolveMe = dsref.Ref{
-		// 	InitID: initID,
-		// }
+		// providing just an initID MUST populate the alias (human side) of a
+		// reference.
+		resolveMe = dsref.Ref{
+			InitID: initID,
 
-		// expectRef = dsref.Ref{
-		// 	Username:  username,
-		// 	Name:      dsname,
-		// 	ProfileID: pubKeyID,
-		// 	Path:      headPath,
-		// 	InitID:    initID,
-		// }
+			// erroneous fields need to be be overwritten
+			Username: "no not good",
+			Name:     "incorrect",
+			Path:     "nope_not_right",
+		}
 
-		// _, err = r.ResolveRef(ctx, &resolveMe)
-		// if err != nil {
-		// 	t.Error(err)
-		// }
-		// if resolveMe.InitID != expectRef.InitID {
-		// 	t.Errorf("providing InitID-only result mismatch. want: %q\ngot:  %q", expectRef.InitID, resolveMe.InitID)
-		// }
-		// if diff := cmp.Diff(expectRef, resolveMe); diff != "" {
-		// 	t.Errorf("provided InitID-only result mismatch. (-want +got):\n%s", diff)
-		// }
+		expectRef = dsref.Ref{
+			Username:  username,
+			Name:      dsname,
+			ProfileID: pubKeyID,
+			Path:      headPath,
+			InitID:    initID,
+		}
+
+		_, err = r.ResolveRef(ctx, &resolveMe)
+		if err != nil {
+			t.Error(err)
+		}
+		if resolveMe.InitID != expectRef.InitID {
+			t.Errorf("providing InitID-only result mismatch. want: %q\ngot:  %q", expectRef.InitID, resolveMe.InitID)
+		}
+		if diff := cmp.Diff(expectRef, resolveMe); diff != "" {
+			t.Errorf("provided InitID-only result mismatch. (-want +got):\n%s", diff)
+		}
+
+		// providing a missing initID MUST return ErrRefNotFound or a wrap thereof
+		resolveMe = dsref.Ref{
+			InitID: "nope_not_here",
+		}
+
+		if _, err = r.ResolveRef(ctx, &resolveMe); !errors.Is(err, dsref.ErrRefNotFound) {
+			t.Errorf("resolving a missing initID must return ErrRefNotFound or a wrap thereof.\ngot: %s", err)
+		}
 
 		// TODO(b5): need to add a test that confirms ResolveRef CANNOT return
 		// paths outside of logbook HEAD. Subsystems that store references to

--- a/remote/client.go
+++ b/remote/client.go
@@ -343,6 +343,7 @@ func resolveRefHTTP(ctx context.Context, ref *dsref.Ref, remoteAddr string) erro
 	u.Path = "/remote/refs"
 
 	q := u.Query()
+	q.Set("initid", ref.InitID)
 	q.Set("username", ref.Username)
 	q.Set("name", ref.Name)
 	q.Set("path", ref.Path)

--- a/remote/server.go
+++ b/remote/server.go
@@ -677,6 +677,7 @@ func (r *Server) RefsHTTPHandler() http.HandlerFunc {
 		switch req.Method {
 		case "GET":
 			ref := &dsref.Ref{
+				InitID:   req.FormValue("initid"),
 				Username: req.FormValue("username"),
 				Name:     req.FormValue("name"),
 				Path:     req.FormValue("path"),

--- a/repo/fs/fs.go
+++ b/repo/fs/fs.go
@@ -104,6 +104,16 @@ func (r *Repo) ResolveRef(ctx context.Context, ref *dsref.Ref) (string, error) {
 		return "", fmt.Errorf("cannot resolve local references without logbook")
 	}
 
+	if ref.InitID != "" {
+		res, err := r.logbook.Ref(ctx, ref.InitID)
+		if err != nil {
+			return "", err
+		}
+
+		*ref = res
+		return "", nil
+	}
+
 	// Preserve the input ref path, and convert to the old style dataset ref for repo.
 	origPath := ref.Path
 	datasetRef := reporef.DatasetRef{


### PR DESCRIPTION
adding in human elements like username & name, along with HEAD path. We need this now because the automation subsystem is the first one to properly store _just_ initIDs