### PR TITLE
feat(registry): refactoring registry, http, search & adding following

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -13,6 +13,7 @@ import (
 	apiutil "github.com/qri-io/qri/api/util"
 	"github.com/qri-io/qri/auth/token"
 	"github.com/qri-io/qri/lib"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/version"
 )
 
@@ -152,14 +153,14 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 // refRouteParams carry a config for a ref based route
 type refRouteParams struct {
-	Endpoint lib.APIEndpoint
+	Endpoint qhttp.APIEndpoint
 	ShortRef bool
 	Selector bool
 	Methods  []string
 }
 
 // newrefRouteParams is a shorthand to generate refRouteParams
-func newrefRouteParams(e lib.APIEndpoint, sr bool, sel bool, methods ...string) refRouteParams {
+func newrefRouteParams(e qhttp.APIEndpoint, sr bool, sel bool, methods ...string) refRouteParams {
 	return refRouteParams{
 		Endpoint: e,
 		ShortRef: sr,
@@ -236,17 +237,17 @@ func NewServerRoutes(s Server) *mux.Router {
 	// non POST/json dataset endpoints
 	m.Handle(AEGetCSVFullRef.String(), s.Middleware(GetBodyCSVHandler(s.Instance))).Methods(http.MethodGet)
 	m.Handle(AEGetCSVShortRef.String(), s.Middleware(GetBodyCSVHandler(s.Instance))).Methods(http.MethodGet)
-	routeParams = newrefRouteParams(lib.AEGet, false, true, http.MethodGet)
-	handleRefRoute(m, routeParams, s.Middleware(GetHandler(s.Instance, lib.AEGet.String())))
+	routeParams = newrefRouteParams(qhttp.AEGet, false, true, http.MethodGet)
+	handleRefRoute(m, routeParams, s.Middleware(GetHandler(s.Instance, qhttp.AEGet.String())))
 	m.Handle(AEUnpack.String(), s.Middleware(UnpackHandler(AEUnpack.NoTrailingSlash())))
 
 	// sync/protocol endpoints
 	if cfg.RemoteServer != nil && cfg.RemoteServer.Enabled {
 		log.Info("running in `remote` mode")
 
-		m.Handle(lib.AERemoteDSync.String(), s.Middleware(s.Instance.RemoteServer().DsyncHTTPHandler()))
-		m.Handle(lib.AERemoteLogSync.String(), s.Middleware(s.Instance.RemoteServer().LogsyncHTTPHandler()))
-		m.Handle(lib.AERemoteRefs.String(), s.Middleware(s.Instance.RemoteServer().RefsHTTPHandler()))
+		m.Handle(qhttp.AERemoteDSync.String(), s.Middleware(s.Instance.RemoteServer().DsyncHTTPHandler()))
+		m.Handle(qhttp.AERemoteLogSync.String(), s.Middleware(s.Instance.RemoteServer().LogsyncHTTPHandler()))
+		m.Handle(qhttp.AERemoteRefs.String(), s.Middleware(s.Instance.RemoteServer().RefsHTTPHandler()))
 	}
 
 	return m

--- a/api/auth.go
+++ b/api/auth.go
@@ -8,11 +8,12 @@ import (
 	"github.com/qri-io/qri/api/util"
 	"github.com/qri-io/qri/auth/token"
 	"github.com/qri-io/qri/lib"
+	qhttp "github.com/qri-io/qri/lib/http"
 )
 
 const (
 	// AEToken is the token provider endpoint
-	AEToken = lib.APIEndpoint("/oauth/token")
+	AEToken qhttp.APIEndpoint = "/oauth/token"
 )
 
 // TokenHandler is a handler to authenticate and generate access & refresh tokens

--- a/api/context.go
+++ b/api/context.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/qri-io/qri/dsref"
-	"github.com/qri-io/qri/lib"
+	qhttp "github.com/qri-io/qri/lib/http"
 	reporef "github.com/qri-io/qri/repo/ref"
 )
 
@@ -28,7 +28,7 @@ func DatasetRefFromReq(r *http.Request) (dsref.Ref, error) {
 	if r.URL.String() == "" || r.URL.Path == "" {
 		return dsref.Ref{}, nil
 	}
-	return lib.DsRefFromPath(r.URL.Path)
+	return qhttp.DsRefFromPath(r.URL.Path)
 }
 
 // DatasetRefFromCtx extracts a Dataset reference from a given

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -1,27 +1,27 @@
 package api
 
 import (
-	"github.com/qri-io/qri/lib"
+	qhttp "github.com/qri-io/qri/lib/http"
 )
 
 const (
 	// base endpoints
 
 	// AEHome is the / endpoint
-	AEHome = lib.APIEndpoint("/")
+	AEHome qhttp.APIEndpoint = "/"
 	// AEHealth is the service health check endpoint
-	AEHealth = lib.APIEndpoint("/health")
+	AEHealth qhttp.APIEndpoint = "/health"
 	// AEIPFS is the IPFS endpoint
-	AEIPFS = lib.APIEndpoint("/qfs/ipfs/{path:.*}")
+	AEIPFS qhttp.APIEndpoint = "/qfs/ipfs/{path:.*}"
 	// AEWebUI serves the remote WebUI
-	AEWebUI = lib.APIEndpoint("/webui")
+	AEWebUI qhttp.APIEndpoint = "/webui"
 
 	// dataset endpoints
 
 	// AEGetCSVFullRef is the route used to get a body as a csv, that can also handle a specific hash
-	AEGetCSVFullRef = lib.APIEndpoint("/ds/get/{username}/{name}/at/{fs}/{hash}/body.csv")
+	AEGetCSVFullRef qhttp.APIEndpoint = "/ds/get/{username}/{name}/at/{fs}/{hash}/body.csv"
 	// AEGetCSVShortRef is the route used to get a body as a csv
-	AEGetCSVShortRef = lib.APIEndpoint("/ds/get/{username}/{name}/body.csv")
+	AEGetCSVShortRef qhttp.APIEndpoint = "/ds/get/{username}/{name}/body.csv"
 	// AEUnpack unpacks a zip file and sends it back
-	AEUnpack = lib.APIEndpoint("/ds/unpack")
+	AEUnpack qhttp.APIEndpoint = "/ds/unpack"
 )

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
 	"github.com/qri-io/qri/lib"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo/test"
 )
@@ -69,7 +70,7 @@ func TestHTTPClient(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	httpClient, err := lib.NewHTTPClient(cfg.API.Address)
+	httpClient, err := qhttp.NewClient(cfg.API.Address)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -78,13 +79,13 @@ func TestHTTPClient(t *testing.T) {
 	httpClient.Address = sURL.Host
 	httpClient.Protocol = "http"
 
-	if err = httpClient.CallRaw(ctx, AEHome, "", nil, &bytes.Buffer{}); err != nil {
+	if err = httpClient.CallRaw(ctx, AEHome.String(), "", nil, &bytes.Buffer{}); err != nil {
 		t.Fatal(err.Error())
 	}
 
 	res := []dsref.VersionInfo{}
 	p := lib.ListParams{}
-	err = httpClient.CallMethod(ctx, lib.AEList, http.MethodPost, "", p, &res)
+	err = httpClient.CallMethod(ctx, lib.AEList.String(), http.MethodPost, "", p, &res)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -79,13 +79,13 @@ func TestHTTPClient(t *testing.T) {
 	httpClient.Address = sURL.Host
 	httpClient.Protocol = "http"
 
-	if err = httpClient.CallRaw(ctx, AEHome.String(), "", nil, &bytes.Buffer{}); err != nil {
+	if err = httpClient.CallRaw(ctx, AEHome, "", nil, &bytes.Buffer{}); err != nil {
 		t.Fatal(err.Error())
 	}
 
 	res := []dsref.VersionInfo{}
 	p := lib.ListParams{}
-	err = httpClient.CallMethod(ctx, lib.AEList.String(), http.MethodPost, "", p, &res)
+	err = httpClient.CallMethod(ctx, qhttp.AEList, http.MethodPost, "", p, &res)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/qri-io/ioes"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/lib"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/spf13/cobra"
 )
 
@@ -157,7 +158,7 @@ func (o *ConfigOptions) Get(args []string) (err error) {
 
 	data, err := o.inst.Config().GetConfig(ctx, params)
 	if err != nil {
-		if errors.Is(err, lib.ErrUnsupportedRPC) {
+		if errors.Is(err, qhttp.ErrUnsupportedRPC) {
 			return fmt.Errorf("%w - this could mean you're running qri connect in another terminal or application", err)
 		}
 		return err
@@ -199,7 +200,7 @@ func (o *ConfigOptions) Set(args []string) (err error) {
 		if photoPaths[path] {
 			profileMethods := o.inst.Profile()
 			if err = setPhotoPath(ctx, &profileMethods, path, args[i+1]); err != nil {
-				if errors.Is(err, lib.ErrUnsupportedRPC) {
+				if errors.Is(err, qhttp.ErrUnsupportedRPC) {
 					return fmt.Errorf("%w - this could mean you're running qri connect in another terminal or application", err)
 				}
 				return err
@@ -218,14 +219,14 @@ func (o *ConfigOptions) Set(args []string) (err error) {
 		}
 	}
 	if _, err := o.inst.Config().SetConfig(ctx, o.inst.GetConfig()); err != nil {
-		if errors.Is(err, lib.ErrUnsupportedRPC) {
+		if errors.Is(err, qhttp.ErrUnsupportedRPC) {
 			return fmt.Errorf("%w - this could mean you're running qri connect in another terminal or application", err)
 		}
 		return err
 	}
 	if profileChanged {
 		if _, err = o.inst.Profile().SetProfile(ctx, &lib.SetProfileParams{Pro: profile}); err != nil {
-			if errors.Is(err, lib.ErrUnsupportedRPC) {
+			if errors.Is(err, qhttp.ErrUnsupportedRPC) {
 				return fmt.Errorf("%w - this could mean you're running qri connect in another terminal or application", err)
 			}
 			return err

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/qri-io/qri/auth/key"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/lib"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/p2p"
 )
 
@@ -22,7 +23,7 @@ type Factory interface {
 	CryptoGenerator() key.CryptoGenerator
 
 	Init() error
-	HTTPClient() *lib.HTTPClient
+	HTTPClient() *qhttp.Client
 	ConnectionNode() (*p2p.QriNode, error)
 }
 

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -10,6 +10,7 @@ import (
 	testcfg "github.com/qri-io/qri/config/test"
 	"github.com/qri-io/qri/event"
 	"github.com/qri-io/qri/lib"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/repo"
 	"github.com/qri-io/qri/repo/test"
@@ -128,6 +129,6 @@ func (t TestFactory) ConnectionNode() (*p2p.QriNode, error) {
 }
 
 // HTTPClient returns nil for tests
-func (t TestFactory) HTTPClient() *lib.HTTPClient {
+func (t TestFactory) HTTPClient() *qhttp.Client {
 	return nil
 }

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -54,7 +54,7 @@ func TestPush(t *testing.T) {
 	if len(results) != 1 {
 		t.Errorf("expected: 1 result, got %d results", len(results))
 	}
-	if results[0].Name != "one_ds" {
-		t.Errorf("expected: dataset named \"one_ds\", got %q", results[0].Name)
+	if results[0].Value.Name != "one_ds" {
+		t.Errorf("expected: dataset named \"one_ds\", got %q", results[0].Value.Name)
 	}
 }

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -13,6 +13,7 @@ import (
 	"github.com/qri-io/qri/auth/key"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/lib"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/remote"
 	"github.com/qri-io/qri/remote/access"
@@ -225,7 +226,7 @@ func (o *QriOptions) CryptoGenerator() key.CryptoGenerator {
 }
 
 // HTTPClient returns a client for performing RPC over HTTP
-func (o *QriOptions) HTTPClient() *lib.HTTPClient {
+func (o *QriOptions) HTTPClient() *qhttp.Client {
 	if err := o.Init(); err != nil {
 		return nil
 	}

--- a/cmd/stringers.go
+++ b/cmd/stringers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
+	"github.com/qri-io/qri/registry"
 	reporef "github.com/qri-io/qri/repo/ref"
 )
 
@@ -151,7 +152,7 @@ func (vis versionInfoStringer) String() string {
 	return w.String()
 }
 
-type searchResultStringer lib.SearchResult
+type searchResultStringer registry.SearchResult
 
 func (r searchResultStringer) String() string {
 	w := &strings.Builder{}

--- a/docs/api_docs.go
+++ b/docs/api_docs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/qri-io/qri/api"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/version"
+	qhttp "github.com/qri-io/qri/lib/http"
 )
 
 type docs struct {
@@ -38,7 +39,7 @@ type libMethod struct {
 	MethodName string
 	Doc        string
 	Params     qriType
-	Endpoint   lib.APIEndpoint
+	Endpoint   qhttp.APIEndpoint
 	HTTPVerb   string
 	Response   response
 	Paginated  bool
@@ -134,7 +135,7 @@ func OpenAPIYAML() (*bytes.Buffer, error) {
 			}
 
 			attrs := methodAttributes[strings.ToLower(i.Name)]
-			if attrs.Endpoint == lib.DenyHTTP {
+			if attrs.Endpoint == qhttp.DenyHTTP {
 				continue
 			}
 
@@ -351,7 +352,7 @@ func addNonLibMethods(methods []libMethod) []libMethod {
 	m = libMethod{
 		MethodSet:  "api",
 		MethodName: "get_ref",
-		Endpoint:   lib.APIEndpoint(fmt.Sprintf("%s/{dsref}", lib.AEGet)),
+		Endpoint:   qhttp.APIEndpoint(fmt.Sprintf("%s/{dsref}", qhttp.AEGet)),
 		HTTPVerb:   "get",
 		Params: qriType{
 			Name: "pathParams",
@@ -370,7 +371,7 @@ func addNonLibMethods(methods []libMethod) []libMethod {
 	m = libMethod{
 		MethodSet:  "api",
 		MethodName: "get_ref_selector",
-		Endpoint:   lib.APIEndpoint(fmt.Sprintf("%s/{dsref}/{selector}", lib.AEGet)),
+		Endpoint:   qhttp.APIEndpoint(fmt.Sprintf("%s/{dsref}/{selector}", qhttp.AEGet)),
 		HTTPVerb:   "get",
 		Params: qriType{
 			Name: "pathParams",

--- a/lib/access.go
+++ b/lib/access.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/qri-io/qri/auth/token"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/profile"
 )
 
@@ -22,7 +23,7 @@ func (m AccessMethods) Name() string {
 // Attributes defines attributes for each method
 func (m AccessMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"createauthtoken": {Endpoint: AECreateAuthToken, HTTPVerb: "POST", DefaultSource: "local"},
+		"createauthtoken": {Endpoint: qhttp.AECreateAuthToken, HTTPVerb: "POST", DefaultSource: "local"},
 	}
 }
 

--- a/lib/api.go
+++ b/lib/api.go
@@ -118,6 +118,10 @@ const (
 	AERegistryProve = APIEndpoint("/remote/registry/profile/prove")
 	// AESearch returns a list of dataset search results
 	AESearch = APIEndpoint("/registry/search")
+	// AERegistryGetFollowing returns a list of datasets a user follows
+	AERegistryGetFollowing = APIEndpoint("/registry/follow/list")
+	// AERegistryFollow updates the follow status of the current user for a given dataset
+	AERegistryFollow = APIEndpoint("/registry/follow")
 
 	// fsi endpoints
 

--- a/lib/automation.go
+++ b/lib/automation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/transform"
 )
@@ -31,8 +32,8 @@ func (m AutomationMethods) Name() string {
 // Attributes defines attributes for each method
 func (m AutomationMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"apply":  {Endpoint: AEApply, HTTPVerb: "POST"},
-		"deploy": {Endpoint: AEDeploy, HTTPVerb: "POST"},
+		"apply":  {Endpoint: qhttp.AEApply, HTTPVerb: "POST"},
+		"deploy": {Endpoint: qhttp.AEDeploy, HTTPVerb: "POST"},
 	}
 }
 

--- a/lib/collection.go
+++ b/lib/collection.go
@@ -11,6 +11,7 @@ import (
 	"github.com/qri-io/qri/dscache/build"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/fsi/linkfile"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/profile"
 	reporef "github.com/qri-io/qri/repo/ref"
 )
@@ -33,8 +34,8 @@ func (m CollectionMethods) Name() string {
 // Attributes defines attributes for each method
 func (m CollectionMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"list":        {Endpoint: AEList, HTTPVerb: "POST"},
-		"listrawrefs": {Endpoint: DenyHTTP},
+		"list":        {Endpoint: qhttp.AEList, HTTPVerb: "POST"},
+		"listrawrefs": {Endpoint: qhttp.DenyHTTP},
 	}
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/qri-io/qri/config"
+	qhttp "github.com/qri-io/qri/lib/http"
 )
 
 // ConfigMethods encapsulates changes to a qri configuration
@@ -25,9 +26,9 @@ func (m ConfigMethods) Name() string {
 func (m ConfigMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
 		// config methods are not allowed over HTTP nor RPC
-		"getconfig":     {Endpoint: DenyHTTP},
-		"getconfigkeys": {Endpoint: DenyHTTP},
-		"setconfig":     {Endpoint: DenyHTTP},
+		"getconfig":     {Endpoint: qhttp.DenyHTTP},
+		"getconfigkeys": {Endpoint: qhttp.DenyHTTP},
+		"setconfig":     {Endpoint: qhttp.DenyHTTP},
 	}
 }
 

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -31,6 +31,7 @@ import (
 	qrierr "github.com/qri-io/qri/errors"
 	"github.com/qri-io/qri/event"
 	"github.com/qri-io/qri/fsi"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/remote"
 	"github.com/qri-io/qri/repo"
@@ -52,21 +53,21 @@ func (m DatasetMethods) Name() string {
 // Attributes defines attributes for each method
 func (m DatasetMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"componentstatus": {Endpoint: AEComponentStatus, HTTPVerb: "POST"},
-		"get":             {Endpoint: AEGet, HTTPVerb: "POST"},
-		"getcsv":          {Endpoint: DenyHTTP}, // getcsv is not part of the json api, but is handled in a separate `GetBodyCSVHandler` function
-		"getzip":          {Endpoint: DenyHTTP}, // getzip is not part of the json api, but is handled is a separate `GetHandler` function
-		"activity":        {Endpoint: AEActivity, HTTPVerb: "POST"},
-		"rename":          {Endpoint: AERename, HTTPVerb: "POST", DefaultSource: "local"},
-		"save":            {Endpoint: AESave, HTTPVerb: "POST"},
-		"pull":            {Endpoint: AEPull, HTTPVerb: "POST", DefaultSource: "network"},
-		"push":            {Endpoint: AEPush, HTTPVerb: "POST", DefaultSource: "local"},
-		"render":          {Endpoint: AERender, HTTPVerb: "POST"},
-		"remove":          {Endpoint: AERemove, HTTPVerb: "POST", DefaultSource: "local"},
-		"validate":        {Endpoint: AEValidate, HTTPVerb: "POST", DefaultSource: "local"},
-		"manifest":        {Endpoint: AEManifest, HTTPVerb: "POST", DefaultSource: "local"},
-		"manifestmissing": {Endpoint: AEManifestMissing, HTTPVerb: "POST", DefaultSource: "local"},
-		"daginfo":         {Endpoint: AEDAGInfo, HTTPVerb: "POST", DefaultSource: "local"},
+		"componentstatus": {Endpoint: qhttp.AEComponentStatus, HTTPVerb: "POST"},
+		"get":             {Endpoint: qhttp.AEGet, HTTPVerb: "POST"},
+		"getcsv":          {Endpoint: qhttp.DenyHTTP}, // getcsv is not part of the json api, but is handled in a separate `GetBodyCSVHandler` function
+		"getzip":          {Endpoint: qhttp.DenyHTTP}, // getzip is not part of the json api, but is handled is a separate `GetHandler` function
+		"activity":        {Endpoint: qhttp.AEActivity, HTTPVerb: "POST"},
+		"rename":          {Endpoint: qhttp.AERename, HTTPVerb: "POST", DefaultSource: "local"},
+		"save":            {Endpoint: qhttp.AESave, HTTPVerb: "POST"},
+		"pull":            {Endpoint: qhttp.AEPull, HTTPVerb: "POST", DefaultSource: "network"},
+		"push":            {Endpoint: qhttp.AEPush, HTTPVerb: "POST", DefaultSource: "local"},
+		"render":          {Endpoint: qhttp.AERender, HTTPVerb: "POST"},
+		"remove":          {Endpoint: qhttp.AERemove, HTTPVerb: "POST", DefaultSource: "local"},
+		"validate":        {Endpoint: qhttp.AEValidate, HTTPVerb: "POST", DefaultSource: "local"},
+		"manifest":        {Endpoint: qhttp.AEManifest, HTTPVerb: "POST", DefaultSource: "local"},
+		"manifestmissing": {Endpoint: qhttp.AEManifestMissing, HTTPVerb: "POST", DefaultSource: "local"},
+		"daginfo":         {Endpoint: qhttp.AEDAGInfo, HTTPVerb: "POST", DefaultSource: "local"},
 	}
 }
 

--- a/lib/diff.go
+++ b/lib/diff.go
@@ -11,6 +11,7 @@ import (
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dsref"
 	qerr "github.com/qri-io/qri/errors"
+	qhttp "github.com/qri-io/qri/lib/http"
 )
 
 // DiffMethods encapsulates logic for diffing Datasets on Qri
@@ -26,8 +27,8 @@ func (m DiffMethods) Name() string {
 // Attributes defines attributes for each method
 func (m DiffMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"changes": {Endpoint: AEChanges, HTTPVerb: "POST"},
-		"diff":    {Endpoint: AEDiff, HTTPVerb: "POST"},
+		"changes": {Endpoint: qhttp.AEChanges, HTTPVerb: "POST"},
+		"diff":    {Endpoint: qhttp.AEDiff, HTTPVerb: "POST"},
 	}
 }
 

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -18,6 +18,8 @@ var (
 	ErrDispatchNilInstance = errors.New("instance is nil, cannot dispatch")
 	// ErrDispatchNilParam indicates that the param passed to dispatch is nil
 	ErrDispatchNilParam = errors.New("param is nil, cannot dispatch")
+	// ErrUnsupportedRPC is an error for when running a method that is not supported via HTTP RPC
+	ErrUnsupportedRPC = errors.New("method is not supported over RPC")
 )
 
 // dispatcher isolates the dispatch method
@@ -130,7 +132,7 @@ func (inst *Instance) dispatchMethodCall(ctx context.Context, method string, par
 			// for it to reliably use GET. All POSTs w/ content type application json work, however.
 			// we may want to just flat out say that as an RPC layer, dispatch will only ever use
 			// json POST to communicate.
-			err = inst.http.CallMethod(ctx, c.Endpoint, "POST", source, param, res)
+			err = inst.http.CallMethod(ctx, c.Endpoint.String(), "POST", source, param, res)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -267,6 +267,7 @@ func (inst *Instance) AllMethods() []MethodSet {
 		inst.Peer(),
 		inst.Profile(),
 		inst.Registry(),
+		inst.Follow(),
 		inst.Remote(),
 		inst.Search(),
 		inst.SQL(),
@@ -288,6 +289,7 @@ func (inst *Instance) RegisterMethods() {
 	inst.registerOne("peer", inst.Peer(), peerImpl{}, reg)
 	inst.registerOne("profile", inst.Profile(), profileImpl{}, reg)
 	inst.registerOne("registry", inst.Registry(), registryImpl{}, reg)
+	inst.registerOne("follow", inst.Follow(), followImpl{}, reg)
 	inst.registerOne("remote", inst.Remote(), remoteImpl{}, reg)
 	inst.registerOne("search", inst.Search(), searchImpl{}, reg)
 	inst.registerOne("sql", inst.SQL(), sqlImpl{}, reg)

--- a/lib/dispatch_test.go
+++ b/lib/dispatch_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/qri-io/qri/api/util"
+	qhttp "github.com/qri-io/qri/lib/http"
 )
 
 func TestRegisterMethods(t *testing.T) {
@@ -209,9 +210,9 @@ func TestDefaultSource(t *testing.T) {
 	}
 }
 
-func serverConnectAndListen(t *testing.T, servInst *Instance, port int) (*HTTPClient, func()) {
+func serverConnectAndListen(t *testing.T, servInst *Instance, port int) (*qhttp.Client, func()) {
 	address := fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", port)
-	connection, err := NewHTTPClient(address)
+	connection, err := qhttp.NewClient(address)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/dispatch_test.go
+++ b/lib/dispatch_test.go
@@ -309,8 +309,8 @@ func (m *animalMethods) Name() string {
 
 func (m *animalMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"cat": {Endpoint: DenyHTTP},
-		"dog": {Endpoint: DenyHTTP},
+		"cat": {Endpoint: qhttp.DenyHTTP},
+		"dog": {Endpoint: qhttp.DenyHTTP},
 	}
 }
 

--- a/lib/follow.go
+++ b/lib/follow.go
@@ -1,0 +1,70 @@
+package lib
+
+import (
+	"context"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/registry"
+	"github.com/qri-io/qri/repo"
+)
+
+// FollowMethods groups together methods for follows
+type FollowMethods struct {
+	d dispatcher
+}
+
+// Name returns the name of this method group
+func (m FollowMethods) Name() string {
+	return "follow"
+}
+
+// Attributes defines attributes for each method
+func (m FollowMethods) Attributes() map[string]AttributeSet {
+	return map[string]AttributeSet{
+		"get":    {Endpoint: AERegistryGetFollowing, HTTPVerb: "POST"},
+		"follow": {Endpoint: AERegistryFollow, HTTPVerb: "POST"},
+	}
+}
+
+// Get returns a list of datasets a user follows
+func (m FollowMethods) Get(ctx context.Context, p *registry.FollowGetParams) ([]*dataset.Dataset, error) {
+	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "get"), p)
+	if res, ok := got.([]*dataset.Dataset); ok {
+		return res, err
+	}
+	return nil, dispatchReturnError(got, err)
+}
+
+// Follow updates the follow status of the current user for a given dataset
+func (m FollowMethods) Follow(ctx context.Context, p *registry.FollowParams) error {
+	_, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "follow"), p)
+	return dispatchReturnError(nil, err)
+}
+
+// followImpl holds the method implementations for follows
+type followImpl struct{}
+
+// Get returns a list of datasets a user follows
+func (followImpl) Get(scope scope, p *registry.FollowGetParams) ([]*dataset.Dataset, error) {
+	client := scope.RegistryClient()
+	if client == nil {
+		return nil, repo.ErrNoRegistry
+	}
+
+	regResults, err := client.GetFollowing(scope.Context(), p)
+	if err != nil {
+		return nil, err
+	}
+
+	return regResults, nil
+}
+
+// Follow updates the follow status of the current user for a given dataset
+func (m followImpl) Follow(scope scope, p *registry.FollowParams) error {
+	client := scope.RegistryClient()
+	if client == nil {
+		return repo.ErrNoRegistry
+	}
+
+	return client.Follow(scope.Context(), p)
+}

--- a/lib/follow.go
+++ b/lib/follow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/qri-io/dataset"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/registry"
 	"github.com/qri-io/qri/repo"
 )
@@ -21,8 +22,8 @@ func (m FollowMethods) Name() string {
 // Attributes defines attributes for each method
 func (m FollowMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"get":    {Endpoint: AERegistryGetFollowing, HTTPVerb: "POST"},
-		"follow": {Endpoint: AERegistryFollow, HTTPVerb: "POST"},
+		"get":    {Endpoint: qhttp.AERegistryGetFollowing, HTTPVerb: "POST"},
+		"follow": {Endpoint: qhttp.AERegistryFollow, HTTPVerb: "POST"},
 	}
 }
 

--- a/lib/fsi.go
+++ b/lib/fsi.go
@@ -13,6 +13,7 @@ import (
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/fsi"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/repo"
 )
 
@@ -29,15 +30,15 @@ func (m FSIMethods) Name() string {
 // Attributes defines attributes for each method
 func (m FSIMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"status":                {Endpoint: AEStatus, HTTPVerb: "POST"},
-		"caninitdatasetworkdir": {Endpoint: AECanInitDatasetWorkDir, HTTPVerb: "POST"},
-		"init":                  {Endpoint: AEInit, HTTPVerb: "POST"},
-		"checkout":              {Endpoint: AECheckout, HTTPVerb: "POST"},
-		"ensureref":             {Endpoint: AEEnsureRef, HTTPVerb: "POST"},
-		"restore":               {Endpoint: AERestore, HTTPVerb: "POST"},
-		"write":                 {Endpoint: AEFSIWrite, HTTPVerb: "POST"},
-		"createlink":            {Endpoint: AEFSICreateLink, HTTPVerb: "POST"},
-		"unlink":                {Endpoint: AEFSIUnlink, HTTPVerb: "POST"},
+		"status":                {Endpoint: qhttp.AEStatus, HTTPVerb: "POST"},
+		"caninitdatasetworkdir": {Endpoint: qhttp.AECanInitDatasetWorkDir, HTTPVerb: "POST"},
+		"init":                  {Endpoint: qhttp.AEInit, HTTPVerb: "POST"},
+		"checkout":              {Endpoint: qhttp.AECheckout, HTTPVerb: "POST"},
+		"ensureref":             {Endpoint: qhttp.AEEnsureRef, HTTPVerb: "POST"},
+		"restore":               {Endpoint: qhttp.AERestore, HTTPVerb: "POST"},
+		"write":                 {Endpoint: qhttp.AEFSIWrite, HTTPVerb: "POST"},
+		"createlink":            {Endpoint: qhttp.AEFSICreateLink, HTTPVerb: "POST"},
+		"unlink":                {Endpoint: qhttp.AEFSIUnlink, HTTPVerb: "POST"},
 	}
 }
 

--- a/lib/http.go
+++ b/lib/http.go
@@ -2,213 +2,15 @@ package lib
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
-	ma "github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr/net"
 	apiutil "github.com/qri-io/qri/api/util"
-	"github.com/qri-io/qri/auth/token"
+	qhttp "github.com/qri-io/qri/lib/http"
 )
-
-// ErrUnsupportedRPC is an error for when running a method that is not supported via HTTP RPC
-var ErrUnsupportedRPC = errors.New("method is not supported over RPC")
-
-const jsonMimeType = "application/json"
-const sourceResolver = "SourceResolver"
-
-// HTTPClient implements the qri http client
-type HTTPClient struct {
-	Address  string
-	Protocol string
-}
-
-// NewHTTPClient instantiates a new HTTPClient
-func NewHTTPClient(multiaddr string) (*HTTPClient, error) {
-	maAddr, err := ma.NewMultiaddr(multiaddr)
-	if err != nil {
-		return nil, err
-	}
-	// we default to the http protocol
-	protocol := "http"
-	protocols := maAddr.Protocols()
-	httpAddr, err := manet.ToNetAddr(maAddr)
-	if err != nil {
-		return nil, err
-	}
-	for _, p := range protocols {
-		// if https is present in the multiAddr we preffer that over http
-		if p.Code == ma.P_HTTPS {
-			protocol = "https"
-		}
-	}
-	return &HTTPClient{
-		Address:  httpAddr.String(),
-		Protocol: protocol,
-	}, nil
-}
-
-// NewHTTPClientWithProtocol instantiates a new HTTPClient with a specified protocol
-func NewHTTPClientWithProtocol(multiaddr string, protocol string) (*HTTPClient, error) {
-	maAddr, err := ma.NewMultiaddr(multiaddr)
-	if err != nil {
-		return nil, err
-	}
-	httpAddr, err := manet.ToNetAddr(maAddr)
-	if err != nil {
-		return nil, err
-	}
-	return &HTTPClient{
-		Address:  httpAddr.String(),
-		Protocol: protocol,
-	}, nil
-}
-
-// Call calls API endpoint and passes on parameters, context info
-func (c HTTPClient) Call(ctx context.Context, apiEndpoint APIEndpoint, source string, params interface{}, result interface{}) error {
-	return c.CallMethod(ctx, apiEndpoint, http.MethodPost, source, params, result)
-}
-
-// CallMethod calls API endpoint and passes on parameters, context info and specific HTTP Method
-func (c HTTPClient) CallMethod(ctx context.Context, apiEndpoint APIEndpoint, httpMethod string, source string, params interface{}, result interface{}) error {
-	// TODO(arqu): work out mimeType configuration/override per API endpoint
-	mimeType := jsonMimeType
-	addr := fmt.Sprintf("%s://%s%s", c.Protocol, c.Address, apiEndpoint)
-
-	return c.do(ctx, addr, httpMethod, mimeType, source, params, result, false)
-}
-
-// CallRaw calls API endpoint and passes on parameters, context info and returns the []byte result
-func (c HTTPClient) CallRaw(ctx context.Context, apiEndpoint APIEndpoint, source string, params interface{}, result interface{}) error {
-	return c.CallMethodRaw(ctx, apiEndpoint, http.MethodPost, source, params, result)
-}
-
-// CallMethodRaw calls API endpoint and passes on parameters, context info, specific HTTP Method and returns the []byte result
-func (c HTTPClient) CallMethodRaw(ctx context.Context, apiEndpoint APIEndpoint, httpMethod string, source string, params interface{}, result interface{}) error {
-	// TODO(arqu): work out mimeType configuration/override per API endpoint
-	mimeType := jsonMimeType
-	addr := fmt.Sprintf("%s://%s%s", c.Protocol, c.Address, apiEndpoint)
-	// TODO(arqu): inject context values into headers
-
-	return c.do(ctx, addr, httpMethod, mimeType, source, params, result, true)
-}
-
-func (c HTTPClient) do(ctx context.Context, addr string, httpMethod string, mimeType string, source string, params interface{}, result interface{}, raw bool) error {
-	var req *http.Request
-	var err error
-
-	log.Debugf("http: %s - %s", httpMethod, addr)
-
-	if httpMethod == http.MethodGet || httpMethod == http.MethodDelete {
-		u, err := url.Parse(addr)
-		if err != nil {
-			return err
-		}
-
-		if params != nil {
-			if pm, ok := params.(map[string]string); ok {
-				qvars := u.Query()
-				for k, v := range pm {
-					qvars.Set(k, v)
-				}
-				u.RawQuery = qvars.Encode()
-			}
-		}
-		req, err = http.NewRequest(httpMethod, u.String(), nil)
-	} else if httpMethod == http.MethodPost || httpMethod == http.MethodPut {
-		payload, err := json.Marshal(params)
-		if err != nil {
-			return err
-		}
-		req, err = http.NewRequest(httpMethod, addr, bytes.NewReader(payload))
-	}
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", mimeType)
-	req.Header.Set("Accept", mimeType)
-
-	if source != "" {
-		req.Header.Set(sourceResolver, source)
-	}
-
-	req, added := token.AddContextTokenToRequest(ctx, req)
-	if !added {
-		log.Debugw("No token was set on an http client request. Unauthenticated requests may fail", "httpMethod", httpMethod, "addr", addr)
-	}
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return err
-	}
-
-	if err = c.checkError(res, body, raw); err != nil {
-		return err
-	}
-
-	if raw {
-		if buf, ok := result.(*bytes.Buffer); ok {
-			buf.Write(body)
-		} else {
-			return fmt.Errorf("HTTPClient raw interface is not a byte buffer")
-		}
-		return nil
-	}
-
-	if result != nil {
-		resData := apiutil.Response{
-			Data: result,
-			Meta: &apiutil.Meta{},
-		}
-		err = json.Unmarshal(body, &resData)
-		if err != nil {
-			log.Debugf("HTTPClient response err: %s", err.Error())
-			return fmt.Errorf("HTTPClient response err: %s", err)
-		}
-	}
-	return nil
-}
-
-func (c HTTPClient) checkError(res *http.Response, body []byte, raw bool) error {
-	metaResponse := struct {
-		Meta *apiutil.Meta
-	}{
-		Meta: &apiutil.Meta{},
-	}
-	parseErr := json.Unmarshal(body, &metaResponse)
-
-	if !raw {
-		if parseErr != nil {
-			log.Debugf("HTTPClient response error: %d - %q", res.StatusCode, body)
-			return fmt.Errorf("failed parsing response: %q", string(body))
-		}
-		if metaResponse.Meta == nil {
-			log.Debugf("HTTPClient response error: %d - %q", res.StatusCode, body)
-			return fmt.Errorf("invalid meta response")
-		}
-	} else if (metaResponse.Meta.Code < 200 || metaResponse.Meta.Code > 299) && metaResponse.Meta.Code != 0 {
-		log.Debugf("HTTPClient response meta error: %d - %q", metaResponse.Meta.Code, metaResponse.Meta.Error)
-		return fmt.Errorf(metaResponse.Meta.Error)
-	}
-
-	if res.StatusCode < 200 || res.StatusCode > 299 {
-		log.Debugf("HTTPClient response error: %d - %q", res.StatusCode, body)
-		return fmt.Errorf(string(body))
-	}
-	return nil
-}
 
 // NewHTTPRequestHandler creates a JSON-API endpoint for a registered dispatch
 // method
@@ -251,7 +53,7 @@ func NewHTTPRequestHandler(inst *Instance, libMethod string) http.HandlerFunc {
 
 // SourceFromRequest retrieves from the http request the source for resolving refs
 func SourceFromRequest(r *http.Request) string {
-	return r.Header.Get(sourceResolver)
+	return r.Header.Get(qhttp.SourceResolver)
 }
 
 // DecodeParams decodes a json body into params

--- a/lib/http/api.go
+++ b/lib/http/api.go
@@ -1,4 +1,4 @@
-package lib
+package http
 
 import (
 	"fmt"
@@ -32,133 +32,133 @@ const (
 	// aggregate endpoints
 
 	// AEList lists all datasets in your collection
-	AEList = APIEndpoint("/list")
+	AEList APIEndpoint = "/list"
 	// AEDiff is an endpoint for generating dataset diffs
-	AEDiff = APIEndpoint("/diff")
+	AEDiff APIEndpoint = "/diff"
 	// AEChanges is an endpoint for generating dataset change reports
-	AEChanges = APIEndpoint("/changes")
+	AEChanges APIEndpoint = "/changes"
 	// AESQL executes SQL commands
-	AESQL = APIEndpoint("/sql")
+	AESQL APIEndpoint = "/sql"
 
 	// auth endpoints
 
 	// AECreateAuthToken creates an auth token for a user
-	AECreateAuthToken = APIEndpoint("/access/token")
+	AECreateAuthToken APIEndpoint = "/access/token"
 
 	// automation endpoints
 
 	// AEApply invokes a transform apply
-	AEApply = APIEndpoint("/auto/apply")
+	AEApply APIEndpoint = "/auto/apply"
 	// AEDeploy creates, updates, or deploys a workflow
-	AEDeploy = APIEndpoint("/auto/deploy")
+	AEDeploy APIEndpoint = "/auto/deploy"
 
 	// dataset endpoints
 
 	// AEComponentStatus returns what changed for a specific commit
-	AEComponentStatus = APIEndpoint("/ds/componentstatus")
+	AEComponentStatus APIEndpoint = "/ds/componentstatus"
 	// AEGet is an endpoint for fetch individual dataset components
-	AEGet = APIEndpoint("/ds/get")
+	AEGet APIEndpoint = "/ds/get"
 	// AEActivity is an endpoint that returns a dataset activity list
-	AEActivity = APIEndpoint("/ds/activity")
+	AEActivity APIEndpoint = "/ds/activity"
 	// AERename is an endpoint for renaming datasets
-	AERename = APIEndpoint("/ds/rename")
+	AERename APIEndpoint = "/ds/rename"
 	// AESave is an endpoint for saving a dataset
-	AESave = APIEndpoint("/ds/save")
+	AESave APIEndpoint = "/ds/save"
 	// AEPull facilittates dataset pull requests from a remote
-	AEPull = APIEndpoint("/ds/pull")
+	AEPull APIEndpoint = "/ds/pull"
 	// AEPush facilitates dataset push requests to a remote
-	AEPush = APIEndpoint("/ds/push")
+	AEPush APIEndpoint = "/ds/push"
 	// AERender renders the current dataset ref
-	AERender = APIEndpoint("/ds/render")
+	AERender APIEndpoint = "/ds/render"
 	// AERemove exposes the dataset remove mechanics
-	AERemove = APIEndpoint("/ds/remove")
+	AERemove APIEndpoint = "/ds/remove"
 	// AEValidate is an endpoint for validating datasets
-	AEValidate = APIEndpoint("/ds/validate")
+	AEValidate APIEndpoint = "/ds/validate"
 	// AEManifest generates a manifest for a dataset path
-	AEManifest = APIEndpoint("/ds/manifest")
+	AEManifest APIEndpoint = "/ds/manifest"
 	// AEManifestMissing generates a manifest of blocks that are not present on this repo for a given manifest
-	AEManifestMissing = APIEndpoint("/ds/manifest/missing")
+	AEManifestMissing APIEndpoint = "/ds/manifest/missing"
 	// AEDAGInfo generates a dag.Info for a dataset path
-	AEDAGInfo = APIEndpoint("/ds/daginfo")
+	AEDAGInfo APIEndpoint = "/ds/daginfo"
 
 	// peer endpoints
 
 	// AEPeer fetches a specific peer
-	AEPeer = APIEndpoint("/peer")
+	AEPeer APIEndpoint = "/peer"
 	// AEConnect initiates an explicit connection to a peer
-	AEConnect = APIEndpoint("/peer/connect")
+	AEConnect APIEndpoint = "/peer/connect"
 	// AEDisconnect closes an explicit connection to a peer
-	AEDisconnect = APIEndpoint("/peer/disconnect")
+	AEDisconnect APIEndpoint = "/peer/disconnect"
 	// AEPeers fetches all the peers
-	AEPeers = APIEndpoint("/peer/list")
+	AEPeers APIEndpoint = "/peer/list"
 
 	// profile endpoints
 
 	// AEGetProfile is an alias for the me endpoint
-	AEGetProfile = APIEndpoint("/profile")
+	AEGetProfile APIEndpoint = "/profile"
 	// AESetProfile is an endpoint to set the profile
-	AESetProfile = APIEndpoint("/profile/set")
+	AESetProfile APIEndpoint = "/profile/set"
 	// AESetProfilePhoto is an endpoint to set the profile photo
-	AESetProfilePhoto = APIEndpoint("/profile/photo")
+	AESetProfilePhoto APIEndpoint = "/profile/photo"
 	// AESetPosterPhoto is an endpoint to set the profile poster
-	AESetPosterPhoto = APIEndpoint("/profile/poster")
+	AESetPosterPhoto APIEndpoint = "/profile/poster"
 
 	// remote client endpoints
 
 	// AEFeeds fetches and index of named feeds
-	AEFeeds = APIEndpoint("/remote/feeds")
+	AEFeeds APIEndpoint = "/remote/feeds"
 	// AEPreview fetches a dataset preview from the registry
-	AEPreview = APIEndpoint("/remote/preview")
+	AEPreview APIEndpoint = "/remote/preview"
 	// AERemoteRemove removes a dataset from a given remote
-	AERemoteRemove = APIEndpoint("/remote/remove")
+	AERemoteRemove APIEndpoint = "/remote/remove"
 	// AERegistryNew creates a new user on the registry
-	AERegistryNew = APIEndpoint("/remote/registry/profile/new")
+	AERegistryNew APIEndpoint = "/remote/registry/profile/new"
 	// AERegistryProve links an the current peer with an existing
 	// user on the registry
-	AERegistryProve = APIEndpoint("/remote/registry/profile/prove")
+	AERegistryProve APIEndpoint = "/remote/registry/profile/prove"
 	// AESearch returns a list of dataset search results
-	AESearch = APIEndpoint("/registry/search")
+	AESearch APIEndpoint = "/registry/search"
 	// AERegistryGetFollowing returns a list of datasets a user follows
-	AERegistryGetFollowing = APIEndpoint("/registry/follow/list")
+	AERegistryGetFollowing APIEndpoint = "/registry/follow/list"
 	// AERegistryFollow updates the follow status of the current user for a given dataset
-	AERegistryFollow = APIEndpoint("/registry/follow")
+	AERegistryFollow APIEndpoint = "/registry/follow"
 
 	// fsi endpoints
 
 	// AEStatus returns the filesystem dataset status
-	AEStatus = APIEndpoint("/wd/status")
+	AEStatus APIEndpoint = "/wd/status"
 	// AEInit invokes a dataset initialization on the filesystem
-	AEInit = APIEndpoint("/wd/init")
+	AEInit APIEndpoint = "/wd/init"
 	// AECanInitDatasetWorkDir returns whether a dataset can be initialized
-	AECanInitDatasetWorkDir = APIEndpoint("/wd/caninitworkdir")
+	AECanInitDatasetWorkDir APIEndpoint = "/wd/caninitworkdir"
 	// AECheckout invokes a dataset checkout to the filesystem
-	AECheckout = APIEndpoint("/wd/checkout")
+	AECheckout APIEndpoint = "/wd/checkout"
 	// AERestore invokes a restore
-	AERestore = APIEndpoint("/wd/restore")
+	AERestore APIEndpoint = "/wd/restore"
 	// AEFSIWrite writes input data to the filesystem
-	AEFSIWrite = APIEndpoint("/wd/write")
+	AEFSIWrite APIEndpoint = "/wd/write"
 	// AEFSICreateLink creates an fsi link
-	AEFSICreateLink = APIEndpoint("/wd/createlink")
+	AEFSICreateLink APIEndpoint = "/wd/createlink"
 	// AEFSIUnlink removes the fsi link
-	AEFSIUnlink = APIEndpoint("/wd/unlink")
+	AEFSIUnlink APIEndpoint = "/wd/unlink"
 	// AEEnsureRef ensures that the ref is fsi linked
-	AEEnsureRef = APIEndpoint("/wd/ensureref")
+	AEEnsureRef APIEndpoint = "/wd/ensureref"
 
 	// sync endpoints
 
 	// AERemoteDSync exposes the dsync mechanics
-	AERemoteDSync = APIEndpoint("/remote/dsync")
+	AERemoteDSync APIEndpoint = "/remote/dsync"
 	// AERemoteLogSync exposes the logsync mechanics
-	AERemoteLogSync = APIEndpoint("/remote/logsync")
+	AERemoteLogSync APIEndpoint = "/remote/logsync"
 	// AERemoteRefs exposes the remote ref resolution mechanics
-	AERemoteRefs = APIEndpoint("/remote/refs")
+	AERemoteRefs APIEndpoint = "/remote/refs"
 
 	// other endpoints
 
 	// AEConnections lists qri & IPFS connections
-	AEConnections = APIEndpoint("/connections")
+	AEConnections APIEndpoint = "/connections"
 	// AEConnectedQriProfiles lists qri profile connections
-	AEConnectedQriProfiles = APIEndpoint("/connections/qri")
+	AEConnectedQriProfiles APIEndpoint = "/connections/qri"
 
 	// DenyHTTP will disable HTTP access to a method
 	DenyHTTP = APIEndpoint("")
@@ -166,13 +166,13 @@ const (
 
 // DsRefFromPath parses a path and returns a dsref.Ref
 func DsRefFromPath(path string) (dsref.Ref, error) {
-	refstr := HTTPPathToQriPath(path)
+	refstr := PathToQriPath(path)
 	return dsref.ParsePeerRef(refstr)
 }
 
-// HTTPPathToQriPath converts a http path to a
+// PathToQriPath converts a http path to a
 // qri path
-func HTTPPathToQriPath(path string) string {
+func PathToQriPath(path string) string {
 	paramIndex := strings.Index(path, "?")
 	if paramIndex != -1 {
 		path = path[:paramIndex]

--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -1,0 +1,211 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	golog "github.com/ipfs/go-log"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+	apiutil "github.com/qri-io/qri/api/util"
+	"github.com/qri-io/qri/auth/token"
+)
+
+var log = golog.Logger("lib")
+
+const jsonMimeType = "application/json"
+
+// SourceResolver header name
+const SourceResolver = "SourceResolver"
+
+// Client implements the qri http client
+type Client struct {
+	Address  string
+	Protocol string
+}
+
+// NewClient instantiates a new Client
+func NewClient(multiaddr string) (*Client, error) {
+	maAddr, err := ma.NewMultiaddr(multiaddr)
+	if err != nil {
+		return nil, err
+	}
+	// we default to the http protocol
+	protocol := "http"
+	protocols := maAddr.Protocols()
+	httpAddr, err := manet.ToNetAddr(maAddr)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range protocols {
+		// if https is present in the multiAddr we preffer that over http
+		if p.Code == ma.P_HTTPS {
+			protocol = "https"
+		}
+	}
+	return &Client{
+		Address:  httpAddr.String(),
+		Protocol: protocol,
+	}, nil
+}
+
+// NewClientWithProtocol instantiates a new Client with a specified protocol
+func NewClientWithProtocol(multiaddr string, protocol string) (*Client, error) {
+	maAddr, err := ma.NewMultiaddr(multiaddr)
+	if err != nil {
+		return nil, err
+	}
+	httpAddr, err := manet.ToNetAddr(maAddr)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		Address:  httpAddr.String(),
+		Protocol: protocol,
+	}, nil
+}
+
+// Call calls API endpoint and passes on parameters, context info
+func (c Client) Call(ctx context.Context, apiEndpoint string, source string, params interface{}, result interface{}) error {
+	return c.CallMethod(ctx, apiEndpoint, http.MethodPost, source, params, result)
+}
+
+// CallMethod calls API endpoint and passes on parameters, context info and specific HTTP Method
+func (c Client) CallMethod(ctx context.Context, apiEndpoint string, httpMethod string, source string, params interface{}, result interface{}) error {
+	// TODO(arqu): work out mimeType configuration/override per API endpoint
+	mimeType := jsonMimeType
+	addr := fmt.Sprintf("%s://%s%s", c.Protocol, c.Address, apiEndpoint)
+
+	return c.do(ctx, addr, httpMethod, mimeType, source, params, result, false)
+}
+
+// CallRaw calls API endpoint and passes on parameters, context info and returns the []byte result
+func (c Client) CallRaw(ctx context.Context, apiEndpoint string, source string, params interface{}, result interface{}) error {
+	return c.CallMethodRaw(ctx, apiEndpoint, http.MethodPost, source, params, result)
+}
+
+// CallMethodRaw calls API endpoint and passes on parameters, context info, specific HTTP Method and returns the []byte result
+func (c Client) CallMethodRaw(ctx context.Context, apiEndpoint string, httpMethod string, source string, params interface{}, result interface{}) error {
+	// TODO(arqu): work out mimeType configuration/override per API endpoint
+	mimeType := jsonMimeType
+	addr := fmt.Sprintf("%s://%s%s", c.Protocol, c.Address, apiEndpoint)
+	// TODO(arqu): inject context values into headers
+
+	return c.do(ctx, addr, httpMethod, mimeType, source, params, result, true)
+}
+
+func (c Client) do(ctx context.Context, addr string, httpMethod string, mimeType string, source string, params interface{}, result interface{}, raw bool) error {
+	var req *http.Request
+	var err error
+
+	log.Debugf("http: %s - %s", httpMethod, addr)
+
+	if httpMethod == http.MethodGet || httpMethod == http.MethodDelete {
+		u, err := url.Parse(addr)
+		if err != nil {
+			return err
+		}
+
+		if params != nil {
+			if pm, ok := params.(map[string]string); ok {
+				qvars := u.Query()
+				for k, v := range pm {
+					qvars.Set(k, v)
+				}
+				u.RawQuery = qvars.Encode()
+			}
+		}
+		req, err = http.NewRequest(httpMethod, u.String(), nil)
+	} else if httpMethod == http.MethodPost || httpMethod == http.MethodPut {
+		payload, err := json.Marshal(params)
+		if err != nil {
+			return err
+		}
+		req, err = http.NewRequest(httpMethod, addr, bytes.NewReader(payload))
+	}
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", mimeType)
+	req.Header.Set("Accept", mimeType)
+
+	if source != "" {
+		req.Header.Set(SourceResolver, source)
+	}
+
+	req, added := token.AddContextTokenToRequest(ctx, req)
+	if !added {
+		log.Debugw("No token was set on an http client request. Unauthenticated requests may fail", "httpMethod", httpMethod, "addr", addr)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	if err = c.checkError(res, body, raw); err != nil {
+		return err
+	}
+
+	if raw {
+		if buf, ok := result.(*bytes.Buffer); ok {
+			buf.Write(body)
+		} else {
+			return fmt.Errorf("Client raw interface is not a byte buffer")
+		}
+		return nil
+	}
+
+	if result != nil {
+		resData := apiutil.Response{
+			Data: result,
+			Meta: &apiutil.Meta{},
+		}
+		err = json.Unmarshal(body, &resData)
+		if err != nil {
+			log.Debugf("Client response err: %s", err.Error())
+			return fmt.Errorf("Client response err: %s", err)
+		}
+	}
+	return nil
+}
+
+func (c Client) checkError(res *http.Response, body []byte, raw bool) error {
+	metaResponse := struct {
+		Meta *apiutil.Meta
+	}{
+		Meta: &apiutil.Meta{},
+	}
+	parseErr := json.Unmarshal(body, &metaResponse)
+
+	if !raw {
+		if parseErr != nil {
+			log.Debugf("Client response error: %d - %q", res.StatusCode, body)
+			return fmt.Errorf("failed parsing response: %q", string(body))
+		}
+		if metaResponse.Meta == nil {
+			log.Debugf("Client response error: %d - %q", res.StatusCode, body)
+			return fmt.Errorf("invalid meta response")
+		}
+	} else if (metaResponse.Meta.Code < 200 || metaResponse.Meta.Code > 299) && metaResponse.Meta.Code != 0 {
+		log.Debugf("Client response meta error: %d - %q", metaResponse.Meta.Code, metaResponse.Meta.Error)
+		return fmt.Errorf(metaResponse.Meta.Error)
+	}
+
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		log.Debugf("Client response error: %d - %q", res.StatusCode, body)
+		return fmt.Errorf(string(body))
+	}
+	return nil
+}

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -423,7 +423,7 @@ func PushToRegistry(ctx context.Context, t *testing.T, inst *Instance, refstr st
 	return *res
 }
 
-func SearchFor(ctx context.Context, t *testing.T, inst *Instance, term string) []SearchResult {
+func SearchFor(ctx context.Context, t *testing.T, inst *Instance, term string) []registry.SearchResult {
 	results, err := inst.Search().Search(ctx, &SearchParams{Query: term})
 	if err != nil {
 		t.Fatal(err)

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -35,6 +35,7 @@ import (
 	"github.com/qri-io/qri/fsi"
 	"github.com/qri-io/qri/fsi/hiddenfile"
 	"github.com/qri-io/qri/fsi/watchfs"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/profile"
@@ -460,7 +461,7 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		}
 		if _, dialErr := manet.Dial(addr); dialErr == nil {
 			// we have a connection
-			inst.http, err = NewHTTPClient(cfg.API.Address)
+			inst.http, err = qhttp.NewClient(cfg.API.Address)
 			if err != nil {
 				return nil, err
 			}
@@ -809,7 +810,7 @@ type Instance struct {
 
 	remoteOptsFuncs []remote.OptionsFunc
 
-	http *HTTPClient
+	http *qhttp.Client
 
 	cancel    context.CancelFunc
 	doneCh    chan struct{}
@@ -1105,7 +1106,7 @@ func (inst *Instance) Dscache() *dscache.Dscache {
 }
 
 // HTTPClient accesses the instance HTTP client if one exists
-func (inst *Instance) HTTPClient() *HTTPClient {
+func (inst *Instance) HTTPClient() *qhttp.Client {
 	if inst == nil {
 		return nil
 	}

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -951,6 +951,11 @@ func (inst *Instance) Registry() RegistryClientMethods {
 	return RegistryClientMethods{d: inst}
 }
 
+// Follow returns the FollowMethods that Instance has registered
+func (inst *Instance) Follow() FollowMethods {
+	return FollowMethods{d: inst}
+}
+
 // Remote returns the RemoteMethods that Instance has registered
 func (inst *Instance) Remote() RemoteMethods {
 	return RemoteMethods{d: inst}

--- a/lib/log.go
+++ b/lib/log.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"context"
 
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/logbook"
 )
 
@@ -20,9 +21,9 @@ func (m LogMethods) Name() string {
 // Attributes defines attributes for each method
 func (m LogMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"log":            {Endpoint: DenyHTTP},
-		"rawlogbook":     {Endpoint: DenyHTTP},
-		"logbooksummary": {Endpoint: DenyHTTP},
+		"log":            {Endpoint: qhttp.DenyHTTP},
+		"rawlogbook":     {Endpoint: qhttp.DenyHTTP},
+		"logbooksummary": {Endpoint: qhttp.DenyHTTP},
 	}
 }
 

--- a/lib/peers.go
+++ b/lib/peers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/qri-io/qri/config"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/p2p"
 	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/repo"
@@ -26,12 +27,12 @@ func (m PeerMethods) Name() string { return "peer" }
 // Attributes defines attributes for each method
 func (m PeerMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"list":                 {Endpoint: AEPeers, HTTPVerb: "POST"},
-		"info":                 {Endpoint: AEPeer, HTTPVerb: "POST"},
-		"connect":              {Endpoint: AEConnect, HTTPVerb: "POST"},
-		"disconnect":           {Endpoint: AEDisconnect, HTTPVerb: "POST"},
-		"connections":          {Endpoint: AEConnections, HTTPVerb: "POST"},
-		"connectedqriprofiles": {Endpoint: AEConnectedQriProfiles, HTTPVerb: "POST"},
+		"list":                 {Endpoint: qhttp.AEPeers, HTTPVerb: "POST"},
+		"info":                 {Endpoint: qhttp.AEPeer, HTTPVerb: "POST"},
+		"connect":              {Endpoint: qhttp.AEConnect, HTTPVerb: "POST"},
+		"disconnect":           {Endpoint: qhttp.AEDisconnect, HTTPVerb: "POST"},
+		"connections":          {Endpoint: qhttp.AEConnections, HTTPVerb: "POST"},
+		"connectedqriprofiles": {Endpoint: qhttp.AEConnectedQriProfiles, HTTPVerb: "POST"},
 	}
 }
 

--- a/lib/profile.go
+++ b/lib/profile.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/config"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/registry"
 )
@@ -29,10 +30,10 @@ func (m ProfileMethods) Name() string {
 // Attributes defines attributes for each method
 func (m ProfileMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"getprofile":      {Endpoint: AEGetProfile, HTTPVerb: "POST", DenyRPC: true},
-		"setprofile":      {Endpoint: AESetProfile, HTTPVerb: "POST", DenyRPC: true},
-		"setprofilephoto": {Endpoint: AESetProfilePhoto, HTTPVerb: "POST", DenyRPC: true},
-		"setposterphoto":  {Endpoint: AESetPosterPhoto, HTTPVerb: "POST", DenyRPC: true},
+		"getprofile":      {Endpoint: qhttp.AEGetProfile, HTTPVerb: "POST", DenyRPC: true},
+		"setprofile":      {Endpoint: qhttp.AESetProfile, HTTPVerb: "POST", DenyRPC: true},
+		"setprofilephoto": {Endpoint: qhttp.AESetProfilePhoto, HTTPVerb: "POST", DenyRPC: true},
+		"setposterphoto":  {Endpoint: qhttp.AESetPosterPhoto, HTTPVerb: "POST", DenyRPC: true},
 	}
 }
 

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/config"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/logbook"
 	"github.com/qri-io/qri/logbook/oplog"
 	"github.com/qri-io/qri/profile"
@@ -27,8 +28,8 @@ func (m RegistryClientMethods) Name() string {
 // Attributes defines attributes for each method
 func (m RegistryClientMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"createprofile":   {Endpoint: DenyHTTP},
-		"proveprofilekey": {Endpoint: DenyHTTP},
+		"createprofile":   {Endpoint: qhttp.DenyHTTP},
+		"proveprofilekey": {Endpoint: qhttp.DenyHTTP},
 	}
 }
 

--- a/lib/remote.go
+++ b/lib/remote.go
@@ -7,6 +7,7 @@ import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/dsref"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/remote"
 )
 
@@ -26,9 +27,9 @@ func (m RemoteMethods) Name() string {
 // Attributes defines attributes for each method
 func (m RemoteMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"feeds":   {Endpoint: AEFeeds, HTTPVerb: "POST"},
-		"preview": {Endpoint: AEPreview, HTTPVerb: "POST"},
-		"remove":  {Endpoint: AERemoteRemove, HTTPVerb: "POST", DefaultSource: "network"},
+		"feeds":   {Endpoint: qhttp.AEFeeds, HTTPVerb: "POST"},
+		"preview": {Endpoint: qhttp.AEPreview, HTTPVerb: "POST"},
+		"remove":  {Endpoint: qhttp.AERemoteRemove, HTTPVerb: "POST", DefaultSource: "network"},
 	}
 }
 

--- a/lib/routes.go
+++ b/lib/routes.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	qhttp "github.com/qri-io/qri/lib/http"
 )
 
 // GiveAPIServer creates an API server that gives access to lib's registered methods
@@ -13,7 +14,7 @@ func (inst *Instance) GiveAPIServer(middleware func(handler http.HandlerFunc) ht
 		if arrayContainsString(ignoreMethods, methodName) {
 			continue
 		}
-		if call.Endpoint == DenyHTTP {
+		if call.Endpoint == qhttp.DenyHTTP {
 			continue
 		}
 		handler := middleware(NewHTTPRequestHandler(inst, methodName))

--- a/lib/search.go
+++ b/lib/search.go
@@ -3,7 +3,7 @@ package lib
 import (
 	"context"
 
-	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/registry"
 	"github.com/qri-io/qri/registry/regclient"
 	"github.com/qri-io/qri/repo"
 )
@@ -32,18 +32,10 @@ type SearchParams struct {
 	Offset int    `json:"offset,omitempty"`
 }
 
-// SearchResult struct
-type SearchResult struct {
-	Type  string           `json:"type"`
-	ID    string           `json:"id"`
-	URL   string           `json:"url"`
-	Value *dataset.Dataset `json:"value"`
-}
-
 // Search queries for items on qri related to given parameters
-func (m SearchMethods) Search(ctx context.Context, p *SearchParams) ([]SearchResult, error) {
+func (m SearchMethods) Search(ctx context.Context, p *SearchParams) ([]registry.SearchResult, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "search"), p)
-	if res, ok := got.([]SearchResult); ok {
+	if res, ok := got.([]registry.SearchResult); ok {
 		return res, err
 	}
 	return nil, dispatchReturnError(got, err)
@@ -55,7 +47,7 @@ func (m SearchMethods) Search(ctx context.Context, p *SearchParams) ([]SearchRes
 type searchImpl struct{}
 
 // Search queries for items on qri related to given parameters
-func (searchImpl) Search(scope scope, p *SearchParams) ([]SearchResult, error) {
+func (searchImpl) Search(scope scope, p *SearchParams) ([]registry.SearchResult, error) {
 	client := scope.RegistryClient()
 	if client == nil {
 		return nil, repo.ErrNoRegistry
@@ -70,12 +62,5 @@ func (searchImpl) Search(scope scope, p *SearchParams) ([]SearchResult, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	searchResults := make([]SearchResult, len(regResults))
-	for i, result := range regResults {
-		searchResults[i].Type = "dataset"
-		searchResults[i].ID = result.Path
-		searchResults[i].Value = result
-	}
-	return searchResults, nil
+	return regResults, nil
 }

--- a/lib/search.go
+++ b/lib/search.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"context"
 
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/registry"
 	"github.com/qri-io/qri/registry/regclient"
 	"github.com/qri-io/qri/repo"
@@ -21,7 +22,7 @@ func (m SearchMethods) Name() string {
 // Attributes defines attributes for each method
 func (m SearchMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"search": {Endpoint: AESearch, HTTPVerb: "POST"},
+		"search": {Endpoint: qhttp.AESearch, HTTPVerb: "POST"},
 	}
 }
 

--- a/lib/search.go
+++ b/lib/search.go
@@ -66,7 +66,7 @@ func (searchImpl) Search(scope scope, p *SearchParams) ([]SearchResult, error) {
 		Offset: p.Offset,
 	}
 
-	regResults, err := client.Search(params)
+	regResults, err := client.Search(scope.Context(), params)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/search_test.go
+++ b/lib/search_test.go
@@ -47,10 +47,10 @@ func TestSearch(t *testing.T) {
 
 var mockResponse = []byte(`{"data":[
   {
-    "Type": "dataset",
-    "ID": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
-    "URL": "https://qri.cloud/nuun/nuun",
-    "Value": {
+    "type": "dataset",
+    "id": "/ipfs/QmZEnjt3Y5RxXsoZyufJfFzcogicBEwfaimJSyDuC7nySA",
+    "url": "https://qri.cloud/nuun/nuun",
+    "value": {
       "commit": {
         "qri": "cm:0",
         "timestamp": "2019-08-31T12:07:56.212858Z",

--- a/lib/sql.go
+++ b/lib/sql.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/sql"
 )
 
@@ -18,7 +19,7 @@ func (m SQLMethods) Name() string { return "sql" }
 // Attributes defines attributes for each method
 func (m SQLMethods) Attributes() map[string]AttributeSet {
 	return map[string]AttributeSet{
-		"exec": {Endpoint: AESQL, HTTPVerb: "POST"},
+		"exec": {Endpoint: qhttp.AESQL, HTTPVerb: "POST"},
 	}
 }
 

--- a/registry/follow.go
+++ b/registry/follow.go
@@ -1,0 +1,46 @@
+package registry
+
+import (
+	"fmt"
+
+	"github.com/qri-io/dataset"
+)
+
+// Follower is an opt-in interface for registries that wish to
+// support dataset following
+type Follower interface {
+	Get(p *FollowGetParams) ([]*dataset.Dataset, error)
+	Follow(p *FollowParams) (*dataset.Dataset, error)
+}
+
+// FollowGetParams encapsulates parameters provided to Follower.Get
+type FollowGetParams struct {
+	Username string `json:"username"`
+	Limit    int    `json:"limit"`
+	Offset   int    `json:"offset"`
+	// TODO(arqu): order by fields are missing
+}
+
+// FollowParams encapsulates parameters provided to Follower.Follow
+type FollowParams struct {
+	Ref    string `json:"ref"`
+	Status int    `json:"status"`
+}
+
+// ErrFollowingNotSupported is the canonical error to indicate following
+// isn't implemented
+var ErrFollowingNotSupported = fmt.Errorf("following not supported")
+
+// NilFollower is a basic implementation of Follower which returns
+// an error to indicate that following is not supported
+type NilFollower bool
+
+// Get returns an error indicating that listing followed datasets is not supported
+func (nf NilFollower) Get(p *FollowGetParams) ([]*dataset.Dataset, error) {
+	return nil, ErrFollowingNotSupported
+}
+
+// Follow returns an error indicating that following a dataset is not supported
+func (nf NilFollower) Follow(p *FollowParams) (*dataset.Dataset, error) {
+	return nil, ErrFollowingNotSupported
+}

--- a/registry/regclient/client.go
+++ b/registry/regclient/client.go
@@ -53,7 +53,7 @@ func NewClient(cfg *Config) *Client {
 	} else {
 		us := u.String()
 		if u.Scheme != "" {
-			us = us[len(u.Scheme)+len("://")+1:]
+			us = us[len(u.Scheme)+len("://"):]
 		}
 		httpClient := &qhttp.Client{
 			Address:  us,

--- a/registry/regclient/follow.go
+++ b/registry/regclient/follow.go
@@ -1,0 +1,30 @@
+package regclient
+
+import (
+	"context"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/registry"
+)
+
+// GetFollowing returns a list of datasets a user follows from the registry
+func (c Client) GetFollowing(ctx context.Context, p *registry.FollowGetParams) ([]*dataset.Dataset, error) {
+	if c.httpClient == nil {
+		return nil, ErrNoRegistry
+	}
+
+	results := []*dataset.Dataset{}
+	err := c.httpClient.Call(ctx, "/registry/follow/list", "", p, results)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// Follow updates the users follow status for a datasets on the registry
+func (c Client) Follow(ctx context.Context, p *registry.FollowParams) error {
+	if c.httpClient == nil {
+		return ErrNoRegistry
+	}
+	return c.httpClient.Call(ctx, "/registry/follow", "", p, nil)
+}

--- a/registry/regclient/follow.go
+++ b/registry/regclient/follow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/qri-io/dataset"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/registry"
 )
 
@@ -14,7 +15,7 @@ func (c Client) GetFollowing(ctx context.Context, p *registry.FollowGetParams) (
 	}
 
 	results := []*dataset.Dataset{}
-	err := c.httpClient.Call(ctx, "/registry/follow/list", "", p, results)
+	err := c.httpClient.Call(ctx, qhttp.AERegistryGetFollowing, "", p, results)
 	if err != nil {
 		return nil, err
 	}
@@ -26,5 +27,5 @@ func (c Client) Follow(ctx context.Context, p *registry.FollowParams) error {
 	if c.httpClient == nil {
 		return ErrNoRegistry
 	}
-	return c.httpClient.Call(ctx, "/registry/follow", "", p, nil)
+	return c.httpClient.Call(ctx, qhttp.AERegistryFollow, "", p, nil)
 }

--- a/registry/regclient/profile.go
+++ b/registry/regclient/profile.go
@@ -135,7 +135,8 @@ func (c Client) doJSONProfileReq(method string, p *registry.Profile) (*registry.
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	res, err := c.httpClient.Do(req)
+	// TODO(arqu): convert to lib/http/HTTPClient
+	res, err := HTTPClient.Do(req)
 	if err != nil {
 		if strings.Contains(err.Error(), "no such host") {
 			return nil, ErrNoRegistry
@@ -202,7 +203,8 @@ func (c Client) doJSONRegistryRequest(method, url string, input interface{}, out
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	res, err := c.httpClient.Do(req)
+	// TODO(arqu): convert to lib/http/HTTPClient
+	res, err := HTTPClient.Do(req)
 	if err != nil {
 		if strings.Contains(err.Error(), "no such host") {
 			return ErrNoRegistry

--- a/registry/regclient/search.go
+++ b/registry/regclient/search.go
@@ -3,7 +3,6 @@ package regclient
 import (
 	"context"
 
-	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/registry"
 )
 
@@ -33,7 +32,7 @@ type SearchParams struct {
 }
 
 // Search makes a registry search request
-func (c Client) Search(ctx context.Context, p *SearchParams) ([]*dataset.Dataset, error) {
+func (c Client) Search(ctx context.Context, p *SearchParams) ([]registry.SearchResult, error) {
 	if c.httpClient == nil {
 		return nil, ErrNoRegistry
 	}
@@ -44,10 +43,10 @@ func (c Client) Search(ctx context.Context, p *SearchParams) ([]*dataset.Dataset
 		Limit:  p.Limit,
 		Offset: p.Offset,
 	}
-	results := []*dataset.Dataset{}
-	err := c.httpClient.CallMethod(ctx, "registry/search", "GET", "", params, results)
+	res := []registry.SearchResult{}
+	err := c.httpClient.CallMethod(ctx, "/registry/search", "GET", "", params, &res)
 	if err != nil {
 		return nil, err
 	}
-	return results, nil
+	return res, nil
 }

--- a/registry/regclient/search_test.go
+++ b/registry/regclient/search_test.go
@@ -1,6 +1,7 @@
 package regclient
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 )
 
 func TestSearchMethods(t *testing.T) {
+	ctx := context.Background()
 
 	reg := registry.Registry{
 		Profiles: registry.NewMemProfiles(),
@@ -22,7 +24,7 @@ func TestSearchMethods(t *testing.T) {
 
 	searchParams := &SearchParams{Query: "presidents", Limit: 100, Offset: 0}
 	// TODO: need to add tests that actually inspect the search results
-	_, err := c.Search(searchParams)
+	_, err := c.Search(ctx, searchParams)
 	if err != nil {
 		t.Errorf("error executing search: %s", err)
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -30,10 +30,11 @@ import (
 
 // Registry a collection of interfaces that together form a registry service
 type Registry struct {
-	Remote   *remote.Server
-	Profiles Profiles
-	Search   Searchable
-	Indexer  Indexer
+	Remote       *remote.Server
+	Profiles     Profiles
+	Search       Searchable
+	Indexer      Indexer
+	Follower     Follower
 }
 
 var (

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -30,11 +30,11 @@ import (
 
 // Registry a collection of interfaces that together form a registry service
 type Registry struct {
-	Remote       *remote.Server
-	Profiles     Profiles
-	Search       Searchable
-	Indexer      Indexer
-	Follower     Follower
+	Remote   *remote.Server
+	Profiles Profiles
+	Search   Searchable
+	Indexer  Indexer
+	Follower Follower
 }
 
 var (

--- a/registry/regserver/handlers/search.go
+++ b/registry/regserver/handlers/search.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	apiutil "github.com/qri-io/qri/api/util"
+	qhttp "github.com/qri-io/qri/lib/http"
 	"github.com/qri-io/qri/registry"
 )
 
@@ -17,7 +18,7 @@ const (
 func NewSearchHandler(s registry.Searchable) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		p := &registry.SearchParams{}
-		if r.Header.Get("Content-Type") == "application/json" && r.Method == "POST" {
+		if r.Header.Get("Content-Type") == qhttp.JSONMimeType && r.Method == http.MethodPost {
 			if err := json.NewDecoder(r.Body).Decode(p); err != nil {
 				apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
 				return

--- a/registry/regserver/mock.go
+++ b/registry/regserver/mock.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"net/http/httptest"
 
-	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/auth/key"
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/config"
@@ -105,17 +104,21 @@ type MockRepoSearch struct {
 }
 
 // Search implements the registry.Searchable interface
-func (ss MockRepoSearch) Search(p registry.SearchParams) ([]*dataset.Dataset, error) {
+func (ss MockRepoSearch) Search(p registry.SearchParams) ([]registry.SearchResult, error) {
 	ctx := context.Background()
 	infos, err := base.ListDatasets(ctx, ss.Repo, p.Q, "", 0, 1000, true, false)
 	if err != nil {
 		return nil, err
 	}
 
-	var res []*dataset.Dataset
+	var res []registry.SearchResult
 	for _, info := range infos {
 		ds := dsref.ConvertVersionInfoToDataset(&info)
-		res = append(res, ds)
+		res = append(res, registry.SearchResult{
+			Type:  "dataset",
+			ID:    ds.Path,
+			Value: ds,
+		})
 	}
 	return res, nil
 }


### PR DESCRIPTION
This is a bit hefty but the grand summary is:
- moved the http client into a sub package of lib so it can be reused across the board without pulling in the full `lib` (also no cycles)
- cleaned up the `regclient` code mainly focusing on search, and in the process made sure all of it fits and aligns nicely so that cloud can have it's take on it too
- added `/registry/follow` support

This will not work until cloud is fully up to speed on this too but we're pretty close on that.

Part of the https://github.com/qri-io/qri/issues/1800 series.