### PR TITLE
refactor(workflow): supply context to all workflow store ops

### DIFF
--- a/automation/orchestrator_test.go
+++ b/automation/orchestrator_test.go
@@ -39,7 +39,7 @@ func TestIntegration(t *testing.T) {
 		Triggers:  []map[string]interface{}{rttListenTest.ToMap()},
 		Active:    true,
 	}
-	wf, err := workflowStore.Put(wf)
+	wf, err := workflowStore.Put(ctx, wf)
 	if err != nil {
 		t.Fatalf("workflowStore.Put unexpected error: %s", err)
 	}
@@ -113,7 +113,7 @@ func TestIntegration(t *testing.T) {
 			}},
 	}
 
-	got, err := o.SaveWorkflow(&workflow.Workflow{
+	got, err := o.SaveWorkflow(ctx, &workflow.Workflow{
 		DatasetID: "dataset_id",
 		OwnerID:   "profile_id",
 		Triggers: []map[string]interface{}{
@@ -132,7 +132,7 @@ func TestIntegration(t *testing.T) {
 		t.Fatal("only triggers of active workflows should be added to the runtimeListener")
 	}
 
-	got, err = o.GetWorkflow(expected.ID)
+	got, err = o.GetWorkflow(ctx, expected.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestIntegration(t *testing.T) {
 	<-done
 
 	expected.Active = true
-	expected, err = o.SaveWorkflow(expected)
+	expected, err = o.SaveWorkflow(ctx, expected)
 	if err != nil {
 		t.Fatalf("SaveWorkflow unexpected error: %s", err)
 	}
@@ -237,7 +237,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	wf.Active = false
-	wf, err = o.SaveWorkflow(wf)
+	wf, err = o.SaveWorkflow(ctx, wf)
 	if err != nil {
 		t.Fatalf("SaveWorkflow unexpected error: %s", err)
 	}
@@ -307,7 +307,7 @@ func TestRunStoreEvents(t *testing.T) {
 	listener := trigger.NewRuntimeListener(ctx, bus)
 	runStore := run.NewMemStore()
 	workflowStore := workflow.NewMemStore()
-	wf, err := workflowStore.Put(&workflow.Workflow{
+	wf, err := workflowStore.Put(ctx, &workflow.Workflow{
 		DatasetID: "dataset_id",
 		OwnerID:   "owner_id",
 		Created:   &time.Time{},

--- a/automation/workflow/filestore.go
+++ b/automation/workflow/filestore.go
@@ -98,7 +98,7 @@ func (s *fileStore) ListDeployed(ctx context.Context, limit, offset int) ([]*Wor
 }
 
 // GetWorkflowByDatasetID gets a workflow with the corresponding datasetID field
-func (s *fileStore) GetByDatasetID(datasetID string) (*Workflow, error) {
+func (s *fileStore) GetByDatasetID(ctx context.Context, datasetID string) (*Workflow, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -111,7 +111,7 @@ func (s *fileStore) GetByDatasetID(datasetID string) (*Workflow, error) {
 }
 
 // GetWorkflow gets workflow details from the store by dataset identifier
-func (s *fileStore) Get(id ID) (*Workflow, error) {
+func (s *fileStore) Get(ctx context.Context, id ID) (*Workflow, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -125,13 +125,13 @@ func (s *fileStore) Get(id ID) (*Workflow, error) {
 
 // PutWorkflow places a workflow in the store. If the workflow name matches the name of a workflow
 // that already exists, it will be overwritten with the new workflow
-func (s *fileStore) Put(wf *Workflow) (*Workflow, error) {
+func (s *fileStore) Put(ctx context.Context, wf *Workflow) (*Workflow, error) {
 	if wf == nil {
 		return nil, ErrNilWorkflow
 	}
 	w := wf.Copy()
 	if wf.ID == "" {
-		if _, err := s.GetByDatasetID(w.DatasetID); !errors.Is(err, ErrNotFound) {
+		if _, err := s.GetByDatasetID(ctx, w.DatasetID); !errors.Is(err, ErrNotFound) {
 			return nil, ErrWorkflowForDatasetExists
 		}
 		w.ID = NewID()
@@ -148,7 +148,7 @@ func (s *fileStore) Put(wf *Workflow) (*Workflow, error) {
 
 // DeleteWorkflow removes a workflow from the store by name. deleting a non-existent workflow
 // won't return an error
-func (s *fileStore) Remove(id ID) error {
+func (s *fileStore) Remove(ctx context.Context, id ID) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if removed := s.workflows.Remove(id); removed {
@@ -158,7 +158,7 @@ func (s *fileStore) Remove(id ID) error {
 }
 
 // Shutdown writes the set of workflows to the filestore
-func (s *fileStore) Shutdown() error {
+func (s *fileStore) Shutdown(ctx context.Context) error {
 	return s.writeToFile()
 }
 

--- a/automation/workflow/filestore_test.go
+++ b/automation/workflow/filestore_test.go
@@ -1,6 +1,7 @@
 package workflow_test
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -16,6 +17,7 @@ import (
 )
 
 func TestFileStoreIntegration(t *testing.T) {
+	ctx := context.Background()
 	tmpdir, err := ioutil.TempDir("", "")
 	if err != nil {
 		log.Fatal(err)
@@ -74,7 +76,7 @@ func TestFileStoreIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := store.Get(expectedWF1.ID)
+	got, err := store.Get(ctx, expectedWF1.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,10 +104,10 @@ func TestFileStoreIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = store.Put(expectedWF2); err != nil {
+	if _, err = store.Put(ctx, expectedWF2); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Shutdown(); err != nil {
+	if err := store.Shutdown(ctx); err != nil {
 		t.Fatal(err)
 	}
 	gotBytes, err := ioutil.ReadFile(filepath.Join(tmpdir, "workflows.json"))

--- a/lib/automation.go
+++ b/lib/automation.go
@@ -153,7 +153,7 @@ func (automationImpl) Apply(scope scope, p *ApplyParams) (*ApplyResult, error) {
 func (automationImpl) Deploy(scope scope, p *DeployParams) error {
 	log.Debugw("deploy", "dataset name", p.Dataset.Name, "peername", p.Dataset.Peername, "workflow id", p.Workflow.ID)
 	if p.Workflow.ID != "" {
-		wf, err := scope.AutomationOrchestrator().GetWorkflow(p.Workflow.ID)
+		wf, err := scope.AutomationOrchestrator().GetWorkflow(scope.Context(), p.Workflow.ID)
 		if err != nil {
 			return fmt.Errorf("deploy: %w", err)
 		}
@@ -254,7 +254,7 @@ func deploy(s scope, p *DeployParams) {
 		}
 	}()
 
-	wf, err = scope.AutomationOrchestrator().SaveWorkflow(wf)
+	wf, err = scope.AutomationOrchestrator().SaveWorkflow(scope.Context(), wf)
 	if err != nil {
 		log.Debugw("deploy save workflow", "error", err)
 		deployPayload.Error = err.Error()


### PR DESCRIPTION
Adds a context to all store operations. This is required for the cloud side of implementation and probably any alternative store would also benefit from it. Useful also for later on if we want to branch this stuff out from a single node.