### PR TITLE
refactor(profile): profile.ID.Encode and Validate methods

### DIFF
--- a/auth/token/token.go
+++ b/auth/token/token.go
@@ -198,8 +198,8 @@ func (a *pkSource) CreateToken(pro *profile.Profile, ttl time.Duration) (string,
 	// set our claims
 	claims := &Claims{
 		StandardClaims: &jwt.StandardClaims{
-			Subject: pro.ID.String(),
-			Issuer:  pro.ID.String(),
+			Subject: pro.ID.Encode(),
+			Issuer:  pro.ID.Encode(),
 		},
 		ClientType: UserClient,
 	}

--- a/auth/token/token_provider.go
+++ b/auth/token/token_provider.go
@@ -159,12 +159,12 @@ func (p *LocalProvider) Token(ctx context.Context, req *Request) (*Response, err
 			log.Debugf("token.Provider private key is nil")
 			return nil, ErrInvalidCredentials
 		}
-		accessToken, err := NewPrivKeyAuthToken(pro.PrivKey, pro.ID.String(), AccessTokenTTL)
+		accessToken, err := NewPrivKeyAuthToken(pro.PrivKey, pro.ID.Encode(), AccessTokenTTL)
 		if err != nil {
 			log.Debugf("token.Provider failed to generate access token: %q", err.Error())
 			return nil, ErrInvalidRequest
 		}
-		refreshToken, err := NewPrivKeyAuthToken(pro.PrivKey, pro.ID.String(), RefreshTokenTTL)
+		refreshToken, err := NewPrivKeyAuthToken(pro.PrivKey, pro.ID.Encode(), RefreshTokenTTL)
 		if err != nil {
 			log.Debugf("token.Provider failed to generate refresh token: %q", err.Error())
 			return nil, ErrInvalidRequest
@@ -192,7 +192,7 @@ func (p *LocalProvider) Token(ctx context.Context, req *Request) (*Response, err
 				log.Debugf("token.Provider profile not found")
 				return nil, ErrNotFound
 			}
-			accessToken, err := NewPrivKeyAuthToken(pro.PrivKey, pro.ID.String(), AccessTokenTTL)
+			accessToken, err := NewPrivKeyAuthToken(pro.PrivKey, pro.ID.Encode(), AccessTokenTTL)
 			if err != nil {
 				log.Debugf("token.Provider failed to generate access token: %q", err.Error())
 				return nil, ErrInvalidRequest

--- a/base/dataset.go
+++ b/base/dataset.go
@@ -184,7 +184,7 @@ func ListDatasets(ctx context.Context, r repo.Repo, term, profileID string, offs
 			}
 		}
 		if profileID != "" {
-			if profileID != ref.ProfileID.String() {
+			if profileID != ref.ProfileID.Encode() {
 				continue
 			}
 		}

--- a/base/ref.go
+++ b/base/ref.go
@@ -16,7 +16,7 @@ import (
 // already resolved
 func InLocalNamespace(ctx context.Context, r repo.Repo, ref dsref.Ref) bool {
 	p := r.Profiles().Owner()
-	return p.ID.String() == ref.ProfileID
+	return p.ID.Encode() == ref.ProfileID
 }
 
 // SetPublishStatus updates the Published field of a dataset ref

--- a/base/save.go
+++ b/base/save.go
@@ -155,7 +155,7 @@ func CreateDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, d
 		// should be ok to skip this error. we may not have the previous
 		// reference locally
 		repo.DeleteVersionInfoShim(ctx, r, dsref.Ref{
-			ProfileID: pro.ID.String(),
+			ProfileID: pro.ID.Encode(),
 			Username:  pro.Peername,
 			Name:      dsName,
 			Path:      ds.PreviousPath,
@@ -167,7 +167,7 @@ func CreateDataset(ctx context.Context, r repo.Repo, writeDest qfs.Filesystem, d
 	if err != nil {
 		return nil, err
 	}
-	ds.ProfileID = pro.ID.String()
+	ds.ProfileID = pro.ID.Encode()
 	ds.Name = dsName
 	ds.Peername = pro.Peername
 	ds.Path = path
@@ -310,7 +310,7 @@ func InferValues(pro *profile.Profile, ds *dataset.Dataset) error {
 	}
 	// NOTE: add author ProfileID here to keep the dataset package agnostic to
 	// all identity stuff except keypair crypto
-	ds.Commit.Author = &dataset.User{ID: pro.ID.String()}
+	ds.Commit.Author = &dataset.User{ID: pro.ID.Encode()}
 
 	// add any missing structure fields
 	if err := detect.Structure(ds); err != nil && !errors.Is(err, dataset.ErrNoBody) {

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -328,7 +328,7 @@ func (s *localSet) handleEvent(ctx context.Context, e event.Event) error {
 	switch e.Type {
 	case event.ETDatasetNameInit:
 		if vi, ok := e.Payload.(dsref.VersionInfo); ok {
-			pid, err := profile.NewB58ID(vi.ProfileID)
+			pid, err := profile.IDB58Decode(vi.ProfileID)
 			if err != nil {
 				log.Debugw("parsing profile ID in name init", "err", err)
 				return err

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -127,9 +127,13 @@ func (s *localSet) List(ctx context.Context, pid profile.ID, lp params.List) ([]
 	s.Lock()
 	defer s.Unlock()
 
+	if err := pid.Validate(); err != nil {
+		return nil, err
+	}
+
 	col, ok := s.collections[pid]
 	if !ok {
-		return nil, fmt.Errorf("%w: no collection for profile ID %q", ErrNotFound, pid.String())
+		return nil, fmt.Errorf("%w: no collection for profile ID %q", ErrNotFound, pid.Encode())
 	}
 
 	if lp.Limit < 0 {
@@ -156,6 +160,10 @@ func (s *localSet) List(ctx context.Context, pid profile.ID, lp params.List) ([]
 func (s *localSet) Put(ctx context.Context, pid profile.ID, items ...dsref.VersionInfo) error {
 	s.Lock()
 	defer s.Unlock()
+
+	if err := pid.Validate(); err != nil {
+		return err
+	}
 
 	for _, item := range items {
 		if err := s.putOne(pid, item); err != nil {
@@ -197,6 +205,10 @@ func (s *localSet) putOne(pid profile.ID, item dsref.VersionInfo) error {
 func (s *localSet) Delete(ctx context.Context, pid profile.ID, initID ...string) error {
 	s.Lock()
 	defer s.Unlock()
+
+	if err := pid.Validate(); err != nil {
+		return err
+	}
 
 	col, ok := s.collections[pid]
 	if !ok {
@@ -284,7 +296,7 @@ func (s *localSet) saveProfileCollection(pid profile.ID) error {
 		return fmt.Errorf("serializing user collection: %w", err)
 	}
 
-	path := filepath.Join(s.basePath, fmt.Sprintf("%s.json", pid.String()))
+	path := filepath.Join(s.basePath, fmt.Sprintf("%s.json", pid.Encode()))
 	return ioutil.WriteFile(path, data, 0644)
 }
 

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -49,7 +49,7 @@ func TestCollectionPersistence(t *testing.T) {
 	missPiggy := profiletest.GetProfile("miss_piggy")
 
 	item1 := dsref.VersionInfo{
-		ProfileID:  kermit.ID.String(),
+		ProfileID:  kermit.ID.Encode(),
 		InitID:     "muppet_names_init_id",
 		Username:   "kermit",
 		Name:       "muppet_names",
@@ -60,7 +60,7 @@ func TestCollectionPersistence(t *testing.T) {
 	}
 
 	item2 := dsref.VersionInfo{
-		ProfileID:  missPiggy.ID.String(),
+		ProfileID:  missPiggy.ID.Encode(),
 		InitID:     "secret_muppet_friends_init_id",
 		Username:   "miss_piggy",
 		Name:       "secret_muppet_friends",
@@ -92,3 +92,34 @@ func TestCollectionPersistence(t *testing.T) {
 		t.Errorf("result mismatch. (-want +got):\n%s", diff)
 	}
 }
+
+const myPid = "QmeL2mdVka1eahKENjehK6tBxkkpk5dNQ1qMcgWi7Hrb4B"
+
+func TestInvalidIDFails(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dir, err := ioutil.TempDir("", "qri_test_invalid_id_fails")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	c, err := collection.NewLocalSet(ctx, event.NilBus, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := c.(collection.WritableSet)
+
+	info := dsref.VersionInfo{
+		ProfileID:  myPid,
+		InitID:     "some_init_id",
+		Username:   "user",
+		Name:       "my_ds",
+		CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err = wc.Put(ctx, myPid, info); err != nil {
+		t.Error(err)
+	}
+}
+

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -111,6 +111,8 @@ func TestInvalidIDFails(t *testing.T) {
 	}
 	wc := c.(collection.WritableSet)
 
+	// Construct an invalid profileID (it's base58 encoded), which
+	// should result in an error
 	info := dsref.VersionInfo{
 		ProfileID:  myPid,
 		InitID:     "some_init_id",
@@ -118,8 +120,13 @@ func TestInvalidIDFails(t *testing.T) {
 		Name:       "my_ds",
 		CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
-	if err = wc.Put(ctx, myPid, info); err != nil {
-		t.Error(err)
+	err = wc.Put(ctx, myPid, info)
+	if err == nil {
+		t.Fatal("expected to get an error, did not get one")
+	}
+	expectErr := `profile.ID invalid, was double encoded as "9tmzz8FC9hjBrY1J9NFFt4gjAzGZWCGrKwB4pcdwuSHC7Y4Y7oPPAkrV48ryPYu". do not pass a base64 encoded string, instead use IDB58Decode(b64encodedID)`
+	if expectErr != err.Error() {
+		t.Errorf("error mismatch, expect: %s, got: %s", expectErr, err)
 	}
 }
 

--- a/collection/spec/collection.go
+++ b/collection/spec/collection.go
@@ -59,9 +59,9 @@ func AssertWritableCollectionSpec(t *testing.T, constructor Constructor) {
 			item    dsref.VersionInfo
 		}{
 			{"empty", dsref.VersionInfo{}},
-			{"no InitID", dsref.VersionInfo{ProfileID: kermit.ID.String()}},
+			{"no InitID", dsref.VersionInfo{ProfileID: kermit.ID.Encode()}},
 			{"no profileID", dsref.VersionInfo{InitID: "init_id"}},
-			{"no name", dsref.VersionInfo{InitID: "init_id", ProfileID: kermit.ID.String()}},
+			{"no name", dsref.VersionInfo{InitID: "init_id", ProfileID: kermit.ID.Encode()}},
 		}
 
 		for _, bad := range badItems {
@@ -74,14 +74,14 @@ func AssertWritableCollectionSpec(t *testing.T, constructor Constructor) {
 
 		err := ec.Put(ctx, kermit.ID,
 			dsref.VersionInfo{
-				ProfileID:  kermit.ID.String(),
+				ProfileID:  kermit.ID.Encode(),
 				InitID:     "muppet_names_init_id",
 				Username:   "kermit",
 				Name:       "muppet_names",
 				CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			dsref.VersionInfo{
-				ProfileID:  kermit.ID.String(),
+				ProfileID:  kermit.ID.Encode(),
 				InitID:     "muppet_names_and_ages_init_id",
 				Username:   "kermit",
 				Name:       "muppet_names_and_ages",
@@ -95,21 +95,21 @@ func AssertWritableCollectionSpec(t *testing.T, constructor Constructor) {
 
 		err = ec.Put(ctx, missPiggy.ID,
 			dsref.VersionInfo{
-				ProfileID:  missPiggy.ID.String(),
+				ProfileID:  missPiggy.ID.Encode(),
 				InitID:     "secret_muppet_friends_init_id",
 				Username:   "miss_piggy",
 				Name:       "secret_muppet_friends",
 				CommitTime: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
 			},
 			dsref.VersionInfo{
-				ProfileID:  missPiggy.ID.String(),
+				ProfileID:  missPiggy.ID.Encode(),
 				InitID:     "muppet_names_init_id",
 				Username:   "kermit",
 				Name:       "muppet_names",
 				CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			dsref.VersionInfo{
-				ProfileID:  missPiggy.ID.String(),
+				ProfileID:  missPiggy.ID.Encode(),
 				InitID:     "famous_muppets_init_id",
 				Username:   "famous_muppets",
 				Name:       "famous_muppets",
@@ -124,14 +124,14 @@ func AssertWritableCollectionSpec(t *testing.T, constructor Constructor) {
 	t.Run("list", func(t *testing.T) {
 		assertCollectionList(ctx, t, kermit, params.ListAll, ec, []dsref.VersionInfo{
 			{
-				ProfileID:  kermit.ID.String(),
+				ProfileID:  kermit.ID.Encode(),
 				InitID:     "muppet_names_init_id",
 				Username:   "kermit",
 				Name:       "muppet_names",
 				CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			{
-				ProfileID:  kermit.ID.String(),
+				ProfileID:  kermit.ID.Encode(),
 				InitID:     "muppet_names_and_ages_init_id",
 				Username:   "kermit",
 				Name:       "muppet_names_and_ages",
@@ -141,21 +141,21 @@ func AssertWritableCollectionSpec(t *testing.T, constructor Constructor) {
 
 		assertCollectionList(ctx, t, missPiggy, params.ListAll, ec, []dsref.VersionInfo{
 			{
-				ProfileID:  missPiggy.ID.String(),
+				ProfileID:  missPiggy.ID.Encode(),
 				InitID:     "famous_muppets_init_id",
 				Username:   "famous_muppets",
 				Name:       "famous_muppets",
 				CommitTime: time.Date(2021, 1, 4, 0, 0, 0, 0, time.UTC),
 			},
 			{
-				ProfileID:  missPiggy.ID.String(),
+				ProfileID:  missPiggy.ID.Encode(),
 				InitID:     "muppet_names_init_id",
 				Username:   "kermit",
 				Name:       "muppet_names",
 				CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			{
-				ProfileID:  missPiggy.ID.String(),
+				ProfileID:  missPiggy.ID.Encode(),
 				InitID:     "secret_muppet_friends_init_id",
 				Username:   "miss_piggy",
 				Name:       "secret_muppet_friends",
@@ -228,7 +228,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		// simulate name initialization, normally emitted by logbook
 		mustPublish(ctx, t, bus, event.ETDatasetNameInit, dsref.VersionInfo{
 			InitID:    muppetNamesInitID,
-			ProfileID: kermit.ID.String(),
+			ProfileID: kermit.ID.Encode(),
 			Username:  kermit.Peername,
 			Name:      muppetNamesName1,
 		})
@@ -236,7 +236,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		expect := []dsref.VersionInfo{
 			{
 				InitID:    muppetNamesInitID,
-				ProfileID: kermit.ID.String(),
+				ProfileID: kermit.ID.Encode(),
 				Username:  kermit.Peername,
 				Name:      muppetNamesName1,
 			},
@@ -246,7 +246,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		// simulate version creation, normally emitted by logbook
 		mustPublish(ctx, t, bus, event.ETDatasetCommitChange, dsref.VersionInfo{
 			InitID:      muppetNamesInitID,
-			ProfileID:   kermit.ID.String(),
+			ProfileID:   kermit.ID.Encode(),
 			Path:        "/mem/PathToMuppetNamesVersionOne",
 			Username:    kermit.Peername,
 			Name:        muppetNamesName1,
@@ -257,7 +257,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		expect = []dsref.VersionInfo{
 			{
 				InitID:      muppetNamesInitID,
-				ProfileID:   kermit.ID.String(),
+				ProfileID:   kermit.ID.Encode(),
 				Username:    kermit.Peername,
 				Name:        muppetNamesName1,
 				NumVersions: 2,
@@ -277,7 +277,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		expect = []dsref.VersionInfo{
 			{
 				InitID:      muppetNamesInitID,
-				ProfileID:   kermit.ID.String(),
+				ProfileID:   kermit.ID.Encode(),
 				Username:    kermit.Peername,
 				Name:        muppetNamesName2,
 				NumVersions: 2,
@@ -316,7 +316,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		// mustPublish(ctx, t, bus, event.ETDatasetNameInit, event.DsChange{
 		// 	InitID:     muppetTweetsInitID,
 		// 	Username:   kermit.Peername,
-		// 	ProfileID:  kermit.ID.String(),
+		// 	ProfileID:  kermit.ID.Encode(),
 		// 	PrettyName: muppetTweetsName,
 		// 	Info: &dsref.VersionInfo{
 		// 		InitID: muppetTweetsInitID,
@@ -327,7 +327,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 			Ref: dsref.Ref{
 				InitID:    muppetTweetsInitID,
 				Username:  kermit.Peername,
-				ProfileID: kermit.ID.String(),
+				ProfileID: kermit.ID.Encode(),
 			},
 		})
 		// simulate version creation, normally emitted by logbook
@@ -335,7 +335,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 			InitID:      muppetTweetsInitID,
 			NumVersions: 2,
 			Path:        "/mem/PathToMuppetTweetsVersionOne",
-			ProfileID:   kermit.ID.String(),
+			ProfileID:   kermit.ID.Encode(),
 			Username:    kermit.Peername,
 			Name:        muppetTweetsName,
 		})
@@ -343,7 +343,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		expect := []dsref.VersionInfo{
 			{
 				InitID:      muppetTweetsInitID,
-				ProfileID:   kermit.ID.String(),
+				ProfileID:   kermit.ID.Encode(),
 				Username:    kermit.Peername,
 				Name:        muppetTweetsName,
 				NumVersions: 2,

--- a/dscache/convert.go
+++ b/dscache/convert.go
@@ -28,7 +28,7 @@ func BuildDscacheFromLogbookAndProfilesAndDsref(ctx context.Context, refs []repo
 
 	userProfileList := make([]userProfilePair, 0, len(profileList))
 	for id, pro := range profileList {
-		pair := userProfilePair{Username: pro.Peername, ProfileID: id.String()}
+		pair := userProfilePair{Username: pro.Peername, ProfileID: id.Encode()}
 		userProfileList = append(userProfileList, pair)
 	}
 
@@ -179,7 +179,7 @@ func convertLogbookAndRefs(ctx context.Context, book *logbook.Book, dsrefs []rep
 		}
 		missingInfoList = append(missingInfoList, &entryInfo{
 			VersionInfo: dsref.VersionInfo{
-				ProfileID: ref.ProfileID.String(),
+				ProfileID: ref.ProfileID.Encode(),
 				Name:      ref.Name,
 				Path:      ref.Path,
 				FSIPath:   ref.FSIPath,
@@ -274,7 +274,7 @@ func findMatchingInfo(ref reporef.DatasetRef, entryInfoList []*entryInfo) *entry
 		// but name is mutable and can be modified at any time. It should not be used as a
 		// primary key, only as for pretty display. We should be using initID everywhere instead,
 		// but dsrefs does not store the initID, which is the whole reason it is going away.
-		if ref.ProfileID.String() == info.ProfileID && ref.Name == info.Name {
+		if ref.ProfileID.Encode() == info.ProfileID && ref.Name == info.Name {
 			return info
 		}
 	}

--- a/dscache/convert_test.go
+++ b/dscache/convert_test.go
@@ -26,22 +26,22 @@ func TestBuildDscacheFlatbuffer(t *testing.T) {
 	userList := []userProfilePair{
 		{
 			Username:  "test_zero",
-			ProfileID: pid0.String(),
+			ProfileID: pid0.Encode(),
 		},
 		{
 			Username:  "test_one",
-			ProfileID: pid1.String(),
+			ProfileID: pid1.Encode(),
 		},
 		{
 			Username:  "test_two",
-			ProfileID: pid2.String(),
+			ProfileID: pid2.Encode(),
 		},
 	}
 	entryInfoList := []*entryInfo{
 		&entryInfo{
 			VersionInfo: dsref.VersionInfo{
 				InitID:    "ds_init_id_0000",
-				ProfileID: pid1.String(),
+				ProfileID: pid1.Encode(),
 				Name:      "my_ds",
 				Path:      "/ipfs/QmExampleFirst",
 			},
@@ -49,7 +49,7 @@ func TestBuildDscacheFlatbuffer(t *testing.T) {
 		&entryInfo{
 			VersionInfo: dsref.VersionInfo{
 				InitID:    "ds_init_id_0001",
-				ProfileID: pid1.String(),
+				ProfileID: pid1.Encode(),
 				Name:      "another_ds",
 				Path:      "/ipfs/QmExampleSecond",
 			},
@@ -57,7 +57,7 @@ func TestBuildDscacheFlatbuffer(t *testing.T) {
 		&entryInfo{
 			VersionInfo: dsref.VersionInfo{
 				InitID:    "ds_init_id_0002",
-				ProfileID: pid1.String(),
+				ProfileID: pid1.Encode(),
 				Name:      "checked_out_ds",
 				Path:      "/ipfs/QmExampleThird",
 				FSIPath:   "/path/to/workspace/checked_out_ds",
@@ -66,7 +66,7 @@ func TestBuildDscacheFlatbuffer(t *testing.T) {
 		&entryInfo{
 			VersionInfo: dsref.VersionInfo{
 				InitID:    "ds_init_id_0003",
-				ProfileID: pid2.String(),
+				ProfileID: pid2.Encode(),
 				Name:      "foreign_ds",
 				Path:      "/ipfs/QmExampleFourth",
 			},

--- a/dscache/dscache.go
+++ b/dscache/dscache.go
@@ -149,7 +149,7 @@ func (d *Dscache) ListRefs() ([]reporef.DatasetRef, error) {
 		d.Root.Refs(&refCache, i)
 
 		proIDStr := string(refCache.ProfileID())
-		profileID, err := profile.NewB58ID(proIDStr)
+		profileID, err := profile.IDB58Decode(proIDStr)
 		if err != nil {
 			log.Errorf("could not parse profileID %q", proIDStr)
 		}

--- a/dscache/dscache_test.go
+++ b/dscache/dscache_test.go
@@ -61,7 +61,7 @@ func TestDscacheAssignSaveAndLoad(t *testing.T) {
 
 	// Construct a dscache, will not save without a filename
 	builder := NewBuilder()
-	builder.AddUser(peername, profile.IDFromPeerID(keyData.PeerID).String())
+	builder.AddUser(peername, profile.IDFromPeerID(keyData.PeerID).Encode())
 	builder.AddDsVersionInfo(dsref.VersionInfo{InitID: "abcd1"})
 	builder.AddDsVersionInfo(dsref.VersionInfo{InitID: "efgh2"})
 	constructed := builder.Build()

--- a/lib/access.go
+++ b/lib/access.go
@@ -92,8 +92,8 @@ func (accessImpl) CreateAuthToken(scp scope, p *CreateAuthTokenParams) (string, 
 
 	pk := grantee.PrivKey
 	if pk == nil {
-		return "", fmt.Errorf("cannot create token for %q (id: %s), private key is required", grantee.Peername, grantee.ID.String())
+		return "", fmt.Errorf("cannot create token for %q (id: %s), private key is required", grantee.Peername, grantee.ID.Encode())
 	}
 
-	return token.NewPrivKeyAuthToken(pk, grantee.ID.String(), p.TTL)
+	return token.NewPrivKeyAuthToken(pk, grantee.ID.Encode(), p.TTL)
 }

--- a/lib/automation.go
+++ b/lib/automation.go
@@ -172,7 +172,7 @@ func (automationImpl) Deploy(scope scope, p *DeployParams) error {
 }
 
 func deploy(s scope, p *DeployParams) {
-	ctx := profile.AddIDToContext(s.AppContext(), s.ActiveProfile().ID.String())
+	ctx := profile.AddIDToContext(s.AppContext(), s.ActiveProfile().ID.Encode())
 	// TODO(ramfox): we need the scope context to last longer than the context
 	// that was passed to us. We are, for now, going to rely on the app context
 	// in the future we will probably want something more sophisticated so that
@@ -306,7 +306,7 @@ func deploy(s scope, p *DeployParams) {
 }
 
 func (inst *Instance) run(ctx context.Context, streams ioes.IOStreams, w *workflow.Workflow, runID string) error {
-	ctxWithProfile := profile.AddIDToContext(ctx, w.OwnerID.String())
+	ctxWithProfile := profile.AddIDToContext(ctx, w.OwnerID.Encode())
 	scope, err := newScope(ctxWithProfile, inst, "local")
 	if err != nil {
 		return err
@@ -332,7 +332,7 @@ func (inst *Instance) run(ctx context.Context, streams ioes.IOStreams, w *workfl
 }
 
 func (inst *Instance) apply(ctx context.Context, wait bool, runID string, wf *workflow.Workflow, ds *dataset.Dataset, secrets map[string]string) error {
-	ctxWithProfile := profile.AddIDToContext(ctx, wf.OwnerID.String())
+	ctxWithProfile := profile.AddIDToContext(ctx, wf.OwnerID.Encode())
 	scope, err := newScope(ctxWithProfile, inst, "local")
 	if err != nil {
 		return err

--- a/lib/collection.go
+++ b/lib/collection.go
@@ -117,7 +117,7 @@ func (collectionImpl) List(scope scope, p *ListParams) ([]dsref.VersionInfo, err
 	}
 
 	reqProfile := scope.Repo().Profiles().Owner()
-	listProfile, err := getProfile(scope.Context(), scope.Repo().Profiles(), reqProfile.ID.String(), p.Username)
+	listProfile, err := getProfile(scope.Context(), scope.Repo().Profiles(), reqProfile.ID.Encode(), p.Username)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/dispatch.go
+++ b/lib/dispatch.go
@@ -111,7 +111,7 @@ func (inst *Instance) dispatchMethodCall(ctx context.Context, method string, par
 			if err != nil {
 				return nil, nil, err
 			}
-			tokstr, err := token.NewPrivKeyAuthToken(p.PrivKey, p.ID.String(), time.Minute)
+			tokstr, err := token.NewPrivKeyAuthToken(p.PrivKey, p.ID.Encode(), time.Minute)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -284,7 +284,7 @@ func TestNewInstanceWithAccessControlPolicy(t *testing.T) {
 		{
 			"title": "pull foo:bar dataset",
 			"effect": "allow",
-			"subject": "` + proID.String() + `",
+			"subject": "` + proID.Encode() + `",
 			"resources": [
 				"dataset:foo:bar"
 			],
@@ -349,7 +349,7 @@ func TestNewInstanceWithCollectionOption(t *testing.T) {
 			InitID:    "init_id",
 			Username:  kermit.Peername,
 			Name:      "dataset",
-			ProfileID: kermit.ID.String(),
+			ProfileID: kermit.ID.Encode(),
 		},
 	}
 

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -111,7 +111,7 @@ func (registryImpl) ProveProfileKey(scope scope, p *RegistryProfileParams) error
 		return err
 	}
 
-	p.Profile.ProfileID = pro.ID.String()
+	p.Profile.ProfileID = pro.ID.Encode()
 	p.Profile.PublicKey = base64.StdEncoding.EncodeToString(pubkeybytes)
 	// TODO(dustmop): Expand the signature to sign more than just the username
 	sigbytes, err := privKey.Sign([]byte(p.Profile.Username))

--- a/profile/id.go
+++ b/profile/id.go
@@ -108,12 +108,3 @@ func IDB58MustDecode(proid string) ID {
 	}
 	return ID(pid)
 }
-
-// NewB58ID creates a peer.ID from a base58 encoded string
-// DEPRECATED: This function is confusing, its name implies that it is returning
-// a base58 string, but actually it takes a base58 string and decodes it.
-// Call IDB58Decode instead.
-func NewB58ID(pid string) (ID, error) {
-	id, err := peer.IDB58Decode(pid)
-	return ID(id), err
-}

--- a/profile/id.go
+++ b/profile/id.go
@@ -1,7 +1,10 @@
 package profile
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
@@ -10,22 +13,43 @@ import (
 // but the mechanics of peer.ID & profile.ID are exactly the same
 type ID peer.ID
 
-// String implements the stringer interface for ID
+// String converts a profileID to a string for debugging
 func (id ID) String() string {
+	bytes := []byte(id)
+	return fmt.Sprintf("profile.ID{%s}", hex.EncodeToString(bytes))
+}
+
+// Encode converts a profileID into a base58 encoded string
+func (id ID) Encode() string {
 	return peer.ID(id).Pretty()
 }
 
-// Validate exposes the validation interface for ID
+// Empty returns whether the id is empty
+func (id ID) Empty() bool {
+	return id.Encode() == ""
+}
+
+// Validate validates the profileID, returning an error if it is invalid
 func (id ID) Validate() error {
-	return peer.ID(id).Validate()
+	if err := peer.ID(id).Validate(); err != nil {
+		return err
+	}
+	b64str := id.Encode()
+	if strings.HasPrefix(b64str, "Qm") {
+		return nil
+	}
+	if strings.HasPrefix(b64str, "9t") {
+		return fmt.Errorf("profile.ID invalid, was double encoded as %q. do not pass a base64 encoded string, instead use IDB58Decode(b64encodedID)", b64str)
+	}
+	return fmt.Errorf("profile.ID invalid, encodes to %q", b64str)
 }
 
-// MarshalJSON implements the json.Marshaler interface for ID
+// MarshalJSON encodes the ID for json marshalling
 func (id ID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(id.String())
+	return json.Marshal(id.Encode())
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface for ID
+// UnmarshalJSON unmarshals an id from json
 func (id *ID) UnmarshalJSON(data []byte) (err error) {
 	var str string
 	if err := json.Unmarshal(data, &str); err != nil {
@@ -35,12 +59,12 @@ func (id *ID) UnmarshalJSON(data []byte) (err error) {
 	return
 }
 
-// MarshalYAML implements the yaml.Marshaler interface for ID
+// MarshalYAML encodes the ID for yaml marshalling
 func (id *ID) MarshalYAML() (interface{}, error) {
-	return id.String(), nil
+	return id.Encode(), nil
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface for ID
+// UnmarshalYAML unmarshals an id from yaml
 func (id *ID) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
 	var str string
 	if err := unmarshal(&str); err != nil {
@@ -50,8 +74,8 @@ func (id *ID) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
 	return
 }
 
-// IDRawByteString constructs an ID from a raw byte string. No decoding happens. Should only
-// be used in tests
+// IDRawByteString constructs an ID from a raw byte string. No base58 decoding happens.
+// Should only be used in tests
 func IDRawByteString(data string) ID {
 	return ID(data)
 }
@@ -61,7 +85,7 @@ func IDFromPeerID(pid peer.ID) ID {
 	return ID(pid)
 }
 
-// IDB58Decode proxies a lower level API b/c I'm lazy & don't like
+// IDB58Decode decodes a base58 string into a profile.ID
 func IDB58Decode(proid string) (ID, error) {
 	pid, err := peer.IDB58Decode(proid)
 	return ID(pid), err
@@ -85,7 +109,10 @@ func IDB58MustDecode(proid string) ID {
 	return ID(pid)
 }
 
-// NewB58ID creates a peer.ID from a base58-encoded string
+// NewB58ID creates a peer.ID from a base58 encoded string
+// DEPRECATED: This function is confusing, its name implies that it is returning
+// a base58 string, but actually it takes a base58 string and decodes it.
+// Call IDB58Decode instead.
 func NewB58ID(pid string) (ID, error) {
 	id, err := peer.IDB58Decode(pid)
 	return ID(id), err

--- a/profile/id_test.go
+++ b/profile/id_test.go
@@ -2,13 +2,17 @@ package profile
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	testkeys "github.com/qri-io/qri/auth/key/test"
 )
 
+const base64encoded = "QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1"
+
 func TestIDJSON(t *testing.T) {
-	idbytes, err := IDB58MustDecode("QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1").MarshalJSON()
+	idbytes, err := IDB58MustDecode(base64encoded).MarshalJSON()
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -30,22 +34,145 @@ func TestPeerID(t *testing.T) {
 	mistakenDecode := "9tmzz8FC9hjBrY1J9NFFt4gjAzGZWCGrKwB4pcdwuSHC7Y4Y7oPPAkrV48ryPYu"
 
 	badlyConstructedProfileID := ID(idStr)
-	if badlyConstructedProfileID.String() != mistakenDecode {
+	if badlyConstructedProfileID.Encode() != mistakenDecode {
 		t.Errorf("unexpected value for encoded peerID, got %s", badlyConstructedProfileID)
 	}
 
 	wellformedProfileID0 := IDB58DecodeOrEmpty(idStr)
-	if wellformedProfileID0.String() != idStr {
+	if wellformedProfileID0.Encode() != idStr {
 		t.Errorf("unexpected value for encoded peerID, got %s", wellformedProfileID0)
 	}
 
 	wellformedProfileID1 := IDFromPeerID(kd.PeerID)
-	if wellformedProfileID1.String() != idStr {
+	if wellformedProfileID1.Encode() != idStr {
 		t.Errorf("unexpected value for encoded peerID, got %s", wellformedProfileID1)
 	}
 
 	wellformedProfileID2 := IDRawByteString(string(kd.PeerID))
-	if wellformedProfileID2.String() != idStr {
+	if wellformedProfileID2.Encode() != idStr {
 		t.Errorf("unexpected value for encoded peerID, got %s", wellformedProfileID2)
+	}
+}
+
+func TestStringifyVsEncode(t *testing.T) {
+	var pid ID
+
+	kd := testkeys.GetKeyData(0)
+	pid = IDFromPeerID(kd.PeerID)
+
+	actual := pid.String()
+	expect := `profile.ID{1220ed925aab9128c318acffebcc9a2b66876cebefb2511d2b1e3256f74ce96549a8}`
+	if diff := cmp.Diff(expect, actual); diff != "" {
+		t.Errorf("profileID.String() (-want +got):\n%s", diff)
+	}
+
+	actual = pid.Encode()
+	expect = kd.EncodedPeerID
+	if diff := cmp.Diff(expect, actual); diff != "" {
+		t.Errorf("profileID.String() (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	var pid ID
+	if !pid.Empty() {
+		t.Fatal("expected: profileID.Empty should be true")
+	}
+
+	kd := testkeys.GetKeyData(0)
+	pid = IDFromPeerID(kd.PeerID)
+	if pid.Empty() {
+		t.Error("expected: profileID.Empty should be false")
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	var pid ID
+
+	kd := testkeys.GetKeyData(0)
+	pid = IDFromPeerID(kd.PeerID)
+
+	data, err := pid.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := string(data)
+	expect := fmt.Sprintf("%q", kd.EncodedPeerID)
+	if diff := cmp.Diff(expect, actual); diff != "" {
+		t.Errorf("profileID.String() (-want +got):\n%s", diff)
+	}
+}
+
+func TestMarshalYAML(t *testing.T) {
+	var pid ID
+
+	kd := testkeys.GetKeyData(0)
+	pid = IDFromPeerID(kd.PeerID)
+
+	actual, err := pid.MarshalYAML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := kd.EncodedPeerID
+	if diff := cmp.Diff(expect, actual); diff != "" {
+		t.Errorf("profileID.String() (-want +got):\n%s", diff)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	var pid ID
+
+	// profile.ID is empty, Validate will fail
+	err := pid.Validate()
+	if err == nil {
+		t.Fatal("error expected, did not get one")
+	}
+	expectErr := `empty peer ID`
+	if expectErr != err.Error() {
+		t.Errorf("error mismatch, expect: %s, got: %s", expectErr, err)
+	}
+
+	// profile.ID is invalid, Validate will fail
+	// NOTE: Do not call this function this way! Only used here to demonstrate
+	// what *not* to do
+	pid = IDRawByteString("bad")
+	err = pid.Validate()
+	if err == nil {
+		t.Fatal("error expected, did not get one")
+	}
+	expectErr = `profile.ID invalid, encodes to "a3c7"`
+	if expectErr != err.Error() {
+		t.Errorf("error mismatch, expect: %s, got: %s", expectErr, err)
+	}
+
+	// profile.ID is invalid due to double-encoding, Validate will fail
+	// NOTE: Do not call this function this way! Only used here to demonstrate
+	// what *not* to do
+	kd := testkeys.GetKeyData(0)
+	pid = IDRawByteString(kd.EncodedPeerID)
+	err = pid.Validate()
+	if err == nil {
+		t.Fatal("error expected, did not get one")
+	}
+	expectErr = `profile.ID invalid, was double encoded as "9tmzz8FC9hjBrY1J9NFFt4gjAzGZWCGrKwB4pcdwuSHC7Y4Y7oPPAkrV48ryPYu". do not pass a base64 encoded string, instead use IDB58Decode(b64encodedID)`
+	if expectErr != err.Error() {
+		t.Errorf("error mismatch, expect: %s, got: %s", expectErr, err)
+	}
+
+	// profile.ID is correctly decoded, Validate will not return an error
+	pid, err = IDB58Decode(kd.EncodedPeerID)
+	if err != nil {
+		t.Fatalf("Decode got error: %s", err)
+	}
+	err = pid.Validate()
+	if err != nil {
+		t.Errorf("Validate() got error: %s", err)
+	}
+
+	// profile.ID is correctly coerced from peer.ID, Validate will not return an error
+	pid = IDFromPeerID(kd.PeerID)
+	err = pid.Validate()
+	if err != nil {
+		t.Errorf("Validate() got error: %s", err)
 	}
 }

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -156,7 +156,7 @@ func (p Profile) Encode() (*config.ProfilePod, error) {
 		addrs = append(addrs, maddr.String())
 	}
 	pp := &config.ProfilePod{
-		ID:           p.ID.String(),
+		ID:           p.ID.Encode(),
 		Type:         p.Type.String(),
 		Peername:     p.Peername,
 		Created:      p.Created,

--- a/profile/store.go
+++ b/profile/store.go
@@ -168,7 +168,7 @@ func (m *MemStore) Active(ctx context.Context) *Profile {
 
 // PutProfile adds a peer to this store
 func (m *MemStore) PutProfile(p *Profile) error {
-	if p.ID.String() == "" {
+	if p.ID.Empty() {
 		return fmt.Errorf("profile.ID is required")
 	}
 
@@ -341,8 +341,8 @@ func (r *LocalStore) Active(ctx context.Context) *Profile {
 
 // PutProfile adds a peer to the store
 func (r *LocalStore) PutProfile(p *Profile) error {
-	log.Debugf("put profile: %s", p.ID.String())
-	if p.ID.String() == "" {
+	log.Debugf("put profile: %s", p.ID.Encode())
+	if p.ID.Empty() {
 		return fmt.Errorf("profile ID is required")
 	}
 
@@ -372,7 +372,7 @@ func (r *LocalStore) PutProfile(p *Profile) error {
 	if err != nil {
 		return err
 	}
-	ps[p.ID.String()] = enc
+	ps[p.ID.Encode()] = enc
 	return r.saveFile(ps)
 }
 
@@ -386,7 +386,7 @@ func (r *LocalStore) PeerIDs(id ID) ([]peer.ID, error) {
 		return nil, err
 	}
 
-	ids := id.String()
+	ids := id.Encode()
 
 	for proid, cp := range ps {
 		if ids == proid {
@@ -445,7 +445,7 @@ func (r *LocalStore) PeernameID(peername string) (ID, error) {
 
 // GetProfile fetches a profile from the store
 func (r *LocalStore) GetProfile(id ID) (*Profile, error) {
-	log.Debugf("get profile: %s", id.String())
+	log.Debugf("get profile: %s", id.Encode())
 
 	r.Lock()
 	defer r.Unlock()
@@ -455,7 +455,7 @@ func (r *LocalStore) GetProfile(id ID) (*Profile, error) {
 		return nil, err
 	}
 
-	ids := id.String()
+	ids := id.Encode()
 
 	for proid, p := range ps {
 		if ids == proid {
@@ -535,7 +535,7 @@ func (r *LocalStore) DeleteProfile(id ID) error {
 	if err != nil {
 		return err
 	}
-	delete(ps, id.String())
+	delete(ps, id.Encode())
 	return r.saveFile(ps)
 }
 

--- a/remote/access/access.go
+++ b/remote/access/access.go
@@ -99,13 +99,13 @@ func (pol Policy) Enforce(subject *profile.Profile, resource, action string) err
 
 	for _, rule := range pol {
 		log.Debugf("rule=%q effect=%q subject=%t resources=%t actions=%t", rule.Title, rule.Effect,
-			(rule.Subject == subject.ID.String() || rule.Subject == matchAll),
+			(rule.Subject == subject.ID.Encode() || rule.Subject == matchAll),
 			rule.Resources.Contains(rsc, subject.Peername),
 			rule.Actions.Contains(act),
 		)
 
 		if rule.Effect == EffectAllow &&
-			(rule.Subject == subject.ID.String() || rule.Subject == matchAll) &&
+			(rule.Subject == subject.ID.Encode() || rule.Subject == matchAll) &&
 			rule.Resources.Contains(rsc, subject.Peername) &&
 			rule.Actions.Contains(act) {
 			log.Debugf("matched rule title=%q", rule.Title)

--- a/remote/server.go
+++ b/remote/server.go
@@ -376,7 +376,7 @@ func (r *Server) dsPushPreCheck(ctx context.Context, info dag.Info, meta map[str
 		}
 	}
 
-	log.Debugf("pid %s pushing ref %s", pid.String(), ref.String())
+	log.Debugf("pid %s pushing ref %s", pid.Encode(), ref.String())
 
 	if r.datasetPushPreCheck != nil {
 		if err := r.datasetPushPreCheck(ctx, pid, ref); err != nil {
@@ -465,7 +465,7 @@ func (r *Server) dsGetDagInfo(ctx context.Context, into dag.Info, meta map[strin
 		return err
 	}
 	pid := subj.ID
-	log.Debugf("pid %s pulling ref %s", pid.String(), ref.String())
+	log.Debugf("pid %s pulling ref %s", pid.Encode(), ref.String())
 
 	if r.datasetPulled != nil {
 		if err = r.datasetPulled(ctx, pid, ref); err != nil {
@@ -491,7 +491,7 @@ func (r *Server) subjAndRefFromMeta(meta map[string]string) (*profile.Profile, d
 
 	pid, err := profile.IDB58Decode(meta["pid"])
 	if err == nil && ref.ProfileID == "" {
-		ref.ProfileID = pid.String()
+		ref.ProfileID = pid.Encode()
 	}
 
 	pro := &profile.Profile{

--- a/remote/signature_test.go
+++ b/remote/signature_test.go
@@ -24,7 +24,7 @@ func TestVerifySigParams(t *testing.T) {
 		Path:      "foo",
 		Username:  "bar",
 		Name:      "baz",
-		ProfileID: profileID.String(),
+		ProfileID: profileID.Encode(),
 	}
 	sigParams, err := sigParams(kd0.PrivKey, "bar", ref)
 	if err != nil {

--- a/remote/signature_test.go
+++ b/remote/signature_test.go
@@ -15,7 +15,7 @@ func TestVerifySigParams(t *testing.T) {
 		t.Errorf(err.Error())
 		return
 	}
-	profileID, err := profile.NewB58ID(pid)
+	profileID, err := profile.IDB58Decode(pid)
 	if err != nil {
 		t.Errorf(err.Error())
 		return

--- a/repo/ref/convert.go
+++ b/repo/ref/convert.go
@@ -11,7 +11,7 @@ import (
 func ConvertToVersionInfo(r *DatasetRef) dsref.VersionInfo {
 	build := dsref.VersionInfo{
 		Username:  r.Peername,
-		ProfileID: r.ProfileID.String(),
+		ProfileID: r.ProfileID.Encode(),
 		Name:      r.Name,
 		Path:      r.Path,
 	}
@@ -53,7 +53,7 @@ func ConvertToDsref(ref DatasetRef) dsref.Ref {
 	return dsref.Ref{
 		Username:  ref.Peername,
 		Name:      ref.Name,
-		ProfileID: ref.ProfileID.String(),
+		ProfileID: ref.ProfileID.Encode(),
 		Path:      ref.Path,
 	}
 }

--- a/repo/ref/dataset_ref.go
+++ b/repo/ref/dataset_ref.go
@@ -49,7 +49,7 @@ func (r DatasetRef) DebugString() string {
 	builder.WriteString("{peername:")
 	builder.WriteString(r.Peername)
 	builder.WriteString(",profileID:")
-	builder.WriteString(r.ProfileID.String())
+	builder.WriteString(r.ProfileID.Encode())
 	builder.WriteString(",name:")
 	builder.WriteString(r.Name)
 	if r.Path != "" {
@@ -73,11 +73,11 @@ func (r DatasetRef) DebugString() string {
 // Absolute implements the same thing as String(), but append ProfileID if it exist
 func (r DatasetRef) Absolute() (s string) {
 	s = r.AliasString()
-	if r.ProfileID.String() != "" || r.Path != "" {
+	if r.ProfileID.Encode() != "" || r.Path != "" {
 		s += "@"
 	}
-	if r.ProfileID.String() != "" {
-		s += r.ProfileID.String()
+	if r.ProfileID.Encode() != "" {
+		s += r.ProfileID.Encode()
 	}
 	if r.Path != "" {
 		s += r.Path

--- a/repo/refstore.go
+++ b/repo/refstore.go
@@ -61,7 +61,7 @@ func PutVersionInfoShim(ctx context.Context, r Repo, vi *dsref.VersionInfo) erro
 	if vi.ProfileID == "" && vi.Username != "" {
 		rref := &reporef.DatasetRef{Peername: vi.Username}
 		if err := canonicalizeProfile(ctx, r, rref); err == nil {
-			vi.ProfileID = rref.ProfileID.String()
+			vi.ProfileID = rref.ProfileID.Encode()
 		}
 	}
 	return r.PutRef(reporef.RefFromVersionInfo(vi))
@@ -222,7 +222,7 @@ func canonicalizeProfile(ctx context.Context, r Repo, ref *reporef.DatasetRef) e
 				return nil
 			}
 			if ref.ProfileID != id {
-				return fmt.Errorf("Peername and ProfileID combination not valid: Peername = %s, ProfileID = %s, but was given ProfileID = %s", ref.Peername, id.String(), ref.ProfileID)
+				return fmt.Errorf("Peername and ProfileID combination not valid: Peername = %s, ProfileID = %s, but was given ProfileID = %s", ref.Peername, id.Encode(), ref.ProfileID)
 			}
 		}
 	}
@@ -233,7 +233,7 @@ func canonicalizeProfile(ctx context.Context, r Repo, ref *reporef.DatasetRef) e
 // describing any difference between the two references
 func CompareDatasetRef(a, b reporef.DatasetRef) error {
 	if a.ProfileID != b.ProfileID {
-		return fmt.Errorf("PeerID mismatch. %s != %s", a.ProfileID, b.ProfileID)
+		return fmt.Errorf("PeerID mismatch. %s != %s", a.ProfileID.Encode(), b.ProfileID.Encode())
 	}
 	if a.Peername != b.Peername {
 		return fmt.Errorf("Peername mismatch. %s != %s", a.Peername, b.Peername)

--- a/repo/serialize.go
+++ b/repo/serialize.go
@@ -63,7 +63,7 @@ func UnmarshalRefsFlatbuffer(data []byte) (ls RefList, err error) {
 // MarshalFlatbuffer writes a ref to a builder
 func MarshalFlatbuffer(r reporef.DatasetRef, builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	peername := builder.CreateString(r.Peername)
-	profileID := builder.CreateString(r.ProfileID.String())
+	profileID := builder.CreateString(r.ProfileID.Encode())
 	name := builder.CreateString(r.Name)
 	path := builder.CreateString(r.Path)
 	fsiPath := builder.CreateString(r.FSIPath)

--- a/repo/test/test_repo.go
+++ b/repo/test/test_repo.go
@@ -209,7 +209,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 	if ds.Commit != nil {
 		// NOTE: add author ProfileID here to keep the dataset package agnostic to
 		// all identity stuff except keypair crypto
-		ds.Commit.Author = &dataset.User{ID: pro.ID.String()}
+		ds.Commit.Author = &dataset.User{ID: pro.ID.Encode()}
 	}
 
 	sw := dsfs.SaveSwitches{Pin: true, ShouldRender: true}
@@ -241,7 +241,7 @@ func createDataset(r repo.Repo, tc dstest.TestCase) (ref reporef.DatasetRef, err
 	}
 
 	// TODO (b5): confirm these assignments happen in dsfs.CreateDataset with tests
-	ds.ProfileID = pro.ID.String()
+	ds.ProfileID = pro.ID.Encode()
 	ds.Peername = pro.Peername
 	ds.Path = path
 


### PR DESCRIPTION
Add methods to profile.ID called Encode and Validate. Encode replaces the old String function, and base58 encodes an ID. The old String function now outputs wrapped hex, to make it clear that profile.IDs have different shape from base58 encoded strings. The Validate method ensures that a profile.ID is not double-encoded. Use this function in collection.Set to prevent callers from breaking their collection by passing invalid IDs.

Fixes #1857

This refactoring was performed by renaming the old `profile.ID.String` method (to `Stringz`) then fixing all of the compilation errors this caused. This renaming uncovered that the function `CompareDatasetRef` was relying on the implicit base58 encoding that `fmt.Errorf` performs.