### PR TITLE
feat(scope): Scope has profileID. ReplaceParentContext method

### DIFF
--- a/event/automation.go
+++ b/event/automation.go
@@ -19,7 +19,6 @@ const (
 	ETAutomationWorkflowStopped = Type("automation:WorkflowStopped")
 	// ETAutomationDeployStart signals that a deploy has started
 	// Payload will be a DeployEvent
-	// This event should not block
 	ETAutomationDeployStart = Type("automation:DeployStart")
 	// ETAutomationDeploySaveDatasetStart signals that we have started the save
 	// dataset portion of the deploy
@@ -49,7 +48,6 @@ const (
 	// ETAutomationDeployEnd signals the deploy has finished
 	// Payload will be a DeployEvent, if the `Error` field is filled,
 	// the deploy ended in error
-	// This event should not block
 	ETAutomationDeployEnd = Type("automation:DeployEnd")
 )
 

--- a/lib/automation.go
+++ b/lib/automation.go
@@ -15,7 +15,6 @@ import (
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
 	qhttp "github.com/qri-io/qri/lib/http"
-	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/transform"
 )
 
@@ -164,6 +163,9 @@ func (automationImpl) Deploy(scope scope, p *DeployParams) error {
 			return fmt.Errorf("deploy: given workflow and workflow on record have different OwnerIDs")
 		}
 	}
+	// Because deploy runs as a background task, re-root execution context atop
+	// the application context
+	scope = scope.ReplaceParentContext(scope.AppContext())
 	// TODO(ramfox): if we decide that you can interact with the automation subsystem when
 	// qri connect is NOT running, we need a `wait` flag in DeployParams, that, when `true`,
 	// does NOT deploy in a go routine
@@ -171,16 +173,7 @@ func (automationImpl) Deploy(scope scope, p *DeployParams) error {
 	return nil
 }
 
-func deploy(s scope, p *DeployParams) {
-	ctx := profile.AddIDToContext(s.AppContext(), s.ActiveProfile().ID.Encode())
-	// TODO(ramfox): we need the scope context to last longer than the context
-	// that was passed to us. We are, for now, going to rely on the app context
-	// in the future we will probably want something more sophisticated so that
-	// the user can cancel a deploy or run themselves
-	scope, err := newScope(ctx, s.inst, s.source)
-	if err != nil {
-		log.Debugw("deploy: creating new scope", "error", err)
-	}
+func deploy(scope scope, p *DeployParams) {
 	vi := dsref.ConvertDatasetToVersionInfo(p.Dataset)
 	ref := vi.SimpleRef().String()
 	deployPayload := event.DeployEvent{
@@ -188,12 +181,10 @@ func deploy(s scope, p *DeployParams) {
 		InitID:     p.Dataset.ID,
 		WorkflowID: p.Workflow.ID.String(),
 	}
+
 	log.Debugw("deploy started", "payload", deployPayload)
-	go func() {
-		if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeployStart, ref, deployPayload); err != nil {
-			log.Debug(err)
-		}
-	}()
+	sendEventAsync(scope, event.ETAutomationDeployStart, ref, deployPayload)
+
 	rollback := true
 	defer func() {
 		if rollback {
@@ -210,11 +201,7 @@ func deploy(s scope, p *DeployParams) {
 		}
 	}()
 
-	go func() {
-		if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeploySaveDatasetStart, ref, deployPayload); err != nil {
-			log.Debug(err)
-		}
-	}()
+	sendEventAsync(scope, event.ETAutomationDeploySaveDatasetStart, ref, deployPayload)
 
 	saveParams := &SaveParams{
 		Ref:     vi.SimpleRef().String(),
@@ -229,89 +216,57 @@ func deploy(s scope, p *DeployParams) {
 	if err != nil && !errors.Is(err, dsfs.ErrNoChanges) {
 		log.Debugw("deploy save dataset", "error", err)
 		deployPayload.Error = err.Error()
-		go func() {
-			if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeployEnd, ref, deployPayload); err != nil {
-				log.Debug(err)
-			}
-		}()
+		sendEventAsync(scope, event.ETAutomationDeployEnd, ref, deployPayload)
 		return
 	}
 
 	deployPayload.InitID = ds.ID
-	go func() {
-		if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeploySaveDatasetEnd, ref, deployPayload); err != nil {
-			log.Debug(err)
-		}
-	}()
+	sendEventAsync(scope, event.ETAutomationDeploySaveDatasetEnd, ref, deployPayload)
 
 	wf := p.Workflow.Copy()
 	wf.InitID = ds.ID
 	wf.OwnerID = scope.ActiveProfile().ID
 
-	go func() {
-		if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeploySaveWorkflowStart, ref, deployPayload); err != nil {
-			log.Debug(err)
-		}
-	}()
+	sendEventAsync(scope, event.ETAutomationDeploySaveWorkflowStart, ref, deployPayload)
 
 	wf, err = scope.AutomationOrchestrator().SaveWorkflow(scope.Context(), wf)
 	if err != nil {
 		log.Debugw("deploy save workflow", "error", err)
 		deployPayload.Error = err.Error()
-		go func() {
-			if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeployEnd, ref, deployPayload); err != nil {
-				log.Debug(err)
-			}
-		}()
+		sendEventAsync(scope, event.ETAutomationDeployEnd, ref, deployPayload)
 		return
 	}
 
 	deployPayload.WorkflowID = wf.ID.String()
-	go func() {
-		if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeploySaveWorkflowEnd, ref, deployPayload); err != nil {
-			log.Debug(err)
-		}
-	}()
+	sendEventAsync(scope, event.ETAutomationDeploySaveWorkflowEnd, ref, deployPayload)
 
 	if p.Run && !saveParams.Apply {
 		runID := run.NewID()
 
 		deployPayload.RunID = runID
-		go func() {
-			if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeployRun, ref, deployPayload); err != nil {
-				log.Debug(err)
-			}
-		}()
+		sendEventAsync(scope, event.ETAutomationDeployRun, ref, deployPayload)
 
 		err := scope.AutomationOrchestrator().RunWorkflow(scope.Context(), wf.ID, runID)
 		if err != nil {
 			log.Debugw("deploy run workflow", "error", err)
 			deployPayload.Error = err.Error()
-			go func() {
-				if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeployEnd, ref, deployPayload); err != nil {
-					log.Debug(err)
-				}
-			}()
+			sendEventAsync(scope, event.ETAutomationDeployEnd, ref, deployPayload)
 			return
 		}
 
 	}
+
 	log.Debug("deploy ended")
-	go func() {
-		if err := scope.Bus().PublishID(scope.Context(), event.ETAutomationDeployEnd, ref, deployPayload); err != nil {
-			log.Debug(err)
-		}
-	}()
+	sendEventAsync(scope, event.ETAutomationDeployEnd, ref, deployPayload)
 	rollback = false
 }
 
-func (inst *Instance) run(ctx context.Context, streams ioes.IOStreams, w *workflow.Workflow, runID string) error {
-	ctxWithProfile := profile.AddIDToContext(ctx, w.OwnerID.Encode())
-	scope, err := newScope(ctxWithProfile, inst, "local")
+func (inst *Instance) run(ctx context.Context, streams ioes.IOStreams, wf *workflow.Workflow, runID string) error {
+	scope, err := newScopeFromWorkflow(ctx, inst, wf)
 	if err != nil {
 		return err
 	}
-	ref := &dsref.Ref{InitID: w.InitID}
+	ref := &dsref.Ref{InitID: wf.InitID}
 	_, err = scope.ResolveReference(ctx, ref)
 	if err != nil {
 		return fmt.Errorf("run error: %w", err)
@@ -319,7 +274,7 @@ func (inst *Instance) run(ctx context.Context, streams ioes.IOStreams, w *workfl
 	p := &SaveParams{
 		Ref: ref.Human(),
 		Dataset: &dataset.Dataset{
-			ID: w.InitID,
+			ID: wf.InitID,
 			Commit: &dataset.Commit{
 				RunID: runID,
 			},
@@ -332,12 +287,19 @@ func (inst *Instance) run(ctx context.Context, streams ioes.IOStreams, w *workfl
 }
 
 func (inst *Instance) apply(ctx context.Context, wait bool, runID string, wf *workflow.Workflow, ds *dataset.Dataset, secrets map[string]string) error {
-	ctxWithProfile := profile.AddIDToContext(ctx, wf.OwnerID.Encode())
-	scope, err := newScope(ctxWithProfile, inst, "local")
+	scope, err := newScopeFromWorkflow(ctx, inst, wf)
 	if err != nil {
 		return err
 	}
 
 	transformer := transform.NewTransformer(scope.AppContext(), scope.Loader(), scope.Bus())
 	return transformer.Apply(ctx, ds, runID, wait, nil, secrets)
+}
+
+func sendEventAsync(scope scope, typ event.Type, id string, payload interface{}) {
+	go func() {
+		if err := scope.Bus().PublishID(scope.Context(), typ, id, payload); err != nil {
+			log.Debug(err)
+		}
+	}()
 }

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -1227,6 +1227,7 @@ func (inst *Instance) activeProfile(ctx context.Context) (pro *profile.Profile, 
 	if profileIDString != "" {
 		pid, err := profile.IDB58Decode(profileIDString)
 		if err != nil {
+			log.Errorw("profile", "id", profileIDString)
 			return nil, fmt.Errorf("invalid profile ID")
 		}
 		pro, err := inst.profiles.GetProfile(pid)

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/qri-io/qfs/muxfs"
 	"github.com/qri-io/qri/automation"
+	"github.com/qri-io/qri/automation/workflow"
 	"github.com/qri-io/qri/collection"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/dscache"
@@ -20,17 +21,17 @@ import (
 	"github.com/qri-io/qri/stats"
 )
 
-// scope represents the lifetime of a method call, abstractly connected to the caller of
-// that method, such that the implementation is unaware of how it has been invoked.
-// Using scope instead of the global data on Instance lets us control user identity,
-// permissions, and configuration, while also setting us up to properly run multiple
-// operations at the same time to support multi-tenancy and multi-processing.
+// scope represents the lifetime of a method call, abstractly connected to the
+// caller of that method, such that the implementation is unaware of how it has
+// been invoked. Using scope instead of the global data on Instance lets us
+// control user identity, permissions, and configuration, while also setting us
+// up to properly run multiple operations at the same time to support
+// multi-tenancy and multi-processing.
 type scope struct {
 	ctx    context.Context
 	inst   *Instance
 	pro    *profile.Profile
 	source string
-	// TODO(dustmop): Additional information, such as user identity, their profile, keys
 	useFSI bool
 }
 
@@ -40,11 +41,23 @@ func newScope(ctx context.Context, inst *Instance, source string) (scope, error)
 		return scope{}, err
 	}
 
+	// Add the profileID to the context to identify this user
+	ctx = profile.AddIDToContext(ctx, pro.ID.String())
 	return scope{
 		ctx:    ctx,
 		inst:   inst,
 		pro:    pro,
 		source: source,
+		useFSI: false,
+	}, nil
+}
+
+func newScopeFromWorkflow(ctx context.Context, inst *Instance, wf *workflow.Workflow) (scope, error) {
+	ctx = profile.AddIDToContext(ctx, wf.OwnerID.String())
+	return scope{
+		ctx:    ctx,
+		inst:   inst,
+		source: "local",
 		useFSI: false,
 	}, nil
 }
@@ -74,14 +87,16 @@ func (s *scope) Config() *config.Config {
 	return s.inst.cfg
 }
 
-// Context returns the context for this scope. Though this pattern is usually discouraged,
-// we're following http.Request's lead, as scope plays the same role. The lifetime of a
-// single scope matches the lifetime of the Context; this ownership is not long-lived
+// Context returns the context for this scope. Though this pattern is usually
+// discouraged, we're following http.Request's lead, as scope plays the same
+// role. The lifetime of a single scope matches the lifetime of the Context;
+// this ownership is not long-lived
 func (s *scope) Context() context.Context {
 	return s.ctx
 }
 
-// AppContext returns the context of the top-level application, to enable graceful shutdowns
+// AppContext returns the context of the top-level application, to enable
+// graceful shutdowns
 func (s *scope) AppContext() context.Context {
 	return s.inst.appCtx
 }
@@ -91,20 +106,38 @@ func (s *scope) CollectionSet() collection.Set {
 	return s.inst.collectionSet
 }
 
+// ReplaceParentContext returns a copy of the scope bound to a new parent
+// context
+func (s *scope) ReplaceParentContext(newParent context.Context) scope {
+	// Copy values from the old context to the new one
+	profileID := profile.IDFromCtx(s.ctx)
+	if profileID != "" {
+		newParent = profile.AddIDToContext(newParent, profileID)
+	}
+	// Return a copy of the scope, except the context is new
+	return scope{
+		ctx:    newParent,
+		inst:   s.inst,
+		pro:    s.pro,
+		source: s.source,
+		useFSI: s.useFSI,
+	}
+}
+
 // Dscache returns the dscache
 func (s *scope) Dscache() *dscache.Dscache {
 	return s.inst.Dscache()
 }
 
-// EnableWorkingDir allows datasets to be loaded from working directories that they
-// may be linked to
+// EnableWorkingDir allows datasets to be loaded from working directories that
+// they may be linked to
 func (s *scope) EnableWorkingDir(state bool) {
 	s.useFSI = state
 }
 
 // FSISubsystem returns a reference to the FSI subsystem
-// TODO(dustmop): This subsystem contains global data, we should move that data out and
-// into scope
+// TODO(dustmop): This subsystem contains global data, we should move that data
+// out and into scope
 func (s *scope) FSISubsystem() *fsi.FSI {
 	return s.inst.fsi
 }
@@ -114,7 +147,8 @@ func (s *scope) Filesystem() *muxfs.Mux {
 	return s.inst.qfs
 }
 
-// GetVersionInfoShim is in the process of being removed. Try not to add new callers.
+// GetVersionInfoShim is in the process of being removed. Try not to add new
+// callers.
 func (s *scope) GetVersionInfoShim(ref dsref.Ref) (*dsref.VersionInfo, error) {
 	r := s.inst.Repo()
 	return repo.GetVersionInfoShim(r, ref)


### PR DESCRIPTION
Always add the profileID to the scope's context. This is used by automation and will soon be used by the event.Bus as well. Allow scope to detach their parent context, so that they can be used for long-running operations that should not be cancelled by their parents.