### PR TITLE
refactor(wf_store): pass in ownerID to enable filtering

### DIFF
--- a/automation/orchestrator.go
+++ b/automation/orchestrator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/qri-io/qri/automation/run"
 	"github.com/qri-io/qri/automation/trigger"
 	"github.com/qri-io/qri/automation/workflow"
+	"github.com/qri-io/qri/base/params"
 	"github.com/qri-io/qri/event"
 )
 
@@ -203,7 +204,7 @@ func (o *Orchestrator) handleContextClose(ctx context.Context) {
 // startListeners passes a list of deployed Workflows to configured trigger
 // Listeners
 func (o *Orchestrator) startListeners(ctx context.Context) error {
-	wfs, err := o.workflows.ListDeployed(ctx, -1, 0)
+	wfs, err := o.workflows.ListDeployed(ctx, "", params.ListAll)
 	if err != nil {
 		return fmt.Errorf("error getting deployed workflows from the store: %w", err)
 	}

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -129,4 +129,3 @@ func TestInvalidIDFails(t *testing.T) {
 		t.Errorf("error mismatch, expect: %s, got: %s", expectErr, err)
 	}
 }
-


### PR DESCRIPTION
The current local store implementations don't really need to filter by ownerID, but other implementations might. This is just passing it in to enable the store to surface the option. Business logic whether that's used lives in `lib`.