### PR TITLE
fix: deploy panics, double version removal, collection clean up

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -307,6 +307,7 @@ func (s *localSet) subscribe(bus event.Bus) {
 		event.ETDatasetCommitChange,
 		event.ETDatasetRename,
 		event.ETDatasetDeleteAll,
+		event.ETDatasetCreateFail,
 
 		// remote & registry events
 		event.ETDatasetPushed,
@@ -354,7 +355,7 @@ func (s *localSet) handleEvent(ctx context.Context, e event.Event) error {
 				vi.Name = rename.NewName
 			})
 		}
-	case event.ETDatasetDeleteAll:
+	case event.ETDatasetDeleteAll, event.ETDatasetCreateFail:
 		profileID := e.ProfileID
 		if initID, ok := e.Payload.(string); ok && profileID != "" {
 			if err := s.deleteFromCollection(profileID, initID); err != nil {

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -307,7 +307,6 @@ func (s *localSet) subscribe(bus event.Bus) {
 		event.ETDatasetCommitChange,
 		event.ETDatasetRename,
 		event.ETDatasetDeleteAll,
-		event.ETDatasetCreateFail,
 
 		// remote & registry events
 		event.ETDatasetPushed,
@@ -355,7 +354,7 @@ func (s *localSet) handleEvent(ctx context.Context, e event.Event) error {
 				vi.Name = rename.NewName
 			})
 		}
-	case event.ETDatasetDeleteAll, event.ETDatasetCreateFail:
+	case event.ETDatasetDeleteAll:
 		profileID := e.ProfileID
 		if initID, ok := e.Payload.(string); ok && profileID != "" {
 			if err := s.deleteFromCollection(profileID, initID); err != nil {

--- a/collection/spec/collection.go
+++ b/collection/spec/collection.go
@@ -293,6 +293,30 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		expect = []dsref.VersionInfo{}
 		assertCollectionList(ctx, t, kermit, params.ListAll, c, expect)
 
+		// simulate name initialization, normally emitted by logbook
+		mustPublish(ctx, t, bus, event.ETDatasetNameInit, dsref.VersionInfo{
+			InitID:    muppetNamesInitID,
+			ProfileID: kermit.ID.Encode(),
+			Username:  kermit.Peername,
+			Name:      muppetNamesName1,
+		})
+
+		expect = []dsref.VersionInfo{
+			{
+				InitID:    muppetNamesInitID,
+				ProfileID: kermit.ID.Encode(),
+				Username:  kermit.Peername,
+				Name:      muppetNamesName1,
+			},
+		}
+		assertCollectionList(ctx, t, kermit, params.ListAll, c, expect)
+
+		// simulate save fail, normally emitted by lib
+		mustPublish(scopedCtx, t, bus, event.ETDatasetCreateFail, muppetNamesInitID)
+
+		expect = []dsref.VersionInfo{}
+		assertCollectionList(ctx, t, kermit, params.ListAll, c, expect)
+
 		// TODO (b5): create a second dataset, use different timestamps for both,
 		// assert default ordering of datasets
 	})

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1379,6 +1379,8 @@ github.com/qri-io/qfs v0.6.1-0.20210805021933-c2dabeb6689b h1:55dXc7lDAG9Tv+K/1F
 github.com/qri-io/qfs v0.6.1-0.20210805021933-c2dabeb6689b/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
 github.com/qri-io/qfs v0.6.1-0.20210806014444-d49f4226a85b h1:tvMqu/8gBzjrS9PBjte+SrvGS647JcBWiOeQYY4Ia6k=
 github.com/qri-io/qfs v0.6.1-0.20210806014444-d49f4226a85b/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
+github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43 h1:3Nlkdpj+MYaiAq7MmZ3riECTO0mdU3btt0IjSapaCls=
+github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
 github.com/qri-io/starlib v0.4.2 h1:ZGzmzT9fOqdluezcwhAZAbTn/v6kMg1tC6ALVjQPhpQ=
 github.com/qri-io/starlib v0.4.2/go.mod h1:2xlZ9r2UV4LF4G9mpYPBWo7CtXtdW0h1RoGIkZ8elOE=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=

--- a/event/dataset.go
+++ b/event/dataset.go
@@ -4,11 +4,15 @@ const (
 	// ETDatasetNameInit is when a dataset is initialized
 	// payload is a dsref.VersionInfo
 	ETDatasetNameInit = Type("dataset:Init")
+	// ETDatasetCreateFail is when a dataset is initialized but failed
+	// when creating the first version of the dataset
+	// payload is an `InitID`
+	ETDatasetCreateFail = Type("dataset:CreateFail")
 	// ETDatasetCommitChange is when a dataset changes its newest commit
 	// payload is a dsref.VersionInfo
 	ETDatasetCommitChange = Type("dataset:CommitChange")
 	// ETDatasetDeleteAll is when a dataset is entirely deleted
-	// payload is a dsref.VersionInfo
+	// payload is an `InitID`
 	ETDatasetDeleteAll = Type("dataset:DeleteAll")
 	// ETDatasetRename is when a dataset is renamed
 	// payload is a dsref.VersionInfo

--- a/event/dataset.go
+++ b/event/dataset.go
@@ -1,36 +1,31 @@
 package event
 
 const (
-	// ETDatasetNameInit is when a dataset is initialized
+	// ETDatasetNameInit occurs when a dataset is first initialized
 	// payload is a dsref.VersionInfo
 	ETDatasetNameInit = Type("dataset:Init")
-	// ETDatasetCreateFail is when a dataset is initialized but failed
-	// when creating the first version of the dataset
-	// payload is an `InitID`
-	ETDatasetCreateFail = Type("dataset:CreateFail")
-	// ETDatasetCommitChange is when a dataset changes its newest commit
+	// ETDatasetCommitChange occurs when a dataset's head commit changes
 	// payload is a dsref.VersionInfo
 	ETDatasetCommitChange = Type("dataset:CommitChange")
-	// ETDatasetDeleteAll is when a dataset is entirely deleted
+	// ETDatasetDeleteAll occurs when a dataset is being deleted
 	// payload is an `InitID`
 	ETDatasetDeleteAll = Type("dataset:DeleteAll")
-	// ETDatasetRename is when a dataset is renamed
+	// ETDatasetRename occurs when a dataset gets renamed
 	// payload is a dsref.VersionInfo
 	ETDatasetRename = Type("dataset:Rename")
-	// ETDatasetCreateLink is when a dataset is linked to a working directory
+	// ETDatasetCreateLink occurs when a dataset gets linked to a working directory
 	// payload is a dsref.VersionInfo
 	ETDatasetCreateLink = Type("dataset:CreateLink")
 
-	// ETDatasetSaveStarted fires when saving a dataset starts
-	// subscriptions do not block the publisher
+	// ETDatasetSaveStarted occurs when a dataset starts being saved
+	// this event is sent asynchronously; the publisher is not blocked
 	// payload will be a DsSaveEvent
 	ETDatasetSaveStarted = Type("dataset:SaveStarted")
-	// ETDatasetSaveProgress indicates a change in progress of dataset version
-	// creation.
-	// subscriptions do not block the publisher
+	// ETDatasetSaveProgress occurs whenever a dataset save makes progress
+	// this event is sent asynchronously; the publisher is not blocked
 	// payload will be a DsSaveEvent
 	ETDatasetSaveProgress = Type("dataset:SaveProgress")
-	// ETDatasetSaveCompleted indicates creating a dataset version finished
+	// ETDatasetSaveCompleted occurs when a dataset save finishes
 	// payload will be a DsSaveEvent
 	ETDatasetSaveCompleted = Type("dataset:SaveCompleted")
 )

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/qri-io/ioes v0.1.1
 	github.com/qri-io/iso8601 v0.1.1-0.20201221213213-f31ee4cdc38b
 	github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449
-	github.com/qri-io/qfs v0.6.1-0.20210806014444-d49f4226a85b
+	github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43
 	github.com/qri-io/starlib v0.4.2
 	github.com/russross/blackfriday/v2 v2.0.2-0.20190629151518-3e56bb68c887
 	github.com/sergi/go-diff v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1354,8 +1354,8 @@ github.com/qri-io/jsonpointer v0.1.1/go.mod h1:DnJPaYgiKu56EuDp8TU5wFLdZIcAnb/uH
 github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449 h1:cAOmZ7Wn2/lDhq8d0qq00pqvrhgwvLQMizMhr+3XLg4=
 github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANPBaaqW+VrI=
 github.com/qri-io/qfs v0.6.1-0.20210629014446-45bdcdb57434/go.mod h1:XX/caqvngrusufIrtnbo4iPtgsNfu0dfrE3pmLGte9w=
-github.com/qri-io/qfs v0.6.1-0.20210806014444-d49f4226a85b h1:tvMqu/8gBzjrS9PBjte+SrvGS647JcBWiOeQYY4Ia6k=
-github.com/qri-io/qfs v0.6.1-0.20210806014444-d49f4226a85b/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
+github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43 h1:3Nlkdpj+MYaiAq7MmZ3riECTO0mdU3btt0IjSapaCls=
+github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
 github.com/qri-io/starlib v0.4.2 h1:ZGzmzT9fOqdluezcwhAZAbTn/v6kMg1tC6ALVjQPhpQ=
 github.com/qri-io/starlib v0.4.2/go.mod h1:2xlZ9r2UV4LF4G9mpYPBWo7CtXtdW0h1RoGIkZ8elOE=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -975,6 +975,7 @@ func (datasetImpl) Save(scope scope, p *SaveParams) (*dataset.Dataset, error) {
 			if err := scope.Logbook().RemoveLog(ctx, ref); err != nil {
 				log.Errorf("couldn't cleanup unused reference: %q", err)
 			}
+			go scope.sendEvent(event.ETDatasetCreateFail, ref, ref.InitID)
 			cancel()
 		}
 	}()

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -975,7 +975,7 @@ func (datasetImpl) Save(scope scope, p *SaveParams) (*dataset.Dataset, error) {
 			if err := scope.Logbook().RemoveLog(ctx, ref); err != nil {
 				log.Errorf("couldn't cleanup unused reference: %q", err)
 			}
-			go scope.sendEvent(event.ETDatasetCreateFail, ref.InitID, ref.InitID)
+			go scope.sendEvent(event.ETDatasetDeleteAll, ref.InitID, ref.InitID)
 			cancel()
 		}
 	}()

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -975,7 +975,7 @@ func (datasetImpl) Save(scope scope, p *SaveParams) (*dataset.Dataset, error) {
 			if err := scope.Logbook().RemoveLog(ctx, ref); err != nil {
 				log.Errorf("couldn't cleanup unused reference: %q", err)
 			}
-			go scope.sendEvent(event.ETDatasetCreateFail, ref, ref.InitID)
+			go scope.sendEvent(event.ETDatasetCreateFail, ref.InitID, ref.InitID)
 			cancel()
 		}
 	}()

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -154,7 +154,7 @@ func (n *QriNode) GoOnline(c context.Context) (err error) {
 	if ipfsfs, ok := n.Repo.Filesystem().Filesystem("ipfs").(*qipfs.Filestore); ok {
 		log.Debugf("using IPFS p2p Host")
 		if !ipfsfs.Online() {
-			if err := ipfsfs.GoOnline(ctx); err != nil {
+			if err := ipfsfs.GoOnline(); err != nil {
 				cancel()
 				return err
 			}


### PR DESCRIPTION
1) update to latest qfs to fix nil ctx bug
2) ensure we have a default source for `deploy`, this extends to the deferred `Remove` that gets triggered if something goes wrong with the deploy
3) adjust the deploy path to only attempt to remove the just saved version if we have an error while deploying after the dataset has saved. If the error occurs during the save, the `Save` path has its own clean up. Also, ensure we are only removing the previous version if this current deploy has saved a previous version. If there were no changes to save, don't erroneously remove a version.
4) Collection needs to be updated when a dataset creation fails. The collection catches the dataset creation information very early in the save process, so we need to also be updated if the creation fails, so that we can remove that dataset from the collection. We are now doing this using the `ETDatasetCreateFail` event