### PR TITLE
fix(lib): `lib.Run` should mirror `lib.Deploy` return ASAP behavior

### DIFF
--- a/lib/automation.go
+++ b/lib/automation.go
@@ -105,7 +105,6 @@ type RunParams struct {
 	Ref        string `json:"ref"`
 	InitID     string `json:"initID"`
 	WorkflowID string `json:"workflowID"`
-	RunID      string `json:"runID"`
 }
 
 // Validate returns an error if RunParams fields are in an invalid state
@@ -365,7 +364,9 @@ func (automationImpl) Run(scope scope, p *RunParams) (string, error) {
 		}
 		p.WorkflowID = wf.WorkflowID()
 	}
-	return scope.AutomationOrchestrator().RunWorkflow(scope.AppContext(), workflow.ID(p.WorkflowID), p.RunID)
+	runID := run.NewID()
+	go scope.AutomationOrchestrator().RunWorkflow(scope.AppContext(), workflow.ID(p.WorkflowID), runID)
+	return runID, nil
 }
 
 // Workflow fetches a workflow by the workflow or dataset id


### PR DESCRIPTION
So the frontend can correctly track runs, and so the frontend's http
requests do not time out if a run lasts very long, return the runID, and
only error if there is something wrong with the request params