### PR TITLE
refactor(collection): rely on `ETAutomationWorkflowCreated` events

### DIFF
--- a/collection/spec/collection.go
+++ b/collection/spec/collection.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/qri-io/qri/automation/workflow"
 	"github.com/qri-io/qri/base/params"
 	"github.com/qri-io/qri/collection"
 	"github.com/qri-io/qri/dsref"
@@ -387,8 +388,21 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		}
 		assertCollectionList(ctx, t, missPiggy, params.ListAll, c, expect)
 
-		// TODO (b5): simulate workflow creation, check that collection updates with
+		// simulate workflow creation, check that collection updates with
 		// workflow ID
+		wf := workflow.Workflow{
+			InitID:  muppetTweetsInitID,
+			OwnerID: kermit.ID,
+			ID:      "workflow_id",
+		}
+		mustPublish(ctx, t, bus, event.ETAutomationWorkflowCreated, wf)
+
+		expect[0].WorkflowID = "workflow_id"
+		assertCollectionList(ctx, t, missPiggy, params.ListAll, c, expect)
+		// simulate workflow removal, check that the collection removes workflowID
+		mustPublish(ctx, t, bus, event.ETAutomationWorkflowRemoved, wf)
+		expect[0].WorkflowID = ""
+		assertCollectionList(ctx, t, missPiggy, params.ListAll, c, expect)
 	})
 
 

--- a/event/automation.go
+++ b/event/automation.go
@@ -17,6 +17,14 @@ const (
 	// Payload will be a WorkflowStoppedEvent
 	// This event should not block
 	ETAutomationWorkflowStopped = Type("automation:WorkflowStopped")
+	// ETAutomationWorkflowCreated signals that a new workflow has been created
+	// Payload will be a workflow.Workflow
+	// This event should not block
+	ETAutomationWorkflowCreated = Type("automation:WorkflowCreated")
+	// ETAutomationWorkflowRemoved signals that a workflow has been removed
+	// Payload will be a workflow.Workflow
+	// This event should not block
+	ETAutomationWorkflowRemoved = Type("automation:WorkflowRemoved")
 	// ETAutomationDeployStart signals that a deploy has started
 	// Payload will be a DeployEvent
 	ETAutomationDeployStart = Type("automation:DeployStart")


### PR DESCRIPTION
We were previously using the `ETAutomationDeploy` events, but unfortunately they don't actually have enough specificity for us to know exactly what is going on when we catch the events in the collection.

We need to follow the same patterns we are using to add to the collection when a dataset is added or removed: rely on events emitted at those exact times.

We need an `ETAutomationWorkflowCreated` and an `ETAutomationWorkflowRemoved` event to let us know that a workflow has been added or removed.