### PR TITLE
fix(collection): maintain `WorkflowID` and run information in collection

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -347,6 +347,11 @@ func (s *localSet) handleEvent(ctx context.Context, e event.Event) error {
 			s.updateOneAcrossAllCollections(vi.InitID, func(m *dsref.VersionInfo) {
 				// preserve fsi path
 				vi.FSIPath = m.FSIPath
+				// preserve workflow id
+				vi.WorkflowID = m.WorkflowID
+				// preserve run information
+				vi.RunID = m.RunID
+				vi.RunStatus = m.RunStatus
 				*m = vi
 			})
 		}


### PR DESCRIPTION
fixes bug that meant any time we added a new version of the dataset, we would also override the workflow id, run status, and previous run id.