### PR TITLE
logbook write fix

### DIFF
--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -342,6 +342,8 @@ func (book *Book) WriteDatasetInit(ctx context.Context, author *profile.Profile,
 
 	dsLog.AddChild(branch)
 	authorLog.AddChild(dsLog)
+
+	book.store.MergeLog(ctx, authorLog.l)
 	initID := dsLog.ID()
 
 	err = book.publisher.Publish(ctx, event.ETDatasetNameInit, dsref.VersionInfo{


### PR DESCRIPTION
As said before the concern with this line is whether it invokes double writes on the core side. For the cloud side this properly invokes the opstore write.