### PR TITLE
test(collection): tests for workflow & new version creation

### DIFF
--- a/lib/automation.go
+++ b/lib/automation.go
@@ -184,6 +184,7 @@ func (automationImpl) Apply(scope scope, p *ApplyParams) (*ApplyResult, error) {
 	if !ref.IsEmpty() {
 		ds.Name = ref.Name
 		ds.Peername = ref.Username
+		ds.ID = ref.InitID
 	}
 	if p.Transform != nil {
 		ds.Transform = p.Transform


### PR DESCRIPTION
add test to prove that if one user `pulls` a dataset, it doesn't effect another user's collection