### PR TITLE
feat(collection): expand `WritableSet` interface, add option to pass in custom `WritableSet`

### DIFF
--- a/automation/orchestrator.go
+++ b/automation/orchestrator.go
@@ -68,8 +68,7 @@ type Orchestrator struct {
 	running      bool
 }
 
-// NewOrchestrator constructs an orchestrator, whose only responsibility, right
-// now, is to create a workflow store, run store, & listen for trigger events
+// NewOrchestrator constructs an orchestrator
 func NewOrchestrator(ctx context.Context, bus event.Bus, runFactory RunFactory, applyFactory ApplyFactory, opts OrchestratorOptions) (*Orchestrator, error) {
 	log.Debugw("NewOrchestrator", "opts", opts)
 

--- a/base/dataset_test.go
+++ b/base/dataset_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/collection"
 	"github.com/qri-io/qri/dsref"
-	"github.com/qri-io/qri/event"
 )
 
 func TestListDatasets(t *testing.T) {
@@ -91,7 +90,7 @@ func TestRawDatasetRefs(t *testing.T) {
 
 	ctx := context.Background()
 	r := newTestRepo(t)
-	s, err := collection.NewLocalSet(ctx, event.NilBus, "")
+	s, err := collection.NewLocalSet(ctx, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/base/dataset_test.go
+++ b/base/dataset_test.go
@@ -96,10 +96,9 @@ func TestRawDatasetRefs(t *testing.T) {
 	}
 
 	ref := addCitiesDataset(t, r)
-	ws := s.(collection.WritableSet)
 	vi := dsref.NewVersionInfoFromRef(ref)
 	vi.InitID = "AnInitID"
-	if err := ws.Put(ctx, r.Profiles().Active(ctx).ID, vi); err != nil {
+	if err := s.Add(ctx, r.Profiles().Active(ctx).ID, vi); err != nil {
 		t.Fatal(err)
 	}
 

--- a/collection/collection_assert_test.go
+++ b/collection/collection_assert_test.go
@@ -44,11 +44,7 @@ func AssertSetSpec(t *testing.T, constructor Constructor) {
 		}
 	})
 
-	t.Run("putlist", func(t *testing.T) {
-		if err := ec.PutList(ctx, kermit.ID, []dsref.VersionInfo{}); err != nil {
-			t.Error("expected put with empty item list NOT to error")
-		}
-
+	t.Run("add", func(t *testing.T) {
 		badItems := []struct {
 			problem string
 			item    dsref.VersionInfo
@@ -61,59 +57,56 @@ func AssertSetSpec(t *testing.T, constructor Constructor) {
 
 		for _, bad := range badItems {
 			t.Run(fmt.Sprintf("bad_item_%s", bad.problem), func(t *testing.T) {
-				if err := ec.PutList(ctx, kermit.ID, []dsref.VersionInfo{bad.item}); err == nil {
+				if err := ec.Add(ctx, kermit.ID, bad.item); err == nil {
 					t.Error("expected error, got nil")
 				}
 			})
 		}
 
-		err := ec.PutList(ctx, kermit.ID,
-			[]dsref.VersionInfo{
-				{
-					ProfileID:  kermit.ID.Encode(),
-					InitID:     "muppet_names_init_id",
-					Username:   "kermit",
-					Name:       "muppet_names",
-					CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ProfileID:  kermit.ID.Encode(),
-					InitID:     "muppet_names_and_ages_init_id",
-					Username:   "kermit",
-					Name:       "muppet_names_and_ages",
-					CommitTime: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				},
-			})
+		err := ec.Add(ctx, kermit.ID,
+			dsref.VersionInfo{
+				ProfileID:  kermit.ID.Encode(),
+				InitID:     "muppet_names_init_id",
+				Username:   "kermit",
+				Name:       "muppet_names",
+				CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			dsref.VersionInfo{
+				ProfileID:  kermit.ID.Encode(),
+				InitID:     "muppet_names_and_ages_init_id",
+				Username:   "kermit",
+				Name:       "muppet_names_and_ages",
+				CommitTime: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+			},
+		)
 
 		if err != nil {
 			t.Fatalf("error adding items: %s", err)
 		}
 
-		err = ec.PutList(ctx, missPiggy.ID,
-			[]dsref.VersionInfo{
-
-				{
-					ProfileID:  missPiggy.ID.Encode(),
-					InitID:     "secret_muppet_friends_init_id",
-					Username:   "miss_piggy",
-					Name:       "secret_muppet_friends",
-					CommitTime: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ProfileID:  missPiggy.ID.Encode(),
-					InitID:     "muppet_names_init_id",
-					Username:   "kermit",
-					Name:       "muppet_names",
-					CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ProfileID:  missPiggy.ID.Encode(),
-					InitID:     "famous_muppets_init_id",
-					Username:   "famous_muppets",
-					Name:       "famous_muppets",
-					CommitTime: time.Date(2021, 1, 4, 0, 0, 0, 0, time.UTC),
-				},
-			})
+		err = ec.Add(ctx, missPiggy.ID,
+			dsref.VersionInfo{
+				ProfileID:  missPiggy.ID.Encode(),
+				InitID:     "secret_muppet_friends_init_id",
+				Username:   "miss_piggy",
+				Name:       "secret_muppet_friends",
+				CommitTime: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
+			},
+			dsref.VersionInfo{
+				ProfileID:  missPiggy.ID.Encode(),
+				InitID:     "muppet_names_init_id",
+				Username:   "kermit",
+				Name:       "muppet_names",
+				CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			dsref.VersionInfo{
+				ProfileID:  missPiggy.ID.Encode(),
+				InitID:     "famous_muppets_init_id",
+				Username:   "famous_muppets",
+				Name:       "famous_muppets",
+				CommitTime: time.Date(2021, 1, 4, 0, 0, 0, 0, time.UTC),
+			},
+		)
 
 		if err != nil {
 			t.Fatalf("error adding items: %s", err)

--- a/collection/collection_assert_test.go
+++ b/collection/collection_assert_test.go
@@ -1,4 +1,4 @@
-package spec
+package collection_test
 
 import (
 	"context"
@@ -17,23 +17,17 @@ import (
 )
 
 // Constructor is a function for creating collections, used by spec tests
-type Constructor func(ctx context.Context, bus event.Bus) (collection.Set, error)
+type Constructor func(ctx context.Context) (collection.WritableSet, error)
 
 // AssertWritableCollectionSpec defines expected behaviours for a Writable
 // collection implementation
 func AssertWritableCollectionSpec(t *testing.T, constructor Constructor) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	bus := event.NewBus(ctx)
 
-	c, err := constructor(ctx, bus)
+	ec, err := constructor(ctx)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	ec, ok := c.(collection.WritableSet)
-	if !ok {
-		t.Fatal("construtor did not return a writable collection set")
 	}
 
 	kermit := profiletest.GetProfile("kermit")
@@ -205,8 +199,13 @@ func AssertWritableCollectionSpec(t *testing.T, constructor Constructor) {
 func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	s, err := constructor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	bus := event.NewBus(ctx)
-	c, err := constructor(ctx, bus)
+	c, err := collection.NewCollection(ctx, bus, s)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -14,12 +14,12 @@ import (
 	profiletest "github.com/qri-io/qri/profile/test"
 )
 
-var constructor = func(ctx context.Context) (collection.WritableSet, error) {
+var constructor = func(ctx context.Context) (collection.Set, error) {
 	return collection.NewLocalSet(ctx, "")
 }
 
 func TestLocalCollection(t *testing.T) {
-	AssertWritableCollectionSpec(t, constructor)
+	AssertSetSpec(t, constructor)
 }
 
 func TestLocalCollectionEvents(t *testing.T) {
@@ -36,12 +36,10 @@ func TestCollectionPersistence(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	c, err := collection.NewLocalSet(ctx, dir)
+	wc, err := collection.NewLocalSet(ctx, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	wc := c.(collection.WritableSet)
 
 	kermit := profiletest.GetProfile("kermit")
 	missPiggy := profiletest.GetProfile("miss_piggy")
@@ -53,7 +51,7 @@ func TestCollectionPersistence(t *testing.T) {
 		Name:       "muppet_names",
 		CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
-	if err = wc.Put(ctx, kermit.ID, item1); err != nil {
+	if err = wc.Add(ctx, kermit.ID, item1); err != nil {
 		t.Error(err)
 	}
 
@@ -64,12 +62,12 @@ func TestCollectionPersistence(t *testing.T) {
 		Name:       "secret_muppet_friends",
 		CommitTime: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
 	}
-	if err = wc.Put(ctx, missPiggy.ID, item2); err != nil {
+	if err = wc.Add(ctx, missPiggy.ID, item2); err != nil {
 		t.Error(err)
 	}
 
 	// create a new collection to rely on persistence
-	c, err = collection.NewLocalSet(ctx, dir)
+	c, err := collection.NewLocalSet(ctx, dir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -103,11 +101,10 @@ func TestInvalidIDFails(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	c, err := collection.NewLocalSet(ctx, dir)
+	wc, err := collection.NewLocalSet(ctx, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	wc := c.(collection.WritableSet)
 
 	// Construct an invalid profileID (it's base58 encoded), which
 	// should result in an error
@@ -118,7 +115,7 @@ func TestInvalidIDFails(t *testing.T) {
 		Name:       "my_ds",
 		CommitTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
-	err = wc.Put(ctx, myPid, info)
+	err = wc.Add(ctx, myPid, info)
 	if err == nil {
 		t.Fatal("expected to get an error, did not get one")
 	}

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -10,22 +10,20 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/qri-io/qri/base/params"
 	"github.com/qri-io/qri/collection"
-	"github.com/qri-io/qri/collection/spec"
 	"github.com/qri-io/qri/dsref"
-	"github.com/qri-io/qri/event"
 	profiletest "github.com/qri-io/qri/profile/test"
 )
 
-var constructor = func(ctx context.Context, bus event.Bus) (collection.Set, error) {
-	return collection.NewLocalSet(ctx, bus, "")
+var constructor = func(ctx context.Context) (collection.WritableSet, error) {
+	return collection.NewLocalSet(ctx, "")
 }
 
 func TestLocalCollection(t *testing.T) {
-	spec.AssertWritableCollectionSpec(t, constructor)
+	AssertWritableCollectionSpec(t, constructor)
 }
 
 func TestLocalCollectionEvents(t *testing.T) {
-	spec.AssertCollectionEventListenerSpec(t, constructor)
+	AssertCollectionEventListenerSpec(t, constructor)
 }
 
 func TestCollectionPersistence(t *testing.T) {
@@ -38,7 +36,7 @@ func TestCollectionPersistence(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	c, err := collection.NewLocalSet(ctx, event.NilBus, dir)
+	c, err := collection.NewLocalSet(ctx, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +69,7 @@ func TestCollectionPersistence(t *testing.T) {
 	}
 
 	// create a new collection to rely on persistence
-	c, err = collection.NewLocalSet(ctx, event.NilBus, dir)
+	c, err = collection.NewLocalSet(ctx, dir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -105,7 +103,7 @@ func TestInvalidIDFails(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	c, err := collection.NewLocalSet(ctx, event.NilBus, dir)
+	c, err := collection.NewLocalSet(ctx, dir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/collection/migrate.go
+++ b/collection/migrate.go
@@ -2,7 +2,6 @@ package collection
 
 import (
 	"context"
-	"errors"
 
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dsref"
@@ -12,11 +11,6 @@ import (
 // MigrateRepoStoreToLocalCollectionSet constructs a local collection.Set from
 // legacy repo data
 func MigrateRepoStoreToLocalCollectionSet(ctx context.Context, s Set, r repo.Repo) error {
-	ws, ok := s.(WritableSet)
-	if !ok {
-		return errors.New("cannot migrate to CollectionSet. Provided CollectionSet is not writable")
-	}
-
 	datasets, err := repo.ListVersionInfoShim(r, 0, 1000000)
 	if err != nil {
 		return err
@@ -57,5 +51,5 @@ func MigrateRepoStoreToLocalCollectionSet(ctx context.Context, s Set, r repo.Rep
 		}
 	}
 
-	return ws.Put(ctx, ownerID, datasets...)
+	return s.PutList(ctx, ownerID, datasets)
 }

--- a/collection/migrate.go
+++ b/collection/migrate.go
@@ -51,5 +51,5 @@ func MigrateRepoStoreToLocalCollectionSet(ctx context.Context, s Set, r repo.Rep
 		}
 	}
 
-	return s.PutList(ctx, ownerID, datasets)
+	return s.Add(ctx, ownerID, datasets...)
 }

--- a/collection/migrate_test.go
+++ b/collection/migrate_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/qri-io/qri/base/params"
 	"github.com/qri-io/qri/dsref"
-	"github.com/qri-io/qri/event"
 	"github.com/qri-io/qri/repo"
 	repotest "github.com/qri-io/qri/repo/test"
 )
@@ -31,7 +30,7 @@ func TestMigrateRepoStoreToLocalCollectionSet(t *testing.T) {
 		t.Fatalf("test repo has no datasets")
 	}
 
-	set, err := NewLocalSet(ctx, event.NilBus, "", func(o *LocalSetOptions) {
+	set, err := NewLocalSet(ctx, "", func(o *LocalSetOptions) {
 		o.MigrateRepo = r
 	})
 	if err != nil {
@@ -46,5 +45,4 @@ func TestMigrateRepoStoreToLocalCollectionSet(t *testing.T) {
 	if diff := cmp.Diff(expect, got, cmpopts.IgnoreFields(dsref.VersionInfo{}, "InitID", "MetaTitle", "ThemeList", "BodySize", "BodyRows", "CommitTime", "NumErrors", "CommitTitle")); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}
-
 }

--- a/lib/collection.go
+++ b/lib/collection.go
@@ -81,9 +81,11 @@ func (collectionImpl) List(scope scope, p *ListParams) ([]dsref.VersionInfo, err
 			// subsystem in the hopes that cloud code won't follow this path. Haven't
 			// confirmed that's the case
 			if scope.FSISubsystem() != nil {
-				// For each reference with a linked fsi working directory, check that the folder exists
-				// and has a .qri-ref file. If it's missing, remove the link from the centralized repo.
-				// Doing this every list operation is a bit inefficient, so the behavior is opt-in.
+				// For each reference with a linked fsi working directory,
+				// check that the folder exists and has a .qri-ref file. If
+				// it's missing, remove the link from the centralized repo.
+				// Doing this every list operation is a bit inefficient, so
+				// the behavior is opt-in.
 				update := make([]dsref.VersionInfo, 0, len(infos))
 				for _, info := range infos {
 					if info.FSIPath != "" && !linkfile.ExistsInDir(info.FSIPath) {
@@ -91,7 +93,7 @@ func (collectionImpl) List(scope scope, p *ListParams) ([]dsref.VersionInfo, err
 						update = append(update, info)
 					}
 				}
-				if err := s.PutList(scope.Context(), scope.ActiveProfile().ID, update); err != nil {
+				if err := s.Add(scope.Context(), scope.ActiveProfile().ID, update...); err != nil {
 					return nil, err
 				}
 			}

--- a/lib/collection.go
+++ b/lib/collection.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/base/params"
-	"github.com/qri-io/qri/collection"
 	"github.com/qri-io/qri/dscache/build"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/fsi/linkfile"
@@ -82,20 +81,18 @@ func (collectionImpl) List(scope scope, p *ListParams) ([]dsref.VersionInfo, err
 			// subsystem in the hopes that cloud code won't follow this path. Haven't
 			// confirmed that's the case
 			if scope.FSISubsystem() != nil {
-				if ws, ok := s.(collection.WritableSet); ok {
-					// For each reference with a linked fsi working directory, check that the folder exists
-					// and has a .qri-ref file. If it's missing, remove the link from the centralized repo.
-					// Doing this every list operation is a bit inefficient, so the behavior is opt-in.
-					update := make([]dsref.VersionInfo, 0, len(infos))
-					for _, info := range infos {
-						if info.FSIPath != "" && !linkfile.ExistsInDir(info.FSIPath) {
-							info.FSIPath = ""
-							update = append(update, info)
-						}
+				// For each reference with a linked fsi working directory, check that the folder exists
+				// and has a .qri-ref file. If it's missing, remove the link from the centralized repo.
+				// Doing this every list operation is a bit inefficient, so the behavior is opt-in.
+				update := make([]dsref.VersionInfo, 0, len(infos))
+				for _, info := range infos {
+					if info.FSIPath != "" && !linkfile.ExistsInDir(info.FSIPath) {
+						info.FSIPath = ""
+						update = append(update, info)
 					}
-					if err := ws.Put(scope.Context(), scope.ActiveProfile().ID, update...); err != nil {
-						return nil, err
-					}
+				}
+				if err := s.Put(scope.Context(), scope.ActiveProfile().ID, update...); err != nil {
+					return nil, err
 				}
 			}
 		}

--- a/lib/collection.go
+++ b/lib/collection.go
@@ -91,7 +91,7 @@ func (collectionImpl) List(scope scope, p *ListParams) ([]dsref.VersionInfo, err
 						update = append(update, info)
 					}
 				}
-				if err := s.Put(scope.Context(), scope.ActiveProfile().ID, update...); err != nil {
+				if err := s.PutList(scope.Context(), scope.ActiveProfile().ID, update); err != nil {
 					return nil, err
 				}
 			}

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -88,7 +88,7 @@ type InstanceOptions struct {
 	keyStore                key.Store
 	profiles                profile.Store
 	bus                     event.Bus
-	collectionSet           collection.WritableSet
+	collectionSet           collection.Set
 	tokenProvider           token.Provider
 	logAll                  bool
 	automationOptions       *automation.OrchestratorOptions
@@ -277,7 +277,7 @@ func OptStatsCache(statsCache stats.Cache) Option {
 }
 
 // OptCollectionSet provides a collection implementation
-func OptCollectionSet(c collection.WritableSet) Option {
+func OptCollectionSet(c collection.Set) Option {
 	return func(o *InstanceOptions) error {
 		o.collectionSet = c
 		return nil
@@ -633,7 +633,7 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 	}
 
 	if o.collectionSet != nil {
-		inst.collection, err = collection.NewCollection(ctx, inst.bus, o.collectionSet)
+		inst.collections, err = collection.NewSetMaintainer(ctx, inst.bus, o.collectionSet)
 		if err != nil {
 			return nil, err
 		}
@@ -832,7 +832,7 @@ func NewInstanceFromConfigAndNodeAndBusAndOrchestratorOpts(ctx context.Context, 
 		panic(err)
 	}
 
-	inst.collection, err = collection.NewCollection(ctx, inst.bus, set)
+	inst.collections, err = collection.NewSetMaintainer(ctx, inst.bus, set)
 	if err != nil {
 		cancel()
 		panic(err)
@@ -870,7 +870,7 @@ type Instance struct {
 	stats         *stats.Service
 	logbook       *logbook.Book
 	dscache       *dscache.Dscache
-	collection    *collection.Collection
+	collections   *collection.SetMaintainer
 	automation    *automation.Orchestrator
 	tokenProvider token.Provider
 	bus           event.Bus

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -342,16 +342,14 @@ func TestNewInstanceWithCollectionOption(t *testing.T) {
 
 	kermit := profiletest.GetProfile("kermit")
 
-	expect := []dsref.VersionInfo{
-		{
-			InitID:    "init_id",
-			Username:  kermit.Peername,
-			Name:      "dataset",
-			ProfileID: kermit.ID.Encode(),
-		},
+	addInfo := dsref.VersionInfo{
+		InitID:    "init_id",
+		Username:  kermit.Peername,
+		Name:      "dataset",
+		ProfileID: kermit.ID.Encode(),
 	}
 
-	err = s.PutList(ctx, kermit.ID, expect)
+	err = s.Add(ctx, kermit.ID, addInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,6 +365,7 @@ func TestNewInstanceWithCollectionOption(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	expect := []dsref.VersionInfo{addInfo}
 
 	if diff := cmp.Diff(expect, got); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -335,9 +335,7 @@ func TestNewInstanceWithCollectionOption(t *testing.T) {
 	}
 	defer tr.Delete()
 
-	bus := event.NewBus(ctx)
-
-	s, err := collection.NewLocalSet(ctx, bus, tr.RootPath)
+	s, err := collection.NewLocalSet(ctx, tr.RootPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -351,7 +351,7 @@ func TestNewInstanceWithCollectionOption(t *testing.T) {
 		},
 	}
 
-	err = s.(collection.WritableSet).Put(ctx, kermit.ID, expect...)
+	err = s.PutList(ctx, kermit.ID, expect)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -118,9 +118,9 @@ func (s *scope) AppContext() context.Context {
 	return s.inst.appCtx
 }
 
-// Collection returns the Instance collection subsystem
+// CollectionSet returns the set of collections
 func (s *scope) CollectionSet() collection.Set {
-	return s.inst.collections.Set()
+	return s.inst.collections
 }
 
 // ReplaceParentContext returns a copy of the scope bound to a new parent

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -119,8 +119,8 @@ func (s *scope) AppContext() context.Context {
 }
 
 // Collection returns the Instance collection subsystem
-func (s *scope) CollectionSet() collection.Set {
-	return s.inst.collectionSet
+func (s *scope) CollectionSet() *collection.Collection {
+	return s.inst.collection
 }
 
 // ReplaceParentContext returns a copy of the scope bound to a new parent

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -119,8 +119,8 @@ func (s *scope) AppContext() context.Context {
 }
 
 // Collection returns the Instance collection subsystem
-func (s *scope) CollectionSet() *collection.Collection {
-	return s.inst.collection
+func (s *scope) CollectionSet() collection.Set {
+	return s.inst.collections.Set()
 }
 
 // ReplaceParentContext returns a copy of the scope bound to a new parent

--- a/remote/mock/client.go
+++ b/remote/mock/client.go
@@ -143,6 +143,7 @@ func (c *Client) PullDataset(ctx context.Context, ref *dsref.Ref, remoteAddr str
 	}
 
 	info := dsref.ConvertDatasetToVersionInfo(ds)
+	info.InitID = ref.InitID
 	info.Username = ref.Username
 	info.Name = ref.Name
 	info.ProfileID = ref.ProfileID
@@ -287,6 +288,7 @@ func (c *Client) mockDagSync(ctx context.Context, ref dsref.Ref) (*dsref.Version
 
 	// Add to our repository
 	vi := dsref.VersionInfo{
+		InitID:    initID,
 		Path:      dsPath,
 		ProfileID: ref.ProfileID,
 		Username:  ref.Username,


### PR DESCRIPTION
Because we need to repeat many of these handler/event patterns in `cloud`, we are dividing up the `Collection` to make it more reusable. 

The `Collection` is now a struct that contains a `WritableSet`. The `Collection` is responsible for listening to events and calling various `Put`-like functions on the `WriteableSet` when certain events are handled. 

To keep things moving, rather than refactor a ton about the `collection` package, first I'm keeping these `Put`-like functions as close as possible to the methods that already existed on `localSet`. These can most likely be narrowed in future prs.

The `spec` package as been remove, and the tests moved into the `collection` packages itself. Although, `AssertWritableCollectionSpec` with some tweaking and additional tests should probably be moved back into a `spec` package, especially once the interface settles.