### PR TITLE
fix(run): add ctx to run.Store

### DIFF
--- a/automation/orchestrator.go
+++ b/automation/orchestrator.go
@@ -337,7 +337,7 @@ func (o *Orchestrator) runWorkflow(ctx context.Context, wf *workflow.Workflow, r
 
 	if o.runs != nil {
 		r := &run.State{ID: runID, WorkflowID: wid}
-		if _, err := o.runs.Create(r); err != nil {
+		if _, err := o.runs.Create(ctx, r); err != nil {
 			return err
 		}
 
@@ -503,7 +503,7 @@ func runEventsHandler(store run.Store) event.Handler {
 			return adder.AddEvent(e.SessionID, e)
 		}
 
-		r, err := store.Get(e.SessionID)
+		r, err := store.Get(ctx, e.SessionID)
 		if err != nil {
 			return err
 		}
@@ -511,7 +511,7 @@ func runEventsHandler(store run.Store) event.Handler {
 			return err
 		}
 
-		_, err = store.Put(r)
+		_, err = store.Put(ctx, r)
 		return err
 	}
 }

--- a/automation/run/filestore.go
+++ b/automation/run/filestore.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"github.com/qri-io/qri/automation/workflow"
 	"github.com/qri-io/qri/base/params"
 	"github.com/qri-io/qri/event"
+	"github.com/qri-io/qri/profile"
 )
 
 type fileStore struct {
@@ -65,34 +67,42 @@ func (s *fileStore) writeToFileNoLock() error {
 }
 
 // Create adds a new run State to the Store
-func (s *fileStore) Create(r *State) (*State, error) { return s.store.Create(r) }
+func (s *fileStore) Create(ctx context.Context, r *State) (*State, error) {
+	return s.store.Create(ctx, r)
+}
 
 // Put puts a run State with an existing run ID into the Store
-func (s *fileStore) Put(r *State) (*State, error) { return s.store.Put(r) }
+func (s *fileStore) Put(ctx context.Context, r *State) (*State, error) { return s.store.Put(ctx, r) }
 
 // Get gets the associated run.State
-func (s *fileStore) Get(id string) (*State, error) { return s.store.Get(id) }
+func (s *fileStore) Get(ctx context.Context, id string) (*State, error) { return s.store.Get(ctx, id) }
 
 // Count returns the number of runs for a given workflow.ID
-func (s *fileStore) Count(wid workflow.ID) (int, error) { return s.store.Count(wid) }
+func (s *fileStore) Count(ctx context.Context, wid workflow.ID) (int, error) {
+	return s.store.Count(ctx, wid)
+}
 
 // List lists all the runs associated with the workflow.ID in reverse
 // chronological order
-func (s *fileStore) List(wid workflow.ID, lp params.List) ([]*State, error) {
-	return s.store.List(wid, lp)
+func (s *fileStore) List(ctx context.Context, wid workflow.ID, lp params.List) ([]*State, error) {
+	return s.store.List(ctx, wid, lp)
 }
 
 // GetLatest returns the most recent run associated with the workflow id
-func (s *fileStore) GetLatest(wid workflow.ID) (*State, error) { return s.store.GetLatest(wid) }
+func (s *fileStore) GetLatest(ctx context.Context, wid workflow.ID) (*State, error) {
+	return s.store.GetLatest(ctx, wid)
+}
 
 // GetStatus returns the status of the latest run based on the
 // workflow.ID
-func (s *fileStore) GetStatus(wid workflow.ID) (Status, error) { return s.store.GetStatus(wid) }
+func (s *fileStore) GetStatus(ctx context.Context, wid workflow.ID) (Status, error) {
+	return s.store.GetStatus(ctx, wid)
+}
 
 // ListByStatus returns a list of run.State entries with a given status
 // looking only at the most recent run of each Workflow
-func (s *fileStore) ListByStatus(status Status, lp params.List) ([]*State, error) {
-	return s.store.ListByStatus(status, lp)
+func (s *fileStore) ListByStatus(ctx context.Context, owner profile.ID, status Status, lp params.List) ([]*State, error) {
+	return s.store.ListByStatus(ctx, owner, status, lp)
 }
 
 // Shutdown writes the run events to the filestore
@@ -105,4 +115,6 @@ func (s *fileStore) Shutdown() error {
 
 // AddEvent writes an event to the store, attaching it to an existing stored
 // run state
-func (s *fileStore) AddEvent(id string, e event.Event) error { return s.store.AddEvent(id, e) }
+func (s *fileStore) AddEvent(id string, e event.Event) error {
+	return s.store.AddEvent(id, e)
+}

--- a/automation/run/filestore_test.go
+++ b/automation/run/filestore_test.go
@@ -1,6 +1,7 @@
 package run_test
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -16,6 +17,7 @@ import (
 )
 
 func TestFileStore(t *testing.T) {
+	ctx := context.Background()
 	tmpdir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatal(err)
@@ -113,7 +115,7 @@ func TestFileStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gotRun, err := store.Get("run1")
+	gotRun, err := store.Get(ctx, "run1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +171,7 @@ func TestFileStore(t *testing.T) {
 		},
 	}
 
-	if _, err := store.Create(r2); err != nil {
+	if _, err := store.Create(ctx, r2); err != nil {
 		t.Fatal(err)
 	}
 

--- a/automation/run/run.go
+++ b/automation/run/run.go
@@ -74,7 +74,7 @@ type State struct {
 	Message    string       `json:"message"`
 	StartTime  *time.Time   `json:"startTime"`
 	StopTime   *time.Time   `json:"stopTime"`
-	Duration   int          `json:"duration"`
+	Duration   int64        `json:"duration"`
 	Steps      []*StepState `json:"steps"`
 }
 
@@ -131,7 +131,7 @@ func (rs *State) AddTransformEvent(e event.Event) error {
 			rs.Status = Status(tl.Status)
 		}
 		if rs.StartTime != nil && rs.StopTime != nil {
-			rs.Duration = int(rs.StopTime.Sub(*rs.StartTime))
+			rs.Duration = int64(rs.StopTime.Sub(*rs.StartTime))
 		}
 		return nil
 	case event.ETTransformStepStart:
@@ -155,7 +155,7 @@ func (rs *State) AddTransformEvent(e event.Event) error {
 			step.Status = RSFailed
 		}
 		if step.StartTime != nil && step.StopTime != nil {
-			step.Duration = int(step.StopTime.Sub(*step.StartTime))
+			step.Duration = int64(step.StopTime.Sub(*step.StartTime))
 		}
 		return nil
 	case event.ETTransformStepSkip:
@@ -198,7 +198,7 @@ type StepState struct {
 	Status    Status        `json:"status"`
 	StartTime *time.Time    `json:"startTime"`
 	StopTime  *time.Time    `json:"stopTime"`
-	Duration  int           `json:"duration"`
+	Duration  int64         `json:"duration"`
 	Output    []event.Event `json:"output"`
 }
 
@@ -220,7 +220,7 @@ type _stepState struct {
 	Status    Status     `json:"status"`
 	StartTime *time.Time `json:"startTime"`
 	StopTime  *time.Time `json:"stopTime"`
-	Duration  int        `json:"duration"`
+	Duration  int64      `json:"duration"`
 	Output    []_event   `json:"output"`
 }
 

--- a/automation/spec/run.go
+++ b/automation/spec/run.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -13,7 +14,8 @@ import (
 
 // AssertRunStore confirms the expected behavior of a run.Store interface
 func AssertRunStore(t *testing.T, store run.Store) {
-	assertCreatePut(t, store)
+	ctx := context.Background()
+	assertCreatePut(ctx, t, store)
 
 	wid := workflow.ID("test id")
 	expectedRuns := [3]*run.State{}
@@ -27,18 +29,18 @@ func AssertRunStore(t *testing.T, store run.Store) {
 		if i == 0 {
 			r.Status = run.RSWaiting
 		}
-		expectedRun, err := store.Create(r)
+		expectedRun, err := store.Create(ctx, r)
 		if err != nil {
 			t.Fatalf("store.Put unexpected error: %s", err)
 		}
 		expectedRuns[i] = expectedRun
 	}
 
-	if _, err := store.Get("bad run id"); !errors.Is(err, run.ErrNotFound) {
+	if _, err := store.Get(ctx, "bad run id"); !errors.Is(err, run.ErrNotFound) {
 		t.Fatalf("store.Get should emit a run.ErrNotFound error if given an unknown run ID")
 	}
 	for i := 0; i < 3; i++ {
-		got, err := store.Get(expectedRuns[i].ID)
+		got, err := store.Get(ctx, expectedRuns[i].ID)
 		if err != nil {
 			t.Fatalf("store.Get unexpected error: %s", err)
 		}
@@ -49,11 +51,11 @@ func AssertRunStore(t *testing.T, store run.Store) {
 	}
 
 	badWID := workflow.ID("bad id")
-	if _, err := store.Count(badWID); !errors.Is(err, run.ErrUnknownWorkflowID) {
+	if _, err := store.Count(ctx, badWID); !errors.Is(err, run.ErrUnknownWorkflowID) {
 		t.Fatalf("store.Count should emit a run.ErrUnknownWorkflowID error when given a workflow ID not associated with any runs in the Store")
 	}
 
-	gotCount, err := store.Count(wid)
+	gotCount, err := store.Count(ctx, wid)
 	if err != nil {
 		t.Fatalf("store.Count unexpected error: %s", err)
 	}
@@ -61,10 +63,10 @@ func AssertRunStore(t *testing.T, store run.Store) {
 		t.Errorf("store.Count count mismatch, expected 3, got %d", gotCount)
 	}
 
-	if _, err := store.List(badWID, params.ListAll); !errors.Is(err, run.ErrUnknownWorkflowID) {
+	if _, err := store.List(ctx, badWID, params.ListAll); !errors.Is(err, run.ErrUnknownWorkflowID) {
 		t.Fatalf("store.List should emit a run.ErrUnknownWorkflowID error when given a workflow ID not associated with any runs in the Store")
 	}
-	gotRuns, err := store.List(wid, params.ListAll)
+	gotRuns, err := store.List(ctx, wid, params.ListAll)
 	if err != nil {
 		t.Fatalf("store.List unexpected error: %s", err)
 	}
@@ -72,10 +74,10 @@ func AssertRunStore(t *testing.T, store run.Store) {
 		t.Errorf("store.List mismatch (-want +got):\n%s", diff)
 	}
 
-	if _, err := store.GetLatest(badWID); !errors.Is(err, run.ErrUnknownWorkflowID) {
+	if _, err := store.GetLatest(ctx, badWID); !errors.Is(err, run.ErrUnknownWorkflowID) {
 		t.Fatalf("store.GetLatest should emit a run.ErrUnknownWorkflowID error when given a workflow ID not associated with any runs in the Store")
 	}
-	got, err := store.GetLatest(wid)
+	got, err := store.GetLatest(ctx, wid)
 	if err != nil {
 		t.Fatalf("store.GetLatest unexpected error: %s", err)
 	}
@@ -83,10 +85,10 @@ func AssertRunStore(t *testing.T, store run.Store) {
 		t.Errorf("store.GetLatest mismatch (-want +got): \n%s", diff)
 	}
 
-	if _, err := store.GetStatus(badWID); !errors.Is(err, run.ErrUnknownWorkflowID) {
+	if _, err := store.GetStatus(ctx, badWID); !errors.Is(err, run.ErrUnknownWorkflowID) {
 		t.Fatalf("store.GetStatus should emit a run.ErrUnknownWorkflowID error when given a workflow ID not associated with any runs in the Store")
 	}
-	gotStatus, err := store.GetStatus(wid)
+	gotStatus, err := store.GetStatus(ctx, wid)
 	if err != nil {
 		t.Fatalf("store.GetStatus unexpected error: %s", err)
 	}
@@ -94,7 +96,7 @@ func AssertRunStore(t *testing.T, store run.Store) {
 		t.Errorf("store.GetStatus mismatch: expected %q, got %q", run.RSWaiting, gotStatus)
 	}
 
-	gotRuns, err = store.ListByStatus(run.RSWaiting, params.ListAll)
+	gotRuns, err = store.ListByStatus(ctx, "", run.RSWaiting, params.ListAll)
 	if err != nil {
 		t.Fatalf("store.ListByStatus unexpected error: %s", err)
 	}
@@ -105,51 +107,51 @@ func AssertRunStore(t *testing.T, store run.Store) {
 }
 
 // assertCreatePut confirms the expected behavior of the run.Store's Put method
-func assertCreatePut(t *testing.T, store run.Store) {
-	if _, err := store.Create(nil); err == nil {
+func assertCreatePut(ctx context.Context, t *testing.T, store run.Store) {
+	if _, err := store.Create(ctx, nil); err == nil {
 		t.Fatal("store.Create should error when passed nil")
 	}
 	expected := &run.State{}
-	if _, err := store.Create(expected); !errors.Is(err, run.ErrNoWorkflowID) {
+	if _, err := store.Create(ctx, expected); !errors.Is(err, run.ErrNoWorkflowID) {
 		t.Fatal("store.Create is expected to emit a run.ErrNoWorkflowID error if you try to create a run.State wit no workflow.ID")
 	}
 
 	wid := workflow.ID("assert test id")
 	expected.WorkflowID = wid
 
-	got, err := store.Create(expected)
+	got, err := store.Create(ctx, expected)
 	if err != nil {
 		t.Fatalf("store.Create unexpected error: %s", err)
 	}
 	if got.ID == "" {
 		t.Fatal("store.Create is expected to fill the run.ID field if given a run.State with an empty ID")
 	}
-	if _, err := store.Create(got); err == nil {
+	if _, err := store.Create(ctx, got); err == nil {
 		t.Fatal("store.Create is expected to error if trying to create a run State with a run ID that already exists in the store")
 	}
 
-	got, err = store.Create(expected)
+	got, err = store.Create(ctx, expected)
 	if err != nil {
 		t.Fatalf("store.Create should be able to add multiple entries for a single workflow.ID. Unexpected error %s", err)
 	}
 
-	if _, err := store.Put(nil); err == nil {
+	if _, err := store.Put(ctx, nil); err == nil {
 		t.Fatal("store.Put should error when passed nil")
 	}
 
-	if _, err := store.Put(&run.State{}); err == nil {
+	if _, err := store.Put(ctx, &run.State{}); err == nil {
 		t.Fatal("store.Put should error when passed a State with no run ID")
 	}
-	if _, err := store.Put(&run.State{ID: "test_id"}); err == nil {
+	if _, err := store.Put(ctx, &run.State{ID: "test_id"}); err == nil {
 		t.Fatal("store.Put should error if you try to add a run.State with no workflow.ID")
 	}
-	if _, err := store.Put(&run.State{ID: "test_id", WorkflowID: "test workflow ID"}); err == nil {
+	if _, err := store.Put(ctx, &run.State{ID: "test_id", WorkflowID: "test workflow ID"}); err == nil {
 		t.Fatal("store.Put should error when passed a new State")
 	}
 	runID := got.ID
 	expected.ID = runID
 	expected.Status = run.RSRunning
-	got, err = store.Put(expected)
+	got, err = store.Put(ctx, expected)
 	if err != nil {
 		t.Fatalf("store.Put unexpected error: %s", err)
 	}
@@ -157,16 +159,16 @@ func assertCreatePut(t *testing.T, store run.Store) {
 		t.Errorf("run.State mismatch (-want +got):\n%s", diff)
 	}
 
-	if _, err := store.Put(expected); err != nil {
+	if _, err := store.Put(ctx, expected); err != nil {
 		t.Fatalf("store.Put should be able to update the same run multiple times. Unexpected error: %s", err)
 	}
 
 	expected.ID = runID
 	expected.WorkflowID = workflow.ID("new id")
-	if _, err = store.Put(expected); err == nil {
+	if _, err = store.Put(ctx, expected); err == nil {
 		t.Fatal("store.Put should error if the WorkflowID of the given run.State does not match the WorkflowID of the run.State stored")
 	}
-	count, err := store.Count(got.WorkflowID)
+	count, err := store.Count(ctx, got.WorkflowID)
 	if err != nil {
 		t.Fatalf("store.Count unexpected error %s", err)
 	}


### PR DESCRIPTION
Also added an `owner profile.ID` to `ListByStatus` as cloud will have to scope it down and from a multi tenancy standpoint makes sense to control for it. And I want to avoid hacks we used to do where we magically pull out the relevant user from context. 