### PR TITLE
fix(collection): use `logbook` to fill in missing run and commit count data during `collection` migration

### DIFF
--- a/collection/migrate.go
+++ b/collection/migrate.go
@@ -2,10 +2,12 @@ package collection
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/logbook"
+	"github.com/qri-io/qri/logbook/oplog"
 	"github.com/qri-io/qri/repo"
 )
 
@@ -44,41 +46,10 @@ func MigrateRepoStoreToLocalCollectionSet(ctx context.Context, s Set, r repo.Rep
 			}
 		}
 
-		ulog, err := book.UserDatasetBranchesLog(ctx, datasets[i].InitID)
-		if err != nil {
-			log.Errorf("can't get user log for dataset %s, %s", datasets[i].InitID, err)
+		if err := addRunAndCommitInfo(ctx, book, &datasets[i]); err != nil {
+			log.Error(err)
 			continue
 		}
-		dlog, err := ulog.Log(datasets[i].InitID)
-		if err != nil {
-			log.Errorf("can't get dataset log for dataset %s, %s", datasets[i].InitID, err)
-			continue
-		}
-		if len(dlog.Logs) < 0 {
-			log.Errorf("no branch logs for dataset log %s, %s", datasets[i].InitID, err)
-			continue
-		}
-		blog := dlog.Logs[0]
-		commitCount := 0
-		runCount := 0
-		mostRecentRunRecorded := false
-		for _, op := range blog.Ops {
-			if op.Model == logbook.CommitModel {
-				commitCount++
-				continue
-			}
-			if op.Model == logbook.RunModel {
-				runCount++
-				if !mostRecentRunRecorded {
-					datasets[i].RunID = op.Ref
-					datasets[i].RunDuration = op.Size
-					datasets[i].RunStatus = op.Note
-					mostRecentRunRecorded = true
-				}
-			}
-		}
-		datasets[i].CommitCount = commitCount
-		datasets[i].RunCount = runCount
 	}
 
 	// remove any datasets that couldn't be resolved
@@ -89,4 +60,48 @@ func MigrateRepoStoreToLocalCollectionSet(ctx context.Context, s Set, r repo.Rep
 	}
 
 	return s.Add(ctx, ownerID, datasets...)
+}
+
+func addRunAndCommitInfo(ctx context.Context, book *logbook.Book, vi *dsref.VersionInfo) error {
+	ulog, err := book.UserDatasetBranchesLog(ctx, vi.InitID)
+	if err != nil {
+		return fmt.Errorf("can't get user log for dataset %s, %w", vi.InitID, err)
+	}
+	dlog, err := ulog.Log(vi.InitID)
+	if err != nil {
+		return fmt.Errorf("can't get dataset log for dataset %s, %w", vi.InitID, err)
+	}
+	if len(dlog.Logs) < 0 {
+		return fmt.Errorf("no branch logs for dataset log %s, %w", vi.InitID, err)
+	}
+	blog := dlog.Logs[0]
+	commitCount := 0
+	runCount := 0
+	mostRecentRunRecorded := false
+	for _, op := range blog.Ops {
+		if op.Model == logbook.CommitModel {
+			switch op.Type {
+			case oplog.OpTypeInit:
+				commitCount++
+			case oplog.OpTypeAmend:
+				continue
+			case oplog.OpTypeRemove:
+				commitCount = int(int64(commitCount) - op.Size)
+			}
+			continue
+		}
+		if op.Model == logbook.RunModel {
+			runCount++
+			if !mostRecentRunRecorded {
+				vi.RunID = op.Ref
+				vi.RunDuration = op.Size
+				vi.RunStatus = op.Note
+				mostRecentRunRecorded = true
+			}
+			continue
+		}
+	}
+	vi.CommitCount = commitCount
+	vi.RunCount = runCount
+	return nil
 }

--- a/collection/migrate_test.go
+++ b/collection/migrate_test.go
@@ -3,9 +3,11 @@ package collection
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/automation/run"
 	"github.com/qri-io/qri/base/params"
 	"github.com/qri-io/qri/dsref"
@@ -33,12 +35,13 @@ func TestMigrateRepoStoreToLocalCollectionSet(t *testing.T) {
 
 	// force log entries for runs
 	book := r.Logbook()
+	pro := r.Profiles().Owner(ctx)
 	citiesRef := &dsref.Ref{Username: "peer", Name: "cities"}
 	_, err = r.ResolveRef(ctx, citiesRef)
 	if err != nil {
 		t.Fatalf("test repo cannot resolve dataset ref %q", "peer/cities")
 	}
-	err = book.WriteTransformRun(ctx, r.Profiles().Owner(ctx), citiesRef.InitID, &run.State{ID: "cities_run_id", Status: run.RSSucceeded, Duration: 1000})
+	err = book.WriteTransformRun(ctx, pro, citiesRef.InitID, &run.State{ID: "cities_run_id", Status: run.RSSucceeded, Duration: 1000})
 	if err != nil {
 		t.Fatalf("unable to add transform run op to logbook for dataset %s, %q", "peer/cities", err)
 	}
@@ -47,6 +50,14 @@ func TestMigrateRepoStoreToLocalCollectionSet(t *testing.T) {
 	expect[0].RunID = "cities_run_id"
 	expect[0].RunStatus = "succeeded"
 	expect[0].RunDuration = 1000
+
+	citiesDS := &dataset.Dataset{ID: citiesRef.InitID, ProfileID: citiesRef.ProfileID, Peername: citiesRef.Username, Name: citiesRef.Name, PreviousPath: citiesRef.Path, Path: "new_path", Commit: &dataset.Commit{Timestamp: time.Unix(10000, 0), Title: "delete this commit"}}
+	if err = book.WriteVersionSave(ctx, pro, citiesDS, nil); err != nil {
+		t.Fatalf("unable to add commit op to logbook for dataset %s, %q", "peer/cities", err)
+	}
+	if err = book.WriteVersionDelete(ctx, pro, citiesRef.InitID, 1); err != nil {
+		t.Fatalf("unable to add delete op to logbook for dataset %s, %q", "peer/cities", err)
+	}
 
 	for i := 0; i < len(expect); i++ {
 		expect[i].CommitCount = 1


### PR DESCRIPTION
closes #1904 