### PR TITLE
refactor(startf): transforms should return a dataset with the `Structure.Entries`

### DIFF
--- a/transform/startf/testdata/set_meta.star
+++ b/transform/startf/testdata/set_meta.star
@@ -1,0 +1,4 @@
+ds = dataset.latest()
+
+ds.set_meta("title", "new title")
+dataset.commit(ds)

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -221,8 +221,9 @@ func compareEventLogs(t *testing.T, expect, log []event.Event) {
 var threeStepDatasetPreview = &dataset.Dataset{
 	Body: json.RawMessage(`[[1,2,3]]`),
 	Structure: &dataset.Structure{
-		Format: "json",
-		Schema: map[string]interface{}{"type": "array"},
+		Format:  "json",
+		Schema:  map[string]interface{}{"type": "array"},
+		Entries: 1,
 	},
 	Transform: &dataset.Transform{
 		Steps: []*dataset.TransformStep{


### PR DESCRIPTION
closes #1907 

also closes qri-io/frontend#254