### PR TITLE
fix(transform): need to pass down InitIDs to `transform.Commit`

### DIFF
--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -1013,7 +1013,7 @@ func (datasetImpl) Save(scope scope, p *SaveParams) (*dataset.Dataset, error) {
 		// apply the transform
 		shouldWait := true
 		transformer := transform.NewTransformer(scope.AppContext(), scope.Loader(), scope.Bus())
-		if err := transformer.Commit(scope.Context(), ds, runID, shouldWait, secrets); err != nil {
+		if err := transformer.Commit(scope.Context(), ref.InitID, ds, runID, shouldWait, secrets); err != nil {
 			log.Errorw("transform run error", "err", err.Error())
 			runState.Message = err.Error()
 			if err := scope.Logbook().WriteTransformRun(scope.Context(), scope.ActiveProfile(), ref.InitID, runState); err != nil {


### PR DESCRIPTION
We rely on the init id in the `TransformLifecyle` event in the
collection and on the frontend to coordinate the events to their proper
datasets. I had an incorrect assumption, and did not realize that the 
datasets passed down to `transform.Commit` would not have their 
`dataset.ID` fields populated.
Instead, we need to pass down the InitID for the dataset (if it exists)
directly into the call to `transform.Commit`. The save path seems to
expect the the ID field NOT be passed in when we go to save the dataset,
which is why I did not choose to just ensure the `dataset.ID` field was
populated before passing the dataset down into `transform.Commit`.

It is not a problem if the `InitID` field is not populated, and it is
actually expected that this field is not populated for "apply" runs.