### PR TITLE
fix(transform): transforms default to CSV format

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -468,7 +468,7 @@ func TestSaveTransformModifiedButSameBody(t *testing.T) {
 	expect := dstest.Template(t, `1   Commit:  {{ .commit1 }}
     Date:    Sun Dec 31 20:02:01 EST 2000
     Storage: local
-    Size:    9 B
+    Size:    6 B
 
     transform added text
     transform:
@@ -477,13 +477,13 @@ func TestSaveTransformModifiedButSameBody(t *testing.T) {
 2   Commit:  {{ .commit2 }}
     Date:    Sun Dec 31 20:01:01 EST 2000
     Storage: local
-    Size:    9 B
+    Size:    6 B
 
     created dataset from tf_123.star
 
 `, map[string]string{
-		"commit1": "/ipfs/QmaCi7v2RH2S4GbrqJXUroMTnkkY5ATGbj9PsGPkr48tdz",
-		"commit2": "/ipfs/QmRVeHcJw3bjBZeTXWAxKNwLYhYB355J51yaV5VMB8pyxN",
+		"commit1": "/ipfs/QmNW9sK3LYopenAuoQVbEznJBBLiNHbzdgRuZMojsNbUD4",
+		"commit2": "/ipfs/QmYSEZWTzZEAArSN5fUVXAezExhTXa4hxyyzSYsafpXvJR",
 	})
 	if diff := cmp.Diff(expect, output); diff != "" {
 		t.Errorf("log (-want +got):\n%s", diff)

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -1076,10 +1076,10 @@ func TestSaveTransformUsingConfigSecret(t *testing.T) {
 
 	// Read body from the dataset that was saved.
 	dsPath := run.GetPathForDataset(t, 0)
-	actualBody := run.ReadBodyFromIPFS(t, dsPath+"/body.json")
+	actualBody := run.ReadBodyFromIPFS(t, dsPath+"/body.csv")
 
 	// Expected result has the config and secret data
-	expectBody := `[["Name","cat"],["Sound","meow"]]`
+	expectBody := "Name,cat\nSound,meow\n"
 
 	// Make sure they match.
 	if diff := cmp.Diff(expectBody, actualBody); diff != "" {

--- a/lib/automation_test.go
+++ b/lib/automation_test.go
@@ -73,7 +73,7 @@ dataset.commit(ds)
 		t.Fatal(err)
 	}
 
-	expectBody := `[["1","2","3"],["4","5","6"]]`
+	expectBody := `[[1,2,3],[4,5,6]]`
 
 	data, err := json.Marshal(res.Body)
 	if err != nil {

--- a/transform/startf/ds/dataset.go
+++ b/transform/startf/ds/dataset.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"reflect"
 	"sort"
 	"sync"
 
@@ -360,13 +359,13 @@ func (d *Dataset) AssignBodyFromDataframe() error {
 	}
 	df, ok := d.bodyFrame.(*dataframe.DataFrame)
 	if !ok {
-		return fmt.Errorf("bodyFrame has invalid type %v", reflect.TypeOf(d.bodyFrame))
+		return fmt.Errorf("bodyFrame has invalid type %T", d.bodyFrame)
 	}
 
 	st := d.ds.Structure
 	if st == nil {
 		st = &dataset.Structure{
-			Format: "json",
+			Format: "csv",
 			Schema: tabular.BaseTabularSchema,
 		}
 	}

--- a/transform/startf/transform_test.go
+++ b/transform/startf/transform_test.go
@@ -142,7 +142,7 @@ func TestExecStep(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual := string(data)
-	expect := `[[1,2,3]]`
+	expect := "1,2,3\n"
 	if actual != expect {
 		t.Errorf("expected: %q, actual: %q", expect, actual)
 	}
@@ -223,9 +223,9 @@ func TestGetMetaNilPrev(t *testing.T) {
 	}
 	data, _ := ioutil.ReadAll(bodyfile)
 	actual := string(data)
-	expect := `[["no title"]]`
+	expect := "no title\n"
 	if actual != expect {
-		t.Errorf("expected: \"%s\", actual: \"%s\"", expect, actual)
+		t.Errorf("expected: %q, actual: %q", expect, actual)
 	}
 }
 
@@ -249,9 +249,9 @@ func TestGetMetaWithPrev(t *testing.T) {
 	}
 	data, _ := ioutil.ReadAll(bodyfile)
 	actual := string(data)
-	expect := `[["title: test_title"]]`
+	expect := "title: test_title\n"
 	if actual != expect {
-		t.Errorf("expected: \"%s\", actual: \"%s\"", expect, actual)
+		t.Errorf("expected: %q, actual: %q", expect, actual)
 	}
 }
 

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -227,8 +227,19 @@ func compareEventLogs(t *testing.T, expect, log []event.Event) {
 var threeStepDatasetPreview = &dataset.Dataset{
 	Body: json.RawMessage(`[[1,2,3]]`),
 	Structure: &dataset.Structure{
-		Format:  "json",
-		Schema:  map[string]interface{}{"type": "array"},
+		Format:       "csv",
+		FormatConfig: map[string]interface{}{"lazyQuotes": true},
+		Schema: map[string]interface{}{
+			"items": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"title": "field_1", "type": "integer"},
+					map[string]interface{}{"title": "field_2", "type": "integer"},
+					map[string]interface{}{"title": "field_3", "type": "integer"},
+				},
+				"type": "array",
+			},
+			"type": "array",
+		},
 		Entries: 1,
 	},
 	Transform: &dataset.Transform{


### PR DESCRIPTION
with our latest switch to using `ds.body` assignment, we've lost the `parse_as` argument that we formerly relied on to set data format. As a short-term fix we'd like to _default_ to CSV data format.

In a follow-up we'll detect the number of dimensions in the body and error if it's higher than 2.

closes #1915