### PR TITLE
fix(run): run store deserialization updated

### DIFF
--- a/automation/orchestrator_test.go
+++ b/automation/orchestrator_test.go
@@ -394,25 +394,29 @@ func TestRunStoreEvents(t *testing.T) {
 			confirmStoredRun(ctx, t, runStore, r)
 
 			// event 2
-			bus.PublishID(ctx, event.ETTransformPrint, r.ID, "transform print")
+			bus.PublishID(ctx, event.ETTransformPrint, r.ID, event.TransformMessage{Msg: "transform print"})
 			ts = nextTimestamp()
 			expectedPrintEvent := event.Event{
 				Type:      event.ETTransformPrint,
 				Timestamp: (*ts).UnixNano(),
 				SessionID: r.ID,
-				Payload:   "transform print",
+				Payload: event.TransformMessage{
+					Msg: "transform print",
+				},
 			}
 			r.Steps[0].Output = []event.Event{expectedPrintEvent}
 			confirmStoredRun(ctx, t, runStore, r)
 
 			// event 3
-			bus.PublishID(ctx, event.ETTransformError, r.ID, "transform error")
+			bus.PublishID(ctx, event.ETTransformError, r.ID, event.TransformMessage{Msg: "transform error"})
 			ts = nextTimestamp()
 			expectedErrorEvent := event.Event{
 				Type:      event.ETTransformError,
 				Timestamp: (*ts).UnixNano(),
 				SessionID: r.ID,
-				Payload:   "transform error",
+				Payload: event.TransformMessage{
+					Msg: "transform error",
+				},
 			}
 			r.Steps[0].Output = []event.Event{expectedPrintEvent, expectedErrorEvent}
 			confirmStoredRun(ctx, t, runStore, r)

--- a/automation/run/filestore_test.go
+++ b/automation/run/filestore_test.go
@@ -76,7 +76,9 @@ func TestFileStore(t *testing.T) {
 					{
 						Type:      event.ETTransformPrint,
 						Timestamp: 3,
-						Payload:   "printing!",
+						Payload: event.TransformMessage{
+							Msg: "printing!",
+						},
 					},
 				},
 			},
@@ -164,7 +166,9 @@ func TestFileStore(t *testing.T) {
 					{
 						Type:      event.ETTransformPrint,
 						Timestamp: 3,
-						Payload:   "printing!",
+						Payload: event.TransformMessage{
+							Msg: "printing!",
+						},
 					},
 				},
 			},

--- a/automation/run/run.go
+++ b/automation/run/run.go
@@ -264,7 +264,7 @@ func (ss *StepState) UnmarshalJSON(data []byte) error {
 			}
 			e.Payload = p
 		case event.ETTransformPrint, event.ETTransformError:
-			p := ""
+			p := event.TransformMessage{}
 			if err := json.Unmarshal(re.Payload, &p); err != nil {
 				return err
 			}


### PR DESCRIPTION
@ramfox This made a lot of issues in parsing the runs from the run store and introduces some follow up behavior issues. 
The only gotcha is that we have to make sure all the payloads do actually conform to the `event.TransformMessage` payload type which I'm still not a 100% on as it's a bit hard to track down.