### PR TITLE
fix(lib): scope the `lib.apply` context

### DIFF
--- a/lib/automation.go
+++ b/lib/automation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
 	qhttp "github.com/qri-io/qri/lib/http"
+	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/transform"
 )
 
@@ -453,6 +454,7 @@ func (inst *Instance) apply(ctx context.Context, wait bool, runID string, wf *wo
 		return err
 	}
 
-	transformer := transform.NewTransformer(scope.AppContext(), scope.Loader(), scope.Bus())
+	ctx = profile.AddIDToContext(scope.AppContext(), scope.ActiveProfile().ID.Encode())
+	transformer := transform.NewTransformer(ctx, scope.Loader(), scope.Bus())
 	return transformer.Apply(ctx, ds, runID, wait, secrets)
 }


### PR DESCRIPTION
Missed this on my first pass because I figured this scoping was taken care of using the `newScopeFromWorkflow` function. However, this only scopes the `scope.Context` not the `scope.AppContext`, which is what we need in `lib.apply`.

Since the `lib.run` and `lib.apply` use the `scope` for the `newScopeFromWorkflow` differently, I thought it best to adjust the scoping issue in `lib.apply` only, rather than `newScopeFromWorkflow`. If there comes a time when `scope.Context()` for both workflow runs and workflow applies are both expected to last the context of the app itself, we may want to make this adjustment in `newScopeFromWorkflow` instead.