### PR TITLE
fix(automation): Print synchronously, keep output in order

### DIFF
--- a/automation/orchestrator.go
+++ b/automation/orchestrator.go
@@ -385,17 +385,15 @@ func (o *Orchestrator) ApplyWorkflow(ctx context.Context, wait bool, scriptOutpu
 	runID := run.NewID()
 	if scriptOutput != nil {
 		o.bus.SubscribeID(func(ctx context.Context, e event.Event) error {
-			go func() {
-				log.Debugw("apply transform event", "type", e.Type, "payload", e.Payload)
-				if e.Type == event.ETTransformPrint {
-					if msg, ok := e.Payload.(event.TransformMessage); ok {
-						if scriptOutput != nil {
-							io.WriteString(scriptOutput, msg.Msg)
-							io.WriteString(scriptOutput, "\n")
-						}
+			log.Debugw("apply transform event", "type", e.Type, "payload", e.Payload)
+			if e.Type == event.ETTransformPrint {
+				if msg, ok := e.Payload.(event.TransformMessage); ok {
+					if scriptOutput != nil {
+						io.WriteString(scriptOutput, msg.Msg)
+						io.WriteString(scriptOutput, "\n")
 					}
 				}
-			}()
+			}
 			return nil
 		}, runID)
 		// TODO (ramfox): defer unsubscribe to id


### PR DESCRIPTION
Before this change, print would be dispatched asynchronously. Since go routines can start running at any time based upon what the scheduler decides, this would cause print statements to output in arbitrary orders. For example this expected output:

```
0: 1
1: 2
2: 3
3: 4
4: 35
```

would instead show up like this (as an example):

```
1: 2
0: 1
3: 4
4: 35
2: 3
```