### PR TITLE
refactor(VersionInfo): add `RunStart` field

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -110,6 +110,7 @@ func (sm *SetMaintainer) handleEvent(ctx context.Context, e event.Event) error {
 					vi.RunID = m.RunID
 					vi.RunStatus = m.RunStatus
 					vi.RunDuration = m.RunDuration
+					vi.RunStart = m.RunStart
 				}
 
 				*m = vi
@@ -221,6 +222,7 @@ func (sm *SetMaintainer) handleEvent(ctx context.Context, e event.Event) error {
 					vi.RunCount++
 					vi.RunStatus = "running"
 					vi.RunID = te.RunID
+					vi.RunStart = nil
 				})
 				if err != nil {
 					log.Debugw("update dataset across all collections", "InitID", te.InitID, "err", err)
@@ -230,6 +232,7 @@ func (sm *SetMaintainer) handleEvent(ctx context.Context, e event.Event) error {
 	case event.ETLogbookWriteRun:
 		if vi, ok := e.Payload.(dsref.VersionInfo); ok {
 			err := sm.UpdateEverywhere(ctx, vi.InitID, func(v *dsref.VersionInfo) {
+				v.RunStart = vi.RunStart
 				v.RunID = vi.RunID
 				v.RunStatus = vi.RunStatus
 				v.RunDuration = vi.RunDuration

--- a/collection/collection_assert_test.go
+++ b/collection/collection_assert_test.go
@@ -290,11 +290,13 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 		expect[0].RunStatus = "running"
 		assertCollectionList(ctx, t, kermit, params.ListAll, s, expect)
 
+		runStart := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
 		// simulate a "WriteTransformRun" in logbook
 		// this might occur if a transform has errored or resulted in no changes
-		mustPublish(ctx, t, bus, event.ETLogbookWriteRun, dsref.VersionInfo{InitID: muppetNamesInitID, RunID: muppetNamesRunID1, RunStatus: "unchanged", RunDuration: 1000})
+		mustPublish(ctx, t, bus, event.ETLogbookWriteRun, dsref.VersionInfo{InitID: muppetNamesInitID, RunID: muppetNamesRunID1, RunStatus: "unchanged", RunDuration: 1000, RunStart: &runStart})
 		expect[0].RunStatus = "unchanged"
 		expect[0].RunDuration = 1000
+		expect[0].RunStart = &runStart
 
 		// simulate version creation with no transform
 		mustPublish(ctx, t, bus, event.ETLogbookWriteCommit, dsref.VersionInfo{
@@ -323,6 +325,7 @@ func AssertCollectionEventListenerSpec(t *testing.T, constructor Constructor) {
 			BodySize:    25,
 			RunID:       muppetNamesRunID2,
 			RunStatus:   "success",
+			RunStart:    &runStart,
 			RunDuration: 2000,
 		})
 		expect[0].Path = "/mem/PathToMuppetNamesVersionTwo"

--- a/dsref/version_info.go
+++ b/dsref/version_info.go
@@ -100,8 +100,11 @@ type VersionInfo struct {
 	// RunDuration is how long the run took/has currently taken in nanoseconds
 	// default value of 0 means no duration data is available.
 	// RunDuration is not stored on a dataset version, and instead must come from
-	// either run state or a cache of run state
+	// either run state or logbook
 	RunDuration int64 `json:"runDuration,omitempty"`
+	// RunStart is the start time of the run. It is not stored on a dataset version
+	// and instead must come from either run state or logbook
+	RunStart *time.Time `json:"runStart,omitempty"`
 	//
 	//
 	// Aggregate Fields

--- a/logbook/logbook.go
+++ b/logbook/logbook.go
@@ -617,6 +617,7 @@ func (book *Book) WriteTransformRun(ctx context.Context, author *profile.Profile
 		RunID:       rs.ID,
 		RunStatus:   string(rs.Status),
 		RunDuration: rs.Duration,
+		RunStart:    rs.StartTime,
 	}
 	if err = book.publisher.Publish(ctx, event.ETLogbookWriteRun, vi); err != nil {
 		log.Error(err)
@@ -1196,11 +1197,12 @@ func versionInfoFromOp(ref dsref.Ref, op oplog.Op) dsref.VersionInfo {
 }
 
 func runItemFromOp(ref dsref.Ref, op oplog.Op) dsref.VersionInfo {
+	runStart := time.Unix(0, op.Timestamp)
 	return dsref.VersionInfo{
 		Username:    ref.Username,
 		ProfileID:   ref.ProfileID,
 		Name:        ref.Name,
-		CommitTime:  time.Unix(0, op.Timestamp),
+		RunStart:    &runStart,
 		RunID:       op.Ref,
 		RunStatus:   op.Note,
 		RunDuration: int64(op.Size),


### PR DESCRIPTION
`RunStart` represents the start time of the run.

We need to track this `RunStart` time in the `Collection`, and ensure that we keep or discard this information the same way we keep and discard the other information we get about the latest run.

closes #1944 