### PR TITLE
feat(automation): `CancelRun` will cancel run associated with the `runID`, if that is the run that is running

### DIFF
--- a/automation/orchestrator.go
+++ b/automation/orchestrator.go
@@ -56,7 +56,11 @@ type Orchestrator struct {
 	// the workflows in the expected order, running only as many at once as configured, and
 	// allows communication back to the user about where they are in the run queue, allows for
 	// cancelling runs that haven't happened yet
-	runLock      sync.Mutex
+	runLock sync.Mutex
+	// TODO(ramfox): `cancelRunCh` is the current shim to ensure we can
+	// cancel the currently running run. Like the above `runLock`, this should be
+	// replaced with a subsystem that queues/orders/cancels runs
+	cancelRunCh  chan string
 	workflows    workflow.Store
 	listeners    map[string]trigger.Listener
 	runs         run.Store
@@ -101,6 +105,7 @@ func NewOrchestrator(ctx context.Context, bus event.Bus, runFactory RunFactory, 
 		workflows:    opts.WorkflowStore,
 		runs:         opts.RunStore,
 		runLock:      sync.Mutex{},
+		cancelRunCh:  make(chan string),
 	}
 
 	for _, l := range opts.Listeners {
@@ -317,11 +322,32 @@ func (o *Orchestrator) RunWorkflow(ctx context.Context, wid workflow.ID, runID s
 	return runID, o.runWorkflow(ctx, wf, runID)
 }
 
+func (o *Orchestrator) listenForCancellation(ctx context.Context, cancel context.CancelFunc, runID string) {
+	log.Debugw("listenForCancellation", "runID", runID)
+	for {
+		select {
+		case cancelRunID := <-o.cancelRunCh:
+			if runID == cancelRunID {
+				cancel()
+				o.runLock.Unlock()
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 func (o *Orchestrator) runWorkflow(ctx context.Context, wf *workflow.Workflow, runID string) error {
 	o.runLock.Lock()
 	defer o.runLock.Unlock()
 	wid := wf.ID
 	log.Debugw("runWorkflow, workflow", "id", wid)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go o.listenForCancellation(ctx, cancel, runID)
 
 	go func(wf *workflow.Workflow) {
 		if err := o.bus.PublishID(ctx, event.ETAutomationWorkflowStarted, wf.ID.String(), event.WorkflowStartedEvent{
@@ -389,8 +415,13 @@ func (o *Orchestrator) ApplyWorkflow(ctx context.Context, wait bool, scriptOutpu
 func (o *Orchestrator) applyWorkflow(ctx context.Context, scriptOutput io.Writer, wf *workflow.Workflow, ds *dataset.Dataset, secrets map[string]string, runID string) error {
 	o.runLock.Lock()
 	defer o.runLock.Unlock()
-	log.Debugw("ApplyWorkflow, workflow", "id", wf.ID)
+
 	apply := o.applyFactory(ctx)
+	log.Debugw("ApplyWorkflow", "workflow id", wf.ID, "run id", runID)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go o.listenForCancellation(ctx, cancel, runID)
 
 	if scriptOutput != nil {
 		o.bus.SubscribeID(func(ctx context.Context, e event.Event) error {

--- a/automation/orchestrator.go
+++ b/automation/orchestrator.go
@@ -322,8 +322,8 @@ func (o *Orchestrator) RunWorkflow(ctx context.Context, wid workflow.ID, runID s
 	return runID, o.runWorkflow(ctx, wf, runID)
 }
 
-func (o *Orchestrator) listenForCancellation(ctx context.Context, cancel context.CancelFunc, runID string) {
-	log.Debugw("listenForCancellation", "runID", runID)
+func (o *Orchestrator) listenForCancelation(ctx context.Context, cancel context.CancelFunc, runID string) {
+	log.Debugw("listenForCancelation", "runID", runID)
 	for {
 		select {
 		case cancelRunID := <-o.cancelRunCh:
@@ -347,7 +347,7 @@ func (o *Orchestrator) runWorkflow(ctx context.Context, wf *workflow.Workflow, r
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go o.listenForCancellation(ctx, cancel, runID)
+	go o.listenForCancelation(ctx, cancel, runID)
 
 	go func(wf *workflow.Workflow) {
 		if err := o.bus.PublishID(ctx, event.ETAutomationWorkflowStarted, wf.ID.String(), event.WorkflowStartedEvent{
@@ -421,7 +421,7 @@ func (o *Orchestrator) applyWorkflow(ctx context.Context, scriptOutput io.Writer
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go o.listenForCancellation(ctx, cancel, runID)
+	go o.listenForCancelation(ctx, cancel, runID)
 
 	if scriptOutput != nil {
 		o.bus.SubscribeID(func(ctx context.Context, e event.Event) error {

--- a/automation/orchestrator_test.go
+++ b/automation/orchestrator_test.go
@@ -271,6 +271,23 @@ func TestIntegration(t *testing.T) {
 	done = shouldTimeout(t, workflowStoppedEventFired, "o.Stop error: orchestrator that has stopped listening should not respond to triggers")
 	runtimeListener.TriggerCh <- wtp
 	<-done
+
+	// test we can receive off of the `cancelRunCh`
+	doneCh := make(chan struct{})
+	runID = "test-cancel-id"
+	go func() {
+		select {
+		case gotID := <-o.cancelRunCh:
+			if gotID != runID {
+				log.Error("o.CancelRun error: run id mismatch, expected %q, got %q", runID, gotID)
+			}
+		case <-time.After(200 * time.Millisecond):
+			log.Error("o.CancelRun error: never received run ID over `Orchestrator.cancelRunCh`")
+		}
+		doneCh <- struct{}{}
+	}()
+	o.CancelRun(ctx, runID)
+	<-doneCh
 }
 
 func errOnTimeout(t *testing.T, c chan string, errMsg string) <-chan struct{} {

--- a/automation/run/run.go
+++ b/automation/run/run.go
@@ -170,6 +170,8 @@ func (rs *State) AddTransformEvent(e event.Event) error {
 		event.ETTransformError,
 		event.ETTransformDatasetPreview:
 		return rs.appendStepOutputLog(e)
+	case event.ETTransformCanceled:
+		return nil
 	}
 	return fmt.Errorf("unexpected event type: %q", e.Type)
 }

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -72,6 +72,7 @@ func (sm *SetMaintainer) subscribe(bus event.Bus) {
 
 		// transform events
 		event.ETTransformStart,
+		event.ETTransformCanceled,
 
 		// log events
 		event.ETLogbookWriteCommit,
@@ -239,6 +240,15 @@ func (sm *SetMaintainer) handleEvent(ctx context.Context, e event.Event) error {
 			})
 			if err != nil {
 				log.Debugw("update dataset across all collections", "InitID", vi.InitID, "err", err)
+			}
+		}
+	case event.ETTransformCanceled:
+		if te, ok := e.Payload.(event.TransformLifecycle); ok {
+			err := sm.UpdateEverywhere(ctx, te.InitID, func(v *dsref.VersionInfo) {
+				v.RunStatus = "failed"
+			})
+			if err != nil {
+				log.Debugw("update dataset across all collections", "InitID", te.InitID, "err", err)
 			}
 		}
 	}

--- a/event/transform.go
+++ b/event/transform.go
@@ -27,6 +27,11 @@ const (
 	// ETTransformDatasetPreview is an abbreviated dataset document in a transform
 	// Payload will be a *dataset.Dataset Preview
 	ETTransformDatasetPreview = Type("tf:DatasetPreview")
+
+	// ETTransformCanceled is for when a transform is canceled before
+	// it can complete its run
+	// Payload will be a TransformLifecycle
+	ETTransformCanceled = Type("tf:Canceled")
 )
 
 // TransformLifecycle captures state about the execution of an entire transform

--- a/lib/http/api.go
+++ b/lib/http/api.go
@@ -53,6 +53,8 @@ const (
 	AEDeploy APIEndpoint = "/auto/deploy"
 	// AERun manually runs a workflow
 	AERun APIEndpoint = "/auto/run"
+	// AECancel cancels a run
+	AECancel APIEndpoint = "/auto/cancel"
 	// AEWorkflow fetches a workflow
 	AEWorkflow APIEndpoint = "/auto/workflow"
 	// AERemoveWorkflow removes a workflow

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -213,6 +213,15 @@ func (t *Transformer) apply(
 							Mode:   runMode,
 							Status: "failed",
 						})
+						err := t.pub.PublishID(ctx, event.ETTransformCanceled, runID, event.TransformLifecycle{
+							InitID: initID,
+							RunID:  runID,
+							Mode:   runMode,
+							Status: "failed",
+						})
+						if err != nil {
+							log.Debugw("error publishing ETTransformCanceled", "err", err)
+						}
 					}
 					return
 				}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -11,6 +11,7 @@ import (
 	"github.com/qri-io/qfs"
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/event"
+	"github.com/qri-io/qri/profile"
 	"github.com/qri-io/qri/transform/startf"
 )
 
@@ -112,6 +113,8 @@ func (t *Transformer) apply(
 		return errors.New("apply requires a runID")
 	}
 
+	ownerID := profile.IDFromCtx(ctx)
+
 	if target.Name != "" {
 		head, err := t.loader.LoadDataset(ctx, fmt.Sprintf("%s/%s", target.Peername, target.Name))
 		if errors.Is(err, dsref.ErrRefNotFound) || errors.Is(err, dsref.ErrNoHistory) {
@@ -165,6 +168,8 @@ func (t *Transformer) apply(
 		// Forward events from the events channel to the eventBus
 		go func() {
 			receivedTransformStopEvt := false
+			inTransformStep := false
+			transformStepPayload := event.TransformStepLifecycle{}
 			for {
 				select {
 				case e := <-eventsCh:
@@ -172,9 +177,42 @@ func (t *Transformer) apply(
 					if e.Type == event.ETTransformStop {
 						receivedTransformStopEvt = true
 					}
+					if e.Type == event.ETTransformStepStart {
+						inTransformStep = true
+						ok := false
+						transformStepPayload, ok = e.Payload.(event.TransformStepLifecycle)
+						if !ok {
+							log.Debug("transform.apply: event.ETTransformStepStart does not have the expected `event.TransformStepLifecycle` payload")
+						}
+					}
+					if e.Type == event.ETTransformStop {
+						inTransformStep = false
+						transformStepPayload = event.TransformStepLifecycle{}
+					}
 				case <-ctx.Done():
 					if !receivedTransformStopEvt {
 						log.Warnw("context closed before transform stop event was sent", "runID", runID)
+
+						ctx, cancel := context.WithCancel(t.appCtx)
+						defer cancel()
+
+						ctx = profile.AddIDToContext(ctx, ownerID)
+
+						t.pub.PublishID(ctx, event.ETTransformError, runID, event.TransformMessage{
+							Lvl:  event.TransformMsgLvlError,
+							Msg:  "run canceled",
+							Mode: runMode,
+						})
+						if inTransformStep {
+							transformStepPayload.Status = "failed"
+							t.pub.PublishID(ctx, event.ETTransformStepStop, runID, transformStepPayload)
+						}
+						t.pub.PublishID(ctx, event.ETTransformStop, runID, event.TransformLifecycle{
+							InitID: initID,
+							RunID:  runID,
+							Mode:   runMode,
+							Status: "failed",
+						})
 					}
 					return
 				}


### PR DESCRIPTION
closes #1946 

Also fixes some `orchestrator.runLock` errors.