### PR TITLE
fix(auth): treat other auth types as no token present

### DIFF
--- a/auth/token/context.go
+++ b/auth/token/context.go
@@ -2,11 +2,8 @@ package token
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/qri-io/qri/api/util"
 )
 
 // CtxKey defines a distinct type for context keys used by the access
@@ -54,7 +51,7 @@ func OAuthTokenMiddleware(next http.Handler) http.Handler {
 		}
 
 		if !strings.HasPrefix(reqToken, httpAuthorizationBearerPrefix) {
-			util.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("bad token"))
+			next.ServeHTTP(w, r)
 			return
 		}
 


### PR DESCRIPTION
this should not be a hard fail but rather treat the request as not authenticated.