### PR TITLE
fix(lib): go routine to assure instance context cancellation now closes properly

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -357,20 +357,19 @@ func OptDscache(dscache *dscache.Dscache) Option {
 // function must check whether their fields are nil or not.
 func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Instance, err error) {
 	log.Debugw("NewInstance", "repoPath", repoPath, "opts", opts)
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				log.Debug("Instance context canceled")
-			}
-		}
-	}()
-
 	ctx, cancel := context.WithCancel(ctx)
 	ok := false
 	defer func() {
 		if !ok {
 			cancel()
+		}
+	}()
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			log.Debug("Instance context canceled")
+			return
 		}
 	}()
 


### PR DESCRIPTION
whelp, intro-ed a bug and now fixing it. Go routine to log that the instance context has canceled never returned properly.