### PR TITLE
feat(automation): `RunQueue` interface to sync & cancel runs

### DIFF
--- a/automation/orchestrator_test.go
+++ b/automation/orchestrator_test.go
@@ -271,23 +271,6 @@ func TestIntegration(t *testing.T) {
 	done = shouldTimeout(t, workflowStoppedEventFired, "o.Stop error: orchestrator that has stopped listening should not respond to triggers")
 	runtimeListener.TriggerCh <- wtp
 	<-done
-
-	// test we can receive off of the `cancelRunCh`
-	doneCh := make(chan struct{})
-	runID = "test-cancel-id"
-	go func() {
-		select {
-		case gotID := <-o.cancelRunCh:
-			if gotID != runID {
-				log.Error("o.CancelRun error: run id mismatch, expected %q, got %q", runID, gotID)
-			}
-		case <-time.After(200 * time.Millisecond):
-			log.Error("o.CancelRun error: never received run ID over `Orchestrator.cancelRunCh`")
-		}
-		doneCh <- struct{}{}
-	}()
-	o.CancelRun(ctx, runID)
-	<-doneCh
 }
 
 func errOnTimeout(t *testing.T, c chan string, errMsg string) <-chan struct{} {

--- a/automation/run/run.go
+++ b/automation/run/run.go
@@ -204,6 +204,19 @@ type StepState struct {
 	Output    []event.Event `json:"output"`
 }
 
+// Copy returns a shallow copy of the receiver
+func (ss *StepState) Copy() *StepState {
+	return &StepState{
+		Name:      ss.Name,
+		Category:  ss.Category,
+		Status:    ss.Status,
+		StartTime: ss.StartTime,
+		StopTime:  ss.StopTime,
+		Duration:  ss.Duration,
+		Output:    ss.Output,
+	}
+}
+
 // NewStepStateFromEvent constructs StepState from an event
 func NewStepStateFromEvent(e event.Event) (*StepState, error) {
 	if tsl, ok := e.Payload.(event.TransformStepLifecycle); ok {

--- a/automation/run_queue.go
+++ b/automation/run_queue.go
@@ -1,0 +1,187 @@
+package automation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/qri-io/qri/event"
+)
+
+var (
+	// ErrEmptyQueue indicates that the queue is empty
+	ErrEmptyQueue = fmt.Errorf("empty queue")
+)
+
+type runQueueFunc func(context.Context) error
+
+// RunQueue queues runs and apply transforms & allows you to cancel runs and apply transforms
+type RunQueue interface {
+	Push(ctx context.Context, ownerID string, runID string, mode string, f runQueueFunc) error
+	Pop(ctx context.Context) (*runQueueInfo, error)
+	Cancel(runID string) error
+	Shutdown() error
+}
+
+type runQueueInfo struct {
+	ownerID string
+	runID   string
+	mode    string
+	f       runQueueFunc
+}
+
+type runQueue struct {
+	queue      []*runQueueInfo
+	qlk        sync.Mutex
+	pub        event.Publisher
+	cancels    map[string]context.CancelFunc
+	clk        sync.Mutex
+	cancelCh   chan string
+	closeQueue context.CancelFunc
+}
+
+var _ RunQueue = (*runQueue)(nil)
+
+// NewRunQueue returns a RunQueue, that polls every interval to run the next
+// run or apply in the queue
+// TODO (ramfox): when the run queue's responsibility expands, add an Options struct
+func NewRunQueue(ctx context.Context, pub event.Publisher, interval time.Duration, workers int) RunQueue {
+	ctx, cancel := context.WithCancel(ctx)
+
+	r := &runQueue{
+		queue:      []*runQueueInfo{},
+		qlk:        sync.Mutex{},
+		pub:        pub,
+		cancels:    map[string]context.CancelFunc{},
+		clk:        sync.Mutex{},
+		cancelCh:   make(chan string),
+		closeQueue: cancel,
+	}
+	if workers == 0 {
+		workers = 1
+	}
+	for i := 0; i < workers; i++ {
+		go r.pollQueue(ctx, interval)
+	}
+	go r.listenForCancelations(ctx)
+	return r
+}
+
+func (r *runQueue) listenForCancelations(ctx context.Context) {
+	log.Debug("listening for run cancelations")
+	for {
+		select {
+		case cancelRunID := <-r.cancelCh:
+			r.clk.Lock()
+			if _, ok := r.cancels[cancelRunID]; !ok {
+				continue
+			}
+			r.cancels[cancelRunID]()
+			r.clk.Unlock()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (r *runQueue) addRunCancel(runID string, cancelFunc context.CancelFunc) {
+	r.clk.Lock()
+	defer r.clk.Unlock()
+	r.cancels[runID] = cancelFunc
+}
+
+func (r *runQueue) removeRunCancel(runID string) {
+	r.clk.Lock()
+	defer r.clk.Unlock()
+	delete(r.cancels, runID)
+}
+
+func (r *runQueue) pollQueue(ctx context.Context, interval time.Duration) {
+	for {
+		select {
+		case <-time.After(interval):
+			info, err := r.Pop(ctx)
+			if err != nil {
+				continue
+			}
+			runCtx, cancel := context.WithCancel(ctx)
+			r.addRunCancel(info.runID, cancel)
+			done := make(chan struct{})
+			go func() {
+				if err := info.f(runCtx); err != nil {
+					log.Debugw("RunQueue", "runID", info.runID, "mode", info.mode, "error", err)
+				}
+				done <- struct{}{}
+			}()
+			select {
+			case <-done:
+				log.Debugw("RunQueue run finished", "runID", info.runID)
+			case <-runCtx.Done():
+				log.Debugw("RunQueue: context canceled before run finished", "runID", info.runID)
+			}
+			r.removeRunCancel(info.runID)
+		case <-ctx.Done():
+			log.Debug("finished polling run queue")
+			return
+		}
+	}
+}
+
+func (r *runQueue) Push(ctx context.Context, ownerID string, runID string, mode string, f runQueueFunc) error {
+	r.qlk.Lock()
+	defer r.qlk.Unlock()
+	go func() {
+		switch mode {
+		case "run":
+			if err := r.pub.Publish(ctx, event.ETAutomationRunQueuePush, &runID); err != nil {
+				log.Debug(err)
+			}
+		case "apply":
+			if err := r.pub.Publish(ctx, event.ETAutomationApplyQueuePush, &runID); err != nil {
+				log.Debug(err)
+			}
+		}
+	}()
+	info := &runQueueInfo{
+		ownerID: ownerID,
+		runID:   runID,
+		mode:    mode,
+		f:       f,
+	}
+	r.queue = append(r.queue, info)
+	return nil
+}
+
+func (r *runQueue) Pop(ctx context.Context) (*runQueueInfo, error) {
+	r.qlk.Lock()
+	defer r.qlk.Unlock()
+	if len(r.queue) == 0 {
+		return nil, ErrEmptyQueue
+	}
+	info := r.queue[0]
+	r.queue = r.queue[1:]
+	go func() {
+		switch info.mode {
+		case "run":
+			if err := r.pub.Publish(ctx, event.ETAutomationRunQueuePop, &info.runID); err != nil {
+				log.Debug(err)
+			}
+		case "apply":
+			if err := r.pub.Publish(ctx, event.ETAutomationApplyQueuePop, &info.runID); err != nil {
+				log.Debug(err)
+			}
+		}
+	}()
+	return info, nil
+}
+
+func (r *runQueue) Cancel(runID string) error {
+	r.cancelCh <- runID
+	return nil
+}
+
+func (r *runQueue) Shutdown() error {
+	r.closeQueue()
+	return nil
+}

--- a/automation/run_queue_test.go
+++ b/automation/run_queue_test.go
@@ -1,0 +1,89 @@
+package automation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/qri-io/qri/event"
+)
+
+func TestRunQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rq := NewRunQueue(ctx, event.NilBus, 50*time.Millisecond, 1)
+	msgs := []string{}
+	expectMsgs := []string{
+		"first message",
+		"second message",
+		"third message",
+	}
+	ownerID := "owner"
+	runID := "run"
+	mode := "apply"
+	f := func(msg string) runQueueFunc {
+		return func(ctx context.Context) error {
+			msgs = append(msgs, msg)
+			return nil
+		}
+	}
+
+	if err := rq.Push(ctx, ownerID, runID, mode, f(expectMsgs[0])); err != nil {
+		t.Fatal(err)
+	}
+	<-time.After(100 * time.Millisecond)
+	if diff := cmp.Diff(expectMsgs[:1], msgs); diff != "" {
+		t.Errorf("response mismatch (-want +got):\n%s", diff)
+		return
+	}
+
+	if err := rq.Push(ctx, ownerID, runID, mode, f(expectMsgs[1])); err != nil {
+		t.Fatal(err)
+	}
+	if err := rq.Push(ctx, ownerID, runID, mode, f(expectMsgs[2])); err != nil {
+		t.Fatal(err)
+	}
+	<-time.After(200 * time.Millisecond)
+	cancel()
+	if err := rq.Push(ctx, ownerID, runID, mode, f("bad message")); err != nil {
+		t.Fatal(err)
+	}
+	<-time.After(100 * time.Millisecond)
+	if diff := cmp.Diff(expectMsgs, msgs); diff != "" {
+		t.Errorf("response mismatch (-want +got):\n%s", diff)
+		return
+	}
+}
+
+func TestRunQueueCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rq := NewRunQueue(ctx, event.NilBus, 50*time.Millisecond, 1)
+	ownerID := "owner"
+	runID := "run"
+	mode := "apply"
+	msg := make(chan string)
+	runStarted := make(chan struct{})
+	f := func(ctx context.Context) error {
+		runStarted <- struct{}{}
+		select {
+		case <-ctx.Done():
+			msg <- "canceled!"
+			return nil
+		case <-time.After(200 * time.Millisecond):
+			msg <- "did not cancel with 100 milliseconds"
+			return nil
+		}
+	}
+
+	if err := rq.Push(ctx, ownerID, runID, mode, f); err != nil {
+		t.Fatal(err)
+	}
+	<-runStarted
+	rq.Cancel(runID)
+	gotMsg := <-msg
+	if gotMsg != "canceled!" {
+		t.Errorf(gotMsg)
+	}
+}


### PR DESCRIPTION
First pass at a basic `RunQueue` interface.

Only 1 queue for both dry runs and runs, no priority.

Once we have a better understanding of how we want to deligate in cloud & how we want the runs scoped (can we run one dry run and one run at a time? Can a user run mulitple runs at a time, or is it scoped one per user) we can expand how we see fit.

--

Also fixes flaky `TestRunStoreEvents` test!

Interestingly enough, there were two problems with the test both stemming from the same issue: since so much of our run process happens async, events are not guaranteed to emit in the same order at the same time. 

In the test as it was, we were comparing the contents of the run store after each emitted transform event. This all happened in the correct order, because we were mocking the run so we could control when the events emitted, and we checked the run store after each event to ensure we were getting the expected run state. We mocked the `event.NowFunc` so we could accurately diff between the expected run states and the given run states. The issue is that this mocked `runFunc` was happening in an uncontrolled environment that ALSO used the `event.NowFunc` outside of what we were immediately testing. We tried to compensate for this by waiting until the last "expected" event occured, but again... events aren't guaranteed to happen synchronously, so this only worked some of the time, and got worse once the `ETAutomationRunQueuePop` event was added, since it was another event that happened async but close to when the `ETTransformStart` event occurs (the first event we are interested in seeing the effect off).  

Ultimately, I decided to by-pass the whole `event.NowFunc` issue, by ignoring any time stamp or duration fields in the run state diff. I looked at our other run state tests, and these fields are tested extensively in the `run` package. Instead, the test now only tests what makes sense at the `automation`package integration level: that if we have a run store & we run a workflow, we receive the transform events during a run, and we are saving that information as expected to the store.

I also removed the "wait" that was in place, waiting for the `ETAutomationWorkflowStart` event to pass before starting to mock the time. I removed it both because it was no longer needed, but also because it seemed to be causing a lock in the event bus, our second flaky problem: We were publishing the `ETAutomationWorkflowStart` event very close to where we were subscribing to the same events, but also listening for the `ETAutomationWorkflowStart` event with our special test handler. I'm not exactly sure what was causing the lock up, but some interaction between these three things was causing a problem. Because we were no longer mocking time, we no longer needed to "wait" for anything before starting the mock, so I didn't look much further into the issue.