### PR TITLE
feat(transform): Detect terminal size, pass it to transform to affect DataFrame rendering

### DIFF
--- a/automation/orchestrator.go
+++ b/automation/orchestrator.go
@@ -40,8 +40,8 @@ type OrchestratorOptions struct {
 // only non-test implementation is lib.Instance, but this interface is used
 // to avoid a direct dependency
 type WorkflowRunner interface {
-	RunEphemeral(context.Context, string, *workflow.Workflow, *dataset.Dataset, bool, WorkflowRunParams) error
-	RunAndCommit(context.Context, string, *workflow.Workflow, ioes.IOStreams, WorkflowRunParams) error
+	RunEphemeral(ctx context.Context, runID string, wf *workflow.Workflow, ds *dataset.Dataset, wait bool, params WorkflowRunParams) error
+	RunAndCommit(ctx context.Context, runID string, wf *workflow.Workflow, streams ioes.IOStreams, params WorkflowRunParams) error
 }
 
 // WorkflowRunParams are additional parameters for a workflow run

--- a/automation/orchestrator_test.go
+++ b/automation/orchestrator_test.go
@@ -172,7 +172,7 @@ func TestIntegration(t *testing.T) {
 	gotWorkflowEvents = []interface{}{}
 
 	done = errOnTimeout(t, applied, "o.ApplyWorkflow error: timed out before apply function called")
-	_, err = o.ApplyWorkflow(ctx, false, nil, got, nil, nil)
+	_, err = o.ApplyWorkflow(ctx, false, nil, got, nil, WorkflowRunParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -454,12 +454,12 @@ func newTestWorkflowRunner(store run.Store, applied chan string) *testWorkflowRu
 	}
 }
 
-func (r *testWorkflowRunner) RunEphemeral(ctx context.Context, runID string, wf *workflow.Workflow, ds *dataset.Dataset, wait bool, secrets map[string]string) error {
+func (r *testWorkflowRunner) RunEphemeral(ctx context.Context, runID string, wf *workflow.Workflow, ds *dataset.Dataset, wait bool, params WorkflowRunParams) error {
 	r.applied <- "applied"
 	return nil
 }
 
-func (r *testWorkflowRunner) RunAndCommit(ctx context.Context, runID string, wf *workflow.Workflow, streams ioes.IOStreams) error {
+func (r *testWorkflowRunner) RunAndCommit(ctx context.Context, runID string, wf *workflow.Workflow, streams ioes.IOStreams, params WorkflowRunParams) error {
 	//return r.owner.run(ctx, streams, wf, runID)
 	// since we don't actually run anything
 	// we need to mock the success of the run
@@ -497,7 +497,7 @@ func newWorkflowRunSimulator(t *testing.T, store run.Store, bus event.Bus, event
 }
 
 // RunAndCommit simulates events emitted by the transform package
-func (r *workflowRunSimulator) RunAndCommit(ctx context.Context, runID string, wf *workflow.Workflow, streams ioes.IOStreams) error {
+func (r *workflowRunSimulator) RunAndCommit(ctx context.Context, runID string, wf *workflow.Workflow, streams ioes.IOStreams, params WorkflowRunParams) error {
 	for _, runEvent := range r.events {
 		r.bus.PublishID(ctx, runEvent.etype, runID, runEvent.payload)
 		confirmStoredRun(ctx, r.t, r.store, runEvent.state)
@@ -505,6 +505,6 @@ func (r *workflowRunSimulator) RunAndCommit(ctx context.Context, runID string, w
 	return nil
 }
 
-func (r *workflowRunSimulator) RunEphemeral(ctx context.Context, runID string, wf *workflow.Workflow, ds *dataset.Dataset, wait bool, secrets map[string]string) error {
+func (r *workflowRunSimulator) RunEphemeral(ctx context.Context, runID string, wf *workflow.Workflow, ds *dataset.Dataset, wait bool, params WorkflowRunParams) error {
 	return nil
 }

--- a/automation/orchestrator_test.go
+++ b/automation/orchestrator_test.go
@@ -49,29 +49,10 @@ func TestIntegration(t *testing.T) {
 		Listeners:     []trigger.Listener{runtimeListener},
 	}
 
-	runFuncFactory := func(ctx context.Context) Run {
-		return func(ctx context.Context, streams ioes.IOStreams, w *workflow.Workflow, runID string) error {
-			// since we don't actually run anything
-			// we need to mock the success of the run
-			runStore.Put(ctx, &run.State{
-				ID:         runID,
-				WorkflowID: w.ID,
-				Status:     run.RSSucceeded,
-			})
-			<-time.After(50 * time.Millisecond)
-			t.Log("ran!")
-			return nil
-		}
-	}
 	applied := make(chan string)
-	applyFuncFactory := func(ctx context.Context) Apply {
-		return func(ctx context.Context, wait bool, runID string, w *workflow.Workflow, ds *dataset.Dataset, secrets map[string]string) error {
-			applied <- "applied"
-			return nil
-		}
-	}
+	runner := newTestWorkflowRunner(runStore, applied)
 
-	o, err := NewOrchestrator(ctx, bus, runFuncFactory, applyFuncFactory, opts)
+	o, err := NewOrchestrator(ctx, bus, runner, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,59 +382,43 @@ func TestRunStoreEvents(t *testing.T) {
 	r7 := r6.Copy()
 	r7.Status = run.RSSucceeded
 
-	// this runFunc simulates events emitted by the transform package
-	runFuncFactory := func(ctx context.Context) Run {
-		return func(ctx context.Context, streams ioes.IOStreams, w *workflow.Workflow, runID string) error {
-			// event 0
-			bus.PublishID(ctx, event.ETTransformStart, runID, nil)
-			confirmStoredRun(ctx, t, runStore, r0)
-
-			// event 1
-			bus.PublishID(ctx, event.ETTransformStepStart, runID, event.TransformStepLifecycle{
+	events := []simulatedRunEvent{
+		{
+			r0, event.ETTransformStart, nil,
+		},
+		{
+			r1, event.ETTransformStepStart, event.TransformStepLifecycle{
 				Name:     "step start",
 				Category: "step start category",
-			})
-			confirmStoredRun(ctx, t, runStore, r1)
-
-			// event 2
-			bus.PublishID(ctx, event.ETTransformPrint, runID, event.TransformMessage{Msg: "transform print"})
-			confirmStoredRun(ctx, t, runStore, r2)
-
-			// event 3
-			bus.PublishID(ctx, event.ETTransformError, runID, event.TransformMessage{Msg: "transform error"})
-			confirmStoredRun(ctx, t, runStore, r3)
-
-			// event 4
-			bus.PublishID(ctx, event.ETTransformDatasetPreview, runID, "transform dataset preview")
-			confirmStoredRun(ctx, t, runStore, r4)
-
-			// event 5
-			bus.PublishID(ctx, event.ETTransformStepStop, runID, event.TransformStepLifecycle{Status: "succeeded"})
-			confirmStoredRun(ctx, t, runStore, r5)
-
-			// event 6
-			bus.PublishID(ctx, event.ETTransformStepSkip, runID, event.TransformStepLifecycle{Name: "step skip", Category: "step skip category", Status: "skipped"})
-			confirmStoredRun(ctx, t, runStore, r6)
-
-			// event 7
-			bus.PublishID(ctx, event.ETTransformStop, runID, event.TransformLifecycle{Status: "succeeded"})
-			confirmStoredRun(ctx, t, runStore, r7)
-
-			return nil
-		}
+			},
+		},
+		{
+			r2, event.ETTransformPrint, event.TransformMessage{Msg: "transform print"},
+		},
+		{
+			r3, event.ETTransformError, event.TransformMessage{Msg: "transform error"},
+		},
+		{
+			r4, event.ETTransformDatasetPreview, "transform dataset preview",
+		},
+		{
+			r5, event.ETTransformStepStop, event.TransformStepLifecycle{Status: "succeeded"},
+		},
+		{
+			r6, event.ETTransformStepSkip, event.TransformStepLifecycle{Name: "step skip", Category: "step skip category", Status: "skipped"},
+		},
+		{
+			r7, event.ETTransformStop, event.TransformLifecycle{Status: "succeeded"},
+		},
 	}
-	applyFuncFactory := func(ctx context.Context) Apply {
-		return func(ctx context.Context, wait bool, runID string, w *workflow.Workflow, ds *dataset.Dataset, secrets map[string]string) error {
-			return nil
-		}
-	}
+	simulator := newWorkflowRunSimulator(t, runStore, bus, events)
 
 	opts := OrchestratorOptions{
 		WorkflowStore: workflowStore,
 		RunStore:      runStore,
 		Listeners:     []trigger.Listener{listener},
 	}
-	o, err := NewOrchestrator(ctx, bus, runFuncFactory, applyFuncFactory, opts)
+	o, err := NewOrchestrator(ctx, bus, simulator, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -474,4 +439,72 @@ func confirmStoredRun(ctx context.Context, t *testing.T, s run.Store, expect *ru
 	if diff := cmp.Diff(expect, got, cmpopts.IgnoreFields(run.State{}, "StartTime", "StopTime", "Duration"), cmpopts.IgnoreFields(run.StepState{}, "StartTime", "StopTime", "Duration"), cmpopts.IgnoreFields(event.Event{}, "Timestamp")); diff != "" {
 		t.Errorf("stored run mismatch: (-want +got):\n%s", diff)
 	}
+}
+
+// a workflow runner that doesn't do too much, just for testing
+type testWorkflowRunner struct {
+	store   run.Store
+	applied chan string
+}
+
+func newTestWorkflowRunner(store run.Store, applied chan string) *testWorkflowRunner {
+	return &testWorkflowRunner{
+		store:   store,
+		applied: applied,
+	}
+}
+
+func (r *testWorkflowRunner) RunEphemeral(ctx context.Context, runID string, wf *workflow.Workflow, ds *dataset.Dataset, wait bool, secrets map[string]string) error {
+	r.applied <- "applied"
+	return nil
+}
+
+func (r *testWorkflowRunner) RunAndCommit(ctx context.Context, runID string, wf *workflow.Workflow, streams ioes.IOStreams) error {
+	//return r.owner.run(ctx, streams, wf, runID)
+	// since we don't actually run anything
+	// we need to mock the success of the run
+	r.store.Put(ctx, &run.State{
+		ID:         runID,
+		WorkflowID: wf.ID,
+		Status:     run.RSSucceeded,
+	})
+	<-time.After(50 * time.Millisecond)
+	return nil
+}
+
+// a simulated event and run state
+type simulatedRunEvent struct {
+	state   *run.State
+	etype   event.Type
+	payload interface{}
+}
+
+// a workflow runner that simulates events
+type workflowRunSimulator struct {
+	t      *testing.T
+	bus    event.Bus
+	store  run.Store
+	events []simulatedRunEvent
+}
+
+func newWorkflowRunSimulator(t *testing.T, store run.Store, bus event.Bus, events []simulatedRunEvent) *workflowRunSimulator {
+	return &workflowRunSimulator{
+		t:      t,
+		bus:    bus,
+		store:  store,
+		events: events,
+	}
+}
+
+// RunAndCommit simulates events emitted by the transform package
+func (r *workflowRunSimulator) RunAndCommit(ctx context.Context, runID string, wf *workflow.Workflow, streams ioes.IOStreams) error {
+	for _, runEvent := range r.events {
+		r.bus.PublishID(ctx, runEvent.etype, runID, runEvent.payload)
+		confirmStoredRun(ctx, r.t, r.store, runEvent.state)
+	}
+	return nil
+}
+
+func (r *workflowRunSimulator) RunEphemeral(ctx context.Context, runID string, wf *workflow.Workflow, ds *dataset.Dataset, wait bool, secrets map[string]string) error {
+	return nil
 }

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -58,3 +58,12 @@ func defaultFilePermMask() int {
 	syscall.Umask(mask)
 	return mask
 }
+
+// sizeOfTerminal returns the width and height of the terminal, or -1, -1 if there isn't one
+func sizeOfTerminal() (int, int) {
+	width, height, err := terminal.GetSize(0)
+	if err != nil {
+		return -1, -1
+	}
+	return width, height
+}

--- a/cmd/system_windows.go
+++ b/cmd/system_windows.go
@@ -15,3 +15,8 @@ func stdoutIsTerminal() bool {
 func defaultFilePermMask() int {
 	return 0
 }
+
+// sizeOfTerminal returns an invalid size on Windows
+func sizeOfTerminal() (int, int) {
+	return -1, -1
+}

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1363,8 +1363,8 @@ github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449/go.mod h1:g7DP
 github.com/qri-io/qfs v0.6.1-0.20210629014446-45bdcdb57434/go.mod h1:XX/caqvngrusufIrtnbo4iPtgsNfu0dfrE3pmLGte9w=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43 h1:3Nlkdpj+MYaiAq7MmZ3riECTO0mdU3btt0IjSapaCls=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
-github.com/qri-io/starlib v0.5.1-0.20211101212344-1f680c0e4fcf h1:l/zygu3T4A9lzXu6jsOfc01CfvvR+9ucsT35tw7dx14=
-github.com/qri-io/starlib v0.5.1-0.20211101212344-1f680c0e4fcf/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
+github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052 h1:emLuElJO/U/vfzN+JnvFLMKyRsDgjtqfxxjt2lCW4AM=
+github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=
 github.com/qri-io/varName v0.1.0/go.mod h1:IGWuuGOHhLJ9ZZg28C/+oMYm1QYP+pAorNZKQpdXhxQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1363,8 +1363,8 @@ github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449/go.mod h1:g7DP
 github.com/qri-io/qfs v0.6.1-0.20210629014446-45bdcdb57434/go.mod h1:XX/caqvngrusufIrtnbo4iPtgsNfu0dfrE3pmLGte9w=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43 h1:3Nlkdpj+MYaiAq7MmZ3riECTO0mdU3btt0IjSapaCls=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
-github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052 h1:emLuElJO/U/vfzN+JnvFLMKyRsDgjtqfxxjt2lCW4AM=
-github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
+github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15 h1:bGUe3r+QdkyoUdQJJN0uqMefrxYiAa6cKw/xddasgcc=
+github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=
 github.com/qri-io/varName v0.1.0/go.mod h1:IGWuuGOHhLJ9ZZg28C/+oMYm1QYP+pAorNZKQpdXhxQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/qri-io/iso8601 v0.1.1-0.20201221213213-f31ee4cdc38b
 	github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449
 	github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43
-	github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052
+	github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15
 	github.com/russross/blackfriday/v2 v2.0.2-0.20190629151518-3e56bb68c887
 	github.com/sergi/go-diff v1.1.0
 	github.com/sirupsen/logrus v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/qri-io/iso8601 v0.1.1-0.20201221213213-f31ee4cdc38b
 	github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449
 	github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43
-	github.com/qri-io/starlib v0.5.1-0.20211101212344-1f680c0e4fcf
+	github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052
 	github.com/russross/blackfriday/v2 v2.0.2-0.20190629151518-3e56bb68c887
 	github.com/sergi/go-diff v1.1.0
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1344,8 +1344,8 @@ github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449/go.mod h1:g7DP
 github.com/qri-io/qfs v0.6.1-0.20210629014446-45bdcdb57434/go.mod h1:XX/caqvngrusufIrtnbo4iPtgsNfu0dfrE3pmLGte9w=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43 h1:3Nlkdpj+MYaiAq7MmZ3riECTO0mdU3btt0IjSapaCls=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
-github.com/qri-io/starlib v0.5.1-0.20211101212344-1f680c0e4fcf h1:l/zygu3T4A9lzXu6jsOfc01CfvvR+9ucsT35tw7dx14=
-github.com/qri-io/starlib v0.5.1-0.20211101212344-1f680c0e4fcf/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
+github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052 h1:emLuElJO/U/vfzN+JnvFLMKyRsDgjtqfxxjt2lCW4AM=
+github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=
 github.com/qri-io/varName v0.1.0/go.mod h1:IGWuuGOHhLJ9ZZg28C/+oMYm1QYP+pAorNZKQpdXhxQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/go.sum
+++ b/go.sum
@@ -1344,8 +1344,8 @@ github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449/go.mod h1:g7DP
 github.com/qri-io/qfs v0.6.1-0.20210629014446-45bdcdb57434/go.mod h1:XX/caqvngrusufIrtnbo4iPtgsNfu0dfrE3pmLGte9w=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43 h1:3Nlkdpj+MYaiAq7MmZ3riECTO0mdU3btt0IjSapaCls=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
-github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052 h1:emLuElJO/U/vfzN+JnvFLMKyRsDgjtqfxxjt2lCW4AM=
-github.com/qri-io/starlib v0.5.1-0.20211112135900-0a04e46f1052/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
+github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15 h1:bGUe3r+QdkyoUdQJJN0uqMefrxYiAa6cKw/xddasgcc=
+github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=
 github.com/qri-io/varName v0.1.0/go.mod h1:IGWuuGOHhLJ9ZZg28C/+oMYm1QYP+pAorNZKQpdXhxQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/lib/automation.go
+++ b/lib/automation.go
@@ -530,3 +530,20 @@ func (automationImpl) AnalyzeTransform(scope scope, p *AnalyzeTransformParams) (
 		Diagnostics: diagnostics,
 	}, nil
 }
+
+// methods that run workflows, used by the automation orchestrator via
+// dependency injection
+type runner struct {
+	owner *Instance
+}
+
+// RunEphemeral runs a workflow only to generate output, not to create a
+// dataset version
+func (r *runner) RunEphemeral(ctx context.Context, runID string, wf *workflow.Workflow, ds *dataset.Dataset, wait bool, secrets map[string]string) error {
+	return r.owner.apply(ctx, wait, runID, wf, ds, secrets)
+}
+
+// RunAndCommit runs a workflow and commits a new dataset version
+func (r *runner) RunAndCommit(ctx context.Context, runID string, wf *workflow.Workflow, streams ioes.IOStreams) error {
+	return r.owner.run(ctx, streams, wf, runID)
+}

--- a/lib/automation_test.go
+++ b/lib/automation_test.go
@@ -286,7 +286,7 @@ func errOnTimeout(t *testing.T, c chan string) <-chan string {
 		select {
 		case msg := <-c:
 			done <- msg
-		case <-time.After(200 * time.Millisecond):
+		case <-time.After(500 * time.Millisecond):
 			done <- "failed to complete before timeout"
 		}
 	}()

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -1042,9 +1042,12 @@ func (datasetImpl) Save(scope scope, p *SaveParams) (*dataset.Dataset, error) {
 			return nil
 		}, runID)
 
+		// TODO(dustmop): Get actual size info from the proper place
+		sizeInfo := transform.SizeInfo{}
+
 		// apply the transform
 		shouldWait := true
-		transformer := transform.NewTransformer(scope.AppContext(), scope.Filesystem(), scope.Loader(), scope.Bus())
+		transformer := transform.NewTransformer(scope.AppContext(), scope.Filesystem(), scope.Loader(), scope.Bus(), sizeInfo)
 		if err := transformer.Commit(scope.Context(), ref.InitID, ds, runID, shouldWait, secrets); err != nil {
 			log.Errorw("transform run error", "err", err.Error())
 			runState.Message = err.Error()

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -644,12 +644,6 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		}
 	}
 
-	runFactory := func(ctx context.Context) automation.Run {
-		return inst.run
-	}
-	applyFactory := func(ctx context.Context) automation.Apply {
-		return inst.apply
-	}
 	if o.automationOptions == nil {
 		// TODO(ramfox): using `DefaultOrchestratorOptions` func for now to generate
 		// basic orchestrator options. When we get the automation configuration settled
@@ -660,7 +654,7 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		}
 		o.automationOptions = &orchestratorOpts
 	}
-	inst.automation, err = automation.NewOrchestrator(ctx, inst.bus, runFactory, applyFactory, *o.automationOptions)
+	inst.automation, err = automation.NewOrchestrator(ctx, inst.bus, &runner{owner: inst}, *o.automationOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -795,13 +789,6 @@ func NewInstanceFromConfigAndNodeAndBusAndOrchestratorOpts(ctx context.Context, 
 		inst.qfs = r.Filesystem()
 	}
 
-	runFactory := func(ctx context.Context) automation.Run {
-		return inst.run
-	}
-	applyFactory := func(ctx context.Context) automation.Apply {
-		return inst.apply
-	}
-
 	var err error
 	// TODO(ramfox): using `DefaultOrchestratorOptions` func for now to generate
 	// basic orchestrator options. When we get the automation configuration settled
@@ -815,7 +802,7 @@ func NewInstanceFromConfigAndNodeAndBusAndOrchestratorOpts(ctx context.Context, 
 			RunStore: run.NewMemStore(),
 		}
 	}
-	inst.automation, err = automation.NewOrchestrator(ctx, inst.bus, runFactory, applyFactory, *o)
+	inst.automation, err = automation.NewOrchestrator(ctx, inst.bus, &runner{owner: inst}, *o)
 	if err != nil {
 		cancel()
 		panic(err)

--- a/transform/startf/ds/bound.go
+++ b/transform/startf/ds/bound.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/qri-io/dataset"
+	"github.com/qri-io/starlib/dataframe"
 	"go.starlark.net/starlark"
 )
 
@@ -12,6 +13,7 @@ type BoundDataset struct {
 	frozen       bool
 	commitCalled bool
 	latest       *dataset.Dataset
+	outconf      *dataframe.OutputConfig
 	onCommit     func(ds *Dataset) error
 	load         func(refstr string) (*Dataset, error)
 }
@@ -23,8 +25,8 @@ var (
 )
 
 // NewBoundDataset constructs a target dataset
-func NewBoundDataset(latest *dataset.Dataset, onCommit func(ds *Dataset) error) *BoundDataset {
-	return &BoundDataset{latest: latest, onCommit: onCommit}
+func NewBoundDataset(latest *dataset.Dataset, outconf *dataframe.OutputConfig, onCommit func(ds *Dataset) error) *BoundDataset {
+	return &BoundDataset{latest: latest, onCommit: onCommit, outconf: outconf}
 }
 
 // String returns the Dataset as a string
@@ -64,7 +66,7 @@ var boundDatasetMethods = map[string]*starlark.Builtin{
 
 func head(thread *starlark.Thread, builtin *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	self := builtin.Receiver().(*BoundDataset)
-	return NewDataset(self.latest), nil
+	return NewDataset(self.latest, self.outconf), nil
 }
 
 func commit(thread *starlark.Thread, builtin *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/transform/startf/ds/dataset.go
+++ b/transform/startf/ds/dataset.go
@@ -56,6 +56,7 @@ type Dataset struct {
 	ds        *dataset.Dataset
 	bodyFrame starlark.Value
 	changes   map[string]struct{}
+	outconf   *dataframe.OutputConfig
 }
 
 // compile-time interface assertions
@@ -76,8 +77,8 @@ var dsMethods = map[string]*starlark.Builtin{
 
 // NewDataset creates a dataset object, intended to be called from go-land to prepare datasets
 // for handing to other functions
-func NewDataset(ds *dataset.Dataset) *Dataset {
-	return &Dataset{ds: ds, changes: make(map[string]struct{})}
+func NewDataset(ds *dataset.Dataset, outconf *dataframe.OutputConfig) *Dataset {
+	return &Dataset{ds: ds, outconf: outconf, changes: make(map[string]struct{})}
 }
 
 // New creates a new dataset from starlark land
@@ -284,7 +285,7 @@ func (d *Dataset) getBody() (starlark.Value, error) {
 	bodyfile := d.ds.BodyFile()
 	if bodyfile == nil {
 		// If no body exists, return an empty data frame
-		df, _ := dataframe.NewDataFrame(nil, nil, nil)
+		df, _ := dataframe.NewDataFrame(nil, nil, nil, d.outconf)
 		d.bodyFrame = df
 		return df, nil
 	}
@@ -320,7 +321,7 @@ func (d *Dataset) getBody() (starlark.Value, error) {
 		rows = append(rows, r)
 	}
 
-	df, err := dataframe.NewDataFrame(rows, columns, nil)
+	df, err := dataframe.NewDataFrame(rows, columns, nil, d.outconf)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +330,7 @@ func (d *Dataset) getBody() (starlark.Value, error) {
 }
 
 func (d *Dataset) setBody(val starlark.Value) error {
-	df, err := dataframe.NewDataFrame(val, nil, nil)
+	df, err := dataframe.NewDataFrame(val, nil, nil, d.outconf)
 	if err != nil {
 		return err
 	}

--- a/transform/startf/ds/dataset_test.go
+++ b/transform/startf/ds/dataset_test.go
@@ -25,7 +25,7 @@ func callMethod(thread *starlark.Thread, v starlark.HasAttrs, name string, tuple
 }
 
 func TestCannotSetIfReadOnly(t *testing.T) {
-	ds := NewDataset(&dataset.Dataset{})
+	ds := NewDataset(&dataset.Dataset{}, nil)
 	ds.Freeze()
 	expect := "cannot set, Dataset is frozen"
 	err := ds.SetField("body", starlark.NewList([]starlark.Value{starlark.NewList([]starlark.Value{starlark.String("a")})}))
@@ -38,7 +38,7 @@ func TestCannotSetIfReadOnly(t *testing.T) {
 }
 
 func TestSetAndGetBody(t *testing.T) {
-	ds := NewDataset(&dataset.Dataset{})
+	ds := NewDataset(&dataset.Dataset{}, nil)
 	err := ds.SetField("body", starlark.NewList([]starlark.Value{starlark.NewList([]starlark.Value{starlark.String("a")})}))
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +102,7 @@ bat,3,meh
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.csv", []byte(text)))
 
-	d := NewDataset(ds)
+	d := NewDataset(ds, nil)
 	return d
 }
 
@@ -155,7 +155,7 @@ func TestCreateColumnsFromStructure(t *testing.T) {
 				Schema: c.schema,
 			},
 		}
-		d := NewDataset(ds)
+		d := NewDataset(ds, nil)
 		actual := d.createColumnsFromStructure()
 		if diff := cmp.Diff(c.expect, actual); diff != "" {
 			t.Errorf("case %d %s: mismatch (-want +got):\n%s", i, c.desc, diff)

--- a/transform/startf/sandbox.go
+++ b/transform/startf/sandbox.go
@@ -22,11 +22,11 @@ type HTTPGuard struct {
 }
 
 // Allowed implements starlib/http RequestGuard
-func (h *HTTPGuard) Allowed(req *http.Request) error {
+func (h *HTTPGuard) Allowed(_ *starlark.Thread, req *http.Request) (*http.Request, error) {
 	if !h.NetworkEnabled {
-		return ErrNtwkDisabled
+		return nil, ErrNtwkDisabled
 	}
-	return nil
+	return req, nil
 }
 
 // EnableNtwk allows network calls

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -51,20 +51,28 @@ const (
 
 // Transformer holds dependencies needed for applying a transform
 type Transformer struct {
-	appCtx  context.Context
-	loader  dsref.Loader
-	fs      qfs.Filesystem
-	pub     event.Publisher
-	changes map[string]struct{}
+	appCtx   context.Context
+	loader   dsref.Loader
+	fs       qfs.Filesystem
+	pub      event.Publisher
+	sizeInfo SizeInfo
+	changes  map[string]struct{}
+}
+
+// SizeInfo is info about the size of the area that output is displayed on
+type SizeInfo struct {
+	OutputWidth  int
+	OutputHeight int
 }
 
 // NewTransformer returns a new transformer
-func NewTransformer(appCtx context.Context, fs qfs.Filesystem, loader dsref.Loader, pub event.Publisher) *Transformer {
+func NewTransformer(appCtx context.Context, fs qfs.Filesystem, loader dsref.Loader, pub event.Publisher, info SizeInfo) *Transformer {
 	return &Transformer{
-		appCtx: appCtx,
-		loader: loader,
-		fs:     fs,
-		pub:    pub,
+		appCtx:   appCtx,
+		loader:   loader,
+		fs:       fs,
+		pub:      pub,
+		sizeInfo: info,
 	}
 }
 
@@ -148,6 +156,7 @@ func (t *Transformer) apply(
 		startf.AddFilesystem(t.fs),
 		startf.AddEventsChannel(eventsCh),
 		startf.TrackChanges(t.changes),
+		startf.SizeInfo(t.sizeInfo.OutputWidth, t.sizeInfo.OutputHeight),
 	}
 
 	doneCh := make(chan error)

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -188,7 +188,7 @@ func applyNoHistoryTransform(t *testing.T, initID string, tf *dataset.Transform,
 	}, runID)
 
 	fs := qfs.NewMemFS()
-	transformer := NewTransformer(ctx, fs, loader, bus)
+	transformer := NewTransformer(ctx, fs, loader, bus, SizeInfo{})
 	if runMode == "apply" {
 		if err := transformer.Apply(ctx, target, runID, false, nil); err != nil {
 			t.Fatal(err)
@@ -277,7 +277,7 @@ func TestApplyAssignsColumnsAndBody(t *testing.T) {
 	loader := &noHistoryLoader{}
 	bus := event.NewBus(ctx)
 	fs := qfs.NewMemFS()
-	transformer := NewTransformer(ctx, fs, loader, bus)
+	transformer := NewTransformer(ctx, fs, loader, bus, SizeInfo{})
 
 	ds := &dataset.Dataset{Transform: &dataset.Transform{}}
 	ds.Transform.SetScriptFile(scriptFile(t, "startf/testdata/csv_with_header.star"))


### PR DESCRIPTION
Depends on https://github.com/qri-io/starlib/pull/146

This PR adds terminal size detection to `qri apply`. The width and height of the terminal is passed down to `lib/` and eventually to `transform/` and `starlib/dataframe/`, where it affects how DataFrames get stringified. Users of the http api can also send this same info via normal arguments, in order to match the correct size of whatever html element they are going to display upon.

The first commit refactors the automation orchestrator a bit, to make passing this info a bit easier. Some new nomenclature is introduced here: rather than `Run` for runs that commit and `Apply` for runs that do not commit, this change uses `RunAndCommit` and `RunEphemeral`. The idea is that `apply` as a piece of terminology was intended as a high level command to contrast with `qri save`. When deeper in the code base, with a different context, it isn't quite as obvious which of these is and isn't making a new commit, especially since those parts of the code are referring to `Workflows` which are being `run` in either case.

Some parts of this are missing functionality. In particular, `qri save --apply` is not handling terminal size information. That can be done in a follow-up PR, the groundwork laid here will make it much easier to implement.