### PR TITLE
feat(lib): run info endpoint

### DIFF
--- a/automation/orchestrator.go
+++ b/automation/orchestrator.go
@@ -510,6 +510,11 @@ func (o *Orchestrator) RemoveWorkflow(ctx context.Context, id workflow.ID) error
 	return nil
 }
 
+// RunInfo returns the run info for the given runID from the run.Store
+func (o *Orchestrator) RunInfo(ctx context.Context, id string) (*run.State, error) {
+	return o.runs.Get(ctx, id)
+}
+
 // runEventsHandler returns a handler that writes run events to a run store
 func runEventsHandler(store run.Store) event.Handler {
 	return func(ctx context.Context, e event.Event) error {

--- a/lib/http/api.go
+++ b/lib/http/api.go
@@ -54,6 +54,8 @@ const (
 	AEDeploy APIEndpoint = "/auto/deploy"
 	// AERun manually runs a workflow
 	AERun APIEndpoint = "/auto/run"
+	// AERunInfo fetches the full run info for a workflow run
+	AERunInfo APIEndpoint = "/auto/runinfo"
 	// AECancel cancels a run
 	AECancel APIEndpoint = "/auto/cancel"
 	// AEWorkflow fetches a workflow


### PR DESCRIPTION
Simply exposes a way to get stuff from the run store, which enables cloud to also serve its own.
Part of https://github.com/qri-io/frontend/issues/265