### PR TITLE
fix(api): Restore the WritePageResponse method

### DIFF
--- a/api/util/responses.go
+++ b/api/util/responses.go
@@ -10,6 +10,10 @@ type Response struct {
 	Data     interface{}  `json:"data,omitempty"`
 	Meta     *Meta        `json:"meta,omitempty"`
 	NextPage *NextPageReq `json:"nextPage,omitempty"`
+	// TODO(dustmop): Cloud depends upon this. Remove once more
+	// methods have started using Cursor/NextPage and cloud is
+	// able to switch over.
+	Pagination *Page `json:"pagination,omitempty"`
 }
 
 // Meta is the JSON API response meta object wrapper
@@ -32,6 +36,26 @@ func WriteResponse(w http.ResponseWriter, data interface{}) error {
 			Code: http.StatusOK,
 		},
 		Data: data,
+	}
+	return jsonResponse(w, env)
+}
+
+// WritePageResponse wraps response data and pagination information in an
+// envelope and writes it
+// TODO(dustmop): Cloud depends upon this
+func WritePageResponse(w http.ResponseWriter, data interface{}, r *http.Request, p Page) error {
+	if p.PrevPageExists() {
+		p.PrevURL = p.Prev().SetQueryParams(r.URL).String()
+	}
+	if p.NextPageExists() {
+		p.NextURL = p.Next().SetQueryParams(r.URL).String()
+	}
+	env := Response{
+		Meta: &Meta{
+			Code: http.StatusOK,
+		},
+		Data:       data,
+		Pagination: &p,
 	}
 	return jsonResponse(w, env)
 }

--- a/api/util/responses_test.go
+++ b/api/util/responses_test.go
@@ -1,14 +1,65 @@
 package util
 
 import (
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
+func TestWritePageResponse(t *testing.T) {
+	cases := []struct {
+		page   Page
+		expect string
+	}{
+		{
+			Page{Number: 1, Size: DefaultPageSize},
+			`{"data":"data","meta":{"code":200},"pagination":{"page":1,"pageSize":50,"nextUrl":"https://example.com?page=2","prevUrl":""}}`,
+		},
+		{
+			Page{Number: 1, Size: DefaultPageSize, ResultCount: 200},
+			`{"data":"data","meta":{"code":200},"pagination":{"page":1,"pageSize":50,"resultCount":200,"nextUrl":"https://example.com?page=2","prevUrl":""}}`,
+		},
+		{
+			Page{Number: 2, Size: DefaultPageSize, ResultCount: 100},
+			`{"data":"data","meta":{"code":200},"pagination":{"page":2,"pageSize":50,"resultCount":100,"nextUrl":"","prevUrl":"https://example.com?page=1"}}`,
+		},
+		{
+			Page{Number: 2, Size: DefaultPageSize, ResultCount: 200},
+			`{"data":"data","meta":{"code":200},"pagination":{"page":2,"pageSize":50,"resultCount":200,"nextUrl":"https://example.com?page=3","prevUrl":"https://example.com?page=1"}}`,
+		},
+		{
+			Page{Number: 2, Size: 5, ResultCount: 200},
+			`{"data":"data","meta":{"code":200},"pagination":{"page":2,"pageSize":5,"resultCount":200,"nextUrl":"https://example.com?page=3\u0026pageSize=5","prevUrl":"https://example.com?page=1\u0026pageSize=5"}}`,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			rr := httptest.NewRecorder()
+
+			req, err := http.NewRequest("GET", "https://example.com", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := WritePageResponse(rr, "data", req, c.page); err != nil {
+				t.Fatal(err)
+			}
+
+			got := rr.Body.String()
+
+			if c.expect != got {
+				t.Errorf("result mismatch. expected:\n%s\ngot:\n%s", c.expect, got)
+			}
+
+		})
+	}
+}
+
 func TestWriteResponseWithNextPage(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	if err := WriteResponseWithNextPage(rr, "data", "/next", map[string]string{"start":"5"}); err != nil {
+	if err := WriteResponseWithNextPage(rr, "data", "/next", map[string]string{"start": "5"}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Partially revert https://github.com/qri-io/qri/pull/1969. Cloud needs the WritePageResponse. Put it back, with a TODO to remove it once more methods switch over to using cursors for pagination.