### PR TITLE
refactor(event): align serialization properties with the rest

### DIFF
--- a/automation/run/run.go
+++ b/automation/run/run.go
@@ -243,6 +243,7 @@ type _event struct {
 	Type      event.Type      `json:"type"`
 	Timestamp int64           `json:"timestamp"`
 	SessionID string          `json:"sessionID"`
+	ProfileID string          `json:"profileID"`
 	Payload   json.RawMessage `json:"payload"`
 }
 
@@ -264,6 +265,7 @@ func (ss *StepState) UnmarshalJSON(data []byte) error {
 			Type:      re.Type,
 			Timestamp: re.Timestamp,
 			SessionID: re.SessionID,
+			ProfileID: re.ProfileID,
 		}
 		switch e.Type {
 		case event.ETTransformStart, event.ETTransformStop:

--- a/lib/websocket/websocket.go
+++ b/lib/websocket/websocket.go
@@ -107,9 +107,9 @@ func (h *connections) messageHandler(_ context.Context, e event.Event) error {
 	ctx := context.Background()
 	evt := map[string]interface{}{
 		"type":      string(e.Type),
-		"ts":        e.Timestamp,
+		"timestamp": e.Timestamp,
 		"sessionID": e.SessionID,
-		"data":      e.Payload,
+		"payload":   e.Payload,
 	}
 
 	profileIDString := e.ProfileID


### PR DESCRIPTION
Event's are breaking out of our default pattern for naming fields when serialized. However due to a lot of these events being user and/or stored elsewhere we need to be able to deserialize either for backwards compatibility.

Fixes https://github.com/qri-io/qri/issues/1989