### PR TITLE
fix(collection): make event handler use independent ctx

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -82,7 +82,9 @@ func (sm *SetMaintainer) subscribe(bus event.Bus) {
 	)
 }
 
-func (sm *SetMaintainer) handleEvent(ctx context.Context, e event.Event) error {
+func (sm *SetMaintainer) handleEvent(_ context.Context, e event.Event) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
 	switch e.Type {
 	case event.ETDatasetNameInit:
 		if vi, ok := e.Payload.(dsref.VersionInfo); ok {


### PR DESCRIPTION
This makes the collection event handler independent of the normal request execution which sometimes caused canceled context due to the event being sent from a go routine attached to a http request.