### PR TITLE
feat(transform): Analyze `if` statements by unioning each branch

### DIFF
--- a/transform/staticlark/call_graph_test.go
+++ b/transform/staticlark/call_graph_test.go
@@ -55,6 +55,8 @@ top_level_func
    print
 branch_elses
  print
+branch_elses_contained
+ print
 `
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/transform/staticlark/control_flow.go
+++ b/transform/staticlark/control_flow.go
@@ -133,6 +133,20 @@ func (b *codeBlock) stringify() string {
 	return result
 }
 
+func (b *codeBlock) isLinear() bool {
+	return len(b.edges) <= 1
+}
+
+func (b *codeBlock) isIfCondition() bool {
+	if len(b.units) == 1 {
+		u := b.units[0]
+		if u.atom == "if" {
+			return true
+		}
+	}
+	return false
+}
+
 func (b *codeBlock) String() string {
 	return b.stringify()
 }

--- a/transform/staticlark/control_flow_test.go
+++ b/transform/staticlark/control_flow_test.go
@@ -18,7 +18,7 @@ func TestControlFlowIf(t *testing.T) {
    [set! b 2]
   out: 1
 1: [if [< a b]]
-  out: 2,3
+  out: 2,3, join: 4
 2: [set! c [+ b 1]]
   out: 4
 3: [set! c [+ a 1]]
@@ -41,7 +41,7 @@ func TestControlFlowIf(t *testing.T) {
    [set! b 2]
   out: 1
 1: [if [< a b]]
-  out: 2,3
+  out: 2,3, join: 3
 2: [set! c [+ b 1]]
    [print [% '%d' c]]
   out: 3
@@ -64,12 +64,12 @@ func TestControlFlowIf(t *testing.T) {
    [set! b 2]
   out: 1
 1: [if [< a b]]
-  out: 2,5
+  out: 2,5, join: 6
 2: [set! c [+ b 1]]
    [set! d a]
   out: 3
 3: [if [> d c]]
-  out: 4,6
+  out: 4,6, join: 6
 4: [set! c [+ d 2]]
   out: 6
 5: [set! c [+ a 1]]
@@ -95,15 +95,15 @@ func TestControlFlowIf(t *testing.T) {
    [set! b 2]
   out: 1
 1: [if [< a b]]
-  out: 2,8
+  out: 2,8, join: 9
 2: [set! c [+ b 1]]
   out: 3
 3: [if [< c 1]]
-  out: 4,5
+  out: 4,5, join: 9
 4: [print 'small']
   out: 9
 5: [if [< c 5]]
-  out: 6,7
+  out: 6,7, join: 9
 6: [print 'medium']
   out: 9
 7: [print 'large']

--- a/transform/staticlark/control_flow_test.go
+++ b/transform/staticlark/control_flow_test.go
@@ -117,6 +117,43 @@ func TestControlFlowIf(t *testing.T) {
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
+
+	// this function has another statement (block 8) which ensures
+	// that the inner if statement is completely contained in the outer
+	funcmap = mustReadScriptFunctionMap(t, "testdata/some_funcs.star")
+	cf, err = newControlFlowFromFunc(funcmap["branch_elses_contained"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect = `0: [set! a 1]
+   [set! b 2]
+  out: 1
+1: [if [< a b]]
+  out: 2,9, join: 10
+2: [set! c [+ b 1]]
+  out: 3
+3: [if [< c 1]]
+  out: 4,5, join: 8
+4: [print 'small']
+  out: 8
+5: [if [< c 5]]
+  out: 6,7, join: 8
+6: [print 'medium']
+  out: 8
+7: [print 'large']
+  out: 8
+8: [print 'sized']
+  out: 10
+9: [print 'ok']
+  out: 10
+10: [print 'done']
+  out: -
+`
+	actual = cf.stringify()
+	if diff := cmp.Diff(expect, actual); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestControlFlowSimpleLoop(t *testing.T) {

--- a/transform/staticlark/functions_test.go
+++ b/transform/staticlark/functions_test.go
@@ -32,6 +32,7 @@ func TestCollectFunctions(t *testing.T) {
 4: top_level_func [use_branch len branch_multiple branch_no_else another_function]
 5: another_function [branch_nested branch_no_else]
 6: branch_elses [print print print print print]
+7: branch_elses_contained [print print print print print print]
 `
 	if diff := cmp.Diff(expect, text); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/transform/staticlark/testdata/control_funcs.star
+++ b/transform/staticlark/testdata/control_funcs.star
@@ -1,0 +1,35 @@
+def get_secret():
+  return 3
+
+def get_public():
+  return 4
+
+def modify(v):
+  return v * 2
+
+def dangerous(s, t):
+  print('Leak %d' % s)
+
+def something(a, b, c):
+  s = a + 1
+  t = b + 2
+  m = 0
+  if c < 10:
+    # c influences control flow, therefore
+    # it is considered sensitive
+    m = a + 3
+  else:
+    # TODO: validate that `m` is derived from `a`
+    # using linear analysis (incorrectly) would have the `else`
+    # branch override the `then` branch. Rather, the two branches
+    # need to be unioned
+    m = b + 4
+  dangerous(m, t)
+
+def top():
+  x = get_public()
+  y = modify(get_public())
+  z = get_secret()
+  something(x, y, z)
+
+top()

--- a/transform/staticlark/testdata/some_funcs.star
+++ b/transform/staticlark/testdata/some_funcs.star
@@ -77,3 +77,19 @@ def branch_elses(container):
   else:
     print('ok')
   print('done')
+
+def branch_elses_contained(container):
+  a = 1
+  b = 2
+  if a < b:
+    c = b + 1
+    if c < 1:
+      print('small')
+    elif c < 5:
+      print('medium')
+    else:
+      print('large')
+    print('sized')
+  else:
+    print('ok')
+  print('done')


### PR DESCRIPTION
In dataflow analysis, each branch of an `if` statement is analyzed separately. Then, the environments from those branches are merged together, since assignments from either one can influence bindings. Furthermore, variables in the conditional itself influences the values of assignments within those branches.

First commit adds a `join` field to `if` statements, which indicates where the two branches join up. This make it much easier to recursively analyze each branch of the control structure.