### PR TITLE
fix(transform): Bump starlib, fix how OutputConfig is used

### DIFF
--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1363,8 +1363,8 @@ github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449/go.mod h1:g7DP
 github.com/qri-io/qfs v0.6.1-0.20210629014446-45bdcdb57434/go.mod h1:XX/caqvngrusufIrtnbo4iPtgsNfu0dfrE3pmLGte9w=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43 h1:3Nlkdpj+MYaiAq7MmZ3riECTO0mdU3btt0IjSapaCls=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
-github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15 h1:bGUe3r+QdkyoUdQJJN0uqMefrxYiAa6cKw/xddasgcc=
-github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
+github.com/qri-io/starlib v0.5.1-0.20211214160444-ce12cf4a9ca1 h1:KM8v7qbGTUR8hqnSWEtXvDDH7f8ZdL0LE0RWbWWHo84=
+github.com/qri-io/starlib v0.5.1-0.20211214160444-ce12cf4a9ca1/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=
 github.com/qri-io/varName v0.1.0/go.mod h1:IGWuuGOHhLJ9ZZg28C/+oMYm1QYP+pAorNZKQpdXhxQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/qri-io/iso8601 v0.1.1-0.20201221213213-f31ee4cdc38b
 	github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449
 	github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43
-	github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15
+	github.com/qri-io/starlib v0.5.1-0.20211214160444-ce12cf4a9ca1
 	github.com/russross/blackfriday/v2 v2.0.2-0.20190629151518-3e56bb68c887
 	github.com/sergi/go-diff v1.1.0
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1344,8 +1344,8 @@ github.com/qri-io/jsonschema v0.2.2-0.20210618085106-a515144d7449/go.mod h1:g7DP
 github.com/qri-io/qfs v0.6.1-0.20210629014446-45bdcdb57434/go.mod h1:XX/caqvngrusufIrtnbo4iPtgsNfu0dfrE3pmLGte9w=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43 h1:3Nlkdpj+MYaiAq7MmZ3riECTO0mdU3btt0IjSapaCls=
 github.com/qri-io/qfs v0.6.1-0.20210809192005-052457575e43/go.mod h1:PCkSctLfc6OAquG5QtiUzddDkUE4wezDIvaUOaeuwu0=
-github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15 h1:bGUe3r+QdkyoUdQJJN0uqMefrxYiAa6cKw/xddasgcc=
-github.com/qri-io/starlib v0.5.1-0.20211118144936-89e2a4842c15/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
+github.com/qri-io/starlib v0.5.1-0.20211214160444-ce12cf4a9ca1 h1:KM8v7qbGTUR8hqnSWEtXvDDH7f8ZdL0LE0RWbWWHo84=
+github.com/qri-io/starlib v0.5.1-0.20211214160444-ce12cf4a9ca1/go.mod h1:Geq0MWa2oq+Ki/05aXaKoJAguFzlCZQd9Fx3hTsAEPU=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=
 github.com/qri-io/varName v0.1.0/go.mod h1:IGWuuGOHhLJ9ZZg28C/+oMYm1QYP+pAorNZKQpdXhxQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/transform/startf/ds/dataset.go
+++ b/transform/startf/ds/dataset.go
@@ -83,7 +83,11 @@ func NewDataset(ds *dataset.Dataset, outconf *dataframe.OutputConfig) *Dataset {
 
 // New creates a new dataset from starlark land
 func New(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	d := &Dataset{ds: &dataset.Dataset{}, changes: make(map[string]struct{})}
+	// TODO(dustmop): Add a function to starlib/dataframe that returns this,
+	// use that instead. That way all uses of the thread local data stay in
+	// that package, instead of leaking out here.
+	outconf, _ := thread.Local("OutputConfig").(*dataframe.OutputConfig)
+	d := &Dataset{ds: &dataset.Dataset{}, outconf: outconf, changes: make(map[string]struct{})}
 	return d, nil
 }
 

--- a/transform/startf/ds/dataset_test.go
+++ b/transform/startf/ds/dataset_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/qfs"
+	"github.com/qri-io/starlib/dataframe"
 	"github.com/qri-io/starlib/testdata"
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
@@ -38,7 +39,8 @@ func TestCannotSetIfReadOnly(t *testing.T) {
 }
 
 func TestSetAndGetBody(t *testing.T) {
-	ds := NewDataset(&dataset.Dataset{}, nil)
+	outconf := &dataframe.OutputConfig{}
+	ds := NewDataset(&dataset.Dataset{}, outconf)
 	err := ds.SetField("body", starlark.NewList([]starlark.Value{starlark.NewList([]starlark.Value{starlark.String("a")})}))
 	if err != nil {
 		t.Fatal(err)
@@ -56,6 +58,7 @@ func TestFile(t *testing.T) {
 	resolve.AllowFloat = true
 	thread := &starlark.Thread{Load: newLoader()}
 	starlarktest.SetReporter(thread, t)
+	dataframe.SetOutputSize(thread, 0, 0)
 
 	// Execute test file
 	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, starlark.StringDict{
@@ -102,7 +105,8 @@ bat,3,meh
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.csv", []byte(text)))
 
-	d := NewDataset(ds, nil)
+	outconf := &dataframe.OutputConfig{}
+	d := NewDataset(ds, outconf)
 	return d
 }
 

--- a/transform/startf/transform.go
+++ b/transform/startf/transform.go
@@ -197,11 +197,7 @@ func NewStepRunner(target *dataset.Dataset, opts ...func(o *ExecOpts)) *StepRunn
 
 	// Store the OutputConfig on the starlark thread. This allows functions
 	// such as the DataFrame constructor to get this configuration
-	outconf := &dataframe.OutputConfig{
-		Width:  o.OutputWidth,
-		Height: o.OutputHeight,
-	}
-	thread.SetLocal("OutputConig", &outconf)
+	outconf := dataframe.SetOutputSize(thread, o.OutputWidth, o.OutputHeight)
 
 	r := &StepRunner{
 		config:    target.Transform.Config,
@@ -237,7 +233,7 @@ func (r *StepRunner) RunStep(ctx context.Context, ds *dataset.Dataset, st *datas
 			// Need to assign to the named return value from
 			// a recovery
 			err = fmt.Errorf("running transform: %w", r)
-			log.Error("%w, stacktrace: %s", err, debug.Stack())
+			log.Errorf("%s, stacktrace: %s", err, debug.Stack())
 		}
 	}()
 


### PR DESCRIPTION
There was a mistake in the spelling of OutputConfig, but this bug was covered up by other bugs in starlib/dataframe. Bump our dependency to fix these bugs, and use the function SetOutputSize instead. Also fix the stack trace display.