### PR TITLE
feat(whatchanged): Restore the `whatchanged` command

### DIFF
--- a/base/component_status.go
+++ b/base/component_status.go
@@ -1,0 +1,205 @@
+package base
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qfs/muxfs"
+	"github.com/qri-io/qri/base/component"
+	"github.com/qri-io/qri/base/dsfs"
+	"github.com/qri-io/qri/dsref"
+)
+
+var (
+	// STUnmodified is "no status"
+	STUnmodified = "unmodified"
+	// STAdd is an added component
+	STAdd = "add"
+	// STChange is a modified component
+	STChange = "modified"
+	// STRemoved is a removed component
+	STRemoved = "removed"
+	// STParseError is a component that didn't parse
+	STParseError = "parse error"
+	// STMissing is a component that is missing
+	STMissing = "missing"
+	// STConflictError is a component with a conflict
+	STConflictError = "conflict error"
+	// ErrWorkingDirectoryDirty is the error for when the working directory is not clean
+	ErrWorkingDirectoryDirty = fmt.Errorf("working directory is dirty")
+)
+
+// StatusItem is the status of a component of a dataset, and whether it
+// was changed at a specific version in history
+type StatusItem struct {
+	SourceFile string    `json:"sourceFile"`
+	Component  string    `json:"component"`
+	Type       string    `json:"type"`
+	Message    string    `json:"message"`
+	Mtime      time.Time `json:"mtime"`
+}
+
+// MarshalJSON marshals a StatusItem, handling mtime specially
+func (si StatusItem) MarshalJSON() ([]byte, error) {
+	obj := struct {
+		SourceFile string `json:"sourceFile"`
+		Component  string `json:"component"`
+		Type       string `json:"type"`
+		Message    string `json:"message"`
+		Mtime      string `json:"mtime,omitempty"`
+	}{
+		SourceFile: si.SourceFile,
+		Component:  si.Component,
+		Type:       si.Type,
+		Message:    si.Message,
+		Mtime:      si.Mtime.Format(time.RFC3339),
+	}
+	return json.Marshal(obj)
+}
+
+// ComponentStatus owns functionality to get change status about components
+type ComponentStatus struct {
+	fs *muxfs.Mux
+}
+
+// NewComponentStatus returns a new ComponentStatus
+func NewComponentStatus(ctx context.Context, fs *muxfs.Mux) *ComponentStatus {
+	return &ComponentStatus{
+		fs: fs,
+	}
+}
+
+// WhatChanged gets changes that happened at a particular version in a dataset's history.
+func (cs *ComponentStatus) WhatChanged(ctx context.Context, ref dsref.Ref) (changes []StatusItem, err error) {
+	if ref.Path == "" {
+		return nil, fmt.Errorf("path is required to determine status at version")
+	}
+
+	var next, prev *dataset.Dataset
+	if next, err = dsfs.LoadDataset(ctx, cs.fs, ref.Path); err != nil {
+		return nil, err
+	}
+
+	prevPath := next.PreviousPath
+	if prevPath == "" {
+		prev = &dataset.Dataset{}
+	} else {
+		if prev, err = dsfs.LoadDataset(ctx, cs.fs, prevPath); err != nil {
+			if strings.Contains(err.Error(), "deadline exceeded") {
+				// TODO (b5) - need to handle this situation gracefully, returning an indication
+				// that the previous version can't be loaded
+				prev = &dataset.Dataset{}
+				err = nil
+			} else {
+				log.Error(err)
+				return nil, err
+			}
+		}
+	}
+
+	prevCompCollect := component.ConvertDatasetToComponents(prev, cs.fs)
+	prevCompCollect.Base().RemoveSubcomponent("commit")
+	prevCompCollect.DropDerivedValues()
+	nextCompCollect := component.ConvertDatasetToComponents(next, cs.fs)
+	nextCompCollect.Base().RemoveSubcomponent("commit")
+	nextCompCollect.DropDerivedValues()
+
+	changes, err = cs.calculateStateTransition(ctx, prevCompCollect, nextCompCollect)
+	if err != nil {
+		return nil, err
+	}
+	for i, ch := range changes {
+		comp := ch.Component
+		if comp == "meta" || comp == "body" || comp == "structure" {
+			changes[i].SourceFile = comp
+		}
+	}
+	return changes, nil
+}
+
+// calculateStateTransition calculates the differences between two versions of a dataset.
+func (cs *ComponentStatus) calculateStateTransition(ctx context.Context, prev, next component.Component) (changes []StatusItem, err error) {
+
+	changes = make([]StatusItem, 0, component.NumberPossibleComponents)
+
+	// See if the dataset itself has a problem.
+	dsComp := next.Base().GetSubcomponent("dataset")
+	if dsComp != nil && dsComp.Base().ProblemKind != "" {
+		changes = append(changes, StatusItem{
+			SourceFile: dsComp.Base().SourceFile,
+			Component:  "dataset",
+			Type:       dsComp.Base().ProblemKind,
+			Mtime:      dsComp.Base().ModTime,
+		})
+	}
+
+	for _, compName := range component.AllSubcomponentNames() {
+		prevComp := prev.Base().GetSubcomponent(compName)
+		nextComp := next.Base().GetSubcomponent(compName)
+
+		// Next component might have a problem, such as a parse error, or permission problem.
+		if nextComp != nil && nextComp.Base().ProblemKind != "" {
+			changes = append(changes, StatusItem{
+				SourceFile: nextComp.Base().SourceFile,
+				Component:  compName,
+				Type:       nextComp.Base().ProblemKind,
+				Mtime:      nextComp.Base().ModTime,
+			})
+			continue
+		}
+
+		if prevComp == nil && nextComp == nil {
+			// Didn't exist before, still doesn't - skip this component.
+			continue
+		} else if prevComp == nil && nextComp != nil {
+			// Didn't exist before, does now - component was added.
+			changes = append(changes, StatusItem{
+				SourceFile: nextComp.Base().SourceFile,
+				Component:  compName,
+				Type:       STAdd,
+				Mtime:      nextComp.Base().ModTime,
+			})
+			continue
+		} else if prevComp != nil && nextComp == nil {
+			// Did exist before, but doesn't now - component was removed.
+			changes = append(changes, StatusItem{
+				Component: compName,
+				Type:      STRemoved,
+			})
+			continue
+		}
+
+		isEqual, err := prevComp.Compare(nextComp)
+		if err != nil {
+			changes = append(changes, StatusItem{
+				SourceFile: nextComp.Base().SourceFile,
+				Component:  compName,
+				Type:       STParseError,
+				Mtime:      nextComp.Base().ModTime,
+			})
+			continue
+		}
+
+		if isEqual {
+			changes = append(changes, StatusItem{
+				SourceFile: nextComp.Base().SourceFile,
+				Component:  compName,
+				Type:       STUnmodified,
+				Mtime:      nextComp.Base().ModTime,
+			})
+		} else {
+			changes = append(changes, StatusItem{
+				SourceFile: nextComp.Base().SourceFile,
+				Component:  compName,
+				Type:       STChange,
+				Mtime:      nextComp.Base().ModTime,
+			})
+		}
+	}
+
+	return changes, nil
+}

--- a/cmd/qri.go
+++ b/cmd/qri.go
@@ -74,6 +74,7 @@ https://github.com/qri-io/qri/issues`,
 		NewSetupCommand(opt, ioStreams),
 		NewValidateCommand(opt, ioStreams),
 		NewVersionCommand(opt, ioStreams),
+		NewWhatChangedCommand(opt, ioStreams),
 	)
 
 	for _, sub := range cmd.Commands() {

--- a/cmd/whatchanged.go
+++ b/cmd/whatchanged.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qri-io/ioes"
+	"github.com/qri-io/qri/lib"
+	"github.com/spf13/cobra"
+)
+
+// NewWhatChangedCommand creates a new `qri whatchanged` command that shows what changed at a commit
+func NewWhatChangedCommand(f Factory, ioStreams ioes.IOStreams) *cobra.Command {
+	o := &WhatChangedOptions{IOStreams: ioStreams}
+	cmd := &cobra.Command{
+		Use:    "whatchanged DATASET",
+		Hidden: true,
+		Short:  "shows what changed at a particular commit",
+		Long: `Shows what changed for components at a particular commit, that is, which
+were added, modified or removed.`,
+		Example: `  # Show what changed for the head commit
+  $ qri whatchanged me/dataset_name`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	return cmd
+}
+
+// WhatChangedOptions encapsulates state for the whatchanged command
+type WhatChangedOptions struct {
+	ioes.IOStreams
+
+	Instance *lib.Instance
+
+	Refs *RefSelect
+}
+
+// Complete adds any missing configuration that can only be added just before calling Run
+func (o *WhatChangedOptions) Complete(f Factory, args []string) (err error) {
+	if o.Instance, err = f.Instance(); err != nil {
+		return err
+	}
+	o.Refs, err = GetCurrentRefSelect(f, args, 1)
+	return err
+}
+
+// Run executes the whatchanged command
+func (o *WhatChangedOptions) Run() (err error) {
+	ctx := context.TODO()
+	inst := o.Instance
+
+	params := lib.WhatChangedParams{Ref: o.Refs.Ref()}
+	res, err := inst.Dataset().WhatChanged(ctx, &params)
+	if err != nil {
+		printErr(o.ErrOut, err)
+		return nil
+	}
+
+	for _, si := range res {
+		printInfo(o.Out, fmt.Sprintf("  %s: %s", si.Component, si.Type))
+	}
+
+	return nil
+}

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -1393,7 +1393,7 @@ func (datasetImpl) Render(scope scope, p *RenderParams) (res []byte, err error) 
 	return res, nil
 }
 
-// Whatchanges ...
+// WhatChanged gets what components changed for the given version
 func (datasetImpl) WhatChanged(scope scope, p *WhatChangedParams) ([]base.StatusItem, error) {
 	ref, err := dsref.Parse(p.Ref)
 	if err != nil {

--- a/lib/datasets.go
+++ b/lib/datasets.go
@@ -67,6 +67,7 @@ func (m DatasetMethods) Attributes() map[string]AttributeSet {
 		"manifest":        {Endpoint: qhttp.AEManifest, HTTPVerb: "POST", DefaultSource: "local"},
 		"manifestmissing": {Endpoint: qhttp.AEManifestMissing, HTTPVerb: "POST", DefaultSource: "local"},
 		"daginfo":         {Endpoint: qhttp.AEDAGInfo, HTTPVerb: "POST", DefaultSource: "local"},
+		"whatchanged":     {Endpoint: qhttp.AEWhatChanged, HTTPVerb: "POST", DefaultSource: "local"},
 	}
 }
 
@@ -531,6 +532,20 @@ func (p *RenderParams) Validate() error {
 func (m DatasetMethods) Render(ctx context.Context, p *RenderParams) ([]byte, error) {
 	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "render"), p)
 	if res, ok := got.([]byte); ok {
+		return res, err
+	}
+	return nil, dispatchReturnError(got, err)
+}
+
+// WhatChangedParams are parameters for the whatchanged command
+type WhatChangedParams struct {
+	Ref string `json:"ref"`
+}
+
+// WhatChanged gets what components have changed at a version in history
+func (m DatasetMethods) WhatChanged(ctx context.Context, p *WhatChangedParams) ([]base.StatusItem, error) {
+	got, _, err := m.d.Dispatch(ctx, dispatchMethodName(m, "whatchanged"), p)
+	if res, ok := got.([]base.StatusItem); ok {
 		return res, err
 	}
 	return nil, dispatchReturnError(got, err)
@@ -1376,4 +1391,16 @@ func (datasetImpl) Render(scope scope, p *RenderParams) (res []byte, err error) 
 		return nil, fmt.Errorf("selector must be one of 'viz' or 'readme'")
 	}
 	return res, nil
+}
+
+// Whatchanges ...
+func (datasetImpl) WhatChanged(scope scope, p *WhatChangedParams) ([]base.StatusItem, error) {
+	ref, err := dsref.Parse(p.Ref)
+	if err != nil {
+		return nil, err
+	}
+	if ref.Path == "" {
+		return nil, fmt.Errorf("whatchanged requires 'Path'")
+	}
+	return scope.ComponentStatus().WhatChanged(scope.Context(), ref)
 }

--- a/lib/http/api.go
+++ b/lib/http/api.go
@@ -91,6 +91,8 @@ const (
 	AEManifestMissing APIEndpoint = "/ds/manifest/missing"
 	// AEDAGInfo generates a dag.Info for a dataset path
 	AEDAGInfo APIEndpoint = "/ds/daginfo"
+	// AEWhatChanged gets what changed at a specific version in history
+	AEWhatChanged APIEndpoint = "/ds/whatchanged"
 
 	// peer endpoints
 

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -27,6 +27,7 @@ import (
 	"github.com/qri-io/qri/automation/run"
 	"github.com/qri-io/qri/automation/trigger"
 	"github.com/qri-io/qri/automation/workflow"
+	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/base/dsfs"
 	"github.com/qri-io/qri/base/hiddenfile"
 	"github.com/qri-io/qri/collection"
@@ -565,6 +566,10 @@ func NewInstance(ctx context.Context, repoPath string, opts ...Option) (qri *Ins
 		}
 	}
 
+	if inst.compStat == nil {
+		inst.compStat = base.NewComponentStatus(ctx, inst.qfs)
+	}
+
 	// Try to make the repo a hidden directory, but it's okay if we can't. Ignore the error.
 	_ = hiddenfile.SetFileHidden(inst.repoPath)
 
@@ -861,6 +866,7 @@ type Instance struct {
 	dscache       *dscache.Dscache
 	collections   *collection.SetMaintainer
 	automation    *automation.Orchestrator
+	compStat      *base.ComponentStatus
 	tokenProvider token.Provider
 	bus           event.Bus
 	appCtx        context.Context

--- a/lib/scope.go
+++ b/lib/scope.go
@@ -6,6 +6,7 @@ import (
 	"github.com/qri-io/qfs/muxfs"
 	"github.com/qri-io/qri/automation"
 	"github.com/qri-io/qri/automation/workflow"
+	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/collection"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/dscache"
@@ -119,6 +120,11 @@ func (s *scope) AppContext() context.Context {
 // CollectionSet returns the set of collections
 func (s *scope) CollectionSet() collection.Set {
 	return s.inst.collections
+}
+
+// ComponentStatus returns functionality concerning component status changes
+func (s *scope) ComponentStatus() *base.ComponentStatus {
+	return s.inst.compStat
 }
 
 // ReplaceParentContext returns a copy of the scope bound to a new parent

--- a/lib/test_runner_test.go
+++ b/lib/test_runner_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/base"
 	"github.com/qri-io/qri/base/dsfs"
 	testcfg "github.com/qri-io/qri/config/test"
 	"github.com/qri-io/qri/dsref"
@@ -225,4 +226,13 @@ func (tr *testRunner) DiffWithParams(p *DiffParams) (string, error) {
 		return "", err
 	}
 	return string(data), nil
+}
+
+func (tr *testRunner) MustWhatChanged(t *testing.T, ref string) []base.StatusItem {
+	p := WhatChangedParams{Ref: ref}
+	items, err := tr.Instance.Dataset().WhatChanged(tr.Ctx, &p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return items
 }


### PR DESCRIPTION
The command `whatchanged` returns what components changed at a specific version of in the history of the dataset.

This command was originally part of FSI, which was removed by commit eaeba31aeb6242bd4aacf79f7c20f9579585d549. However, this command is kind of its own thing, and does not have a hard dependency on FSI functionality. This change adds the command only, without the similar `status` command, which *did* depend on FSI.