### PR TITLE
delete minor unreachable code caused by log.Fatal

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -62,7 +62,6 @@ func main() {
 		err = os.MkdirAll(dir, 0755)
 		if err != nil {
 			log.Fatal(err)
-			os.Exit(1)
 		}
 	}
 
@@ -70,7 +69,6 @@ func main() {
 		buf, err := OpenAPIYAML()
 		if err != nil {
 			log.Fatal(err)
-			os.Exit(1)
 		}
 
 		path := filepath.Join(dir, "open_api_spec.yaml")


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

https://pkg.go.dev/log#Fatalf
> Fatalf is equivalent to Printf() followed by a call to os.Exit(1).

